### PR TITLE
chore(build): ensure supervisor scripts have correct exec perms

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -176,10 +176,9 @@ RUN cd /tmp/dll-patcher && \
 # Copy system files
 COPY docker/rootfs/ /
 
-# Make custom scripts executable
-RUN chmod +x \
-    /opt/base/bin/attach-cli \
-    /opt/base/bin/server-command-loop
+# Make custom scripts and supervisor services executable
+RUN chmod +x /startapp.sh /opt/base/bin/* && \
+    find /etc/services.d -type f \( -name "run" -o -name "is_ready" -o -name "kill" -o -name "finish" \) -exec chmod +x {} \;
 
 # Copy mod from build stage (no game files included in image)
 COPY --from=mod-builder /output/JunimoServer /data/Mods/JunimoServer


### PR DESCRIPTION
### 📚 Description

Supervisor script were missing executable permissions, thank you Git for Windows

<img width="1284" height="82" alt="image" src="https://github.com/user-attachments/assets/f843360b-7de2-4609-859d-51ec60938278" />
