### PR TITLE
fix(ci): add permissions to reusable workflow calls

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -235,6 +235,9 @@ jobs:
   build-steam-service-preview:
     name: Build Steam Service Preview
     needs: calculate-version
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/steam-service
@@ -248,6 +251,9 @@ jobs:
   build-discord-bot-preview:
     name: Build Discord Bot Preview
     needs: calculate-version
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/discord-bot
@@ -261,6 +267,8 @@ jobs:
   build-docs:
     name: Build Preview Docs
     needs: build-server-preview
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-docs.yml
     with:
       version: preview
@@ -270,6 +278,11 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     needs: build-docs
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
     uses: ./.github/workflows/deploy-docs.yml
     with:
       version: preview

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -127,6 +127,9 @@ jobs:
     name: Build Steam Service
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/steam-service
@@ -141,6 +144,9 @@ jobs:
     name: Build Discord Bot
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/discord-bot
@@ -154,6 +160,8 @@ jobs:
   build-docs:
     name: Build Latest Docs
     needs: build-and-publish
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-docs.yml
     with:
       version: latest
@@ -163,6 +171,11 @@ jobs:
   deploy-docs:
     name: Deploy Documentation
     needs: build-docs
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+      actions: read
     uses: ./.github/workflows/deploy-docs.yml
     with:
       version: latest


### PR DESCRIPTION
## Summary

Jobs calling reusable workflows need explicit permissions when the parent workflow has `permissions: {}`.

Adds required permissions to:
- `build-steam-service` / `build-discord-bot` jobs (contents: read, packages: write)
- `build-docs` jobs (contents: read)
- `deploy-docs` jobs (contents: read, pages: write, id-token: write, actions: read)

## Test plan

- [ ] Verify build-preview workflow runs without permission errors
- [ ] Verify build-release workflow runs without permission errors