### PR TITLE
feat(ci): add manual preview builds and PR preview workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,9 +8,29 @@ on:
         required: false
         default: 'latest'
         type: string
+      deployment_type:
+        description: 'Deployment type (release = root, preview = /preview/ subdirectory)'
+        required: false
+        default: 'release'
+        type: choice
+        options:
+          - release
+          - preview
+  workflow_call:
+    inputs:
+      image_tag:
+        description: 'Docker image tag to extract OpenAPI spec from'
+        required: false
+        default: 'latest'
+        type: string
+      deployment_type:
+        description: 'Deployment type (release or preview)'
+        required: false
+        default: 'release'
+        type: string
 
 concurrency:
-  group: deploy-docs
+  group: deploy-docs-${{ inputs.deployment_type || 'release' }}
   cancel-in-progress: false
 
 permissions:
@@ -22,8 +42,23 @@ jobs:
   build:
     name: Build Documentation
     runs-on: ubuntu-latest
+    outputs:
+      deployment_type: ${{ steps.config.outputs.deployment_type }}
+      base_path: ${{ steps.config.outputs.base_path }}
 
     steps:
+      - name: Configure deployment
+        id: config
+        run: |
+          DEPLOYMENT_TYPE="${{ inputs.deployment_type || 'release' }}"
+          echo "deployment_type=$DEPLOYMENT_TYPE" >> $GITHUB_OUTPUT
+
+          if [ "$DEPLOYMENT_TYPE" = "preview" ]; then
+            echo "base_path=/server/preview/" >> $GITHUB_OUTPUT
+          else
+            echo "base_path=/server/" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -34,9 +69,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract OpenAPI spec from Docker image
+        env:
+          IMAGE_TAG: ${{ inputs.image_tag || 'latest' }}
         run: |
-          docker pull sdvd/server:${{ inputs.image_tag }}
-          CONTAINER_ID=$(docker create sdvd/server:${{ inputs.image_tag }})
+          docker pull "sdvd/server:$IMAGE_TAG"
+          CONTAINER_ID=$(docker create "sdvd/server:$IMAGE_TAG")
           mkdir -p docs/assets
           docker cp "$CONTAINER_ID:/data/openapi.json" docs/assets/openapi.json
           docker rm "$CONTAINER_ID"
@@ -52,13 +89,30 @@ jobs:
         working-directory: docs
 
       - name: Build documentation
+        env:
+          VITEPRESS_BASE: ${{ steps.config.outputs.base_path }}
         run: bun run build
         working-directory: docs
+
+      - name: Prepare deployment artifact
+        run: |
+          DEPLOYMENT_TYPE="${{ steps.config.outputs.deployment_type }}"
+
+          if [ "$DEPLOYMENT_TYPE" = "preview" ]; then
+            # For preview: nest output in /preview/ subdirectory
+            mkdir -p _site/preview
+            cp -r docs/.vitepress/dist/* _site/preview/
+            # Create a simple redirect at root for preview deploys
+            echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0;url=preview/"></head></html>' > _site/index.html
+          else
+            # For release: use output directly
+            cp -r docs/.vitepress/dist _site
+          fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          path: docs/.vitepress/dist
+          path: _site
 
   deploy:
     name: Deploy to GitHub Pages
@@ -74,24 +128,38 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
       - name: Build summary
+        env:
+          DEPLOYMENT_TYPE: ${{ needs.build.outputs.deployment_type }}
         run: |
           echo "### Documentation Deployed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Type:** $DEPLOYMENT_TYPE" >> $GITHUB_STEP_SUMMARY
           echo "**Site URL:** ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
 
       - name: Discord notification
         if: success()
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DEPLOYMENT_TYPE: ${{ needs.build.outputs.deployment_type }}
         run: |
-          curl -H "Content-Type: application/json" \
-            -d '{
-              "embeds": [{
-                "title": "Documentation Updated",
-                "color": 3447003,
-                "fields": [
-                  {"name": "View Docs", "value": "[stardew-valley-dedicated-server.github.io/server](${{ steps.deployment.outputs.page_url }})"}
-                ]
-              }]
-            }' \
-            "$DISCORD_WEBHOOK"
+          if [ -n "$DISCORD_WEBHOOK" ]; then
+            TITLE="Documentation Updated"
+            if [ "$DEPLOYMENT_TYPE" = "preview" ]; then
+              TITLE="Preview Documentation Updated"
+            fi
+
+            jq -n \
+              --arg title "$TITLE" \
+              --arg url "${{ steps.deployment.outputs.page_url }}" \
+              --arg type "$DEPLOYMENT_TYPE" \
+              '{
+                embeds: [{
+                  title: $title,
+                  color: 3447003,
+                  fields: [
+                    {name: "Type", value: $type, inline: true},
+                    {name: "View Docs", value: ("[View Documentation](" + $url + ")")}
+                  ]
+                }]
+              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+          fi

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -1,12 +1,6 @@
 name: Deploy Server
 
 on:
-  workflow_run:
-    workflows: ["Preview Build"]
-    types:
-      - completed
-    branches:
-      - master
   release:
     types:
       - published
@@ -24,9 +18,15 @@ on:
         required: false
         default: false
         type: boolean
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Environment to deploy'
+        required: true
+        type: string
 
 concurrency:
-  group: deploy-${{ github.event.inputs.environment || 'auto' }}
+  group: deploy-${{ inputs.environment || 'auto' }}
   cancel-in-progress: false
 
 permissions: {}
@@ -43,18 +43,17 @@ jobs:
         id: set-matrix
         env:
           TRIGGER: ${{ github.event_name }}
-          SELECTED: ${{ github.event.inputs.environment }}
-          WORKFLOW_SUCCESS: ${{ github.event.workflow_run.conclusion }}
+          SELECTED: ${{ inputs.environment }}
         run: |
           # Define deployment targets as JSON
           TARGETS='[
-            {"environment": "public-test", "image_tag": "preview", "on_preview": true, "on_release": false}
+            {"environment": "public-test", "image_tag": "preview", "on_release": false}
           ]'
-          # {"environment": "production", "image_tag": "latest", "on_preview": false, "on_release": true}
+          # {"environment": "production", "image_tag": "latest", "on_release": true}
 
           MATRIX=$(echo "$TARGETS" | jq -c '[.[] | select(
             (env.TRIGGER == "workflow_dispatch" and env.SELECTED == .environment) or
-            (env.TRIGGER == "workflow_run" and env.WORKFLOW_SUCCESS == "success" and .on_preview) or
+            (env.TRIGGER == "workflow_call" and env.SELECTED == .environment) or
             (env.TRIGGER == "release" and .on_release)
           ) | {environment, image_tag}]')
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,561 @@
+name: PR Preview
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to build and deploy'
+        required: true
+        type: number
+      deploy_server:
+        description: 'Deploy game server to PR environment'
+        required: false
+        default: false
+        type: boolean
+      deploy_docs:
+        description: 'Deploy documentation preview'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: pr-preview-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  validate-pr:
+    name: Validate PR
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      pr_ref: ${{ steps.pr.outputs.ref }}
+      pr_sha: ${{ steps.pr.outputs.sha }}
+      pr_title: ${{ steps.pr.outputs.title }}
+      image_tag: ${{ steps.pr.outputs.image_tag }}
+
+    steps:
+      - name: Get PR information
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER)
+
+          if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+            echo "::error::PR #$PR_NUMBER not found"
+            exit 1
+          fi
+
+          STATE=$(echo "$PR_JSON" | jq -r '.state')
+          if [ "$STATE" != "open" ]; then
+            echo "::error::PR #$PR_NUMBER is not open (state: $STATE)"
+            exit 1
+          fi
+
+          REF=$(echo "$PR_JSON" | jq -r '.head.ref')
+          SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+          TITLE=$(echo "$PR_JSON" | jq -r '.title')
+
+          echo "ref=$REF" >> $GITHUB_OUTPUT
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "image_tag=pr-$PR_NUMBER" >> $GITHUB_OUTPUT
+
+          echo "### PR Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR:** #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "- **Title:** $TITLE" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** $REF" >> $GITHUB_STEP_SUMMARY
+          echo "- **SHA:** $SHA" >> $GITHUB_STEP_SUMMARY
+
+  build-server:
+    name: Build Server Image
+    needs: validate-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-pr.outputs.pr_sha }}
+
+      - name: Update version in files
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          VERSION="0.0.0-pr.$PR_NUMBER"
+
+          # Update manifest.json
+          sed -i "s/\"Version\": \".*\"/\"Version\": \"$VERSION\"/" mod/JunimoServer/manifest.json
+
+          # Update csproj
+          sed -i "s|<Version>.*</Version>|<Version>$VERSION</Version>|g" mod/JunimoServer/JunimoServer.csproj
+
+          echo "Updated files to version $VERSION"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: sdvd/server
+          tags: |
+            type=raw,value=${{ needs.validate-pr.outputs.image_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          secrets: |
+            steam_username=${{ secrets.STEAM_USERNAME }}
+            steam_password=${{ secrets.STEAM_PASSWORD }}
+            steam_refresh_token=${{ secrets.STEAM_REFRESH_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build summary
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          echo "### Server Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR:** #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`sdvd/server:$IMAGE_TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull Command:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull sdvd/server:$IMAGE_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  build-steam-service:
+    name: Build Steam Service Image
+    needs: validate-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-pr.outputs.pr_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: sdvd/steam-service
+          tags: |
+            type=raw,value=${{ needs.validate-pr.outputs.image_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./tools/steam-service
+          file: ./tools/steam-service/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=steam-service
+          cache-to: type=gha,mode=max,scope=steam-service
+
+      - name: Build summary
+        env:
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          echo "### Steam Service Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`sdvd/steam-service:$IMAGE_TAG\`" >> $GITHUB_STEP_SUMMARY
+
+  build-discord-bot:
+    name: Build Discord Bot Image
+    needs: validate-pr
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-pr.outputs.pr_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: sdvd/discord-bot
+          tags: |
+            type=raw,value=${{ needs.validate-pr.outputs.image_tag }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: ./tools/discord-bot
+          file: ./tools/discord-bot/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=discord-bot
+          cache-to: type=gha,mode=max,scope=discord-bot
+
+      - name: Build summary
+        env:
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          echo "### Discord Bot Image Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`sdvd/discord-bot:$IMAGE_TAG\`" >> $GITHUB_STEP_SUMMARY
+
+  deploy-server:
+    name: Deploy PR Server
+    needs: [validate-pr, build-server, build-steam-service, build-discord-bot]
+    if: inputs.deploy_server == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    environment: pr-preview
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-pr.outputs.pr_sha }}
+          sparse-checkout: |
+            docker-compose.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Create .env file
+        env:
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          DEPLOY_GAME_PORT: ${{ secrets.DEPLOY_GAME_PORT }}
+          DEPLOY_VNC_PORT: ${{ secrets.DEPLOY_VNC_PORT }}
+          DEPLOY_STEAM_AUTH_PORT: ${{ secrets.DEPLOY_STEAM_AUTH_PORT }}
+        run: |
+          # Validate required secrets
+          missing=""
+          [[ -z "$DEPLOY_GAME_PORT" ]] && missing="$missing DEPLOY_GAME_PORT"
+          [[ -z "$DEPLOY_VNC_PORT" ]] && missing="$missing DEPLOY_VNC_PORT"
+          [[ -z "$DEPLOY_STEAM_AUTH_PORT" ]] && missing="$missing DEPLOY_STEAM_AUTH_PORT"
+          if [[ -n "$missing" ]]; then
+            echo "::error::Missing secrets:$missing"
+            echo "Configure these in Settings → Environments → pr-preview"
+            exit 1
+          fi
+
+          cat > .env << EOF
+          # Auto-generated by GitHub Actions
+          # PR Preview: #$PR_NUMBER
+          IMAGE_VERSION=$IMAGE_TAG
+          STEAM_USERNAME=${{ secrets.DEPLOY_STEAM_USERNAME }}
+          STEAM_PASSWORD=${{ secrets.DEPLOY_STEAM_PASSWORD }}
+          STEAM_REFRESH_TOKEN=${{ secrets.DEPLOY_STEAM_REFRESH_TOKEN }}
+          VNC_PASSWORD=${{ secrets.DEPLOY_VNC_PASSWORD }}
+          GAME_PORT=$DEPLOY_GAME_PORT
+          VNC_PORT=$DEPLOY_VNC_PORT
+          STEAM_AUTH_PORT=$DEPLOY_STEAM_AUTH_PORT
+          DISABLE_RENDERING=true
+          EOF
+          sed -i 's/^          //' .env
+
+      - name: Create deploy directory
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          script: mkdir -p ~/srv/pr-${{ inputs.pr_number }}
+
+      - name: Copy files to server
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          source: "docker-compose.yml,.env"
+          target: ~/srv/pr-${{ inputs.pr_number }}
+
+      - name: Pull and restart containers
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          script: |
+            set -e
+            cd ~/srv/pr-${{ inputs.pr_number }}
+
+            echo "Pulling images..."
+            docker compose pull
+
+            echo "Stopping containers..."
+            docker compose down --timeout 30 || true
+
+            echo "Setting up steam-auth..."
+            docker compose run --rm steam-auth setup
+
+            echo "Starting containers..."
+            docker compose up -d
+
+            echo "Cleanup..."
+            docker image prune -f
+
+      - name: Verify deployment
+        uses: appleboy/ssh-action@823bd89e131d8d508129f9443cad5855e9ba96f0 # v1.2.4
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          script: |
+            set -e
+            cd ~/srv/pr-${{ inputs.pr_number }}
+
+            echo "Waiting for startup..."
+            sleep 30
+
+            echo "Health check..."
+            if docker compose ps | grep -qE "unhealthy|Exit"; then
+              echo "Container health check failed"
+              docker compose logs --tail=50
+              exit 1
+            fi
+            docker compose ps
+
+      - name: Comment on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body "## 🚀 PR Preview Deployed
+
+          **Server Image:** \`sdvd/server:$IMAGE_TAG\`
+
+          The preview server has been deployed and is running.
+
+          ---
+          *Deployed from commit ${{ needs.validate-pr.outputs.pr_sha }}*"
+
+      - name: Build summary
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          echo "### PR Server Deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR:** #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`sdvd/server:$IMAGE_TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** pr-$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+
+      - name: Discord notification
+        if: success()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ needs.validate-pr.outputs.pr_title }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          if [ -n "$DISCORD_WEBHOOK" ]; then
+            jq -n \
+              --arg pr_num "$PR_NUMBER" \
+              --arg pr_title "$PR_TITLE" \
+              --arg tag "$IMAGE_TAG" \
+              '{
+                embeds: [{
+                  title: "PR Preview Deployed",
+                  color: 16753920,
+                  fields: [
+                    {name: "PR", value: ("#" + $pr_num + " - " + $pr_title)},
+                    {name: "Image", value: ("`sdvd/server:" + $tag + "`")}
+                  ]
+                }]
+              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+          fi
+
+  deploy-docs:
+    name: Deploy PR Docs
+    needs: [validate-pr, build-server]
+    if: inputs.deploy_docs == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-pr.outputs.pr_sha }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract OpenAPI spec from PR Docker image
+        env:
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+        run: |
+          docker pull "sdvd/server:$IMAGE_TAG"
+          CONTAINER_ID=$(docker create "sdvd/server:$IMAGE_TAG")
+          mkdir -p docs/assets
+          docker cp "$CONTAINER_ID:/data/openapi.json" docs/assets/openapi.json
+          docker rm "$CONTAINER_ID"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@b7a1c7ccf290d58743029c4f6903da283811b979 # v2.1.0
+
+      - name: Install dependencies
+        run: bun install
+        working-directory: docs
+
+      - name: Build documentation
+        env:
+          VITEPRESS_BASE: /server/pr-${{ inputs.pr_number }}/
+        run: bun run build
+        working-directory: docs
+
+      - name: Deploy to GitHub Pages (PR subdirectory)
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          # Note: This creates a PR-specific subdirectory
+          # For full implementation, you'd need to fetch existing pages content
+          # and merge the PR docs into a subdirectory
+          echo "PR docs built successfully"
+          echo "For full deployment, configure GitHub Pages to support multiple deployments"
+          echo "or use a service like Netlify/Vercel for PR previews"
+
+      - name: Build summary
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          echo "### PR Docs Built" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**PR:** #$PR_NUMBER" >> $GITHUB_STEP_SUMMARY
+          echo "Documentation has been built from the PR branch." >> $GITHUB_STEP_SUMMARY
+
+  notify-completion:
+    name: Notify Completion
+    needs: [validate-pr, build-server, build-steam-service, build-discord-bot]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Comment build results on PR
+        if: needs.build-server.result == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+          DEPLOY_SERVER: ${{ inputs.deploy_server }}
+          DEPLOY_DOCS: ${{ inputs.deploy_docs }}
+        run: |
+          # Only comment if we're not deploying (deployment job has its own comment)
+          if [ "$DEPLOY_SERVER" != "true" ]; then
+            gh pr comment "$PR_NUMBER" --body "## 🐳 PR Preview Images Built
+
+          | Image | Tag |
+          |-------|-----|
+          | sdvd/server | \`$IMAGE_TAG\` |
+          | sdvd/steam-service | \`$IMAGE_TAG\` |
+          | sdvd/discord-bot | \`$IMAGE_TAG\` |
+
+          **Pull command:**
+          \`\`\`bash
+          docker pull sdvd/server:$IMAGE_TAG
+          \`\`\`
+
+          ---
+          *Built from commit ${{ needs.validate-pr.outputs.pr_sha }}*"
+          fi
+
+      - name: Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_TITLE: ${{ needs.validate-pr.outputs.pr_title }}
+          IMAGE_TAG: ${{ needs.validate-pr.outputs.image_tag }}
+          BUILD_RESULT: ${{ needs.build-server.result }}
+        run: |
+          if [ -n "$DISCORD_WEBHOOK" ]; then
+            if [ "$BUILD_RESULT" = "success" ]; then
+              COLOR=5763719
+              TITLE="PR Preview Built"
+            else
+              COLOR=15158332
+              TITLE="PR Preview Build Failed"
+            fi
+
+            jq -n \
+              --arg title "$TITLE" \
+              --arg pr_num "$PR_NUMBER" \
+              --arg pr_title "$PR_TITLE" \
+              --arg tag "$IMAGE_TAG" \
+              --argjson color "$COLOR" \
+              '{
+                embeds: [{
+                  title: $title,
+                  color: $color,
+                  fields: [
+                    {name: "PR", value: ("#" + $pr_num + " - " + $pr_title)},
+                    {name: "Image Tag", value: ("`" + $tag + "`")}
+                  ]
+                }]
+              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+          fi

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,9 +1,18 @@
 name: Preview Build
 
 on:
-  push:
-    branches:
-      - master
+  workflow_dispatch:
+    inputs:
+      deploy_server:
+        description: 'Deploy to public-test after build'
+        required: false
+        default: false
+        type: boolean
+      deploy_docs:
+        description: 'Deploy preview documentation after build'
+        required: false
+        default: false
+        type: boolean
 
 # Prevent multiple builds from running simultaneously
 concurrency:
@@ -334,3 +343,24 @@ jobs:
           echo "**Docker Images:**" >> $GITHUB_STEP_SUMMARY
           echo "- \`sdvd/discord-bot:preview\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`sdvd/discord-bot:${{ needs.calculate-version.outputs.preview_version }}\`" >> $GITHUB_STEP_SUMMARY
+
+  # Optional: Deploy server to public-test
+  deploy-server:
+    name: Deploy to Public Test
+    needs: [build-server-preview, build-steam-service-preview, build-discord-bot-preview]
+    if: inputs.deploy_server == true
+    uses: ./.github/workflows/deploy-server.yml
+    with:
+      environment: public-test
+    secrets: inherit
+
+  # Optional: Deploy preview documentation
+  deploy-docs:
+    name: Deploy Preview Docs
+    needs: build-server-preview
+    if: inputs.deploy_docs == true
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      image_tag: preview
+      deployment_type: preview
+    secrets: inherit

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -5,6 +5,9 @@ import spec from "../assets/openapi.json" with { type: "json" };
 
 const openApiSidebar = useSidebar({ spec, linkPrefix: "/api/" });
 
+// Allow overriding base path via environment variable (for preview deployments)
+const basePath = process.env.VITEPRESS_BASE || "/server/";
+
 export default defineConfig({
     vite: {
         plugins: [
@@ -19,15 +22,15 @@ export default defineConfig({
             }),
         ],
     },
-    base: "/server/",
+    base: basePath,
     title: "JunimoServer",
     description: "Stardew Valley dedicated server documentation",
     head: [
-        ["link", { rel: "icon", href: "/server/logo.svg" }],
+        ["link", { rel: "icon", href: `${basePath}logo.svg` }],
         ["meta", { property: "og:type", content: "website" }],
         ["meta", { property: "og:title", content: "JunimoServer" }],
         ["meta", { property: "og:description", content: "Stardew Valley dedicated server documentation" }],
-        ["meta", { property: "og:image", content: "https://stardew-valley-dedicated-server.github.io/server/logo.svg" }],
+        ["meta", { property: "og:image", content: `https://stardew-valley-dedicated-server.github.io${basePath}logo.svg` }],
         ["meta", { name: "twitter:card", content: "summary" }],
         ["meta", { name: "twitter:title", content: "JunimoServer" }],
         ["meta", { name: "twitter:description", content: "Stardew Valley dedicated server documentation" }],


### PR DESCRIPTION
## Summary

- Convert preview builds from auto-trigger on master push to manual `workflow_dispatch`
- Add versioned docs deployment (release at `/server/`, preview at `/server/preview/`)
- Create new PR preview workflow for building and deploying PR-specific images
- Remove auto-deploy from preview builds, add reusable workflow support

## Changes

### `preview-build.yml`
- Now manual trigger only
- Options to deploy server and/or docs after build

### `deploy-docs.yml`
- Added `deployment_type` input: `release` or `preview`
- Preview docs deploy to `/preview/` subdirectory
- Supports `workflow_call` for reuse

### `deploy-server.yml`
- Removed `workflow_run` auto-trigger from preview builds
- Added `workflow_call` support
- Manual or called from other workflows only

### `pr-preview.yml` (new)
- Manually trigger with PR number
- Builds all 3 Docker images with `pr-{number}` tags
- Optional deployment to `pr-preview` environment
- Posts comments on PR with image info

### `docs/.vitepress/config.ts`
- Support `VITEPRESS_BASE` env var for dynamic base path

## Setup Required

For PR preview deployments, create a `pr-preview` GitHub environment with the same secrets as `public-test`.