### PR TITLE
fix(discord-bot): use supported activity type for offline detection

### DIFF
--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -78,10 +78,10 @@ async function updatePresence(): Promise<void> {
     activities: [
       {
         name: activityName,
-        type: ActivityType.Custom,
+        type: ActivityType.Watching,
       },
     ],
-    status: "online",
+    status: status?.isOnline ? "online" : "idle",
   });
 
   console.log(`[Discord Bot] Status updated: ${activityName}`);


### PR DESCRIPTION
## Summary
- Bots cannot use `ActivityType.Custom` - it's a Discord API limitation that only works for user accounts, causing the bot to display incorrectly when server is offline
- Changed to `ActivityType.Watching` which properly displays status text like "Watching Server Offline" or "Watching 2/4 players | S-XXXX"
- Set bot status to "idle" when server is offline for additional visual feedback

## Test plan
- [ ] Start the Discord bot with the server stopped - verify it shows "Watching Server Offline" with idle status
- [ ] Start the server - verify it shows "Watching X/Y players | invite-code" with online status
- [ ] Stop the server while bot is running - verify it transitions back to offline display