### PR TITLE
fix(server): Fix AdminSteamIds auto-promotion for Steam SDR connections

### DIFF
--- a/mod/JunimoServer/Services/Roles/RoleService.cs
+++ b/mod/JunimoServer/Services/Roles/RoleService.cs
@@ -1,4 +1,5 @@
 using JunimoServer.Services.Settings;
+using JunimoServer.Services.SteamGameServer;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -38,6 +39,7 @@ namespace JunimoServer.Services.Roles
             _settings = settings;
             helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
             helper.Events.Multiplayer.PeerConnected += OnPeerConnected;
+            SteamGameServerNetServer.FarmhandAccepted += OnSteamFarmhandAccepted;
         }
 
         private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
@@ -103,7 +105,8 @@ namespace JunimoServer.Services.Roles
         }
 
         /// <summary>
-        /// Called when a player connects. Checks if their Steam ID is in the admin list.
+        /// Called when a player connects via SMAPI (Galaxy/invite code connections).
+        /// Note: This does NOT fire for Steam SDR connections — see OnSteamFarmhandAccepted.
         /// </summary>
         private void OnPeerConnected(object sender, PeerConnectedEventArgs e)
         {
@@ -111,9 +114,20 @@ namespace JunimoServer.Services.Roles
         }
 
         /// <summary>
-        /// Checks if a player's Steam ID is in the configured admin list and promotes them if so.
+        /// Called when a farmhand is accepted via Steam SDR (SteamGameServerNetServer).
+        /// SMAPI's PeerConnected does not fire for custom server implementations,
+        /// so we handle admin promotion directly here with the known Steam ID.
         /// </summary>
-        public void TryAutoPromoteAdmin(long playerId)
+        private void OnSteamFarmhandAccepted(long playerId, string steamId)
+        {
+            TryAutoPromoteAdmin(playerId, steamId);
+        }
+
+        /// <summary>
+        /// Checks if a player's Steam ID is in the configured admin list and promotes them if so.
+        /// When steamId is provided (SDR path), uses it directly. Otherwise resolves via reflection.
+        /// </summary>
+        public void TryAutoPromoteAdmin(long playerId, string steamId = null)
         {
             var adminSteamIds = _settings.AdminSteamIds;
             if (adminSteamIds == null || adminSteamIds.Length == 0)
@@ -123,8 +137,8 @@ namespace JunimoServer.Services.Roles
             if (IsPlayerAdmin(playerId))
                 return;
 
-            // Get the player's Steam ID via the game server
-            var steamId = GetPlayerSteamId(playerId);
+            // Use provided Steam ID (SDR path) or resolve via reflection (Galaxy path)
+            steamId ??= GetPlayerSteamId(playerId);
             if (string.IsNullOrEmpty(steamId))
             {
                 _monitor.Log($"[Roles] Cannot get Steam ID for player {playerId}", LogLevel.Trace);

--- a/mod/JunimoServer/Services/SteamGameServer/SteamGameServerNetServer.cs
+++ b/mod/JunimoServer/Services/SteamGameServer/SteamGameServerNetServer.cs
@@ -48,6 +48,14 @@ namespace JunimoServer.Services.SteamGameServer
         /// <summary>Connection data by Steam ID (for O(1) lookup).</summary>
         private Dictionary<ulong, ConnectionData> _steamIdConnectionMap;
 
+        /// <summary>
+        /// Raised when a farmhand is accepted via Steam SDR.
+        /// Parameters: (farmerId, steamId).
+        /// Used by RoleService for admin auto-promotion since SMAPI's PeerConnected
+        /// does not fire for custom server implementations.
+        /// </summary>
+        internal static event Action<long, string> FarmhandAccepted;
+
         /// <summary>Connections that recently joined (for poll group transitions).</summary>
         private HashSet<HSteamNetConnection> _recentlyJoined;
 
@@ -276,6 +284,7 @@ namespace JunimoServer.Services.SteamGameServer
                     connectionData.FarmerId = farmerId;
                     connectionData.Online = true;
                     _farmerConnectionMap[farmerId] = connectionData;
+                    FarmhandAccepted?.Invoke(farmerId, connectionData.SteamId.m_SteamID.ToString());
                 });
         }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves https://github.com/stardew-valley-dedicated-server/server/issues/246

### 📚 Description

Fixes `AdminSteamIds` auto-promotion not working for Steam SDR connections.

**Root cause:** SMAPI's `PeerConnected` event does not fire for players connecting through the custom `SteamGameServerNetServer` — only for Galaxy/invite code connections. This meant `TryAutoPromoteAdmin` was never called for Steam players.

**Fix:**
- Added a `FarmhandAccepted` event on `SteamGameServerNetServer` that fires with `(playerId, steamId)` when a farmhand is accepted via SDR
- `RoleService` subscribes to this event and calls `TryAutoPromoteAdmin` with the known Steam ID directly (no reflection needed)
- `TryAutoPromoteAdmin` now accepts an optional `steamId` parameter — when provided (SDR path), it uses it directly; otherwise falls back to resolving via reflection (Galaxy path)


**NB! AI help was used for doing this change**

<img width="906" height="246" alt="image" src="https://github.com/user-attachments/assets/bd842eab-4431-41df-a946-dafcfed8fcdf" />


<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://stardew-valley-dedicated-server.github.io/server/community/contributing
- Make sure the PR title follows conventional commits (https://www.conventionalcommits.org)

Thank you for contributing!
----------------------------------------------------------------------->
