### PR TITLE
fix(deps): make tmux version a Dockerfile ARG so Renovate bumps propagate

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -114,6 +114,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 FROM --platform=$BUILDPLATFORM jlesage/baseimage-gui:debian-11-v4.11.3 AS server
 
 ARG SMAPI_VERSION
+ARG TMUX_VERSION=3.6a
 
 ENV APP_NAME="Stardew Dedicated Server" \
     USER_ID=0 \
@@ -179,10 +180,10 @@ RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/release
     rm -rf /tmp/ffmpeg*
 
 # Install tmux (binary download, separate layer for cacheability)
-RUN curl -L -O https://github.com/tmux/tmux-builds/releases/download/v3.6a/tmux-3.6a-linux-x86_64.tar.gz && \
-    tar -xzf tmux-3.6a-linux-x86_64.tar.gz && \
+RUN curl -L -O https://github.com/tmux/tmux-builds/releases/download/v${TMUX_VERSION}/tmux-${TMUX_VERSION}-linux-x86_64.tar.gz && \
+    tar -xzf tmux-${TMUX_VERSION}-linux-x86_64.tar.gz && \
     install -m 0755 ./tmux /usr/local/bin/tmux && \
-    rm -r ./tmux tmux-3.6a-linux-x86_64.tar.gz
+    rm -r ./tmux tmux-${TMUX_VERSION}-linux-x86_64.tar.gz
 
 # Install vsdbg for remote debugging
 # TODO: Make installation optional for local/debug builds, commented for now

--- a/renovate.json
+++ b/renovate.json
@@ -96,10 +96,10 @@
     },
     {
       "customType": "regex",
-      "description": "tmux version in download URL (docker/Dockerfile only; test-client has no tmux, modern/ excluded). Uses 'deb' versioning so the letter-suffix tags (3.6a < 3.6b) order correctly — dpkg compares non-digit runs lexically by ASCII. No other scheme (semver/loose/regex/docker) orders the letter; deb/rpm/apk are the only ones built for alphanumeric version segments.",
+      "description": "tmux version (ARG TMUX_VERSION in docker/Dockerfile; referenced via ${TMUX_VERSION} in the install RUN so one bump propagates to URL and tarball name alike). Uses 'deb' versioning so the letter-suffix tags (3.6a < 3.6b) order correctly — dpkg compares non-digit runs lexically by ASCII. No other scheme (semver/loose/regex/docker) orders the letter; deb/rpm/apk are the only ones built for alphanumeric version segments.",
       "managerFilePatterns": ["/^docker/Dockerfile(\\.[^/]+)?$/"],
       "matchStrings": [
-        "tmux-builds/releases/download/v(?<currentValue>[0-9.]+[a-z]?)/"
+        "ARG TMUX_VERSION=(?<currentValue>[0-9.]+[a-z]?)"
       ],
       "depNameTemplate": "tmux/tmux-builds",
       "datasourceTemplate": "github-releases",


### PR DESCRIPTION
Follow-up to the Renovate migration (#279).

## Problem
Renovate's regex custom manager replaces only the text span it matched. The tmux pin had the version in **four** places across the install `RUN` block (the URL path plus three tarball-filename references), but the manager matched only the URL — so a bump produced a broken Dockerfile: it downloaded `…/download/v3.6b/…` while still extracting/removing `tmux-3.6a-…tar.gz`. This is why the first Renovate tmux PR (#281) failed `Validate Build`.

## Fix
Hoist the version to `ARG TMUX_VERSION=3.6a` and reference it via `${TMUX_VERSION}` in the install `RUN`, mirroring the existing `ARG SMAPI_VERSION` pattern in the same file. The literal version now appears exactly once, so single-span replacement cannot desync. The custom manager matches the ARG (`ARG TMUX_VERSION=(?<currentValue>[0-9.]+[a-z]?)`).

## Verification
Dry-run (`renovate --platform=local --dry-run=lookup`) against the edited working tree confirmed:
- tmux extracts `currentValue: 3.6a` from the new ARG and proposes `newValue: 3.6b` (`updateType: patch`) via `deb` versioning — the `preview` tag is not proposed.
- SMAPI extraction (`4.5.2`, `4.5.1`) is unaffected.

`Validate Build` on this PR is the final gate — it exercises the real `${TMUX_VERSION}` expansion in the Docker build (a dry-run cannot).

## After merge
Close the obsolete tmux PR #281 (`renovate/dockerfile-tools`); Renovate will regenerate it correctly against the fixed config on its next run.