### PR TITLE
fix: Catch System.ObjectDisposedException when the request is already disposed

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -676,6 +676,12 @@ namespace JunimoServer.Services.Api
                     await WriteJsonAsync(response, new { error = "Method not allowed" });
                 }
             }
+            catch (Exception ex) when (request.IsWebSocketRequest)
+            {
+                // WebSocket upgrade failed or WebSocket session errored — response is already
+                // disposed by the upgrade handshake, so we must not attempt to write to it.
+                Monitor.Log($"WebSocket handling error: {ex}", LogLevel.Warn);
+            }
             catch (Exception ex)
             {
                 Monitor.Log($"Error handling request: {ex}", LogLevel.Warn);
@@ -691,10 +697,15 @@ namespace JunimoServer.Services.Api
             }
             finally
             {
-                try { response.Close(); }
-                catch (Exception closeEx)
+                // Don't close the response for WebSocket requests — it's already been
+                // consumed/disposed by the WebSocket upgrade handshake.
+                if (!request.IsWebSocketRequest)
                 {
-                    Monitor.Log($"Failed to close response: {closeEx}", LogLevel.Debug);
+                    try { response.Close(); }
+                    catch (Exception closeEx)
+                    {
+                        Monitor.Log($"Failed to close response: {closeEx}", LogLevel.Debug);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Resolves #223 .

### 📚 Description

Do not attempt to access an already disposed Response object when a WebSocket request comes in and it fails during the process. After the change, this exception will be caught and not result in a warning any more.
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://stardew-valley-dedicated-server.github.io/server/community/contributing
- Make sure the PR title follows conventional commits (https://www.conventionalcommits.org)

Thank you for contributing!
----------------------------------------------------------------------->
