### PR TITLE
feat(cli): #34 Support SMAPI CLI input when running inside docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,9 @@ mod/JunimoServer/obj/
 mods/
 sub_modules/
 
+# Dependency folders
+node_modules/
+
 # Project files
 .dockerignore
 .editorconfig

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ logs
 /bin
 /debug
 /decompiled
+/.game-files
+
+# Dependency folders
+node_modules/
 
 # Decompiler version file
 /version.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -90,11 +90,10 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 
-# Install SteamCMD
+# Install SteamCMD (needed for runtime game download)
 RUN echo steam steam/question select "I AGREE" | debconf-set-selections && \
     echo steam steam/license note '' | debconf-set-selections && \
-    apt-get install -y \
-    steamcmd && \
+    apt-get install -y steamcmd && \
     mv /usr/games/steamcmd /opt/base/bin/ && \
     steamcmd +force_install_dir /data/steam +@sSteamCmdForcePlatformType linux +login anonymous +app_update 1007 +quit && \
     mkdir -p /root/.steam/sdk64 && \
@@ -114,7 +113,8 @@ RUN apt-get install -y \
 RUN apt-get install -y \
     exa \
     htop \
-    nano
+    nano \
+    tmux
 
 # Install TigerVNC (replaces pre-compiled x11 to include GLX extension)
 RUN apt-get install -y \
@@ -153,6 +153,11 @@ RUN \
 
 # Copy system files
 COPY docker/rootfs/ /
+
+# Make custom scripts executable
+RUN chmod +x \
+    /opt/base/bin/attach-cli \
+    /opt/base/bin/server-command-loop
 
 # Copy mod from build stage (no game files included in image)
 COPY --from=mod-builder /output/JunimoServer /data/Mods/JunimoServer

--- a/docker/rootfs/opt/base/bin/attach-cli
+++ b/docker/rootfs/opt/base/bin/attach-cli
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Attach to the Stardew Valley server tmux session with an interactive CLI
+# This creates a per-invocation isolated session with split-pane view:
+# - Top pane: Server logs (read-only view)
+# - Bottom pane: Interactive command input
+# Each 'docker compose exec' gets its own isolated session
+
+SESSION_NAME="stardew-server-$$"
+LOG_FILE="/tmp/server-output.log"
+
+# Check if server is running by checking if log file exists
+if [ ! -f "$LOG_FILE" ]; then
+    echo "Error: Server log file not found at $LOG_FILE"
+    echo "The server may not be running yet. Please wait for it to start."
+    exit 1
+fi
+
+# Create new session with log viewer
+tmux new-session -d -s "$SESSION_NAME" "tail -n 1000 -f ${LOG_FILE}"
+
+# Add command input pane at bottom (exactly 2 lines - tmux minimum)
+tmux split-window -t "$SESSION_NAME":0 -v -l 2 "bash --rcfile /opt/base/bin/server-command-loop -i"
+
+# Configure tmux options for better UX
+tmux set-option -t "$SESSION_NAME" mouse on 2>/dev/null || true
+tmux set-option -t "$SESSION_NAME" history-limit 50000 2>/dev/null || true
+tmux set-option -t "$SESSION_NAME" prefix C-b 2>/dev/null || true
+
+# Disable tmux text selection while keeping mouse scrolling
+# (allows native terminal selection to work)
+tmux unbind-key -T root MouseDrag1Pane 2>/dev/null || true
+tmux unbind-key -T root MouseDown1Pane 2>/dev/null || true
+
+# Disable dangerous keys to prevent accidental pane/window closing
+tmux unbind-key x 2>/dev/null || true  # Disable kill-pane (Ctrl+B x)
+tmux unbind-key & 2>/dev/null || true  # Disable kill-window (Ctrl+B &)
+
+# Bind Ctrl+Q to detach
+tmux bind-key -n C-q detach-client 2>/dev/null || true
+
+# Set window-size to follow current client (allows window to resize with terminal)
+tmux set-option -t "$SESSION_NAME" window-size latest 2>/dev/null || true
+
+# Set status bar
+tmux set-option -t "$SESSION_NAME" status-left "SDVD CLI " 2>/dev/null || true
+tmux set-option -t "$SESSION_NAME" status-left-length 20 2>/dev/null || true
+tmux set-option -t "$SESSION_NAME" status-right-length 100 2>/dev/null || true
+tmux set-option -t "$SESSION_NAME" status-right "Ctrl+Q or 'cli exit' to detach | Mouse/PgUp/PgDn to scroll" 2>/dev/null || true
+
+# Hide window list (the "0:sh*" part)
+tmux set-window-option -t "$SESSION_NAME" window-status-format "" 2>/dev/null || true
+tmux set-window-option -t "$SESSION_NAME" window-status-current-format "" 2>/dev/null || true
+
+# Add hooks to maintain 2-line bottom pane when window/client resizes
+# Use both hooks to catch all resize events
+tmux set-hook -t "$SESSION_NAME" client-resized "resize-pane -t $SESSION_NAME:0.1 -y 2" 2>/dev/null || true
+tmux set-hook -t "$SESSION_NAME" after-resize-window "resize-pane -t $SESSION_NAME:0.1 -y 2" 2>/dev/null || true
+
+# Set pane borders and labels
+tmux set-window-option -t "$SESSION_NAME" pane-border-status top 2>/dev/null || true
+tmux set-window-option -t "$SESSION_NAME" pane-border-format '#{?#{==:#{pane_index},0},#[bold]Output#[default],#[bold]Input#[default]}' 2>/dev/null || true
+
+# Select the command input pane (so user can type immediately)
+tmux select-pane -t "$SESSION_NAME":0.1
+
+# Cleanup: Kill session when this script exits (on detach or exit)
+trap "tmux kill-session -t '$SESSION_NAME' 2>/dev/null" EXIT
+
+# Attach to the session
+exec tmux attach-session -t "$SESSION_NAME"

--- a/docker/rootfs/opt/base/bin/server-command-loop
+++ b/docker/rootfs/opt/base/bin/server-command-loop
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+INPUT_FIFO="/tmp/smapi-input"
+
+send_to_server() {
+    local command="$1"
+    echo "$command" >> "$INPUT_FIFO"
+}
+
+clear
+stty -echoctl  # hide ^C
+
+# Function to redraw prompt and clear line on CTRL+C
+handle_sigint() {
+    # Move to beginning of line, clear it, show prompt again
+    printf "\r\033[Kserver> "
+}
+
+# Trap SIGINT
+trap 'handle_sigint' INT
+
+while true; do
+    # Read input into REPLY
+    if ! read -r -e -p "server> "; then
+        # CTRL+D (EOF)
+        echo
+        tmux detach-client 2>/dev/null || exit 0
+        break
+    fi
+
+    # Always clear to keep the panel at one visible line (+ one empty for bottom "padding")
+    clear
+
+    case "$REPLY" in
+        "cli exit"|"cli quit"|"cli detach")
+            tmux detach-client 2>/dev/null || exit 0
+            break
+            ;;
+        "cli clear")
+            clear
+            continue
+            ;;
+        "cli help")
+            echo ""
+            echo "Local CLI commands:"
+            echo "  cli help   - Show this help message"
+            echo "  cli clear  - Clear console output"
+            echo "  cli exit   - Detach from console"
+            echo "Keyboard shortcuts:"
+            echo "  Ctrl+C     - Cancel current input line"
+            echo "  Ctrl+D     - Detach from console"
+            echo ""
+            continue
+            ;;
+        "")
+            continue
+            ;;
+        *)
+            send_to_server "$REPLY"
+            ;;
+    esac
+done

--- a/docker/rootfs/root/.bashrc
+++ b/docker/rootfs/root/.bashrc
@@ -1,0 +1,34 @@
+# ~/.bashrc: executed by bash(1) for interactive shells
+
+# If not running interactively, don't do anything
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+
+# Display welcome message
+cat << 'EOF'
+═══════════════════════════════════════════════════════════════════
+   STARDEW VALLEY DEDICATED SERVER - CONTAINER SHELL
+═══════════════════════════════════════════════════════════════════
+You are in the Docker container's bash shell.
+
+To interact with the server:
+  /opt/base/bin/attach-cli    - Attach to server CLI (recommended)
+
+Common shell tasks:
+  ls /config/xdg/config/StardewValley/Saves  - View save files
+  ls /data/Stardew/Mods                       - View installed mods
+  cat /tmp/server-output.log                  - View raw server logs
+
+To exit this shell:
+  exit    - Return to your host terminal
+═══════════════════════════════════════════════════════════════════
+
+EOF
+
+# Enable some basic bash features
+shopt -s checkwinsize
+
+# Set a basic prompt
+PS1='\u@\h:\w\$ '

--- a/docker/rootfs/root/.profile
+++ b/docker/rootfs/root/.profile
@@ -1,0 +1,15 @@
+# ~/.profile: executed by sh for login shells
+
+# Display welcome message
+cat << 'EOF'
+Connected to the docker container shell.
+
+Exit and run 'make cli' if you want to use the server CLI.
+EOF
+
+# If running bash, source .bashrc if it exists
+if [ -n "$BASH_VERSION" ]; then
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi


### PR DESCRIPTION
### 🔗 Linked issue

#34 

### 📚 Description

MVP for custom CLI accessible via `make cli`, shows split-terminal using tmux to see logs/console output and enter console commands 
