### PR TITLE
chore(deps): scope renovate commits per module and clean up wording

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "semanticCommits": "enabled",
     "semanticCommitType": "chore",
     "semanticCommitScope": "deps",
+    "commitMessageTopic": "{{depName}}",
     "rebaseWhen": "conflicted",
     "automerge": true,
     "automergeType": "pr",

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,22 @@
                 "mod/JunimoServer/JunimoServer.csproj",
                 "mod/JunimoServer.Shared/JunimoServer.Shared.csproj"
             ],
+            "semanticCommitScope": "deps/server",
             "groupName": "server"
+        },
+        {
+            "description": "steam-service — standalone Steam auth sidecar (NuGet).",
+            "matchManagers": ["nuget"],
+            "matchFileNames": ["tools/steam-service/SteamService.csproj"],
+            "semanticCommitScope": "deps/steam-service",
+            "groupName": "steam-service"
+        },
+        {
+            "description": "discord-bot — Discord integration bot (bun.lock).",
+            "matchManagers": ["bun"],
+            "matchFileNames": ["tools/discord-bot/package.json"],
+            "semanticCommitScope": "deps/discord-bot",
+            "groupName": "discord-bot"
         },
         {
             "description": "test-runner — E2E harness: JunimoServer.TestRunner + JunimoServer.Tests, grouped so xunit.v3 (Tests) and xunit.v3.runner.utility (TestRunner) move in lockstep (NuGet).",
@@ -41,19 +56,22 @@
                 "tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj",
                 "tests/JunimoServer.Tests/JunimoServer.Tests.csproj"
             ],
+            "semanticCommitScope": "deps/test-runner",
             "groupName": "test-runner"
         },
         {
             "description": "test-client — E2E automation mod: JunimoTestClient (NuGet).",
             "matchManagers": ["nuget"],
             "matchFileNames": ["tests/test-client/JunimoTestClient.csproj"],
+            "semanticCommitScope": "deps/test-client",
             "groupName": "test-client"
         },
         {
-            "description": "steam-service — standalone Steam auth sidecar (NuGet).",
-            "matchManagers": ["nuget"],
-            "matchFileNames": ["tools/steam-service/SteamService.csproj"],
-            "groupName": "steam-service"
+            "description": "test-ui — Vue test monitoring UI (bun.lock).",
+            "matchManagers": ["bun"],
+            "matchFileNames": ["tests/test-ui/package.json"],
+            "semanticCommitScope": "deps/test-ui",
+            "groupName": "test-ui"
         },
         {
             "description": "tools — low-traffic helpers (dll-patcher, openapi-generator, netdebug) plus solution CLI tools (.config/dotnet-tools.json: csharpier, trxtoextentreport) (NuGet).",
@@ -64,36 +82,34 @@
                 "tools/netdebug/NetDebug.csproj",
                 ".config/dotnet-tools.json"
             ],
+            "semanticCommitScope": "deps/tools",
             "groupName": "tools"
         },
         {
-            "description": "root — repo tooling: commitlint, lefthook, pako (package-lock.json).",
+            "description": "project — repo tooling: commitlint, lefthook, pako (package-lock.json).",
             "matchManagers": ["npm"],
             "matchFileNames": ["package.json"],
-            "groupName": "root"
+            "semanticCommitScope": "deps/project",
+            "groupName": "project"
         },
         {
             "description": "docs — VitePress site (bun.lock).",
             "matchManagers": ["bun"],
             "matchFileNames": ["docs/package.json"],
+            "semanticCommitScope": "deps/docs",
             "groupName": "docs"
         },
         {
-            "description": "discord-bot — Discord integration bot (bun.lock).",
-            "matchManagers": ["bun"],
-            "matchFileNames": ["tools/discord-bot/package.json"],
-            "groupName": "discord-bot"
-        },
-        {
-            "description": "test-ui — Vue test monitoring UI (bun.lock).",
-            "matchManagers": ["bun"],
-            "matchFileNames": ["tests/test-ui/package.json"],
-            "groupName": "test-ui"
-        },
-        {
-            "description": "docker — base images across all in-scope Dockerfiles.",
-            "matchManagers": ["dockerfile"],
+            "description": "docker — base images (dockerfile) plus custom Dockerfile download-URL/ARG pins, SMAPI + tmux (custom.regex).",
+            "matchManagers": ["dockerfile", "custom.regex"],
+            "semanticCommitScope": "deps/docker",
             "groupName": "docker"
+        },
+        {
+            "description": "github-actions — all workflow action bumps.",
+            "matchManagers": ["github-actions"],
+            "semanticCommitScope": "deps/github-actions",
+            "groupName": "github-actions"
         },
         {
             "description": "PIN — test-client mod-builder .NET 6 must match the game's runtime. Scoped to tag 6.0 in this file only; the 10.0 stages here and in docker/Dockerfile stay updatable.",
@@ -134,16 +150,6 @@
             ],
             "matchPackageNames": ["SixLabors.ImageSharp"],
             "allowedVersions": "<4.0.0"
-        },
-        {
-            "description": "github-actions — all workflow action bumps.",
-            "matchManagers": ["github-actions"],
-            "groupName": "github-actions"
-        },
-        {
-            "description": "dockerfile-tools — custom Dockerfile download-URL/ARG pins: SMAPI, tmux.",
-            "matchManagers": ["custom.regex"],
-            "groupName": "dockerfile-tools"
         },
         {
             "description": "MAJOR — every major update gets its own PR, no exceptions. Clears the per-module groupName for any major bump (last-match-wins), so each major lands standalone. Must stay last to override every group above.",


### PR DESCRIPTION
## What

Makes Renovate commit messages carry the **module scope** so they're groupable/scannable in git log and PR lists, plus a few related cleanups to the grouping config.

## Changes

- **Per-module commit scope** — each group rule sets `semanticCommitScope: "deps/<module>"`, so commits read `chore(deps/server): …`, `chore(deps/tools): …`, etc. **Majors inherit the module scope automatically**: the trailing `MAJOR` rule clears only `groupName`, and `semanticCommitScope` is a non-mergeable string, so a major bump keeps its module's scope while still landing as a standalone PR — e.g. `chore(deps/server): update websocket.client to v5`. The global `deps` scope remains the fallback for unmatched deps.
- **Drop "dependency" from single-update topics** — `commitMessageTopic: "{{depName}}"`, so standalone (per-package major) PRs read `update websocket.client to v5` instead of `update dependency websocket.client to v5`. Grouped PRs are unaffected (their topic comes from the group name, e.g. `update tools`).
- **Rename `root` → `project`** (group + scope `deps/project`) — fits the repo-tooling group better.
- **Merge `dockerfile-tools` into `docker`** — one rule matching `dockerfile` + `custom.regex` (base images and the SMAPI/tmux ARG pins are complementary build inputs). The regex manager *definitions* are unchanged.
- **Reorder group rules by nature/priority** (cosmetic — the rules don't overlap, so behavior is identical): shipping artifacts (server, steam-service, discord-bot) → test harness (test-runner, test-client, test-ui) → dev/build (tools, project, docs) → CI infra (docker, github-actions).

## Verification

- `renovate-config-validator` passes.
- `chore(deps/<module>)` (incl. the de-noised major shape) passes the project commitlint config — confirmed for `deps/server`, `deps/project`, `deps/docker`.
- PIN/CAP rule ordering preserved (each still sits after its module rule; the disabled .NET 6 PIN still follows the merged `docker` rule).

## Note

The "majors inherit scope" behavior relies on Renovate's last-match-wins field merge and can only be fully confirmed on a live run — after merge, glance at the Dependency Dashboard / next run that a major PR shows `chore(deps/<module>): update <name> to vX`.
