### PR TITLE
ci: validate commit messages in the merge queue

### DIFF
--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -2,9 +2,10 @@
 # commit is trusted, already-approved, base-repo code, so there is no fork-secret threat model
 # here — hence no `authorize` gate and no environment, unlike validate-pr.yml. This is a separate
 # file rather than a trigger added to validate-pr.yml on purpose: the merge_group payload has no
-# `github.event.pull_request.*` fields, and one workflow per event keeps a single required check
-# per name. The job name (`Validate Build`) matches the pull-request check so the ruleset's
-# required check is satisfied in-queue. See docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
+# `github.event.pull_request.*` fields, and one workflow per event keeps one required check per
+# name. Both required checks (`Validate Build`, `Validate Commits`) are reproduced here under the
+# same names: a required check with no merge_group producer leaves every queued PR stuck in
+# AWAITING_CHECKS until timeout. See docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
 name: Validate Merge Group
 
 on:
@@ -19,6 +20,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate-commits:
+    name: Validate Commits
+    runs-on: ubuntu-latest
+
+    steps:
+      # The merge-queue branch lives in the base repo, so checking out head_sha with full history
+      # provides both the commits to lint and the tooling (commitlint.config.js, package*.json).
+      - name: Checkout queue branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.merge_group.head_sha }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate commit messages
+        run: npx commitlint --from ${{ github.event.merge_group.base_sha }} --to ${{ github.event.merge_group.head_sha }} --verbose
+
   validate-build:
     name: Validate Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes a merge-queue deadlock: the \`master\` ruleset requires both \`Validate Build\` and \`Validate Commits\`, but \`validate-merge-group.yml\` only produced \`Validate Build\`. With no merge-group producer for \`Validate Commits\`, every queued PR stalls in \`AWAITING_CHECKS\` until the 60-minute timeout.

## Change

- Add a \`validate-commits\` job to \`validate-merge-group.yml\` that runs commitlint over the \`merge_group\` commit range (\`base_sha\`..\`head_sha\`), mirroring the pull-request \`Validate Commits\` check under the same name so the required check reports in-queue.

## Notes

- Action SHA pins, \`node-version\`, and the commitlint invocation match \`validate-pr.yml\` exactly (no skew). Renovate's \`github-actions\` group keeps both files in sync atomically.
- The \`base_sha\`..\`head_sha\` range is exact at merge-queue group size 1 (each queue branch = master + one PR); a larger group size would re-lint already-passed commits ahead in the group (harmless).
- Merge via admin bypass to break the current deadlock; once on \`master\` the queue heals and the stuck PRs pass on their next attempt.