### PR TITLE
fix(ci): fetch tags explicitly in build-preview workflow

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all history for version calculation
+          fetch-tags: true
 
       - name: Get next version from release-please PR
         id: version


### PR DESCRIPTION
## Summary
- The checkout action with `fetch-depth: 0` fetches all commits but not necessarily the latest tags
- This caused the preview version counter to use stale tag data, resulting in repeated version numbers (e.g., publishing `1.5.0-preview.40` four times instead of incrementing)
- Fix: add `fetch-tags: true` to ensure latest tags are fetched

## Test plan
- [ ] Verify next preview build increments to .41