### PR TITLE
docs: add Steam SDR ports to docker-compose and networking docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     ports:
       - "${VNC_PORT:-5800}:5800"
       - "${API_PORT:-8080}:8080"
-      - "${GAME_PORT:-24642}:24642/udp"
+      # Steam SDR ports (used by GameServer.Init for relay network)
+      - "${SDR_GAME_PORT:-24642}:24642/udp"
+      - "${SDR_QUERY_PORT:-27015}:27015/udp"
     cap_add:
       # Required to sync time, ensures GOG GalaxyAuth works
       - SYS_TIME

--- a/docs/guide/networking.md
+++ b/docs/guide/networking.md
@@ -34,12 +34,21 @@ Direct IP connections don't provide user IDs, so the server can't track farmhand
 
 ## Ports
 
-| Port | Protocol | Purpose |
-|------|----------|---------|
-| 24642 | UDP | Direct IP connections (disabled by default) |
-| 5800 | TCP | VNC web interface |
+| Port | Protocol | Purpose | Forwarding Required |
+|------|----------|---------|---------------------|
+| 24642 | UDP | Steam SDR game port | No (relay handles NAT) |
+| 27015 | UDP | Steam SDR query port | No (relay handles NAT) |
+| 5800 | TCP | VNC web interface | Only for remote access |
+| 8080 | TCP | HTTP API | Only for external access |
 
-Steam SDR and GOG Galaxy use dynamic ports and handle NAT traversal automatically.
+Steam SDR uses these ports internally but traffic goes through Valve's relay network - no port forwarding required. GOG Galaxy uses dynamic ports.
+
+To change the host-side port mappings (e.g., if you have port conflicts):
+
+```bash
+SDR_GAME_PORT=24643
+SDR_QUERY_PORT=27016
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add SDR game port (24642/udp) and query port (27015/udp) to docker-compose
- Make host ports configurable via `SDR_GAME_PORT` and `SDR_QUERY_PORT` env vars
- Update networking.md with complete port table and configuration instructions
