### PR TITLE
fix(tests): repair broken tests after multiple merges

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -4,6 +4,7 @@ using JunimoServer.Services.ServerOptim;
 using JunimoServer.Services.Settings;
 using JunimoServer.Util;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;

--- a/tests/JunimoServer.Tests/Fixtures/IntegrationTestFixture.cs
+++ b/tests/JunimoServer.Tests/Fixtures/IntegrationTestFixture.cs
@@ -900,7 +900,7 @@ public class IntegrationTestFixture : IAsyncLifetime
         LogStepDuration(stepStart);
     }
 
-    private async Task RunBuildCommand(string command, string arguments, string workingDirectory, string description, TimeSpan timeout, bool quiet = true)
+    private async Task RunBuildCommand(string command, string arguments, string workingDirectory, string description, TimeSpan timeout)
     {
         Log($"Building {description}...");
 
@@ -930,7 +930,7 @@ public class IntegrationTestFixture : IAsyncLifetime
             while (await process.StandardOutput.ReadLineAsync() is { } line)
             {
                 stdoutLines.Add(line);
-                if (!quiet)
+                if (VerboseContainerLogs)
                 {
                     AnsiConsole.MarkupLine($"[grey]{Markup.Escape(BuildPrefix)} {Markup.Escape(line)}[/]");
                 }
@@ -942,7 +942,7 @@ public class IntegrationTestFixture : IAsyncLifetime
             while (await process.StandardError.ReadLineAsync() is { } line)
             {
                 stderrLines.Add(line);
-                if (!quiet)
+                if (VerboseContainerLogs)
                 {
                     AnsiConsole.MarkupLine($"[grey]{Markup.Escape(BuildPrefix)} {Markup.Escape(line)}[/]");
                 }


### PR DESCRIPTION
## Summary
- Add missing `Newtonsoft.Json.Linq` using for `JObject` in ApiService.cs (build error)
- Make `DownloadValidationTests` use `IntegrationTestFixture` to ensure images are built before tests run (fixes stale Docker image issue where old code was skipping downloads)
- Respect `SDVD_TEST_VERBOSE` for build output in test fixture

## Test plan
- [ ] Run `dotnet test` and verify tests pass
- [ ] Verify verbose build output shows when `SDVD_TEST_VERBOSE=true`