### PR TITLE
feat(tests): add containerized game client support for E2E tests

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -11,3 +11,25 @@
 #   Windows: GAME_PATH="C:/Program Files (x86)/Steam/steamapps/common/Stardew Valley"
 #   Linux:   GAME_PATH="/home/user/.steam/steam/steamapps/common/Stardew Valley"
 GAME_PATH="C:/Program Files (x86)/Steam/steamapps/common/Stardew Valley"
+
+########################################
+#      Test Configuration              #
+########################################
+
+# Set to "true" to show all container logs during tests (disables noise filtering)
+#SDVD_TEST_VERBOSE=true
+
+# Set to "true" to disable unicode status icons in test output
+#SDVD_TEST_ICONS=false
+
+# Override color output detection (true/false)
+#SDVD_COLOR=true
+
+# Set to "true" to skip Docker image builds during test setup
+#SDVD_SKIP_BUILD=true
+
+# Docker image tag to use for tests (default: "local" for locally built images)
+#SDVD_IMAGE_TAG=local
+
+# Docker volume prefix for shared volumes (default: "server")
+#SDVD_VOLUME_PREFIX=server

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -1,0 +1,158 @@
+# Dockerfile for containerized game test client
+# Used by E2E tests to run multiple game client instances
+#
+# Build: make build-test-client
+# Usage: Managed by Testcontainers in IntegrationTestFixture
+#
+# NOTE: This Dockerfile reuses the game-downloader stage from the main Dockerfile
+# to get game DLLs needed for building the test-client mod.
+
+# Global build arguments
+ARG SMAPI_VERSION=4.4.0
+
+# ============================================================================
+# Stage 1: Build steam-service downloader (same as main Dockerfile)
+# ============================================================================
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS steam-service-builder
+WORKDIR /src
+
+COPY ./tools/steam-service/*.csproj ./
+RUN dotnet restore
+
+COPY ./tools/steam-service/ .
+RUN dotnet publish -c Release -o /app --no-restore
+
+# ============================================================================
+# Stage 2: Download game files (same as main Dockerfile)
+# ============================================================================
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS game-downloader
+
+ARG SMAPI_VERSION
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=steam-service-builder /app /steam-service
+WORKDIR /steam-service
+
+# Download game (skip SDK during build)
+RUN --mount=type=secret,id=steam_username \
+    --mount=type=secret,id=steam_password \
+    --mount=type=secret,id=steam_refresh_token \
+    if [ -f /run/secrets/steam_username ]; then export STEAM_USERNAME="$(cat /run/secrets/steam_username)"; fi && \
+    if [ -f /run/secrets/steam_password ]; then export STEAM_PASSWORD="$(cat /run/secrets/steam_password)"; fi && \
+    if [ -f /run/secrets/steam_refresh_token ]; then export STEAM_REFRESH_TOKEN="$(cat /run/secrets/steam_refresh_token)"; fi && \
+    export GAME_DIR=/game && \
+    dotnet SteamService.dll download --skip-sdk
+
+# Download and install SMAPI
+RUN curl -L "https://github.com/Pathoschild/SMAPI/releases/download/${SMAPI_VERSION}/SMAPI-${SMAPI_VERSION}-installer.zip" -o /tmp/smapi.zip && \
+    unzip -q /tmp/smapi.zip -d /tmp/smapi && \
+    printf "2\n\n" | "/tmp/smapi/SMAPI ${SMAPI_VERSION} installer/internal/linux/SMAPI.Installer" \
+    --install \
+    --game-path /game && \
+    rm -rf /tmp/smapi /tmp/smapi.zip
+
+# ============================================================================
+# Stage 3: Build test-client mod using game DLLs
+# ============================================================================
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS mod-builder
+
+ARG BUILD_CONFIGURATION=Release
+
+# Copy game DLLs from downloader stage
+COPY --from=game-downloader /game /game
+
+# Copy project files first for better layer caching
+COPY ./Directory.Build.props /src/
+COPY ./tools/test-client/JunimoTestClient.csproj /src/tools/test-client/
+
+# Restore dependencies
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet restore /src/tools/test-client/JunimoTestClient.csproj
+
+# Copy source and build
+COPY ./tools/test-client /src/tools/test-client
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet build /src/tools/test-client/JunimoTestClient.csproj \
+    --configuration ${BUILD_CONFIGURATION} \
+    --no-restore \
+    /p:GamePath=/game \
+    /p:EnableModDeploy=false \
+    -o /output/JunimoTestClient
+
+# ============================================================================
+# Stage 4: Final runtime image
+# ============================================================================
+FROM jlesage/baseimage-gui:debian-11-v4.10.7 AS client
+
+ARG SMAPI_VERSION
+
+ENV APP_NAME="Stardew Test Client" \
+    USER_ID=0 \
+    GROUP_ID=0 \
+    HOME=/root \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8 \
+    ACCEPT_EULA=Y \
+    DEBIAN_FRONTEND=noninteractive \
+    TERMINAL=xterm \
+    DARK_MODE=1 \
+    # Display
+    DISPLAY=:0 \
+    DISPLAY_HEIGHT=720 \
+    DISPLAY_WIDTH=1280 \
+    # SMAPI
+    SMAPI_USE_CURRENT_SHELL=true \
+    SMAPI_VERSION=${SMAPI_VERSION} \
+    SMAPI_MODS_PATH=/data/Mods \
+    # Test client API port (can be overridden per container)
+    JUNIMO_TEST_PORT=5123
+
+# Install minimal packages needed for game client
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    curl \
+    locales \
+    procps \
+    unzip \
+    x11-utils \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# System cleanup
+RUN \
+    # Fix stuck dbus statoverride
+    rm -f /var/lib/dpkg/statoverride && \
+    # Prevent unnecessary logs
+    rm -f /etc/cont-init.d/89-info.sh && \
+    # Prevent overriding OpenGL drivers
+    rm -rf /etc/cont-env.d/LIBGL_DRIVERS_PATH
+
+# Copy SMAPI config (client-specific settings)
+COPY docker/rootfs-test-client/data/smapi-config.json /data/smapi-config.json
+
+# Copy startup script
+COPY docker/rootfs-test-client/startapp.sh /startapp.sh
+RUN chmod +x /startapp.sh
+
+# Copy test-client mod from build stage
+COPY --from=mod-builder /output/JunimoTestClient /data/Mods/JunimoTestClient
+
+# Game files provided via volume mount (shared with server)
+VOLUME [ "/data/game" ]
+
+# Expose test client API port
+EXPOSE 5123
+
+# Health check - wait for test client API to respond
+HEALTHCHECK --interval=2s --timeout=2s --start-period=60s --retries=60 \
+    CMD curl -sf http://localhost:${JUNIMO_TEST_PORT}/ping || exit 1
+
+WORKDIR /data

--- a/docker/rootfs-test-client/data/smapi-config.json
+++ b/docker/rootfs-test-client/data/smapi-config.json
@@ -1,0 +1,23 @@
+{
+    "SuppressUpdateChecks": ["JunimoHost.TestClient"],
+    "CheckForUpdates": false,
+    "CheckContentIntegrity": false,
+    "ListenForConsoleInput": true,
+    "DeveloperMode": true,
+    "ParanoidWarnings": false,
+    "LogTechnicalDetailsForBrokenMods": true,
+    "ConsoleColors": {
+        "UseScheme": "DarkBackground",
+        "Schemes": {
+            "DarkBackground": {
+                "Trace": "DarkGray",
+                "Debug": "Gray",
+                "Info": "White",
+                "Warn": "Yellow",
+                "Error": "Red",
+                "Alert": "Magenta",
+                "Success": "DarkGreen"
+            }
+        }
+    }
+}

--- a/docker/rootfs-test-client/startapp.sh
+++ b/docker/rootfs-test-client/startapp.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Game client startup script for test containers
+# Simpler than server - no Steam SDK setup, no server mods
+
+MODS_DEST_DIR="/data/Mods"
+GAME_DEST_DIR="/data/game"
+GAME_EXECUTABLE="${GAME_DEST_DIR}/StardewValley"
+SMAPI_EXECUTABLE="${GAME_DEST_DIR}/StardewModdingAPI"
+
+print_error() {
+    echo -e "\e[31m$1\e[0m"
+}
+
+init_xauthority() {
+    # X authority setup for GUI access
+    touch ~/.Xauthority
+    xauth generate :0 . trusted
+    xauth add :0 . `mcookie`
+    export XAUTHORITY=~/.Xauthority
+}
+
+wait_for_game_files() {
+    # Game files are mounted via shared volume from steam-auth
+    if [ -e "${GAME_EXECUTABLE}" ]; then
+        echo "Game files found at ${GAME_DEST_DIR}"
+        return
+    fi
+
+    echo "Waiting for game files at ${GAME_DEST_DIR}..."
+    while [ ! -e "${GAME_EXECUTABLE}" ]; do
+        sleep 2
+        echo "Still waiting for game files..."
+    done
+    echo "Game files detected!"
+}
+
+init_smapi() {
+    if [ -e "${SMAPI_EXECUTABLE}" ]; then
+        echo "SMAPI already installed"
+    else
+        echo "Installing SMAPI ${SMAPI_VERSION}..."
+
+        curl -L "https://github.com/Pathoschild/SMAPI/releases/download/${SMAPI_VERSION}/SMAPI-${SMAPI_VERSION}-installer.zip" -o /tmp/smapi.zip
+        unzip -q /tmp/smapi.zip -d /tmp/smapi/
+
+        printf "2\n\n" | "/tmp/smapi/SMAPI ${SMAPI_VERSION} installer/internal/linux/SMAPI.Installer" \
+            --install \
+            --game-path "${GAME_DEST_DIR}"
+
+        rm -rf /tmp/smapi /tmp/smapi.zip
+        echo "SMAPI installed successfully!"
+    fi
+
+    # Apply SMAPI config overrides
+    if [ -f /data/smapi-config.json ]; then
+        echo "Applying SMAPI config overrides..."
+        cp -f /data/smapi-config.json "${GAME_DEST_DIR}/smapi-internal/config.user.json"
+    fi
+}
+
+init_mods() {
+    # Copy default SMAPI mods (ErrorHandler, ConsoleCommands)
+    mkdir -p "${MODS_DEST_DIR}/smapi"
+    if [ -d "${GAME_DEST_DIR}/Mods" ]; then
+        cp -r "${GAME_DEST_DIR}/Mods/"* "${MODS_DEST_DIR}/smapi/" 2>/dev/null || true
+    fi
+
+    # Ensure test-client mod is in place (already copied during docker build)
+    if [ ! -d "${MODS_DEST_DIR}/JunimoTestClient" ]; then
+        print_error "JunimoTestClient mod not found!"
+        exit 1
+    fi
+
+    echo "Mods ready: $(ls -1 ${MODS_DEST_DIR} | tr '\n' ' ')"
+}
+
+init_permissions() {
+    chmod +x "${GAME_EXECUTABLE}"
+    chmod -R 755 "${GAME_DEST_DIR}"
+}
+
+# Initialize
+echo "=== Stardew Test Client Starting ==="
+echo "API Port: ${JUNIMO_TEST_PORT:-5123}"
+
+init_xauthority
+wait_for_game_files
+init_smapi
+init_mods
+init_permissions
+
+# Run the game through SMAPI
+LOG_FILE="/tmp/client-output.log"
+touch "${LOG_FILE}"
+
+echo "Starting SMAPI..."
+exec "${SMAPI_EXECUTABLE}" 2>&1 | tee "${LOG_FILE}"

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -223,6 +223,15 @@ public class CoopClient
         return _client.PostAsync<NavigationResult>("/coop/invite-code/submit", new InviteCodeParams { InviteCode = inviteCode });
     }
 
+    /// <summary>
+    /// Join a server via LAN/IP address.
+    /// POST /coop/join-lan?address=X
+    /// </summary>
+    /// <param name="address">Server address in "host:port" or "host" format.</param>
+    public Task<NavigationResult?> JoinLan(string address = "localhost")
+    {
+        return _client.PostAsync<NavigationResult>($"/coop/join-lan?address={Uri.EscapeDataString(address)}", new { });
+    }
 }
 
 public class FarmhandClient

--- a/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
@@ -1,0 +1,307 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Images;
+using DotNet.Testcontainers.Networks;
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Manages a containerized game client instance for E2E testing.
+/// Each container runs Stardew Valley with the JunimoTestClient mod.
+/// </summary>
+public class GameClientContainer : IAsyncDisposable
+{
+    private readonly IContainer _container;
+    private readonly GameTestClient _apiClient;
+    private readonly int _clientIndex;
+    private readonly GameClientOptions _options;
+    private readonly Action<string>? _logCallback;
+
+    private CancellationTokenSource? _logStreamCts;
+    private Task? _logStreamTask;
+    private long _logPosition;
+
+    /// <summary>
+    /// Numeric index of this client (0, 1, 2...).
+    /// </summary>
+    public int ClientIndex => _clientIndex;
+
+    /// <summary>
+    /// The internal container port for the test client API.
+    /// </summary>
+    public const int ContainerApiPort = 5123;
+
+    /// <summary>
+    /// The mapped host port for the test client API.
+    /// </summary>
+    public int ApiPort { get; private set; }
+
+    /// <summary>
+    /// Base URL for the test client API (http://localhost:{ApiPort}).
+    /// </summary>
+    public string BaseUrl => $"http://localhost:{ApiPort}";
+
+    /// <summary>
+    /// HTTP client for controlling the game client.
+    /// </summary>
+    public GameTestClient Client => _apiClient;
+
+    /// <summary>
+    /// The underlying Testcontainers container.
+    /// </summary>
+    public IContainer Container => _container;
+
+    private GameClientContainer(
+        IContainer container,
+        int clientIndex,
+        GameClientOptions options,
+        Action<string>? logCallback)
+    {
+        _container = container;
+        _clientIndex = clientIndex;
+        _options = options;
+        _logCallback = logCallback;
+        _apiClient = new GameTestClient(); // Will be reconfigured after start
+    }
+
+    /// <summary>
+    /// Creates a new game client container.
+    /// </summary>
+    /// <param name="clientIndex">Numeric index for this client (0, 1, 2...).</param>
+    /// <param name="options">Configuration options.</param>
+    /// <param name="network">Optional Docker network to join.</param>
+    /// <param name="logCallback">Optional callback for log output.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public static async Task<GameClientContainer> CreateAsync(
+        int clientIndex,
+        GameClientOptions options,
+        INetwork? network = null,
+        Action<string>? logCallback = null,
+        CancellationToken ct = default)
+    {
+        var containerName = $"sdvd-test-client-{clientIndex}-{Guid.NewGuid():N}";
+
+        var builder = new ContainerBuilder()
+            .WithLogger(NullLogger.Instance)
+            .WithImage($"sdvd/test-client:{options.ImageTag}")
+            .WithImagePullPolicy(options.ImageTag == "local" ? PullPolicy.Never : PullPolicy.Missing)
+            .WithName(containerName)
+            .WithPortBinding(ContainerApiPort, true) // Dynamic host port
+            .WithVolumeMount(options.GameDataVolume, "/data/game", AccessMode.ReadOnly)
+            .WithEnvironment("JUNIMO_TEST_PORT", ContainerApiPort.ToString())
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(r => r
+                    .ForPort(ContainerApiPort)
+                    .ForPath("/ping")
+                    .ForStatusCode(System.Net.HttpStatusCode.OK))
+                .AddCustomWaitStrategy(new WaitUntilApiHealthy(ContainerApiPort)));
+
+        if (network != null)
+        {
+            builder = builder
+                .WithNetwork(network)
+                .WithNetworkAliases($"test-client-{clientIndex}");
+        }
+
+        var container = builder.Build();
+
+        return new GameClientContainer(container, clientIndex, options, logCallback);
+    }
+
+    /// <summary>
+    /// Starts the container and waits for the API to be ready.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_options.StartupTimeout);
+
+        try
+        {
+            await _container.StartAsync(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            var logs = await _container.GetLogsAsync();
+            throw new TimeoutException(
+                $"Game client {_clientIndex} failed to start within {_options.StartupTimeout.TotalSeconds}s.\n" +
+                $"Logs:\n{logs.Stdout}\n\nErrors:\n{logs.Stderr}");
+        }
+
+        // Get the dynamically mapped port
+        ApiPort = _container.GetMappedPublicPort(ContainerApiPort);
+
+        // Reconfigure the API client with the correct URL
+        _apiClient.Dispose();
+        var newClient = new GameTestClient(BaseUrl);
+        // Copy the client reference (GameTestClient is a wrapper, we need to update the internal HttpClient)
+        typeof(GameTestClient)
+            .GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+            ?.SetValue(_apiClient, typeof(GameTestClient)
+                .GetField("_httpClient", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(newClient));
+
+        // Start log streaming
+        _logStreamCts = new CancellationTokenSource();
+        _logStreamTask = Task.Run(() => StreamLogsAsync(_logStreamCts.Token));
+    }
+
+    /// <summary>
+    /// Connect to the server via invite code (Steam/Galaxy).
+    /// </summary>
+    public async Task<ConnectionResult> ConnectViaInviteCodeAsync(
+        string inviteCode,
+        CancellationToken ct = default)
+    {
+        var helper = new ConnectionHelper(_apiClient, new ConnectionOptions
+        {
+            MaxAttempts = 3,
+            FarmhandMenuTimeout = _options.ConnectionTimeout
+        });
+
+        return await helper.ConnectToServerAsync(inviteCode, ct);
+    }
+
+    /// <summary>
+    /// Connect to the server via LAN/IP address.
+    /// </summary>
+    /// <param name="address">Server address (hostname or IP).</param>
+    /// <param name="port">Server game port (default: 24642).</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<ConnectionResult> ConnectViaLanAsync(
+        string address,
+        int port = 24642,
+        CancellationToken ct = default)
+    {
+        var helper = new ConnectionHelper(_apiClient, new ConnectionOptions
+        {
+            MaxAttempts = 3,
+            FarmhandMenuTimeout = _options.ConnectionTimeout
+        });
+
+        return await helper.ConnectViaLanAsync(address, port, ct);
+    }
+
+    /// <summary>
+    /// Disconnect from the server and return to title screen.
+    /// </summary>
+    public async Task DisconnectAsync(CancellationToken ct = default)
+    {
+        await _apiClient.Exit();
+        await _apiClient.Wait.ForTitle(TimeSpan.FromSeconds(10));
+    }
+
+    private async Task StreamLogsAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var logs = await _container.GetLogsAsync(timestampsEnabled: false, ct: ct);
+                var combinedOutput = (logs.Stdout ?? "") + (logs.Stderr ?? "");
+                var allLines = combinedOutput.Split('\n');
+
+                for (var i = (int)_logPosition; i < allLines.Length; i++)
+                {
+                    var line = allLines[i];
+                    if (!string.IsNullOrWhiteSpace(line))
+                    {
+                        _logCallback?.Invoke($"[Client {_clientIndex}] {line.Trim()}");
+                    }
+                }
+
+                _logPosition = allLines.Length;
+                await Task.Delay(500, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                if (!ct.IsCancellationRequested)
+                {
+                    await Task.Delay(1000, ct);
+                }
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Stop log streaming
+        if (_logStreamCts != null)
+        {
+            _logStreamCts.Cancel();
+            if (_logStreamTask != null)
+            {
+                try
+                {
+                    await _logStreamTask.WaitAsync(TimeSpan.FromSeconds(5));
+                }
+                catch { }
+            }
+            _logStreamCts.Dispose();
+        }
+
+        _apiClient.Dispose();
+
+        try
+        {
+            await _container.DisposeAsync();
+        }
+        catch
+        {
+            // Fallback: force remove via Docker CLI
+            try
+            {
+                var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "docker",
+                    Arguments = $"rm -f {_container.Name}",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                });
+                if (proc != null)
+                {
+                    await proc.WaitForExitAsync();
+                }
+            }
+            catch { }
+        }
+    }
+
+    /// <summary>
+    /// Custom wait strategy that verifies the API is truly healthy.
+    /// </summary>
+    private class WaitUntilApiHealthy : IWaitUntil
+    {
+        private readonly int _port;
+
+        public WaitUntilApiHealthy(int port)
+        {
+            _port = port;
+        }
+
+        public async Task<bool> UntilAsync(IContainer container)
+        {
+            try
+            {
+                var mappedPort = container.GetMappedPublicPort(_port);
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
+                var response = await client.GetAsync($"http://localhost:{mappedPort}/health");
+                return response.IsSuccessStatusCode;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/tests/JunimoServer.Tests/Containers/GameClientManager.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientManager.cs
@@ -1,0 +1,170 @@
+using DotNet.Testcontainers.Networks;
+using JunimoServer.Tests.Helpers;
+
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Manages multiple containerized game clients for multi-player E2E tests.
+/// </summary>
+public class GameClientManager : IAsyncDisposable
+{
+    private readonly List<GameClientContainer> _clients = new();
+    private readonly GameClientOptions _defaultOptions;
+    private readonly INetwork? _network;
+    private readonly Action<string>? _logCallback;
+    private readonly object _lock = new();
+    private int _nextClientIndex;
+
+    /// <summary>
+    /// All active game client containers.
+    /// </summary>
+    public IReadOnlyList<GameClientContainer> Clients => _clients;
+
+    /// <summary>
+    /// Number of active clients.
+    /// </summary>
+    public int ClientCount => _clients.Count;
+
+    /// <summary>
+    /// Creates a new game client manager.
+    /// </summary>
+    /// <param name="defaultOptions">Default options for new clients.</param>
+    /// <param name="network">Optional Docker network for clients to join.</param>
+    /// <param name="logCallback">Optional callback for log output.</param>
+    public GameClientManager(
+        GameClientOptions? defaultOptions = null,
+        INetwork? network = null,
+        Action<string>? logCallback = null)
+    {
+        _defaultOptions = defaultOptions ?? new GameClientOptions();
+        _network = network;
+        _logCallback = logCallback;
+    }
+
+    /// <summary>
+    /// Get a client by index.
+    /// </summary>
+    public GameClientContainer this[int index]
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (index < 0 || index >= _clients.Count)
+                    throw new ArgumentOutOfRangeException(nameof(index),
+                        $"Client index {index} out of range. Active clients: {_clients.Count}");
+                return _clients[index];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates and starts a new game client container.
+    /// </summary>
+    /// <param name="options">Optional custom options (uses defaults if null).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The newly created and started client container.</returns>
+    public async Task<GameClientContainer> CreateClientAsync(
+        GameClientOptions? options = null,
+        CancellationToken ct = default)
+    {
+        int clientIndex;
+        lock (_lock)
+        {
+            clientIndex = _nextClientIndex++;
+        }
+
+        var effectiveOptions = options ?? _defaultOptions;
+
+        _logCallback?.Invoke($"Creating game client {clientIndex}...");
+
+        var client = await GameClientContainer.CreateAsync(
+            clientIndex,
+            effectiveOptions,
+            _network,
+            _logCallback,
+            ct);
+
+        await client.StartAsync(ct);
+
+        lock (_lock)
+        {
+            _clients.Add(client);
+        }
+
+        _logCallback?.Invoke($"Game client {clientIndex} ready at {client.BaseUrl}");
+
+        return client;
+    }
+
+    /// <summary>
+    /// Connect all clients to the server via LAN.
+    /// </summary>
+    /// <param name="address">Server address.</param>
+    /// <param name="port">Server game port.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Connection results for each client.</returns>
+    public async Task<ConnectionResult[]> ConnectAllViaLanAsync(
+        string address,
+        int port,
+        CancellationToken ct = default)
+    {
+        var tasks = _clients.Select(c => c.ConnectViaLanAsync(address, port, ct));
+        return await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Connect all clients to the server via invite code.
+    /// </summary>
+    /// <param name="inviteCode">Server invite code.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Connection results for each client.</returns>
+    public async Task<ConnectionResult[]> ConnectAllViaInviteCodeAsync(
+        string inviteCode,
+        CancellationToken ct = default)
+    {
+        var tasks = _clients.Select(c => c.ConnectViaInviteCodeAsync(inviteCode, ct));
+        return await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Disconnect all clients from the server.
+    /// </summary>
+    public async Task DisconnectAllAsync(CancellationToken ct = default)
+    {
+        var tasks = _clients.Select(c => c.DisconnectAsync(ct));
+        await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Disposes all client containers.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        List<GameClientContainer> clientsToDispose;
+        lock (_lock)
+        {
+            clientsToDispose = new List<GameClientContainer>(_clients);
+            _clients.Clear();
+        }
+
+        _logCallback?.Invoke($"Disposing {clientsToDispose.Count} game client(s)...");
+
+        // Dispose in parallel for speed
+        var disposeTasks = clientsToDispose.Select(async client =>
+        {
+            try
+            {
+                await client.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logCallback?.Invoke($"Error disposing client {client.ClientIndex}: {ex.Message}");
+            }
+        });
+
+        await Task.WhenAll(disposeTasks);
+
+        _logCallback?.Invoke("All game clients disposed");
+    }
+}

--- a/tests/JunimoServer.Tests/Containers/GameClientOptions.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientOptions.cs
@@ -1,0 +1,52 @@
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Configuration options for containerized game clients.
+/// </summary>
+public class GameClientOptions
+{
+    /// <summary>
+    /// Connection method to use when joining the server.
+    /// Default is LAN for reliability (no Steam accounts needed).
+    /// </summary>
+    public ConnectionMethod ConnectionMethod { get; set; } = ConnectionMethod.Lan;
+
+    /// <summary>
+    /// Docker image tag to use for the test client container.
+    /// Default is "local" for locally built images.
+    /// </summary>
+    public string ImageTag { get; set; } = "local";
+
+    /// <summary>
+    /// Name of the Docker volume containing game files (shared with server).
+    /// </summary>
+    public string GameDataVolume { get; set; } = "server_game-data";
+
+    /// <summary>
+    /// Timeout for container startup (waiting for API to respond).
+    /// </summary>
+    public TimeSpan StartupTimeout { get; set; } = TimeSpan.FromSeconds(120);
+
+    /// <summary>
+    /// Timeout for connection attempts.
+    /// </summary>
+    public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(30);
+}
+
+/// <summary>
+/// Method used to connect game clients to the server.
+/// </summary>
+public enum ConnectionMethod
+{
+    /// <summary>
+    /// Connect via Steam/Galaxy invite code.
+    /// Requires valid Steam credentials and tests the production connection path.
+    /// </summary>
+    InviteCode,
+
+    /// <summary>
+    /// Connect via direct IP/LAN using Lidgren networking.
+    /// More reliable for testing, doesn't require multiple Steam accounts.
+    /// </summary>
+    Lan
+}

--- a/tests/JunimoServer.Tests/JunimoServer.Tests.runsettings
+++ b/tests/JunimoServer.Tests/JunimoServer.Tests.runsettings
@@ -2,6 +2,11 @@
 <RunSettings>
   <RunConfiguration>
     <ResultsDirectory>..\..\TestResults</ResultsDirectory>
+    <EnvironmentVariables>
+      <!-- Set to "true" to use containerized game clients instead of local process -->
+      <SDVD_CONTAINERIZED_CLIENTS>true</SDVD_CONTAINERIZED_CLIENTS>
+      <SDVD_TEST_VERBOSE>true</SDVD_TEST_VERBOSE>
+    </EnvironmentVariables>
   </RunConfiguration>
   <LoggerRunSettings>
     <Loggers>


### PR DESCRIPTION
## Summary

- Add Docker infrastructure for running game clients in containers during E2E tests
- Add `GameClientContainer`, `GameClientManager`, `GameClientOptions` classes for managing containerized clients
- Add LAN/IP connection support to `ConnectionHelper` (avoids Steam auth in CI)
- Add immediate abort on server errors with cancellation token support
- Add `IgnoredErrorPatterns` list for non-fatal errors (e.g., XACT audio)
- Improve test banner with Junimo ASCII art and environment info
- Add test configuration env vars to `.env.dev.example`

Enable containerized clients via `SDVD_CONTAINERIZED_CLIENTS=true`.

## Test plan

- [ ] Run tests locally with `SDVD_CONTAINERIZED_CLIENTS=false` (default, uses local game)
- [ ] Run tests with `SDVD_CONTAINERIZED_CLIENTS=true` (uses Docker clients)
- [ ] Verify server errors trigger immediate test abort
- [ ] Verify XACT errors are ignored and don't abort tests