### PR TITLE
fix: release preparation fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ clean:
 
 test:
 	@dotnet tool restore
-	@dotnet test ./tests/JunimoServer.Tests/ --settings ./tests/JunimoServer.Tests/JunimoServer.Tests.runsettings || true
+	@dotnet test ./tests/JunimoServer.Tests/ --settings ./tests/JunimoServer.Tests/JunimoServer.Tests.runsettings
 	@echo Generating test report...
 	@dotnet TrxToExtentReport -t ./TestResults/TestResults.trx -o ./TestResults/TestReport.html
 
@@ -142,4 +142,4 @@ help:
 	@echo.
 	@echo Note: Use GitHub Actions for building and pushing release images
 
-.DEFAULT_GOAL := run
+.DEFAULT_GOAL := help

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -69,7 +69,9 @@ namespace JunimoServer.Services.AlwaysOn
 
         private void OnReturnedToTitle(object sender, ReturnedToTitleEventArgs e)
         {
-            // TODO: Restart the server if we happen to return to the title, this should not happen during regular operations
+            // This should not happen during regular operations - log error for operators
+            Monitor.Log("CRITICAL: Server unexpectedly returned to title screen. Automation disabled.", LogLevel.Error);
+            Monitor.Log("Container may need restart. Check game logs for crash details.", LogLevel.Error);
             IsAutomating = false;
             ServerOptimizerOverrides.SetAutomationInputSuppression(false);
         }

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -40,9 +40,13 @@ namespace JunimoServer.Services.GameManager
 
         private void OnOneSecondTicked(object sender, OneSecondUpdateTickedEventArgs e)
         {
-            // TODO: Healthcheck triggers during init, should be postponed until "gameMode was 'loadingMode (6)', set to 'playingGameMode (3)'."
-            RunHealthCheck();
             ConditionallyStartGame();
+
+            // Only run healthcheck after game has started (prevents false negatives during init)
+            if (_gameStarted)
+            {
+                RunHealthCheck();
+            }
         }
 
         private void OnRenderedActiveMenu(object sender, RenderedActiveMenuEventArgs e)


### PR DESCRIPTION
## Summary
- Fix Makefile default goal (`run` → `help`) - running `make` without args now shows help
- Fix test command to not mask failures (remove `|| true`) - test failures are now properly reported
- Fix healthcheck timing to only run after game has started - prevents false negatives during init
- Add error logging when server unexpectedly returns to title screen - alerts operators to issues

## Test plan
- [ ] Run `make` and verify help is displayed
- [ ] Run `make test` with a failing test and verify it reports failure
- [ ] Start server and verify healthcheck doesn't run until game is loaded
- [ ] (Manual) Verify title screen return logs error message