### PR TITLE
ci(label): add reopened event to label-pr workflow

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -2,7 +2,7 @@ name: Label PR
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Adds `reopened` to `pull_request_target` triggers so closing/reopening a PR re-runs labeling