### PR TITLE
ci: collapse validate-pr to a single pull_request_target trigger

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,10 +1,11 @@
+# Runs on pull_request_target, which is privileged for fork PRs (the workflow file and
+# secrets come from the base repo, not the PR head). The `authorize` job gates fork code
+# and secrets behind fork-pr reviewer approval, and the validation jobs run only once it
+# passes (needs: authorize). Do not add a `pull_request` trigger — a single trigger keeps
+# one required check per name. See docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
 name: Validate PR
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - master
   pull_request_target:
     types: [opened, synchronize, reopened]
     branches:
@@ -13,21 +14,29 @@ on:
 permissions:
   contents: read
 
-# Cancel in-progress runs when a new workflow with the same group name is triggered
+# Cancel superseded runs for the same PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  authorize:
+    name: Start PR Checks
+    # Fork PRs resolve to the 'fork-pr' environment (required reviewer); same-repo + Renovate PRs
+    # resolve to an empty string, i.e. no environment — so the gate passes immediately with no approval.
+    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr' || '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Fork PRs require maintainer approval before checks run; same-repo PRs run automatically."
+
   validate-commits:
     name: Validate Commits
-    # Prevents duplicate runs: same-repo PRs use pull_request, fork PRs use pull_request_target
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    needs: authorize
     runs-on: ubuntu-latest
 
     steps:
+      # Checks out base-repo files only (default ref under pull_request_target) and reads commit
+      # metadata via git fetch — never the fork head — so npm ci runs against trusted lockfiles.
       - name: Checkout base repo code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -43,8 +52,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci
@@ -54,13 +63,11 @@ jobs:
 
   validate-build:
     name: Validate Build
-    # Prevents duplicate runs: same-repo PRs use pull_request, fork PRs use pull_request_target
-    if: >-
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
+    # Checks out fork head and exposes Steam secrets — `needs: authorize` keeps both behind the
+    # fork-pr approval gate. Do not remove it, and do not add an `environment:` here (that would
+    # double-gate forks with a second approval prompt).
+    needs: authorize
     runs-on: ubuntu-latest
-    # Fork PRs require approval via fork-pr environment before secrets are available
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'fork-pr' || '' }}
 
     steps:
       - name: Checkout code

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -130,6 +130,31 @@ The validation pipeline runs on every pull request targeting `master`. It ensure
 - **Commit messages** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - **Docker build** - Ensures the image builds successfully (without pushing)
 
+These surface as two required status checks — `Validate Build` and `Validate Commits` — that must pass before a PR can merge.
+
+### Trigger & Security Model
+
+The pipeline triggers on `pull_request_target`. Unlike `pull_request`, this event runs the workflow file and grants secrets from the **base** repository, not the PR head — which is what lets fork PRs be built with the Steam credentials the Docker image needs. It also means fork code is running in a privileged context, so access is gated:
+
+1. **`authorize`** — runs first. Its `environment:` is chosen by an expression: fork PRs resolve to **`fork-pr`** (a required reviewer must approve before the job — and therefore the rest of the pipeline — proceeds); same-repo and Renovate PRs resolve to an empty string, i.e. **no environment**, so the job passes instantly with no approval.
+2. **`validate-commits`** and **`validate-build`** declare `needs: authorize`, so neither starts until the gate passes. For a fork PR this means a maintainer reviews the diff before fork code is checked out or secrets are exposed.
+
+`validate-commits` only reads commit metadata and base-repo files (it never checks out the fork head), so it is safe under the privileged trigger. `validate-build` checks out the fork head and uses the Steam secrets — which is exactly why it sits behind the `authorize` gate.
+
+::: warning
+Keep this a single `pull_request_target` trigger. Adding `pull_request` back produces duplicate check entries (one per event), and the build job must keep `needs: authorize` rather than its own `environment:` — otherwise fork PRs are gated twice.
+:::
+
+### GitHub Environment
+
+The pipeline uses a single GitHub Environment, `fork-pr`, purely as an authorization gate (it holds no deploy secrets):
+
+| Environment | Used for | Protection rules |
+|-------------|----------|------------------|
+| `fork-pr` | Fork PRs — pauses the pipeline for maintainer approval before fork code or secrets run | Required reviewer |
+
+Same-repo and Renovate PRs resolve the `authorize` job's `environment:` expression to an empty string, which GitHub treats as **no environment** — so no gate, no approval, and nothing extra in the repo's environment list.
+
 ## Deploy Docs Pipeline
 
 [Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/deploy-docs.yml)


### PR DESCRIPTION
## Problem

Every PR showed **four** required-check entries — `Validate Build` and `Validate Commits`, each duplicated for `(pull_request)` and `(pull_request_target)` — with two always grey "skipped". On a rebase the two events raced and the always-skipped `pull_request_target` run cancelled the real `pull_request` run via a shared concurrency group, surfacing the required check as a **0-second cancellation** (this falsely blocked Renovate PR #293).

## Changes

- Drop the dual `pull_request` + `pull_request_target` trigger; run on `pull_request_target` only, so there is exactly one check entry per name (no event qualifiers, no skipped entries).
- Add an `authorize` gate job with a dynamic `environment:`: fork PRs resolve to `fork-pr` (required-reviewer approval gates secrets before any fork code runs); same-repo and Renovate PRs resolve to an empty string (no environment, passes instantly).
- `validate-commits` and `validate-build` declare `needs: authorize`, so fork code is checked out and secrets exposed only after the gate passes.
- Remove the now-dead `if:` event-routing guards and `validate-build`'s inline `environment:` (the gate owns secret authorization — avoids double-gating forks).
- Revert the concurrency key to PR-scoped now that there is a single event.
- Document the trigger, security model, and the `fork-pr` gate environment in `docs/developers/contributing/ci-cd.md`; add inline comments marking the security invariants (no `pull_request` trigger; keep `needs: authorize`; no inline `environment:` on the build job).

## Result

Exactly two required checks per PR (`Validate Build`, `Validate Commits`) — no duplicates, no skips, no cross-event self-cancellation. Fork-PR support is preserved with secret-gated Docker builds behind maintainer approval. Required-check names are unchanged, so the `master` ruleset needs no edit.

## Security note

Single `pull_request_target` is privileged for forks. Two invariants hold:
- `validate-commits` reads only commit metadata and base-repo files (sparse checkout of package.json / package-lock.json / commitlint.config.js); it never checks out the fork head, so `npm ci` runs against trusted lockfiles.
- `validate-build` checks out the fork head and uses Steam secrets only behind `needs: authorize` → `fork-pr` reviewer approval.