### PR TITLE
feat: add missing game options

### DIFF
--- a/docs/admins/configuration/server-settings.md
+++ b/docs/admins/configuration/server-settings.md
@@ -31,7 +31,17 @@ This file is auto-created with defaults on first server startup. If the file doe
     "FarmType": 0,
     "ProfitMargin": 1.0,
     "StartingCabins": 1,
-    "SpawnMonstersAtNight": "auto"
+    "SpawnMonstersAtNight": "auto",
+    "RemixBundles": false,
+    "RemixMines": false,
+    "CommunityCenterYear1": false,
+    "CabinLayoutNearby": false,
+    "UseLegacyRandom": false,
+    "RandomSeed": null,
+    "PetBreed": 1,
+    "PetName": "Apples",
+    "MushroomCave": true,
+    "BuyJoja": false
   },
   "Server": {
     "MaxPlayers": 10,
@@ -59,6 +69,16 @@ These settings only take effect when creating a **new** game. They are ignored w
 | `ProfitMargin` | Sell price multiplier | `1.0` |
 | `StartingCabins` | Number of cabins created with new game | `1` |
 | `SpawnMonstersAtNight` | Monster spawning: `"true"`, `"false"`, or `"auto"` | `"auto"` |
+| `RemixBundles` | Use remixed or default CC bundles | `"false"` |
+| `RemixMines` | Use remixed or default mines rewards | `"false"` |
+| `CommunityCenterYear1` | Guarantee the community center is completable in year 1 | `false` |
+| `CabinLayoutNearby` | Whether to use nearby cabin layout. Only has an effect when CabinStrategy is `"None"` | `false` |
+| `UseLegacyRandom` | Use the legacy RNG algorithms | `false` |
+| `RandomSeed` | Seed to use for RNG. `"null"` for a random seed | `"null"` |
+| `PetBreed` | Breed of pet. [0-4] are cats, [5-9] are dogs. -1 for no pet | `1` |
+| `PetName` | Name of starting pet | `"Apples"` |
+| `MushroomCave` | Makes the farm cave a mushroom cave. Set to false for fruit bats. | `true` |
+| `BuyJoja` | Whether to buy the Joja membership when available. | `false` |
 
 ### Farm Types
 

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -177,7 +177,8 @@ namespace JunimoServer
             SmapiLogConfig.SetVerboseLogging(ModManifest.UniqueID, verboseLogging, Monitor);
 
             services.AddSingleton<PersistentOptions>();
-            services.AddSingleton<AlwaysOnConfig>();
+            AlwaysOnConfig alwaysOnConfig = AlwaysOnConfig.FromSettings(settingsLoader);
+            services.AddSingleton(alwaysOnConfig);
         }
 
         private void LoadServices(ServiceCollection services)

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -459,6 +459,13 @@ namespace JunimoServer.Services.AlwaysOn
                 return;
             }
 
+            if (!Config.ShouldCreatePet)
+            {
+                Monitor.Log($"[Automation] Not creating a pet", LogLevel.Info);
+                _petChoiceHandled = true;
+                return;
+            }
+
             // Call hostActionNamePet directly via reflection, avoiding the throwaway
             // Event() + namePet() pattern which calls Game1.exitActiveMenu() and
             // would destroy any active menu (e.g. ReadyCheckDialog from sleep).

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnConfig.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnConfig.cs
@@ -1,13 +1,25 @@
+using JunimoServer.Services.Settings;
 using StardewModdingAPI;
 
 namespace JunimoServer.Services.AlwaysOn
 {
     public class AlwaysOnConfig
     {
+        public static AlwaysOnConfig FromSettings(ServerSettingsLoader settings)
+        {
+            return new AlwaysOnConfig()
+            {
+                PetName = settings.PetName,
+                FarmCaveChoiceIsMushrooms = settings.MushroomCave,
+                IsCommunityCenterRun = !settings.BuyJoja,
+                ShouldCreatePet = settings.PetBreed is >= 0 and <= 9,
+            };
+        }
         public SButton HotKeyToggleAutoMode { get; set; } = SButton.F9;
         public SButton HotKeyToggleVisibility { get; set; } = SButton.F10;
 
         public string PetName { get; set; } = "Apples";
+        public bool ShouldCreatePet { get; set; } = true;
         public bool FarmCaveChoiceIsMushrooms { get; set; } = true;
         public bool IsCommunityCenterRun { get; set; } = true;
 

--- a/mod/JunimoServer/Services/Commands/SettingsCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SettingsCommand.cs
@@ -100,6 +100,16 @@ namespace JunimoServer.Services.Commands
                 ? _settings.SpawnMonstersAtNight.Value.ToString()
                 : "auto";
             _monitor.Log($"  SpawnMonstersAtNight = {monstersLabel}", LogLevel.Info);
+            _monitor.Log($"  RemixBundles = {_settings.RemixBundles}", LogLevel.Info);
+            _monitor.Log($"  RemixMines = {_settings.RemixMines}", LogLevel.Info);
+            _monitor.Log($"  CommunityCenterYear1 = {_settings.CommunityCenterYear1}", LogLevel.Info);
+            _monitor.Log($"  CabinLayoutNearby = {_settings.CabinLayoutNearby}", LogLevel.Info);
+            _monitor.Log($"  UseLegacyRandom = {_settings.UseLegacyRandom}", LogLevel.Info);
+            _monitor.Log($"  RandomSeed = {_settings.RandomSeed}", LogLevel.Info);
+            _monitor.Log($"  PetBreed = {_settings.PetBreed}", LogLevel.Info);
+            _monitor.Log($"  PetName = {_settings.PetName}", LogLevel.Info);
+            _monitor.Log($"  MushroomCave = {_settings.MushroomCave}", LogLevel.Info);
+            _monitor.Log($"  BuyJoja = {_settings.BuyJoja}", LogLevel.Info);
 
             _monitor.Log("  -- Runtime settings (applied on every startup) --", LogLevel.Info);
             _monitor.Log($"  MaxPlayers           = {_settings.MaxPlayers}", LogLevel.Info);

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -66,6 +66,28 @@ namespace JunimoServer.Services.GameCreator
 
             Game1.player.team.useSeparateWallets.Value = config.UseSeparateWallets;
 
+            Game1.cabinsSeparate = !config.CabinLayoutNearby;
+            Game1.bundleType = config.BundlesRemix ? Game1.BundleType.Remixed : Game1.BundleType.Default;
+            Game1.game1.SetNewGameOption("MineChests",  config.MinesRemix ? Game1.MineChestType.Remixed : Game1.MineChestType.Default);
+            Game1.game1.SetNewGameOption("YearOneCompletable", config.CommunityCenterYear1);
+            Game1.startingGameSeed = config.RandomSeed;
+            Game1.UseLegacyRandom = config.UseLegacyRandom;
+
+            const int dogIndex = 5;
+            if (config.PetBreed is >= 0 and <= 9)
+            {
+                if (config.PetBreed < dogIndex)
+                {
+                    Game1.player.whichPetType = "Cat";
+                    Game1.player.whichPetBreed = config.PetBreed.ToString();
+                }
+                else
+                {
+                    Game1.player.whichPetType = "Dog";
+                    Game1.player.whichPetBreed = (config.PetBreed - dogIndex).ToString();
+                }
+            }
+
             // For CabinStack/FarmhouseStack: BuildStartingCabins is patched out, so this value
             // is unused; we create cabins ourselves at the hidden location.
             // For None strategy: this controls how many vanilla cabins are placed at
@@ -108,9 +130,6 @@ namespace JunimoServer.Services.GameCreator
 
             // Monster spawning: explicit override or auto-detect from farm type
             Game1.spawnMonstersAtNight = config.SpawnMonstersAtNight ?? (config.WhichFarm == 4);
-
-            // Dedicated server always uses cat as the farm pet
-            Game1.player.whichPetType = "Cat";
 
             Game1.player.Name = "Server";
             Game1.player.displayName = Game1.player.Name;

--- a/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
+++ b/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
@@ -13,6 +13,15 @@ namespace JunimoServer.Services.GameCreator
         public int MaxPlayers { get; set; } = 10;
         public CabinStrategy CabinStrategy { get; set; } = CabinStrategy.CabinStack;
 
+        // advanced creation options
+        public bool BundlesRemix { get; set; } = false;
+        public bool MinesRemix { get; set; } = false;
+        public bool CommunityCenterYear1 { get; set; } = false;
+        public bool CabinLayoutNearby { get; set; } = false;
+        public bool UseLegacyRandom { get; set; } = false;
+        public ulong? RandomSeed { get; set; } = null;
+        public int PetBreed { get; set; } = 1;
+
         /// <summary>
         /// Nullable: null means "auto" (true only for Wilderness farm type 4).
         /// </summary>
@@ -35,6 +44,14 @@ namespace JunimoServer.Services.GameCreator
                 SpawnMonstersAtNight = settings.SpawnMonstersAtNight,
                 ProfitMargin = settings.ProfitMargin,
                 StartingCabins = settings.StartingCabins,
+
+                BundlesRemix = settings.RemixBundles,
+                MinesRemix = settings.RemixMines,
+                CommunityCenterYear1 = settings.CommunityCenterYear1,
+                CabinLayoutNearby = settings.CabinLayoutNearby,
+                UseLegacyRandom = settings.UseLegacyRandom,
+                RandomSeed = settings.RandomSeed,
+                PetBreed = settings.PetBreed,
             };
         }
 
@@ -71,7 +88,14 @@ namespace JunimoServer.Services.GameCreator
                    $"{nameof(MaxPlayers)}: {MaxPlayers}, {nameof(CabinStrategy)}: {CabinStrategy}, " +
                    $"{nameof(UseSeparateWallets)}: {UseSeparateWallets}, " +
                    $"{nameof(SpawnMonstersAtNight)}: {SpawnMonstersAtNight?.ToString() ?? "auto"}, " +
-                   $"{nameof(ProfitMargin)}: {ProfitMargin}, {nameof(StartingCabins)}: {StartingCabins}";
+                   $"{nameof(ProfitMargin)}: {ProfitMargin}, {nameof(StartingCabins)}: {StartingCabins}, " +
+                   $"{nameof(BundlesRemix)}: {BundlesRemix}, " +
+                   $"{nameof(MinesRemix)}: {MinesRemix}, " +
+                   $"{nameof(CommunityCenterYear1)}: {CommunityCenterYear1}, " +
+                   $"{nameof(CabinLayoutNearby)}: {CabinLayoutNearby}, " +
+                   $"{nameof(UseLegacyRandom)}: {UseLegacyRandom}, " +
+                   $"{nameof(RandomSeed)}: {RandomSeed}, " +
+                   $"{nameof(PetBreed)}: {PetBreed}";
         }
     }
 }

--- a/mod/JunimoServer/Services/Settings/ServerSettings.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettings.cs
@@ -26,6 +26,17 @@ namespace JunimoServer.Services.Settings
         public float ProfitMargin { get; set; } = 1.0f;
         public int StartingCabins { get; set; } = 1;
         public string SpawnMonstersAtNight { get; set; } = "auto";
+        // advanced creation options
+        public bool RemixBundles { get; set; } = false;
+        public bool RemixMines { get; set; } = false;
+        public bool CommunityCenterYear1 { get; set; } = false;
+        public bool CabinLayoutNearby { get; set; } = false;
+        public bool UseLegacyRandom { get; set; } = false;
+        public ulong? RandomSeed { get; set; } = null;
+        public int PetBreed { get; set; } = 1;
+        public string PetName { get; set; } = "Apples";
+        public bool MushroomCave { get; set; } = true;
+        public bool BuyJoja { get; set; } = false;
     }
 
     public class ServerRuntimeSettings

--- a/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
@@ -32,6 +32,18 @@ namespace JunimoServer.Services.Settings
         public float ProfitMargin => _settings.Game.ProfitMargin;
         public int StartingCabins => _settings.Game.StartingCabins;
 
+        public bool RemixBundles => _settings.Game.RemixBundles;
+        public bool RemixMines => _settings.Game.RemixMines;
+        public bool CommunityCenterYear1 => _settings.Game.CommunityCenterYear1;
+        public bool CabinLayoutNearby => _settings.Game.CabinLayoutNearby;
+        public bool UseLegacyRandom => _settings.Game.UseLegacyRandom;
+        public ulong? RandomSeed => _settings.Game.RandomSeed;
+        public int PetBreed => _settings.Game.PetBreed;
+        public string PetName => _settings.Game.PetName;
+        public bool MushroomCave => _settings.Game.MushroomCave;
+        public bool BuyJoja => _settings.Game.BuyJoja;
+
+
         /// <summary>
         /// Nullable bool: null means "auto" (true only for Wilderness farm type 4).
         /// </summary>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #300 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

I have added several options to `ServerSettings` and implemented their effects in `GameCreatorService` and `AlwaysOnService`. 

A server admin is now able to configure the following settings in `server-settings.json`:
 - Remixed CC bundles
 - Remixed mines rewards
 - Guarantee CC year 1 completable
 - Cabin layout (for when `CabinStratgy` is `None`)
 - Random seed & legacy Random options
 - Pet breed & name
 - Farm cave type
 - Whether to buy Joja membership automatically

These settings have been added to the admin documentation pages.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it. 
- Read the contribution docs at https://stardew-valley-dedicated-server.github.io/server/community/contributing
- Make sure the PR title follows conventional commits (https://www.conventionalcommits.org)

Thank you for contributing!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added advanced game-creation options: bundle/mine remixes, community-center year-one toggle, cabin layout proximity, legacy/random seed options, mushroom cave toggle, Joja availability, pet breed selection and custom pet naming
  * Option to skip automatic pet creation at game start

* **Documentation**
  * Server settings docs updated to show new creation options and defaults

* **Display**
  * Settings output now lists the new creation options for easier review
<!-- end of auto-generated comment: release notes by coderabbit.ai -->