### PR TITLE
fix: set correct Steam AppID for SDR connections

### DIFF
--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -167,6 +167,10 @@ init_steam_sdk() {
     else
         echo "Steam SDK already linked"
     fi
+
+    # Create steam_appid.txt with Stardew Valley's AppID
+    # The SDK defaults to 480 (Spacewar) which causes SDR connection failures
+    echo "413150" > "${GAME_DEST_DIR}/steam_appid.txt"
 }
 
 init_gui() {


### PR DESCRIPTION
## Summary
The Steamworks SDK defaults to AppID 480 (Spacewar) which causes Steam clients to fail connecting via SDR. This creates `steam_appid.txt` with Stardew Valley's AppID (413150) during startup.

## Problem
- Server logs showed `Setting breakpad minidump AppID = 480`
- Steam clients could find the lobby and GameServer Steam ID
- Connection attempts timed out after 10 seconds with no server-side logs
- GOG P2P connections worked fine

## Root cause
The Steamworks SDK redistributable (AppID 1007) either ships with `steam_appid.txt` containing 480, or defaults to it. SDR connections fail because the client (Stardew Valley, 413150) and server (Spacewar, 480) have mismatched AppIDs.

## Test plan
- [ ] Deploy to server
- [ ] Verify logs show `Setting breakpad minidump AppID = 413150`
- [ ] Connect via Steam invite code