### PR TITLE
chore(deps): drop separateMultipleMajor to avoid intermediate-major PR staircase

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
     "platformAutomerge": true,
     "prHourlyLimit": 0,
     "prConcurrentLimit": 0,
-    "separateMultipleMajor": true,
     "dependencyDashboard": true,
     "lockFileMaintenance": {
         "enabled": false


### PR DESCRIPTION
## Problem

`separateMultipleMajor: true` (added in #305) opens a separate PR for **every intermediate major** between a package's current version and the latest — not just the latest. Observed in the dashboard:

```
microsoft.extensions.dependencyinjection to v6
microsoft.extensions.dependencyinjection to v7
microsoft.extensions.dependencyinjection to v8
microsoft.extensions.dependencyinjection to v9
microsoft.extensions.dependencyinjection to v10
coverlet.collector to v8 / to v10
vite to v7 / to v8
```

Each of these touches the build context (`mod/**` for DI), so each is a **full Docker build in the merge queue** — five sequential queue cycles to advance one package from v5→v10, every merge rebasing and re-running the next.

## Fix

Remove `separateMultipleMajor` (revert to the default `false`): one PR straight to the latest major per package.

## What's unchanged

The per-package major splitting from #305 stays — the `MAJOR` rule (`matchUpdateTypes: ["major"]` → `groupName: null`) still gives each package's major its own PR, separate from other packages and from minor/patch. This PR only collapses the *intermediate-version staircase* for a single package down to one latest-major PR.

`renovate-config-validator` passes.
