### PR TITLE
ci: tune merge-queue dependency flow and cut redundant builds

### DIFF
--- a/.claude/plans/features/ci-workflow-update.md
+++ b/.claude/plans/features/ci-workflow-update.md
@@ -1,7 +1,7 @@
 # GitHub Workflows Audit & Fixes
 
 ## Context
-Audit of all 11 GitHub workflow files, with fixes for 9 issues spanning JSON-injection vectors, unscoped GHA caches, fragile heredoc/sed shell stitching, and labeler/dependabot completeness. Preview builds become manual-trigger only — push-to-master previews produce too many throwaway releases. The deploy chain (`deploy-server` auto-deploys on `Build Preview` completion) is preserved.
+Audit of the GitHub workflow files, with fixes spanning JSON-injection vectors, unscoped GHA caches, fragile heredoc/sed shell stitching, and labeler completeness. Preview builds become manual-trigger only — push-to-master previews produce too many throwaway releases. The deploy chain (`deploy-server` auto-deploys on `Build Preview` completion) is preserved.
 
 ---
 
@@ -25,9 +25,9 @@ The `concurrency` block and `cancel-in-progress: true` can stay as-is (prevents 
 ---
 
 ## Issue 2: Discord JSON injection in `build-release.yml`
-**File:** `.github/workflows/build-release.yml:110-124`
+**File:** `.github/workflows/build-release.yml:105-124`
 
-The release Discord notification uses raw `${{ }}` interpolation inside a JSON string passed to `curl -d`. If `tag_name` contained quotes or special characters, the JSON would break or allow injection. Every other Discord notification in the repo (`build-preview.yml:206-235`, `deploy-server.yml:221-256`) already uses `jq -n --arg` for safe construction.
+The release Discord notification uses raw `${{ }}` interpolation inside a JSON string passed to `curl -d`. If `tag_name` contained quotes or special characters, the JSON would break or allow injection. Every other Discord notification in the repo (`build-preview.yml:197-235`, `deploy-server.yml:215-257`) already uses `jq -n --arg` for safe construction.
 
 **Fix:** Rewrite to use `jq -n --arg` + `curl -d @-`, matching `build-preview.yml`'s pattern. Move `${{ }}` values into `env:` block.
 
@@ -37,7 +37,7 @@ The release Discord notification uses raw `${{ }}` interpolation inside a JSON s
 **Files:**
 - `.github/workflows/build-preview.yml:155-156`
 - `.github/workflows/build-release.yml:77-78`
-- `.github/workflows/validate-pr.yml:65-66`
+- `.github/workflows/validate-pr.yml:92-93`
 
 The server image builds in all three workflows share the default `type=gha` cache scope. A PR build can write layers that pollute preview/release builds, and preview/release can overwrite each other.
 
@@ -46,7 +46,7 @@ The reusable `build-image.yml` already supports `cache_scope` — steam-service 
 **Fix:**
 - `build-preview.yml`: Add `scope=server-preview` to `cache-from` and `cache-to`
 - `build-release.yml`: Add `scope=server-release` to `cache-from` and `cache-to`
-- `validate-pr.yml`: Make cache **read-only** — keep `cache-from: type=gha` but remove `cache-to` entirely. PR validation builds are throwaway and shouldn't persist cache.
+- `validate-pr.yml`: Make cache **read-only** — keep `cache-from: type=gha` but remove `cache-to` entirely. The `validate-build` job's images are throwaway and shouldn't persist cache. (Cache config sits inside the `Build Docker image (validation only)` step, which runs behind the `authorize` gate — the gate doesn't affect the cache change.)
 
 ---
 
@@ -66,7 +66,7 @@ echo "IMAGE_VERSION=${{ matrix.image_tag }}" >> .env
 ---
 
 ## Issue 5: `deploy-docs.yml` Discord notification uses raw JSON interpolation
-**File:** `.github/workflows/deploy-docs.yml:219-230`
+**File:** `.github/workflows/deploy-docs.yml:213-230`
 
 Same pattern as Issue 2. The docs deploy Discord notification uses inline `${{ }}` inside a `curl -d` JSON string. The `page_url` output comes from `actions/deploy-pages` and is unlikely to contain injection-prone characters, but it's inconsistent with the rest of the repo and fragile.
 
@@ -88,109 +88,6 @@ tests:
 
 ---
 
-## Issue 7: `dependabot.yml` missing `tests/test-ui` npm ecosystem
-**File:** `.github/dependabot.yml`
-
-The `tests/test-ui/` directory contains a Vue.js app with `package.json` and `bun.lock`, but Dependabot isn't configured to track its npm dependencies. The docs and discord-bot directories are already tracked.
-
-**Fix:** Add an entry:
-```yaml
-  - package-ecosystem: "npm"
-    directory: "/tests/test-ui"
-    schedule:
-      interval: "weekly"
-    groups:
-      test-ui:
-        patterns:
-          - "*"
-```
-
----
-
-## Issue 8: Auto-rebase Dependabot PRs after merges
-**File:** `.github/workflows/dependabot-rebase.yml` (new file)
-
-When PRs merge to master, open Dependabot PRs can fall behind and get merge conflicts. This workflow comments `@dependabot rebase` on all open Dependabot PRs after each push to master, keeping them up-to-date automatically.
-
-**Fix:** Create `.github/workflows/dependabot-rebase.yml`:
-```yaml
-name: Rebase Dependabot PRs
-
-on:
-  push:
-    branches: [master]
-
-permissions:
-  pull-requests: write
-  contents: write
-
-jobs:
-  rebase:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Comment rebase on all Dependabot PRs
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr list --repo ${{ github.repository }} --author 'app/dependabot' --json number -q '.[].number' | while read pr; do
-            gh pr comment "$pr" --repo ${{ github.repository }} --body '@dependabot rebase'
-          done
-```
-
----
-
-## Issue 9: Dependabot auto-merge for patch bumps
-**File:** `.github/workflows/dependabot-automerge.yml` (new file)
-
-Pairs with Issue 8 (auto-rebase). Patch version bumps from Dependabot are low-risk and often pile up. A workflow that auto-approves and enables auto-merge for Dependabot patch/minor PRs (after CI passes) reduces maintenance burden.
-
-**Fix:** Create `.github/workflows/dependabot-automerge.yml`:
-```yaml
-name: Auto-merge Dependabot PRs
-
-on:
-  pull_request:
-
-permissions:
-  contents: write
-  pull-requests: write
-
-jobs:
-  auto-merge:
-    if: github.actor == 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Auto-merge patch and minor updates
-        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr review "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --approve
-          gh pr merge "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --squash --auto
-```
-
----
-
-## Issue 10: Pending Dependabot action version bumps (no action — informational)
-There are 5 pending Dependabot PRs for GitHub Actions version bumps on remote branches:
-- `docker/setup-buildx-action` 3.12.0 -> 4.0.0
-- `docker/login-action` 3.7.0 -> 4.0.0
-- `docker/metadata-action` 5.10.0 -> 6.0.0
-- `actions/setup-node` 6.2.0 -> 6.3.0
-- `oven-sh/setup-bun` 2.1.2 -> 2.1.3
-
-These are major version bumps for 3 of the Docker actions. They should be reviewed and merged (or the pin hashes updated in the workflow fixes above).
-
-**Decision:** Not part of this PR — handle separately by reviewing/merging the Dependabot PRs. But the fixes in this plan should use the **current** pinned versions to avoid conflicts.
-
----
-
 ## Summary of changes
 
 | # | File | Type | Risk |
@@ -201,9 +98,6 @@ These are major version bumps for 3 of the Docker actions. They should be review
 | 4 | `deploy-server.yml` | Fragility fix (heredoc) | Low |
 | 5 | `deploy-docs.yml` | Bug fix (JSON injection) | Low |
 | 6 | `.github/labeler.yml` | Improvement (missing label) | None |
-| 7 | `.github/dependabot.yml` | Improvement (missing ecosystem) | None |
-| 8 | `dependabot-rebase.yml` | New workflow (auto-rebase) | None |
-| 9 | `dependabot-automerge.yml` | New workflow (auto-merge patch/minor) | Low |
 
 ## Verification
 - **Issue 1:** Manually dispatch Build Preview from Actions tab; confirm deploy-server auto-triggers on completion
@@ -211,6 +105,3 @@ These are major version bumps for 3 of the Docker actions. They should be review
 - **Issue 3:** After merge, open a PR and confirm no `cache-to` in buildx logs; push to master and confirm `scope=server-preview` appears
 - **Issue 4:** Run deploy-server workflow manually, SSH into server and verify `.env` has no leading whitespace
 - **Issue 6:** Open a PR touching `tests/`, verify `tests` label is applied
-- **Issue 7:** After merge, Dependabot should start creating PRs for test-ui dependencies
-- **Issue 8:** Merge a PR to master; confirm `@dependabot rebase` comments appear on open Dependabot PRs
-- **Issue 9:** Open a Dependabot patch PR; confirm it gets auto-approved and auto-merge enabled after CI passes

--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -20,6 +20,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Build-Context Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      # On merge_group, paths-filter needs an explicit base/ref (the event provides no PR refs) and
+      # a checkout to diff against. The filter is an allowlist of the paths the Docker build context
+      # actually consumes (the Dockerfile COPY surface) — keep it in sync with docker/Dockerfile, not
+      # with .dockerignore. Must match validate-pr.yml's filter exactly so PR-time and in-queue agree.
+      - name: Checkout queue branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.merge_group.head_sha }}
+          fetch-depth: 0
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          base: ${{ github.event.merge_group.base_sha }}
+          ref: ${{ github.event.merge_group.head_sha }}
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'mod/**'
+              - 'tools/steam-service/**'
+              - 'tools/dll-patcher/**'
+              - 'tools/netdebug/**'
+              - 'tools/openapi-generator/**'
+              - 'Directory.Build.props'
+
   validate-commits:
     name: Validate Commits
     runs-on: ubuntu-latest
@@ -47,18 +79,50 @@ jobs:
 
   validate-build:
     name: Validate Build
+    # Always runs so the required check always reports — but the actual Docker build only runs when
+    # the merge group touches the build context (see the `changes` job). A change that can't affect
+    # the build context can't affect the build result, so skipping is safe and keeps the check green.
+    needs: changes
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.docker == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.merge_group.head_sha }}
 
       - name: Set up Docker Buildx
+        id: buildx
+        if: needs.changes.outputs.docker == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+      # type=gha does not persist BuildKit `--mount=type=cache` directories (the Dockerfile uses one
+      # for /root/.nuget/packages on every restore), so NuGet re-downloads on each run. actions/cache
+      # persists a local dir across runs; inject seeds the mount before the build, extract writes it
+      # back after. Mirrors validate-pr.yml so the in-queue build is as cache-warm as the PR build.
+      - name: Cache NuGet mount
+        id: nuget-cache
+        if: needs.changes.outputs.docker == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: nuget-cache-mount
+          key: nuget-cache-mount-${{ hashFiles('mod/**/*.csproj', 'tools/steam-service/**/*.csproj', 'Directory.Build.props') }}
+
+      - name: Inject NuGet mount
+        if: needs.changes.outputs.docker == 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          skip-extraction: ${{ steps.nuget-cache.outputs.cache-hit }}
+
       - name: Build Docker image (validation only)
+        if: needs.changes.outputs.docker == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -72,9 +136,27 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Extract NuGet mount
+        if: needs.changes.outputs.docker == 'true' && steps.nuget-cache.outputs.cache-hit != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          extract: true
+
       - name: Build summary
         run: |
-          echo "### Merge Queue Build Validation Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Queue branch:** \`${{ github.event.merge_group.head_ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`${{ github.event.merge_group.head_sha }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.changes.outputs.docker }}" = "true" ]; then
+            echo "### Merge Queue Build Validation Passed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Queue branch:** \`${{ github.event.merge_group.head_ref }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit:** \`${{ github.event.merge_group.head_sha }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Merge Queue Build Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This merge group does not touch the Docker build context, so the image build was skipped." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -29,6 +29,31 @@ jobs:
     steps:
       - run: echo "Fork PRs require maintainer approval before checks run; same-repo PRs run automatically."
 
+  changes:
+    name: Detect Build-Context Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      # paths-filter reads the changed-file list via the GitHub API (it never checks out fork
+      # code), so it is safe to run before the authorize gate. The filter is an allowlist of the
+      # paths the Docker build context actually consumes (the Dockerfile COPY surface) — keep it
+      # in sync with docker/Dockerfile, not with .dockerignore. A path missing here means a build
+      # that should have run is skipped, so err toward including.
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'mod/**'
+              - 'tools/steam-service/**'
+              - 'tools/dll-patcher/**'
+              - 'tools/netdebug/**'
+              - 'tools/openapi-generator/**'
+              - 'Directory.Build.props'
+
   validate-commits:
     name: Validate Commits
     needs: authorize
@@ -63,22 +88,54 @@ jobs:
 
   validate-build:
     name: Validate Build
+    # Always runs so the required check always reports — but the actual Docker build only runs when
+    # the PR touches the build context (see the `changes` job). A PR that can't change the build
+    # context can't change the build result, so skipping the build is safe and keeps the check green.
     # Checks out fork head and exposes Steam secrets — `needs: authorize` keeps both behind the
-    # fork-pr approval gate. Do not remove it, and do not add an `environment:` here (that would
-    # double-gate forks with a second approval prompt).
-    needs: authorize
+    # fork-pr approval gate. Do not remove `authorize`, and do not add an `environment:` here (that
+    # would double-gate forks with a second approval prompt).
+    needs: [authorize, changes]
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.docker == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Docker Buildx
+        id: buildx
+        if: needs.changes.outputs.docker == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
+      # type=gha does not persist BuildKit `--mount=type=cache` directories (the Dockerfile uses
+      # one for /root/.nuget/packages on every restore), so NuGet re-downloads on each run. The
+      # cache-dance bridges that gap: actions/cache persists a local `nuget-cache-mount` dir across
+      # runs, the inject step seeds the BuildKit mount from it before the build, and the extract
+      # step (after the build) writes the updated mount back for actions/cache to save.
+      - name: Cache NuGet mount
+        id: nuget-cache
+        if: needs.changes.outputs.docker == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: nuget-cache-mount
+          key: nuget-cache-mount-${{ hashFiles('mod/**/*.csproj', 'tools/steam-service/**/*.csproj', 'Directory.Build.props') }}
+
+      - name: Inject NuGet mount
+        if: needs.changes.outputs.docker == 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          skip-extraction: ${{ steps.nuget-cache.outputs.cache-hit }}
+
       - name: Build Docker image (validation only)
+        if: needs.changes.outputs.docker == 'true'
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
@@ -92,10 +149,28 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Extract NuGet mount
+        if: needs.changes.outputs.docker == 'true' && steps.nuget-cache.outputs.cache-hit != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          extract: true
+
       - name: Build summary
         run: |
-          echo "### Build Validation Passed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.head_ref }}\` → \`${{ github.base_ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.changes.outputs.docker }}" = "true" ]; then
+            echo "### Build Validation Passed" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**PR:** #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+            echo "**Branch:** \`${{ github.head_ref }}\` → \`${{ github.base_ref }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Build Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "This PR does not touch the Docker build context, so the image build was skipped." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -9,6 +9,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 | [Build Release](#build-release-pipeline) | Merge release candidate PR to `master` | Creates releases and publishes stable Docker images |
 | [Build Preview](#build-preview-pipeline) | Push to `master` | Builds and publishes preview Docker images |
 | [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits and builds |
+| [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
 | [Deploy Docs](#deploy-docs-pipeline) | After build / manual | Deploys documentation to GitHub Pages |
 | [Cleanup Preview Tags](#cleanup-preview-tags) | Weekly schedule / manual | Deletes old preview tags from DockerHub |
@@ -154,6 +155,27 @@ The pipeline uses a single GitHub Environment, `fork-pr`, purely as an authoriza
 | `fork-pr` | Fork PRs — pauses the pipeline for maintainer approval before fork code or secrets run | Required reviewer |
 
 Same-repo and Renovate PRs resolve the `authorize` job's `environment:` expression to an empty string, which GitHub treats as **no environment** — so no gate, no approval, and nothing extra in the repo's environment list.
+
+## Merge Queue
+
+Merges to `master` go through a [GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue). You do not merge a PR directly — once it is approved and its checks pass, enabling auto-merge adds it to the queue, and GitHub merges it for you.
+
+### How a PR merges
+
+1. The PR passes its [Validate PR](#validate-pr-pipeline) checks and receives the required approval.
+2. Enabling auto-merge (or, for Renovate PRs, Renovate arming it automatically) hands the PR to the queue.
+3. The queue builds a temporary `gh-readonly-queue/master/...` branch containing the latest `master` plus the PR's changes, and runs the required checks against it. This is what the **Validate Merge Group** workflow ([`validate-merge-group.yml`](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/validate-merge-group.yml)) validates — the PR is re-tested against the current tip of `master`, not the stale base it was branched from.
+4. If those checks pass, the queue fast-forwards `master`. PRs are merged one at a time, each squashed into a single commit.
+
+A PR sitting in the queue shows **`AWAITING_CHECKS`** while its merge-group build runs, and **`UNMERGEABLE`** if its changes no longer apply cleanly on top of the current `master` (typically because an overlapping PR merged ahead of it). An unmergeable PR is dropped from the queue; rebasing it onto `master` and re-queuing resolves it.
+
+### Why Validate Merge Group is a separate workflow
+
+The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-pipeline) does not respond to (it triggers on `pull_request_target`). The merge queue requires the same `Validate Build` and `Validate Commits` checks to report **on the merge-group ref**, so `validate-merge-group.yml` reproduces both under the same names. It runs the same commitlint and Docker build, but without the `authorize` gate — merge-group code is already approved and runs from the base repository, so there is no fork-secret exposure to gate.
+
+::: warning
+Both required checks (`Validate Build`, `Validate Commits`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too.
+:::
 
 ## Deploy Docs Pipeline
 

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "chore",
   "semanticCommitScope": "deps",
-  "rebaseWhen": "behind-base-branch",
+  "rebaseWhen": "conflicted",
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
Three improvements to the Renovate + merge-queue flow, plus documentation.

## Changes

- **`renovate.json`** — `rebaseWhen: behind-base-branch` → `conflicted`. The merge queue already brings PRs up to date in its own temp branches, so Renovate only needs to rebase on a genuine conflict. This stops routine follower force-pushes from dismissing a standing approval, so a batch of approved dependency PRs drains through the queue without re-approval. `dismiss_stale_reviews_on_push` stays **on** — a real new commit still dismisses approval, so this is not a security relaxation.
- **`validate-pr.yml` + `validate-merge-group.yml`** — skip the Docker build when a PR doesn't touch the build context, via a `dorny/paths-filter` allowlist mirroring the Dockerfile's `COPY` surface (`docker/**`, `mod/**`, `tools/{steam-service,dll-patcher,netdebug,openapi-generator}/**`, `Directory.Build.props`). The `Validate Build` job still runs so the required check stays green; only the build step is gated. Most dependency PRs (GitHub Actions, root-npm, docs) no longer build the image at PR-time *or* in-queue.
- **Both workflows** — persist the BuildKit NuGet cache mount across runs (`buildkit-cache-dance` + `actions/cache`). `type=gha` doesn't cover `--mount=type=cache` dirs, so NuGet was re-downloading on every build.
- **`docs/developers/contributing/ci-cd.md`** — document the merge queue and the merge-group workflow.
- **`.claude/plans/...`** — remove the now-implemented merge-queue item from the pending CI-audit plan.

## Verification (watch the first run)

The build-skip-keeps-check-green and cache-dance behaviors are runtime-verified on first merge, not statically provable:
- A dependency PR that doesn't touch the build context should show **Validate Build = green via the skip path** (not blocked).
- The cache-dance steps should run without error; a cache miss only slows the build, never breaks it.
- The allowlist is load-bearing and duplicated in both workflows — a new top-level dir consumed by the Dockerfile must be added to both, or its build silently skips.