### PR TITLE
chore(build): ensure *all* supervisor scripts are executable

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,7 +178,7 @@ COPY docker/rootfs/ /
 
 # Make custom scripts and supervisor services executable
 RUN chmod +x /startapp.sh /opt/base/bin/* && \
-    find /etc/services.d -type f \( -name "run" -o -name "is_ready" -o -name "kill" -o -name "finish" \) -exec chmod +x {} \;
+    find /etc/services.d -type f ! -name "*.dep" -exec chmod +x {} \;
 
 # Copy mod from build stage (no game files included in image)
 COPY --from=mod-builder /output/JunimoServer /data/Mods/JunimoServer


### PR DESCRIPTION
### 📚 Description

This should fix the "buffer too small" error. Reading the docs properly help, all executables must be... executable, surprise!
