### PR TITLE
feat(discord-bot): add two-way chat relay and dynamic nickname

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,18 @@ API_PORT="8080"
 #         Discord Bot (Optional)       #
 ########################################
 
-# Discord bot token for server status display
+# Discord bot token for server status display and chat relay
 # Create a bot at https://discord.com/developers/applications
+# Required permissions: Send Messages, Read Message History
 # DISCORD_BOT_TOKEN=""
+
+# Bot nickname in Discord servers (optional)
+# If empty, automatically uses the farm name from the server
+# Set a custom value to override (e.g., "Stardew Server")
+# DISCORD_BOT_NICKNAME=""
+
+# Channel ID for two-way chat relay (optional)
+# Right-click channel > Copy ID (requires Developer Mode in Discord settings)
+# Requires Message Content Intent enabled in Discord Developer Portal
+# Leave empty to disable chat relay
+# DISCORD_CHAT_CHANNEL_ID=""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       STEAM_REFRESH_TOKEN: "${STEAM_REFRESH_TOKEN:-}"
     restart: unless-stopped
 
-  # Discord bot for server status display
+  # Discord bot for server status display and chat relay
   discord-bot:
     build:
       context: ./tools/discord-bot
@@ -69,6 +69,10 @@ services:
       API_URL: "http://server:8080"
       # Min 20s to respect Discord rate limits, default 30s
       UPDATE_INTERVAL_MS: "30000"
+      # Bot nickname (optional, falls back to farm name)
+      DISCORD_BOT_NICKNAME: "${DISCORD_BOT_NICKNAME:-}"
+      # Channel ID for two-way chat relay (optional)
+      DISCORD_CHAT_CHANNEL_ID: "${DISCORD_CHAT_CHANNEL_ID:-}"
     depends_on:
       - server
     # on-failure: won't restart when disabled (exit 0), will restart on crashes

--- a/docs/api/introduction.md
+++ b/docs/api/introduction.md
@@ -14,3 +14,63 @@ The API provides endpoints for:
 - **Settings** — Server configuration from `server-settings.json`
 - **Cabins** — Cabin state and positions
 - **Time** — In-game time control
+
+## WebSocket
+
+The server also provides a WebSocket endpoint at `/ws` for real-time bidirectional communication, primarily used for chat relay with the Discord bot.
+
+### Connection
+
+```
+ws://localhost:8080/ws
+```
+
+### Message Format
+
+All messages are JSON with a `type` field and optional `payload`:
+
+```json
+{
+  "type": "message_type",
+  "payload": { ... }
+}
+```
+
+### Message Types
+
+#### Client → Server
+
+| Type | Description | Payload |
+|------|-------------|---------|
+| `ping` | Heartbeat | None |
+| `chat_send` | Send chat message to game | `{ "author": "Name", "message": "Hello" }` |
+
+#### Server → Client
+
+| Type | Description | Payload |
+|------|-------------|---------|
+| `pong` | Heartbeat response | None |
+| `chat` | Player chat message from game | `{ "playerName": "Name", "message": "Hello", "timestamp": "ISO8601" }` |
+
+### Example
+
+```javascript
+const ws = new WebSocket("ws://localhost:8080/ws");
+
+// Send heartbeat
+ws.send(JSON.stringify({ type: "ping" }));
+
+// Send chat to game
+ws.send(JSON.stringify({
+  type: "chat_send",
+  payload: { author: "Discord User", message: "Hello from Discord!" }
+}));
+
+// Receive game chat
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "chat") {
+    console.log(`${msg.payload.playerName}: ${msg.payload.message}`);
+  }
+};
+```

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -119,6 +119,9 @@ Environment variables in `.env` control Docker infrastructure, credentials, and 
 | `API_ENABLED` | Enable HTTP API for external tools and monitoring | true |
 | `API_PORT` | Port for the HTTP API server | 8080 |
 | `VERBOSE_LOGGING` | Override verbose logging setting (overrides `server-settings.json`) | - |
+| `DISCORD_BOT_TOKEN` | Discord bot token for server status and chat relay (see [Discord Integration](#discord-integration)) | - |
+| `DISCORD_BOT_NICKNAME` | Custom bot nickname in Discord servers (optional, defaults to farm name) | - |
+| `DISCORD_CHAT_CHANNEL_ID` | Discord channel ID for two-way chat relay (optional) | - |
 
 ::: tip
 Set `DISABLE_RENDERING=true` to improve performance when using VNC. The game will still run normally, but rendering will be optimized for server environments.
@@ -139,6 +142,43 @@ These variables are only relevant during the build process when compiling from s
 
 ::: info
 Build variables are only needed when building from source. If you're using the pre-built Docker images, you can ignore these settings.
+:::
+
+## Discord Integration
+
+The optional Discord bot provides server status display and two-way chat relay between Discord and the game.
+
+### Setup
+
+1. Create a Discord application at the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Go to the **Bot** tab, click "Reset Token" and copy it
+3. Invite the bot to your server with permissions: Send Messages, Read Message History
+4. Set `DISCORD_BOT_TOKEN` in your `.env` file
+
+This is enough for server status display. For chat relay, see below.
+
+### Bot Nickname
+
+The bot's nickname in Discord servers can be configured:
+
+- **Default**: Uses the farm name from the game server
+- **Custom**: Set `DISCORD_BOT_NICKNAME` to override with a fixed name
+
+### Chat Relay
+
+To enable two-way chat between Discord and the game:
+
+1. Enable the [Message Content Intent](https://support-dev.discord.com/hc/en-us/articles/4404772028055-Message-Content-Privileged-Intent-FAQ) in the [Developer Portal](https://discord.com/developers/applications) (Bot → Privileged Gateway Intents)
+2. Enable Developer Mode in Discord (Settings → Advanced → Developer Mode)
+3. Right-click the channel you want to use → Copy ID
+4. Set `DISCORD_CHAT_CHANNEL_ID` in your `.env` file
+
+Once configured:
+- Messages from players in-game appear in the Discord channel as `**PlayerName**: message`
+- Messages from Discord users appear in-game as `(Web) DiscordName: message`
+
+::: warning Security Note
+The chat relay does not currently implement rate limiting. Discord users could potentially spam the game chat. Consider using Discord's built-in slowmode on the relay channel if this is a concern.
 :::
 
 ## Variable Details
@@ -177,6 +217,10 @@ VNC_PORT=5800
 GAME_PORT=24642
 DISABLE_RENDERING=true
 
+# Optional: Discord Bot
+# DISCORD_BOT_TOKEN=your_bot_token
+# DISCORD_BOT_NICKNAME=My Stardew Server
+# DISCORD_CHAT_CHANNEL_ID=123456789012345678
 ```
 
 ::: info

--- a/mod/JunimoServer/Services/Api/WebSocketModels.cs
+++ b/mod/JunimoServer/Services/Api/WebSocketModels.cs
@@ -1,0 +1,44 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace JunimoServer.Services.Api
+{
+    /// <summary>
+    /// Base WebSocket message envelope.
+    /// </summary>
+    public class WebSocketMessage
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; } = "";
+
+        [JsonProperty("payload")]
+        public JObject? Payload { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for chat_send messages (Discord → Game).
+    /// </summary>
+    public class ChatSendPayload
+    {
+        [JsonProperty("author")]
+        public string Author { get; set; } = "";
+
+        [JsonProperty("message")]
+        public string Message { get; set; } = "";
+    }
+
+    /// <summary>
+    /// Payload for chat events (Game → Discord).
+    /// </summary>
+    public class ChatEventPayload
+    {
+        [JsonProperty("playerName")]
+        public string PlayerName { get; set; } = "";
+
+        [JsonProperty("message")]
+        public string Message { get; set; } = "";
+
+        [JsonProperty("timestamp")]
+        public string Timestamp { get; set; } = "";
+    }
+}

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -292,13 +292,23 @@ public class CabinInfoResponse
 public class ServerApiClient : IDisposable
 {
     private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
 
     public ServerApiClient(string baseUrl = "http://localhost:8080")
     {
+        _baseUrl = baseUrl;
         _httpClient = new HttpClient
         {
             BaseAddress = new Uri(baseUrl)
         };
+    }
+
+    /// <summary>
+    /// Gets the WebSocket URL for the /ws endpoint.
+    /// </summary>
+    public string GetWebSocketUrl()
+    {
+        return _baseUrl.Replace("http://", "ws://").Replace("https://", "wss://") + "/ws";
     }
 
     /// <summary>

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -1,8 +1,11 @@
-import { Client, Events, GatewayIntentBits, ActivityType } from "discord.js";
+import { Client, Events, GatewayIntentBits, ActivityType, TextChannel } from "discord.js";
 
 // Configuration from environment
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
 const API_URL = process.env.API_URL || "http://server:8080";
+const WS_URL = process.env.WS_URL || API_URL.replace("http://", "ws://").replace("https://", "wss://") + "/ws";
+const DISCORD_CHAT_CHANNEL_ID = process.env.DISCORD_CHAT_CHANNEL_ID;
+const DISCORD_BOT_NICKNAME = process.env.DISCORD_BOT_NICKNAME;
 
 // Discord rate limit for presence updates is ~5 per 20 seconds.
 // 30 seconds is a safe default that won't trigger rate limits.
@@ -25,11 +28,30 @@ interface ServerStatus {
   serverVersion: string;
   isOnline: boolean;
   lastUpdated: string;
+  farmName?: string;
 }
 
-const client = new Client({
-  intents: [GatewayIntentBits.Guilds],
-});
+interface WebSocketMessage {
+  type: string;
+  payload?: {
+    playerName?: string;
+    message?: string;
+    timestamp?: string;
+  };
+}
+
+// Only request message intents if chat relay is enabled
+const intents = [GatewayIntentBits.Guilds];
+if (DISCORD_CHAT_CHANNEL_ID) {
+  intents.push(GatewayIntentBits.GuildMessages, GatewayIntentBits.MessageContent);
+}
+
+const client = new Client({ intents });
+
+// WebSocket connection state
+let ws: WebSocket | null = null;
+let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let wsHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
 /**
  * Fetches the server status from the HTTP API.
@@ -87,16 +109,163 @@ async function updatePresence(): Promise<void> {
   console.log(`[Discord Bot] Status updated: ${activityName}`);
 }
 
+/**
+ * Updates the bot's nickname in all guilds.
+ * Uses DISCORD_BOT_NICKNAME env var if set, otherwise uses farm name from server.
+ */
+async function updateBotNickname(): Promise<void> {
+  let nickname = DISCORD_BOT_NICKNAME;
+
+  if (!nickname) {
+    const status = await fetchServerStatus();
+    if (status?.farmName) {
+      nickname = status.farmName;
+    }
+  }
+
+  if (!nickname) return;
+
+  for (const guild of client.guilds.cache.values()) {
+    try {
+      const currentNickname = guild.members.me?.nickname;
+      if (currentNickname !== nickname) {
+        await guild.members.me?.setNickname(nickname);
+        console.log(`[Discord Bot] Nickname set to "${nickname}" in ${guild.name}`);
+      }
+    } catch (error) {
+      // May lack permissions in some guilds
+      if (error instanceof Error) {
+        console.error(`[Discord Bot] Failed to set nickname in ${guild.name}: ${error.message}`);
+      }
+    }
+  }
+}
+
+/**
+ * Connects to the game server's WebSocket for real-time chat relay.
+ */
+function connectWebSocket(): void {
+  if (!DISCORD_CHAT_CHANNEL_ID) {
+    console.log("[Discord Bot] DISCORD_CHAT_CHANNEL_ID not set - chat relay disabled");
+    return;
+  }
+
+  if (ws) {
+    try {
+      ws.close();
+    } catch {
+      // Ignore close errors
+    }
+    ws = null;
+  }
+
+  console.log(`[Discord Bot] Connecting to WebSocket: ${WS_URL}`);
+
+  try {
+    ws = new WebSocket(WS_URL);
+
+    ws.onopen = () => {
+      console.log("[Discord Bot] WebSocket connected");
+
+      // Start heartbeat
+      if (wsHeartbeatTimer) clearInterval(wsHeartbeatTimer);
+      wsHeartbeatTimer = setInterval(() => {
+        if (ws?.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "ping" }));
+        }
+      }, 30000);
+    };
+
+    ws.onmessage = async (event) => {
+      try {
+        const msg: WebSocketMessage = JSON.parse(event.data.toString());
+
+        if (msg.type === "chat" && msg.payload) {
+          // Game -> Discord
+          const channel = client.channels.cache.get(DISCORD_CHAT_CHANNEL_ID);
+          if (channel?.isTextBased()) {
+            const { playerName, message } = msg.payload;
+            if (playerName && message) {
+              await (channel as TextChannel).send(`**${playerName}**: ${message}`);
+            }
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error) {
+          console.error(`[Discord Bot] Failed to process WebSocket message: ${error.message}`);
+        }
+      }
+    };
+
+    ws.onclose = () => {
+      console.log("[Discord Bot] WebSocket disconnected, reconnecting in 5s...");
+      ws = null;
+      if (wsHeartbeatTimer) {
+        clearInterval(wsHeartbeatTimer);
+        wsHeartbeatTimer = null;
+      }
+      wsReconnectTimer = setTimeout(connectWebSocket, 5000);
+    };
+
+    ws.onerror = (error) => {
+      console.error(`[Discord Bot] WebSocket error:`, error);
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`[Discord Bot] Failed to create WebSocket: ${error.message}`);
+    }
+    wsReconnectTimer = setTimeout(connectWebSocket, 5000);
+  }
+}
+
+/**
+ * Sends a chat message from Discord to the game server via WebSocket.
+ */
+function sendChatToGame(author: string, message: string): void {
+  if (!ws || ws.readyState !== WebSocket.OPEN) {
+    console.log("[Discord Bot] WebSocket not connected, cannot send chat");
+    return;
+  }
+
+  ws.send(JSON.stringify({
+    type: "chat_send",
+    payload: { author, message }
+  }));
+}
+
+// Handle Discord messages for chat relay
+client.on(Events.MessageCreate, async (message) => {
+  // Ignore bot messages
+  if (message.author.bot) return;
+
+  // Only process messages from the configured chat channel
+  if (message.channel.id !== DISCORD_CHAT_CHANNEL_ID) return;
+
+  // Get display name (server nickname if set, otherwise global display name)
+  const displayName = message.member?.displayName || message.author.displayName;
+
+  sendChatToGame(displayName, message.content);
+});
+
 client.once(Events.ClientReady, () => {
   console.log(`[Discord Bot] Logged in as ${client.user?.tag}`);
   console.log(`[Discord Bot] API URL: ${API_URL}`);
   console.log(`[Discord Bot] Update interval: ${UPDATE_INTERVAL_MS}ms`);
 
-  // Initial status update
+  if (DISCORD_CHAT_CHANNEL_ID) {
+    console.log(`[Discord Bot] Chat relay channel: ${DISCORD_CHAT_CHANNEL_ID}`);
+  }
+
+  // Initial updates
   updatePresence();
+  updateBotNickname();
+
+  // Connect WebSocket for chat relay
+  connectWebSocket();
 
   // Periodic updates
   setInterval(updatePresence, UPDATE_INTERVAL_MS);
+  setInterval(updateBotNickname, UPDATE_INTERVAL_MS);
 });
 
 client.on(Events.Error, (error) => {
@@ -104,17 +273,29 @@ client.on(Events.Error, (error) => {
 });
 
 // Graceful shutdown
-process.on("SIGINT", () => {
+function shutdown() {
   console.log("[Discord Bot] Shutting down...");
-  client.destroy();
-  process.exit(0);
-});
 
-process.on("SIGTERM", () => {
-  console.log("[Discord Bot] Shutting down...");
+  if (wsReconnectTimer) {
+    clearTimeout(wsReconnectTimer);
+  }
+  if (wsHeartbeatTimer) {
+    clearInterval(wsHeartbeatTimer);
+  }
+  if (ws) {
+    try {
+      ws.close();
+    } catch {
+      // Ignore close errors
+    }
+  }
+
   client.destroy();
   process.exit(0);
-});
+}
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
 
 // Start the bot
 console.log("[Discord Bot] Starting...");


### PR DESCRIPTION
## Summary

- Add WebSocket endpoint (`/ws`) to API for real-time bidirectional chat relay
- Discord bot connects via WebSocket to relay chat between game and Discord channel
- Bot nickname configurable via `DISCORD_BOT_NICKNAME` env var or auto-uses farm name
- Only requests Message Content Intent when chat relay is enabled

## Changes

**Server (C#):**
- WebSocket support in ApiService (connect, ping/pong, chat messages, client cleanup)
- New `WebSocketModels.cs` for message types
- ChatCommandsService broadcasts game chat and handles incoming external messages
- Input sanitization for external messages (length limits, control char removal)

**Discord Bot (TypeScript):**
- WebSocket client with auto-reconnect and heartbeat
- Two-way chat relay (game ↔ Discord channel)
- Dynamic nickname updates
- Conditional intents (MessageContent only when chat relay enabled)

**Configuration:**
- New env vars: `DISCORD_BOT_NICKNAME`, `DISCORD_CHAT_CHANNEL_ID`
- Graceful fallback when env vars not set

**Documentation:**
- Discord Integration section in configuration docs
- WebSocket API documentation with message format and examples

## Test plan

- [ ] Bot starts without `DISCORD_CHAT_CHANNEL_ID` (status-only mode)
- [ ] Bot starts with chat relay configured
- [ ] Game messages appear in Discord channel
- [ ] Discord messages appear in game as `(Web) Author: message`
- [ ] Bot nickname updates from farm name or env var
- [ ] WebSocket reconnects after disconnect
- [ ] Run `make test` for integration tests