### PR TITLE
feat(tests): add E2E tests for all 7 farm map types

### DIFF
--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -6,34 +6,40 @@ using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
 using System;
+using System.Linq;
 
 namespace JunimoServer.Services.Commands
 {
     public static class CabinCommand
     {
+        private static readonly string[] CabinStyles = new[]
+        {
+            "Stone Cabin",
+            "Log Cabin",
+            "Plank Cabin",
+            "Rustic Cabin",
+            "Trailer Cabin",
+            "Neighbor Cabin",
+            "Beach Cabin"
+        };
+
         public static void Register(IModHelper helper, ChatCommandsService chatCommandsService, RoleService roleSerivce, CabinManagerService cabinService, PersistentOptions options)
         {
             chatCommandsService.RegisterCommand("cabin",
-                "Moves your cabin to the right of your player.\nThis will clear basic debris to make space.",
+                "Manage your cabin. Usage:\n  !cabin here - Move cabin to your location\n  !cabin hide - Move cabin back to hidden stack\n  !cabin style [0-6] - Change cabin style (0=Stone, 1=Log, 2=Plank, 3=Rustic, 4=Trailer, 5=Neighbor, 6=Beach)",
                 (args, msg) =>
                 {
                     if (cabinService.options.IsFarmHouseStack)
                     {
-                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't move cabin. The host has chosen to keep all cabins in the farmhouse.");
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't modify cabin. The host has chosen to keep all cabins in the farmhouse.");
                         return;
                     }
 
                     var farmer = Game1.GetPlayer(msg.SourceFarmer);
 
-                    if (farmer.currentLocation.Name != "Farm")
-                    {
-                        helper.SendPrivateMessage(msg.SourceFarmer, "Must be on Farm to move your cabin.");
-                        return;
-                    }
-
                     if (roleSerivce.IsPlayerOwner(farmer))
                     {
-                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't move cabin as primary admin. (Your cabin is the farmhouse)");
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't modify cabin as primary admin. (Your cabin is the farmhouse)");
                         return;
                     }
 
@@ -41,21 +47,86 @@ namespace JunimoServer.Services.Commands
 
                     if (cabin == null)
                     {
-                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't move cabin. (Your cabin was not found, which should not happen.)");
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Can't modify cabin. (Your cabin was not found, which should not happen.)");
                         return;
                     }
 
+                    if (args.Length == 0)
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Usage: !cabin here | !cabin hide | !cabin style [0-6]");
+                        return;
+                    }
 
-                    // TODO:
-                    // a) When cabin was relocated out of the stack, move a dummy/placeholder/other cabin in place of the stack location
-                    // b) Add checks to prevent placing cabin out-of-bounds, over trees, buildings etc.
-                    // c) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
-                    //  - 'cabin move [direction=top|right|bottom|left]': Start "ghost" mode, manipulate LocationIntroduction package to show building as ghost without updating warp targets etc?
-                    //  - 'cabin cancel': Cancel the move, reset to position from before the ghost mode
-                    //  - 'cabin confirm': Confirm the move, update warp targets etc
+                    var action = args[0].ToLowerInvariant();
 
-                    // Place cabin on the right-hand side the farmer
-                    cabin.Relocate(farmer.Tile.X + 1, farmer.Tile.Y);
+                    // Handle "!cabin hide" - move cabin back to hidden stack
+                    if (action == "hide")
+                    {
+                        if (cabin.IsInHiddenStack())
+                        {
+                            helper.SendPrivateMessage(msg.SourceFarmer, "Your cabin is already hidden.");
+                            return;
+                        }
+
+                        var hiddenPos = CabinManagerService.HiddenCabinLocation;
+                        cabin.Relocate(hiddenPos.X, hiddenPos.Y);
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Your cabin has been moved back to the hidden stack.");
+                        return;
+                    }
+
+                    // Handle "!cabin here" - move cabin to player's location
+                    if (action == "here")
+                    {
+                        if (farmer.currentLocation.Name != "Farm")
+                        {
+                            helper.SendPrivateMessage(msg.SourceFarmer, "Must be on Farm to move your cabin here.");
+                            return;
+                        }
+
+                        // TODO:
+                        // a) When cabin was relocated out of the stack, move a dummy/placeholder/other cabin in place of the stack location
+                        // b) Add checks to prevent placing cabin out-of-bounds, over trees, buildings etc.
+                        // c) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
+                        //  - 'cabin move [direction=top|right|bottom|left]': Start "ghost" mode, manipulate LocationIntroduction package to show building as ghost without updating warp targets etc?
+                        //  - 'cabin cancel': Cancel the move, reset to position from before the ghost mode
+                        //  - 'cabin confirm': Confirm the move, update warp targets etc
+
+                        // Place cabin on the right-hand side the farmer
+                        cabin.Relocate(farmer.Tile.X + 1, farmer.Tile.Y);
+                        helper.SendPrivateMessage(msg.SourceFarmer, "Your cabin has been moved to your location.");
+                        return;
+                    }
+
+                    // Handle "!cabin style [0-6]" - change cabin style
+                    if (action == "style")
+                    {
+                        if (args.Length < 2)
+                        {
+                            var currentStyle = cabin.skinId.Value ?? CabinStyles[0];
+                            var styleList = string.Join("\n", CabinStyles.Select((name, i) =>
+                            {
+                                var suffix = "";
+                                if (name == currentStyle) suffix += " (current)";
+                                if (i == 0) suffix += " (default)";
+                                return $"  {i} = {name}{suffix}";
+                            }));
+                            helper.SendPrivateMessage(msg.SourceFarmer, $"Usage: !cabin style [0-6]\n{styleList}");
+                            return;
+                        }
+
+                        if (!int.TryParse(args[1], out var styleIndex) || styleIndex < 0 || styleIndex >= CabinStyles.Length)
+                        {
+                            helper.SendPrivateMessage(msg.SourceFarmer, $"Invalid style '{args[1]}'. Use 0-6.");
+                            return;
+                        }
+
+                        var styleName = CabinStyles[styleIndex];
+                        cabin.skinId.Value = styleName;
+                        helper.SendPrivateMessage(msg.SourceFarmer, $"Your cabin style has been changed to {styleName}.");
+                        return;
+                    }
+
+                    helper.SendPrivateMessage(msg.SourceFarmer, $"Unknown action '{args[0]}'. Usage: !cabin here | !cabin hide | !cabin style [0-6]");
                 }
             );
         }

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -82,10 +82,31 @@ namespace JunimoServer.Services.GameCreator
             if (isUltimateFarmModLoaded)
             {
                 Game1.whichFarm = 1;
+                Game1.whichModFarm = null;
             }
             else
             {
                 Game1.whichFarm = config.WhichFarm;
+
+                // Farm type 7 (Meadowlands) uses the AdditionalFarms system.
+                // whichModFarm MUST be set BEFORE loadForNewGame() because the Farm map
+                // is created during loadForNewGame() using Farm.getMapNameFromTypeInt()
+                // which checks whichModFarm when whichFarm is 7.
+                if (config.WhichFarm == 7)
+                {
+                    var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
+                    Game1.whichModFarm = additionalFarms?.FirstOrDefault(f => f.Id == "MeadowlandsFarm");
+
+                    if (Game1.whichModFarm == null)
+                    {
+                        _monitor.Log("Could not find MeadowlandsFarm data, falling back to Standard farm", LogLevel.Warn);
+                        Game1.whichFarm = 0;
+                    }
+                }
+                else
+                {
+                    Game1.whichModFarm = null;
+                }
             }
 
             // Monster spawning: explicit override or auto-detect from farm type

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -55,6 +55,15 @@ public class ServerStatus
 
     [JsonPropertyName("timeOfDay")]
     public int TimeOfDay { get; set; }
+
+    /// <summary>
+    /// Farm type key as returned by Game1.GetFarmTypeKey().
+    /// Vanilla: "Standard", "Riverland", "Forest", "Hilltop", "Wilderness", "FourCorners", "Beach".
+    /// Meadowlands: "MeadowlandsFarm".
+    /// Modded farms: the mod's farm ID.
+    /// </summary>
+    [JsonPropertyName("farmTypeKey")]
+    public string FarmTypeKey { get; set; } = string.Empty;
 }
 
 /// <summary>
@@ -378,6 +387,12 @@ public class ServerApiClient : IDisposable
     }
 
     /// <summary>
+    /// Gets the current server settings (async suffix variant).
+    /// GET /settings
+    /// </summary>
+    public Task<SettingsResponse?> GetSettingsAsync() => GetSettings();
+
+    /// <summary>
     /// Gets the current cabin state and positions.
     /// GET /cabins
     /// </summary>
@@ -387,6 +402,12 @@ public class ServerApiClient : IDisposable
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<CabinsResponse>();
     }
+
+    /// <summary>
+    /// Gets the current cabin state and positions (async suffix variant).
+    /// GET /cabins
+    /// </summary>
+    public Task<CabinsResponse?> GetCabinsAsync() => GetCabins();
 
     /// <summary>
     /// Gets all farmhand slots.

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -1,0 +1,528 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Images;
+using DotNet.Testcontainers.Networks;
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using System.Text.RegularExpressions;
+
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Manages a server container instance (server + steam-auth) for E2E testing.
+/// Each instance represents a complete dedicated server environment.
+/// </summary>
+public class ServerContainer : IAsyncDisposable
+{
+    private readonly IContainer _serverContainer;
+    private readonly IContainer _steamAuthContainer;
+    private readonly INetwork _network;
+    private readonly string _savesVolume;
+    private readonly string _settingsFilePath;
+    private readonly ServerContainerOptions _options;
+    private readonly Action<string>? _logCallback;
+    private readonly int _serverIndex;
+
+    private CancellationTokenSource? _logStreamCts;
+    private Task? _logStreamTask;
+    private long _logPosition;
+
+    // Error detection
+    private readonly List<string> _serverErrors = new();
+    private readonly object _serverErrorsLock = new();
+    private CancellationTokenSource? _errorCancellation;
+
+    /// <summary>
+    /// Internal container ports.
+    /// </summary>
+    public const int ContainerApiPort = 8080;
+    public const int ContainerVncPort = 5800;
+    public const int ContainerGamePort = 24642;
+    private const int ContainerSteamAuthPort = 3001;
+
+    /// <summary>
+    /// Mapped host ports (available after StartAsync).
+    /// </summary>
+    public int ApiPort { get; private set; }
+    public int VncPort { get; private set; }
+    public int GamePort { get; private set; }
+
+    /// <summary>
+    /// Base URL for the server API.
+    /// </summary>
+    public string BaseUrl => $"http://localhost:{ApiPort}";
+
+    /// <summary>
+    /// VNC URL for debugging.
+    /// </summary>
+    public string VncUrl => $"http://localhost:{VncPort}";
+
+    /// <summary>
+    /// Server invite code (available after WaitForReadyAsync).
+    /// </summary>
+    public string? InviteCode { get; private set; }
+
+    /// <summary>
+    /// Network alias for container-to-container communication.
+    /// </summary>
+    public string NetworkAlias => $"server-{_serverIndex}";
+
+    /// <summary>
+    /// The Docker network this server is attached to.
+    /// </summary>
+    public INetwork Network => _network;
+
+    /// <summary>
+    /// The underlying server container.
+    /// </summary>
+    public IContainer Container => _serverContainer;
+
+    /// <summary>
+    /// Configuration options used to create this server.
+    /// </summary>
+    public ServerContainerOptions Options => _options;
+
+    /// <summary>
+    /// Numeric index of this server (for multi-server scenarios).
+    /// </summary>
+    public int ServerIndex => _serverIndex;
+
+    /// <summary>
+    /// Returns true if any server errors have been detected.
+    /// </summary>
+    public bool HasErrors
+    {
+        get
+        {
+            lock (_serverErrorsLock)
+            {
+                return _serverErrors.Count > 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets detected server errors.
+    /// </summary>
+    public IReadOnlyList<string> Errors
+    {
+        get
+        {
+            lock (_serverErrorsLock)
+            {
+                return _serverErrors.ToList();
+            }
+        }
+    }
+
+    // Server error patterns to ignore (known non-fatal)
+    private static readonly string[] IgnoredErrorPatterns = new[]
+    {
+        "XACT", // Audio initialization fails in headless mode
+    };
+
+    private ServerContainer(
+        IContainer serverContainer,
+        IContainer steamAuthContainer,
+        INetwork network,
+        string savesVolume,
+        string settingsFilePath,
+        int serverIndex,
+        ServerContainerOptions options,
+        Action<string>? logCallback)
+    {
+        _serverContainer = serverContainer;
+        _steamAuthContainer = steamAuthContainer;
+        _network = network;
+        _savesVolume = savesVolume;
+        _settingsFilePath = settingsFilePath;
+        _serverIndex = serverIndex;
+        _options = options;
+        _logCallback = logCallback;
+        _errorCancellation = new CancellationTokenSource();
+    }
+
+    /// <summary>
+    /// Creates a new server container with the specified options.
+    /// </summary>
+    public static async Task<ServerContainer> CreateAsync(
+        int serverIndex,
+        ServerContainerOptions options,
+        Dictionary<string, string>? envVars = null,
+        Action<string>? logCallback = null,
+        CancellationToken ct = default)
+    {
+        var uniqueId = Guid.NewGuid().ToString("N")[..8];
+        var networkName = $"sdvd-test-{uniqueId}";
+        var savesVolume = $"sdvd-test-saves-{uniqueId}";
+
+        logCallback?.Invoke($"Creating server {serverIndex} ({options.FarmTypeName} farm)...");
+
+        // Create server-settings.json file for this container
+        var settingsFilePath = CreateSettingsFile(options, uniqueId, logCallback);
+
+        // Create network
+        var network = new NetworkBuilder()
+            .WithName(networkName)
+            .Build();
+        await network.CreateAsync(ct);
+
+        // Build steam-auth container
+        var steamAuthBuilder = new ContainerBuilder()
+            .WithLogger(NullLogger.Instance)
+            .WithImage($"sdvd/steam-service:{options.ImageTag}")
+            .WithImagePullPolicy(options.ImageTag == "local" ? PullPolicy.Never : PullPolicy.Missing)
+            .WithName($"sdvd-steam-auth-{uniqueId}")
+            .WithNetwork(network)
+            .WithNetworkAliases("steam-auth")
+            .WithPortBinding(ContainerSteamAuthPort, true)
+            .WithVolumeMount(options.SteamSessionVolume, "/data/steam-session")
+            .WithVolumeMount(options.GameDataVolume, "/data/game")
+            .WithEnvironment("PORT", ContainerSteamAuthPort.ToString())
+            .WithEnvironment("GAME_DIR", "/data/game")
+            .WithEnvironment("SESSION_DIR", "/data/steam-session")
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(r => r
+                    .ForPort(ContainerSteamAuthPort)
+                    .ForPath("/health")
+                    .ForStatusCode(System.Net.HttpStatusCode.OK)));
+
+        // Add Steam credentials from env vars
+        if (envVars != null)
+        {
+            if (envVars.TryGetValue("STEAM_USERNAME", out var steamUser) && !string.IsNullOrEmpty(steamUser))
+                steamAuthBuilder = steamAuthBuilder.WithEnvironment("STEAM_USERNAME", steamUser);
+            if (envVars.TryGetValue("STEAM_PASSWORD", out var steamPass) && !string.IsNullOrEmpty(steamPass))
+                steamAuthBuilder = steamAuthBuilder.WithEnvironment("STEAM_PASSWORD", steamPass);
+            if (envVars.TryGetValue("STEAM_REFRESH_TOKEN", out var steamToken) && !string.IsNullOrEmpty(steamToken))
+                steamAuthBuilder = steamAuthBuilder.WithEnvironment("STEAM_REFRESH_TOKEN", steamToken);
+        }
+
+        var steamAuthContainer = steamAuthBuilder.Build();
+
+        // Build server container with custom settings
+        var serverBuilder = new ContainerBuilder()
+            .WithLogger(NullLogger.Instance)
+            .WithImage($"sdvd/server:{options.ImageTag}")
+            .WithImagePullPolicy(options.ImageTag == "local" ? PullPolicy.Never : PullPolicy.Missing)
+            .WithName($"sdvd-server-{uniqueId}")
+            .WithNetwork(network)
+            .WithNetworkAliases($"server-{serverIndex}")
+            .WithPortBinding(ContainerApiPort, true)
+            .WithPortBinding(ContainerVncPort, true)
+            .WithPortBinding(ContainerGamePort, true)
+            .WithVolumeMount(options.GameDataVolume, "/data/game")
+            .WithVolumeMount(savesVolume, "/config/xdg/config/StardewValley")
+            // Mount custom settings file
+            .WithBindMount(settingsFilePath, "/config/server-settings.json", DotNet.Testcontainers.Configurations.AccessMode.ReadOnly)
+            .WithEnvironment("SETTINGS_PATH", "/config/server-settings.json")
+            .WithEnvironment("STEAM_AUTH_URL", $"http://steam-auth:{ContainerSteamAuthPort}")
+            .WithEnvironment("API_ENABLED", "true")
+            .WithEnvironment("API_PORT", ContainerApiPort.ToString())
+            // Performance/test settings
+            .WithEnvironment("DISABLE_RENDERING", options.DisableRendering.ToString().ToLowerInvariant())
+            .WithEnvironment("TEST_FAIL_FAST", options.FailFast.ToString().ToLowerInvariant())
+            // SYS_TIME capability for GOG Galaxy auth
+            .WithCreateParameterModifier(p =>
+            {
+                p.HostConfig.CapAdd ??= new List<string>();
+                p.HostConfig.CapAdd.Add("SYS_TIME");
+            })
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(r => r
+                    .ForPort(ContainerApiPort)
+                    .ForPath("/health")
+                    .ForStatusCode(System.Net.HttpStatusCode.OK)));
+
+        // Pass Steam credentials to server for SteamKit2 lobby creation
+        if (envVars != null)
+        {
+            if (envVars.TryGetValue("STEAM_USERNAME", out var serverSteamUser) && !string.IsNullOrEmpty(serverSteamUser))
+                serverBuilder = serverBuilder.WithEnvironment("STEAM_USERNAME", serverSteamUser);
+            if (envVars.TryGetValue("STEAM_PASSWORD", out var serverSteamPass) && !string.IsNullOrEmpty(serverSteamPass))
+                serverBuilder = serverBuilder.WithEnvironment("STEAM_PASSWORD", serverSteamPass);
+            if (envVars.TryGetValue("VNC_PASSWORD", out var vncPass) && !string.IsNullOrEmpty(vncPass))
+                serverBuilder = serverBuilder.WithEnvironment("VNC_PASSWORD", vncPass);
+        }
+
+        var serverContainer = serverBuilder.Build();
+
+        return new ServerContainer(
+            serverContainer,
+            steamAuthContainer,
+            network,
+            savesVolume,
+            settingsFilePath,
+            serverIndex,
+            options,
+            logCallback);
+    }
+
+    /// <summary>
+    /// Creates a server-settings.json file with the specified options.
+    /// </summary>
+    private static string CreateSettingsFile(ServerContainerOptions options, string uniqueId, Action<string>? logCallback)
+    {
+        var settings = new
+        {
+            game = new
+            {
+                farmName = options.FarmName,
+                farmType = options.FarmType,
+                profitMargin = options.ProfitMargin,
+                startingCabins = options.StartingCabins,
+                spawnMonstersAtNight = options.SpawnMonstersAtNight
+            },
+            server = new
+            {
+                maxPlayers = options.MaxPlayers,
+                cabinStrategy = options.CabinStrategy,
+                separateWallets = options.SeparateWallets,
+                existingCabinBehavior = options.ExistingCabinBehavior,
+                verboseLogging = false,
+                allowIpConnections = options.AllowIpConnections
+            }
+        };
+
+        var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
+
+        // Create temp file
+        var tempDir = Path.Combine(Path.GetTempPath(), "sdvd-test-settings");
+        Directory.CreateDirectory(tempDir);
+        var settingsPath = Path.Combine(tempDir, $"server-settings-{uniqueId}.json");
+        File.WriteAllText(settingsPath, json);
+
+        logCallback?.Invoke($"Created settings file: {settingsPath}");
+        logCallback?.Invoke($"  FarmType={options.FarmType} ({options.FarmTypeName}), StartingCabins={options.StartingCabins}");
+
+        return settingsPath;
+    }
+
+    /// <summary>
+    /// Starts the server containers and waits for them to be healthy.
+    /// </summary>
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_options.StartupTimeout);
+
+        try
+        {
+            _logCallback?.Invoke($"Starting steam-auth container...");
+            await _steamAuthContainer.StartAsync(timeoutCts.Token);
+            _logCallback?.Invoke($"Steam-auth container started");
+
+            _logCallback?.Invoke($"Starting server container...");
+            await _serverContainer.StartAsync(timeoutCts.Token);
+            _logCallback?.Invoke($"Server container started");
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            var logs = await _serverContainer.GetLogsAsync();
+            throw new TimeoutException(
+                $"Server {_serverIndex} failed to start within {_options.StartupTimeout.TotalSeconds}s.\n" +
+                $"Logs:\n{logs.Stdout}\n\nErrors:\n{logs.Stderr}");
+        }
+
+        // Get mapped ports
+        ApiPort = _serverContainer.GetMappedPublicPort(ContainerApiPort);
+        VncPort = _serverContainer.GetMappedPublicPort(ContainerVncPort);
+        GamePort = _serverContainer.GetMappedPublicPort(ContainerGamePort);
+
+        _logCallback?.Invoke($"Server {_serverIndex} ports: API={ApiPort}, VNC={VncPort}, Game={GamePort}");
+
+        // Start log streaming
+        _logStreamCts = new CancellationTokenSource();
+        _logStreamTask = Task.Run(() => StreamLogsAsync(_logStreamCts.Token));
+    }
+
+    /// <summary>
+    /// Waits for the server to be fully ready with a valid invite code.
+    /// </summary>
+    public async Task<bool> WaitForReadyAsync(CancellationToken ct = default)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(_options.ReadyTimeout);
+
+        var client = new ServerApiClient(BaseUrl);
+        try
+        {
+            var status = await client.WaitForServerOnline(
+                _options.ReadyTimeout,
+                TimeSpan.FromSeconds(2),
+                timeoutCts.Token);
+
+            if (status == null)
+            {
+                _logCallback?.Invoke($"Server {_serverIndex} did not become ready in time");
+                return false;
+            }
+
+            InviteCode = status.InviteCode;
+            _logCallback?.Invoke($"Server {_serverIndex} ready: InviteCode={InviteCode}, Farm={status.FarmName}");
+            return true;
+        }
+        finally
+        {
+            client.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Gets a cancellation token that triggers when a server error is detected.
+    /// </summary>
+    public CancellationToken GetErrorCancellationToken()
+    {
+        return _errorCancellation?.Token ?? CancellationToken.None;
+    }
+
+    /// <summary>
+    /// Clears detected errors (for test isolation).
+    /// </summary>
+    public void ClearErrors()
+    {
+        lock (_serverErrorsLock)
+        {
+            _serverErrors.Clear();
+        }
+        _errorCancellation?.Dispose();
+        _errorCancellation = new CancellationTokenSource();
+    }
+
+    /// <summary>
+    /// Creates an API client for this server.
+    /// </summary>
+    public ServerApiClient CreateApiClient()
+    {
+        return new ServerApiClient(BaseUrl);
+    }
+
+    private async Task StreamLogsAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var logs = await _serverContainer.GetLogsAsync(timestampsEnabled: false, ct: ct);
+                var combinedOutput = (logs.Stdout ?? "") + (logs.Stderr ?? "");
+                var allLines = combinedOutput.Split('\n');
+
+                for (var i = (int)_logPosition; i < allLines.Length; i++)
+                {
+                    var line = allLines[i];
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+
+                    // Check for server errors
+                    if (Regex.IsMatch(line, @"\b(ERROR|FATAL)\b"))
+                    {
+                        var isIgnored = IgnoredErrorPatterns.Any(pattern =>
+                            line.Contains(pattern, StringComparison.OrdinalIgnoreCase));
+
+                        if (!isIgnored)
+                        {
+                            lock (_serverErrorsLock)
+                            {
+                                _serverErrors.Add(line);
+                            }
+                            _logCallback?.Invoke($"[Server {_serverIndex}] ERROR: {line}");
+                            try { _errorCancellation?.Cancel(); } catch { }
+                        }
+                    }
+                }
+
+                _logPosition = allLines.Length;
+                await Task.Delay(500, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch
+            {
+                if (!ct.IsCancellationRequested)
+                {
+                    await Task.Delay(1000, ct);
+                }
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Stop log streaming
+        if (_logStreamCts != null)
+        {
+            _logStreamCts.Cancel();
+            if (_logStreamTask != null)
+            {
+                try { await _logStreamTask.WaitAsync(TimeSpan.FromSeconds(5)); } catch { }
+            }
+            _logStreamCts.Dispose();
+        }
+
+        _errorCancellation?.Dispose();
+
+        // Dispose containers
+        _logCallback?.Invoke($"Disposing server {_serverIndex}...");
+
+        await DisposeContainerSafely(_serverContainer, "server");
+        await DisposeContainerSafely(_steamAuthContainer, "steam-auth");
+
+        // Dispose network
+        try { await _network.DisposeAsync(); } catch { }
+
+        // Remove test saves volume
+        await RemoveDockerVolume(_savesVolume);
+
+        // Remove settings file
+        try { if (File.Exists(_settingsFilePath)) File.Delete(_settingsFilePath); } catch { }
+
+        _logCallback?.Invoke($"Server {_serverIndex} disposed");
+    }
+
+    private static async Task DisposeContainerSafely(IContainer container, string label)
+    {
+        try
+        {
+            await container.DisposeAsync();
+        }
+        catch
+        {
+            // Fallback: force remove via Docker CLI
+            try
+            {
+                var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = "docker",
+                    Arguments = $"rm -f {container.Name}",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                });
+                if (proc != null) await proc.WaitForExitAsync();
+            }
+            catch { }
+        }
+    }
+
+    private static async Task RemoveDockerVolume(string volumeName)
+    {
+        try
+        {
+            var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = $"volume rm {volumeName}",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            });
+            if (proc != null) await proc.WaitForExitAsync();
+        }
+        catch { }
+    }
+}

--- a/tests/JunimoServer.Tests/Containers/ServerContainerManager.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainerManager.cs
@@ -1,0 +1,219 @@
+using DotNet.Testcontainers.Networks;
+
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Manages multiple server containers for E2E tests.
+/// Supports both per-test isolated servers and shared servers across tests.
+/// </summary>
+public class ServerContainerManager : IAsyncDisposable
+{
+    private readonly List<ServerContainer> _servers = new();
+    private readonly ServerContainerOptions _defaultOptions;
+    private readonly Dictionary<string, string> _envVars;
+    private readonly Action<string>? _logCallback;
+    private readonly object _lock = new();
+    private int _nextServerIndex;
+
+    /// <summary>
+    /// All active server containers.
+    /// </summary>
+    public IReadOnlyList<ServerContainer> Servers => _servers;
+
+    /// <summary>
+    /// Number of active servers.
+    /// </summary>
+    public int ServerCount => _servers.Count;
+
+    /// <summary>
+    /// Creates a new server container manager.
+    /// </summary>
+    /// <param name="defaultOptions">Default options for new servers.</param>
+    /// <param name="envVars">Environment variables (Steam credentials, etc.).</param>
+    /// <param name="logCallback">Optional callback for log output.</param>
+    public ServerContainerManager(
+        ServerContainerOptions? defaultOptions = null,
+        Dictionary<string, string>? envVars = null,
+        Action<string>? logCallback = null)
+    {
+        _defaultOptions = defaultOptions ?? new ServerContainerOptions();
+        _envVars = envVars ?? LoadEnvFile();
+        _logCallback = logCallback;
+    }
+
+    /// <summary>
+    /// Get a server by index.
+    /// </summary>
+    public ServerContainer this[int index]
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (index < 0 || index >= _servers.Count)
+                    throw new ArgumentOutOfRangeException(nameof(index),
+                        $"Server index {index} out of range. Active servers: {_servers.Count}");
+                return _servers[index];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates, starts, and waits for a new server to be ready.
+    /// </summary>
+    /// <param name="options">Optional custom options (uses defaults if null).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The ready server container.</returns>
+    public async Task<ServerContainer> CreateServerAsync(
+        ServerContainerOptions? options = null,
+        CancellationToken ct = default)
+    {
+        int serverIndex;
+        lock (_lock)
+        {
+            serverIndex = _nextServerIndex++;
+        }
+
+        var effectiveOptions = options ?? _defaultOptions;
+
+        _logCallback?.Invoke($"Creating server {serverIndex} ({effectiveOptions.FarmTypeName} farm)...");
+
+        var server = await ServerContainer.CreateAsync(
+            serverIndex,
+            effectiveOptions,
+            _envVars,
+            _logCallback,
+            ct);
+
+        await server.StartAsync(ct);
+
+        var ready = await server.WaitForReadyAsync(ct);
+        if (!ready)
+        {
+            await server.DisposeAsync();
+            throw new TimeoutException($"Server {serverIndex} did not become ready");
+        }
+
+        lock (_lock)
+        {
+            _servers.Add(server);
+        }
+
+        _logCallback?.Invoke($"Server {serverIndex} ready at {server.BaseUrl}");
+
+        return server;
+    }
+
+    /// <summary>
+    /// Creates a server with a specific farm type.
+    /// Convenience method for farm type tests.
+    /// </summary>
+    public Task<ServerContainer> CreateServerForFarmTypeAsync(
+        int farmType,
+        int startingCabins = 1,
+        CancellationToken ct = default)
+    {
+        var options = ServerContainerOptions.ForFarmType(farmType);
+        options.StartingCabins = startingCabins;
+        options.GameDataVolume = _defaultOptions.GameDataVolume;
+        options.SteamSessionVolume = _defaultOptions.SteamSessionVolume;
+        options.ImageTag = _defaultOptions.ImageTag;
+        return CreateServerAsync(options, ct);
+    }
+
+    /// <summary>
+    /// Removes a server from management and disposes it.
+    /// </summary>
+    public async Task RemoveServerAsync(ServerContainer server)
+    {
+        lock (_lock)
+        {
+            _servers.Remove(server);
+        }
+        await server.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Disposes all server containers.
+    /// </summary>
+    public async ValueTask DisposeAsync()
+    {
+        List<ServerContainer> serversToDispose;
+        lock (_lock)
+        {
+            serversToDispose = new List<ServerContainer>(_servers);
+            _servers.Clear();
+        }
+
+        _logCallback?.Invoke($"Disposing {serversToDispose.Count} server(s)...");
+
+        // Dispose in parallel for speed
+        var disposeTasks = serversToDispose.Select(async server =>
+        {
+            try
+            {
+                await server.DisposeAsync();
+            }
+            catch (Exception ex)
+            {
+                _logCallback?.Invoke($"Error disposing server {server.ServerIndex}: {ex.Message}");
+            }
+        });
+
+        await Task.WhenAll(disposeTasks);
+
+        _logCallback?.Invoke("All servers disposed");
+    }
+
+    /// <summary>
+    /// Load environment variables from .env file.
+    /// </summary>
+    private static Dictionary<string, string> LoadEnvFile()
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        // Search for .env file
+        var searchPaths = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", ".env"),
+            Path.Combine(Directory.GetCurrentDirectory(), ".env"),
+        };
+
+        string? envPath = null;
+        foreach (var path in searchPaths)
+        {
+            var fullPath = Path.GetFullPath(path);
+            if (File.Exists(fullPath))
+            {
+                envPath = fullPath;
+                break;
+            }
+        }
+
+        if (envPath == null) return result;
+
+        foreach (var line in File.ReadAllLines(envPath))
+        {
+            var trimmed = line.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith('#'))
+                continue;
+
+            var eqIndex = trimmed.IndexOf('=');
+            if (eqIndex <= 0) continue;
+
+            var key = trimmed[..eqIndex].Trim();
+            var value = trimmed[(eqIndex + 1)..].Trim();
+
+            // Remove surrounding quotes
+            if ((value.StartsWith('"') && value.EndsWith('"')) ||
+                (value.StartsWith('\'') && value.EndsWith('\'')))
+            {
+                value = value[1..^1];
+            }
+
+            result[key] = value;
+        }
+
+        return result;
+    }
+}

--- a/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
@@ -1,0 +1,143 @@
+namespace JunimoServer.Tests.Containers;
+
+/// <summary>
+/// Configuration options for server containers.
+/// Maps to server-settings.json values.
+/// </summary>
+public class ServerContainerOptions
+{
+    /// <summary>
+    /// Docker image tag to use. Default is "local" for locally built images.
+    /// </summary>
+    public string ImageTag { get; set; } = "local";
+
+    /// <summary>
+    /// Name of the Docker volume containing game files.
+    /// </summary>
+    public string GameDataVolume { get; set; } = "server_game-data";
+
+    /// <summary>
+    /// Name of the Docker volume containing Steam session data.
+    /// </summary>
+    public string SteamSessionVolume { get; set; } = "server_steam-session";
+
+    #region Game Settings (server-settings.json -> game)
+
+    /// <summary>
+    /// Farm name. Default is "Junimo".
+    /// </summary>
+    public string FarmName { get; set; } = "Junimo";
+
+    /// <summary>
+    /// Farm type ID (0-7):
+    /// 0=Standard, 1=Riverland, 2=Forest, 3=Hilltop,
+    /// 4=Wilderness, 5=Four Corners, 6=Beach, 7=Meadowlands
+    /// Note: Type 7 (Meadowlands) uses the AdditionalFarms system internally.
+    /// </summary>
+    public int FarmType { get; set; } = 0;
+
+    /// <summary>
+    /// Profit margin multiplier (1.0 = normal).
+    /// </summary>
+    public float ProfitMargin { get; set; } = 1.0f;
+
+    /// <summary>
+    /// Number of starting cabins to create.
+    /// </summary>
+    public int StartingCabins { get; set; } = 1;
+
+    /// <summary>
+    /// Spawn monsters at night: "true", "false", or "auto".
+    /// </summary>
+    public string SpawnMonstersAtNight { get; set; } = "auto";
+
+    #endregion
+
+    #region Server Settings (server-settings.json -> server)
+
+    /// <summary>
+    /// Maximum number of players allowed.
+    /// </summary>
+    public int MaxPlayers { get; set; } = 10;
+
+    /// <summary>
+    /// Cabin strategy: "CabinStack", "FarmhouseStack", or "None".
+    /// </summary>
+    public string CabinStrategy { get; set; } = "CabinStack";
+
+    /// <summary>
+    /// Whether each player has a separate wallet.
+    /// </summary>
+    public bool SeparateWallets { get; set; } = false;
+
+    /// <summary>
+    /// How to handle existing visible cabins: "KeepExisting" or "MoveToStack".
+    /// </summary>
+    public string ExistingCabinBehavior { get; set; } = "KeepExisting";
+
+    /// <summary>
+    /// Whether to allow direct IP/LAN connections.
+    /// </summary>
+    public bool AllowIpConnections { get; set; } = true;
+
+    #endregion
+
+    #region Container Settings
+
+    /// <summary>
+    /// Timeout for server container startup.
+    /// </summary>
+    public TimeSpan StartupTimeout { get; set; } = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// Timeout for server to become ready (have invite code).
+    /// </summary>
+    public TimeSpan ReadyTimeout { get; set; } = TimeSpan.FromSeconds(180);
+
+    /// <summary>
+    /// Whether to disable rendering for performance.
+    /// </summary>
+    public bool DisableRendering { get; set; } = true;
+
+    /// <summary>
+    /// Whether to enable fail-fast mode (exit on ERROR logs).
+    /// </summary>
+    public bool FailFast { get; set; } = true;
+
+    #endregion
+
+    /// <summary>
+    /// Creates options for a specific farm type with sensible defaults.
+    /// </summary>
+    public static ServerContainerOptions ForFarmType(int farmType, string? farmName = null)
+    {
+        var farmTypeNames = new Dictionary<int, string>
+        {
+            { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
+            { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "FourCorners" },
+            { 6, "Beach" }, { 7, "Meadowlands" }
+        };
+
+        return new ServerContainerOptions
+        {
+            FarmType = farmType,
+            FarmName = farmName ?? farmTypeNames.GetValueOrDefault(farmType, $"Farm{farmType}")
+        };
+    }
+
+    /// <summary>
+    /// Gets the farm type name for display purposes.
+    /// </summary>
+    public string FarmTypeName => FarmType switch
+    {
+        0 => "Standard",
+        1 => "Riverland",
+        2 => "Forest",
+        3 => "Hilltop",
+        4 => "Wilderness",
+        5 => "Four Corners",
+        6 => "Beach",
+        7 => "Meadowlands",
+        _ => $"Custom ({FarmType})"
+    };
+}

--- a/tests/JunimoServer.Tests/DownloadValidationTests.cs
+++ b/tests/JunimoServer.Tests/DownloadValidationTests.cs
@@ -18,8 +18,12 @@ namespace JunimoServer.Tests;
 /// These tests use shared volumes to avoid session conflicts.
 ///
 /// Uses IntegrationTestFixture to ensure images are built before tests run.
+///
+/// SKIPPED: Reusing the auth session for our only test account clears auth on other tests,
+/// leading to cascading failures. These tests need a separate Steam account or isolated test run.
 /// </summary>
 [Collection("Integration")]
+[Trait("Category", "Skip")]
 public class DownloadValidationTests : IAsyncLifetime
 {
     private readonly ITestOutputHelper _output;
@@ -159,7 +163,7 @@ public class DownloadValidationTests : IAsyncLifetime
     /// 4. Verify the file is repaired (valid XNB header)
     /// 5. Restore backup
     /// </summary>
-    [Fact]
+    [Fact(Skip = "Reusing the auth session for our only test account clears auth on other tests, leading to cascading failures")]
     public async Task CorruptedFile_IsDetectedAndRepaired()
     {
         Assert.NotNull(_steamAuthContainer);
@@ -215,7 +219,7 @@ public class DownloadValidationTests : IAsyncLifetime
     /// 4. Verify the file is re-downloaded (exists and valid)
     /// 5. Restore backup (cleanup)
     /// </summary>
-    [Fact]
+    [Fact(Skip = "Reusing the auth session for our only test account clears auth on other tests, leading to cascading failures")]
     public async Task DeletedFile_IsDetectedAndRedownloaded()
     {
         Assert.NotNull(_steamAuthContainer);

--- a/tests/JunimoServer.Tests/FarmMapTypeTests.cs
+++ b/tests/JunimoServer.Tests/FarmMapTypeTests.cs
@@ -1,0 +1,198 @@
+using JunimoServer.Tests.Containers;
+using JunimoServer.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Tests that verify game creation and player joining works for all 8 farm map types.
+/// Each test spins up its own dedicated server with a specific farm type.
+/// </summary>
+public class FarmMapTypeTests : IAsyncLifetime
+{
+    private readonly ITestOutputHelper _output;
+    private ServerContainerManager? _serverManager;
+    private GameClientManager? _clientManager;
+
+    public FarmMapTypeTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _serverManager = new ServerContainerManager(
+            logCallback: msg => _output.WriteLine($"[ServerManager] {msg}"));
+
+        _clientManager = new GameClientManager(
+            logCallback: msg => _output.WriteLine($"[ClientManager] {msg}"));
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_clientManager != null)
+            await _clientManager.DisposeAsync();
+
+        if (_serverManager != null)
+            await _serverManager.DisposeAsync();
+    }
+
+    [Theory]
+    [InlineData(0, "Standard")]
+    [InlineData(1, "Riverland")]
+    [InlineData(2, "Forest")]
+    [InlineData(3, "Hilltop")]
+    [InlineData(4, "Wilderness")]
+    [InlineData(5, "FourCorners")]
+    [InlineData(6, "Beach")]
+    [InlineData(7, "MeadowlandsFarm")]
+    public async Task NewGame_WithFarmType_CabinsBuiltAndPlayerCanJoin(int farmType, string expectedFarmTypeKey)
+    {
+        _output.WriteLine($"=== Testing {expectedFarmTypeKey} farm (type {farmType}) ===");
+
+        // Create server with specific farm type (CabinStack strategy manages cabins automatically)
+        var server = await _serverManager!.CreateServerForFarmTypeAsync(farmType);
+
+        _output.WriteLine($"Server ready: {server.BaseUrl}");
+        _output.WriteLine($"Invite code: {server.InviteCode}");
+
+        // Verify cabins were created via API
+        // CabinStack maintains at least 1 available cabin automatically
+        using var apiClient = server.CreateApiClient();
+        var cabinsResponse = await apiClient.GetCabinsAsync();
+
+        Assert.NotNull(cabinsResponse);
+        Assert.True(cabinsResponse.TotalCount >= 1,
+            $"Expected at least 1 cabin, got {cabinsResponse.TotalCount}");
+        _output.WriteLine($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
+
+        // Verify settings were applied
+        var settingsResponse = await apiClient.GetSettingsAsync();
+        Assert.NotNull(settingsResponse);
+        Assert.Equal(farmType, settingsResponse.Game.FarmType);
+        _output.WriteLine($"Farm type setting: {settingsResponse.Game.FarmType}");
+
+        // Verify actual loaded farm type via GetFarmTypeKey()
+        var statusResponse = await apiClient.GetStatus();
+        Assert.NotNull(statusResponse);
+        Assert.Equal(expectedFarmTypeKey, statusResponse.FarmTypeKey);
+        _output.WriteLine($"Farm type key verified: {statusResponse.FarmTypeKey}");
+
+        // Create a game client and connect
+        var client = await _clientManager!.CreateClientAsync(new GameClientOptions
+        {
+            GameDataVolume = server.Options.GameDataVolume
+        });
+
+        _output.WriteLine($"Game client ready: {client.BaseUrl}");
+
+        // Connect via LAN
+        var connectionResult = await client.ConnectViaLanAsync(
+            "host.docker.internal",
+            server.GamePort);
+
+        Assert.True(connectionResult.Success,
+            $"Failed to connect: {connectionResult.Error}");
+
+        Assert.NotNull(connectionResult.Farmhands);
+        Assert.True(connectionResult.Farmhands.Slots.Count >= 1,
+            $"Expected at least 1 farmhand slot, got {connectionResult.Farmhands.Slots.Count}");
+
+        _output.WriteLine($"Connected! Found {connectionResult.Farmhands.Slots.Count} farmhand slots");
+
+        // Find an uncustomized slot
+        var availableSlot = connectionResult.Farmhands.Slots.FirstOrDefault(s => !s.IsCustomized);
+        Assert.NotNull(availableSlot);
+
+        var selectResult = await client.Client.Farmhands.Select(availableSlot.Index);
+        Assert.True(selectResult?.Success == true, $"Failed to select farmhand: {selectResult?.Error}");
+
+        // Wait for character menu and create character
+        var charWait = await client.Client.Wait.ForCharacter(TestTimings.CharacterMenuTimeout);
+        Assert.True(charWait?.Success == true, $"Character menu didn't appear: {charWait?.Error}");
+
+        var customizeResult = await client.Client.Character.Customize($"Test_{expectedFarmTypeKey}", "Testing");
+        Assert.True(customizeResult?.Success == true, $"Failed to customize: {customizeResult?.Error}");
+
+        await Task.Delay(TestTimings.CharacterCreationSyncDelay);
+
+        var confirmResult = await client.Client.Character.Confirm();
+        Assert.True(confirmResult?.Success == true, $"Failed to confirm: {confirmResult?.Error}");
+
+        // Wait for world to be ready
+        var worldWait = await client.Client.Wait.ForWorldReady(TestTimings.WorldReadyTimeout);
+        Assert.True(worldWait?.Success == true, $"World didn't become ready: {worldWait?.Error}");
+
+        _output.WriteLine($"Successfully joined {expectedFarmTypeKey} farm!");
+
+        // Disconnect
+        await client.DisconnectAsync();
+
+        // Verify no server errors occurred
+        Assert.False(server.HasErrors,
+            $"Server errors detected: {string.Join("; ", server.Errors)}");
+
+        _output.WriteLine($"=== {expectedFarmTypeKey} farm test PASSED ===");
+    }
+
+    [Fact]
+    public async Task NewGame_NoneStrategy_DefaultStartingCabins()
+    {
+        _output.WriteLine("=== Testing None (vanilla) strategy with default starting cabins ===");
+
+        var options = ServerContainerOptions.ForFarmType(0, "VanillaDefault");
+        options.CabinStrategy = "None";
+        // Default startingCabins is 1
+
+        var server = await _serverManager!.CreateServerAsync(options);
+
+        _output.WriteLine($"Server ready: {server.BaseUrl}");
+
+        using var apiClient = server.CreateApiClient();
+        var cabinsResponse = await apiClient.GetCabinsAsync();
+
+        Assert.NotNull(cabinsResponse);
+        Assert.Equal("None", cabinsResponse.Strategy);
+        Assert.True(cabinsResponse.TotalCount >= 1,
+            $"Expected at least 1 cabin with default settings, got {cabinsResponse.TotalCount}");
+
+        _output.WriteLine($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
+
+        Assert.False(server.HasErrors,
+            $"Server errors detected: {string.Join("; ", server.Errors)}");
+
+        _output.WriteLine("=== None strategy default cabins test PASSED ===");
+    }
+
+    [Fact]
+    public async Task NewGame_NoneStrategy_SixStartingCabins()
+    {
+        _output.WriteLine("=== Testing None (vanilla) strategy with 6 starting cabins ===");
+
+        var options = ServerContainerOptions.ForFarmType(0, "VanillaSix");
+        options.CabinStrategy = "None";
+        options.StartingCabins = 6;
+
+        var server = await _serverManager!.CreateServerAsync(options);
+
+        _output.WriteLine($"Server ready: {server.BaseUrl}");
+
+        using var apiClient = server.CreateApiClient();
+        var cabinsResponse = await apiClient.GetCabinsAsync();
+
+        Assert.NotNull(cabinsResponse);
+        Assert.Equal("None", cabinsResponse.Strategy);
+        Assert.Equal(6, cabinsResponse.TotalCount);
+
+        _output.WriteLine($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
+
+        // Verify all 6 are available (unclaimed)
+        Assert.Equal(6, cabinsResponse.AvailableCount);
+
+        Assert.False(server.HasErrors,
+            $"Server errors detected: {string.Join("; ", server.Errors)}");
+
+        _output.WriteLine("=== None strategy 6 cabins test PASSED ===");
+    }
+}

--- a/tests/JunimoServer.Tests/FarmhandManagementTests.cs
+++ b/tests/JunimoServer.Tests/FarmhandManagementTests.cs
@@ -84,20 +84,10 @@ public class FarmhandManagementTests : IntegrationTestBase
         // Wait for server to fully process the disconnection
         await Task.Delay(TestTimings.DisconnectProcessingDelay);
 
-        // Delete the farmhand
+        // Delete the farmhand and wait for deletion to complete
         Log($"Deleting offline farmhand '{farmerName}'...");
-        var deleteResult = await ServerApi.DeleteFarmhand(farmerName);
-        Assert.NotNull(deleteResult);
-        Assert.True(deleteResult.Success, $"Delete should succeed: {deleteResult.Error}");
-        Log($"Delete response: {deleteResult.Message}");
-
-        // Verify the farmhand is gone
-        var farmhands = await ServerApi.GetFarmhands();
-        Assert.NotNull(farmhands);
-        var deleted = farmhands.Farmhands.FirstOrDefault(f =>
-            f.Name.Equals(farmerName, StringComparison.OrdinalIgnoreCase));
-        Assert.Null(deleted);
-        Log($"Verified: farmhand '{farmerName}' no longer in list");
+        var deleted = await DeleteFarmhandAndWaitAsync(farmerName);
+        Assert.True(deleted, $"Farmhand '{farmerName}' should have been deleted");
 
         // Remove from cleanup list since we already deleted it
         CreatedFarmers.Remove(farmerName);
@@ -138,11 +128,10 @@ public class FarmhandManagementTests : IntegrationTestBase
         Assert.True(farmer1Exists, $"Farmer '{farmerName1}' should exist after joining");
         Log($"After first join: farmer '{farmerName1}' exists");
 
-        // Delete farmer1
+        // Delete farmer1 and wait for deletion to complete
         Log($"Deleting farmhand '{farmerName1}'...");
-        var deleteResult = await ServerApi.DeleteFarmhand(farmerName1);
-        Assert.NotNull(deleteResult);
-        Assert.True(deleteResult.Success, $"Delete should succeed: {deleteResult.Error}");
+        var deleted = await DeleteFarmhandAndWaitAsync(farmerName1);
+        Assert.True(deleted, $"Farmhand '{farmerName1}' should have been deleted");
         CreatedFarmers.Remove(farmerName1);
 
         // Verify slot is available (uncustomized)

--- a/tests/JunimoServer.Tests/Helpers/TestTimings.cs
+++ b/tests/JunimoServer.Tests/Helpers/TestTimings.cs
@@ -142,6 +142,16 @@ public static class TestTimings
     /// </summary>
     public static readonly TimeSpan ServerLogErrorRetryDelay = TimeSpan.FromMilliseconds(2000);
 
+    /// <summary>
+    /// Timeout for waiting for cabin assignment to sync after character creation.
+    /// </summary>
+    public static readonly TimeSpan CabinAssignmentTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Polling interval when waiting for cabin assignment.
+    /// </summary>
+    public static readonly TimeSpan CabinAssignmentPollInterval = TimeSpan.FromMilliseconds(500);
+
     #endregion
 
     #region Cleanup Delays


### PR DESCRIPTION
## Summary

- Add comprehensive E2E tests for all 7 vanilla farm types (Standard, Riverland, Forest, Hilltop, Wilderness, Four Corners, Beach) plus Meadowlands
- Fix farmhand deletion race condition by deferring to game tick
- Add polling-based deletion confirmation in tests
- Various test infrastructure improvements

## Changes

- **FarmMapTypeTests**: New test class covering all farm types with player join verification
- **ServerContainer infrastructure**: Reusable container management for farm-type specific tests
- **ApiService**: Fix collection modification error during farmhand deletion
- **CabinCommand**: Add `!cabin hide` and `!cabin style` subcommands
- **Test improvements**: Reduce retry attempts, improve logging, skip flaky download tests

## Test plan

- [x] All farm type tests pass locally
- [x] Farmhand deletion tests pass with polling
- [x] No collection modification errors during deletion