### PR TITLE
fix(ci): sort preview tags by version and filter server-only tags

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -66,8 +66,9 @@ jobs:
 
           echo "Next version: $NEXT_VERSION"
 
-          # Get current preview tag to determine counter
-          PREVIEW_TAG=$(git tag -l 'preview-*' | head -n 1)
+          # Get current preview tag to determine counter (sort by version, highest first)
+          # Use preview-[0-9]* to exclude preview-steam-service-* and similar
+          PREVIEW_TAG=$(git tag -l 'preview-[0-9]*' --sort=-version:refname | head -n 1)
           if [ -n "$PREVIEW_TAG" ]; then
             # Parse existing tag: preview-{version}.{counter}
             PREVIEW_TAG_VERSION=$(echo "$PREVIEW_TAG" | sed 's/preview-\(.*\)\.[0-9]*$/\1/')


### PR DESCRIPTION
## Summary
Two fixes for preview version calculation:

1. **Sort by version**: Use `--sort=-version:refname` to get highest version first
   - Fixes `preview-1.5.0.39` being selected over `preview-1.5.0.40` (lexicographic `39` < `40`)

2. **Filter pattern**: Use `preview-[0-9]*` pattern to exclude `preview-steam-service-*` tags
   - Without this, `preview-steam-service-1.2.0.1` would be selected as the 'latest' tag

## Test plan
- [ ] Verify next preview build increments to .41 (or whatever is correct)