### PR TITLE
chore(ci): configure release-please to update version files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
 
   build-and-publish:

--- a/mod/JunimoServer/JunimoServer.csproj
+++ b/mod/JunimoServer/JunimoServer.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>JunimoServer</AssemblyName>
 		<RootNamespace>JunimoServer</RootNamespace>
-		<Version>1.0.2</Version>
+		<Version>1.1.0</Version>
 		<TargetFramework>net6.0</TargetFramework>
 		<EnableHarmony>true</EnableHarmony>
 		<EnableModDeploy>true</EnableModDeploy>

--- a/mod/JunimoServer/manifest.json
+++ b/mod/JunimoServer/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "JunimoServer",
     "Author": "JunimoHost",
-    "Version": "1.0.2",
+    "Version": "1.1.0",
     "Description": "JunimoHost's remote game manager",
     "UniqueID": "JunimoHost.Server",
     "EntryDll": "JunimoServer.dll",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,9 +10,9 @@
           "jsonpath": "$.Version"
         },
         {
-          "type": "generic",
+          "type": "xml",
           "path": "mod/JunimoServer/JunimoServer.csproj",
-          "glob": false
+          "xpath": "/Project/PropertyGroup/Version"
         }
       ],
       "changelog-sections": [


### PR DESCRIPTION
### 📚 Description

Previous (first) automatic release did not bump versions at all. Probably from conflicting and partially wrong config values.
