### PR TITLE
chore(deps): fix nuget version pins to actually suppress (versioning:semver)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -121,17 +121,19 @@
             "enabled": false
         },
         {
-            "description": "PIN — SteamKit2 at 2.4.1 in the SMAPI mod (net6.0); 2.5.0+ and the 3.x major are incompatible with the in-game runtime. Scoped to JunimoServer.csproj only, so tools/steam-service/SteamService.csproj (on 3.x) stays updatable.",
+            "description": "PIN — SteamKit2 at exactly 2.4.1 in the SMAPI mod (net6.0); 2.5.0+ and the 3.x major are incompatible with the in-game runtime. Scoped to JunimoServer.csproj only, so tools/steam-service/SteamService.csproj (on 3.x) stays updatable. versioning:semver is required — under the default nuget scheme allowedVersions silently no-ops for SteamKit2 because its version list interleaves prereleases (2.5.0-beta, 3.0.0-alpha); semver evaluates the constraint correctly. =2.4.1 (not bare 2.4.1, which semver reads as a >= floor).",
             "matchManagers": ["nuget"],
             "matchFileNames": ["mod/JunimoServer/JunimoServer.csproj"],
             "matchPackageNames": ["SteamKit2"],
-            "allowedVersions": "2.4.1"
+            "versioning": "semver",
+            "allowedVersions": "=2.4.1"
         },
         {
-            "description": "CAP — Microsoft.OpenApi below 2.0 in the test-client. The 2.0/3.x rewrite changes Type (string→JsonSchemaType enum), makes SerializeAsJson/Yaml async, and redesigns OpenApiReference/OperationType, so OpenApiGenerator.cs would not compile. Lift once OpenApiGenerator.cs is ported to the 2.x model.",
+            "description": "CAP — Microsoft.OpenApi below 2.0 in the test-client. The 2.0/3.x rewrite changes Type (string→JsonSchemaType enum), makes SerializeAsJson/Yaml async, and redesigns OpenApiReference/OperationType, so OpenApiGenerator.cs would not compile. Lift once OpenApiGenerator.cs is ported to the 2.x model. versioning:semver — the default nuget scheme can silently no-op allowedVersions for packages with interleaved prereleases.",
             "matchManagers": ["nuget"],
             "matchFileNames": ["tests/test-client/JunimoTestClient.csproj"],
             "matchPackageNames": ["Microsoft.OpenApi"],
+            "versioning": "semver",
             "allowedVersions": "<2.0.0"
         },
         {
@@ -141,6 +143,7 @@
                 "tests/JunimoServer.Tests/JunimoServer.Tests.csproj"
             ],
             "matchPackageNames": ["Microsoft.NET.Test.Sdk"],
+            "versioning": "semver",
             "allowedVersions": "<18.0.0"
         },
         {
@@ -150,6 +153,7 @@
                 "tests/JunimoServer.Tests/JunimoServer.Tests.csproj"
             ],
             "matchPackageNames": ["SixLabors.ImageSharp"],
+            "versioning": "semver",
             "allowedVersions": "<4.0.0"
         },
         {


### PR DESCRIPTION
The four nuget freeze/cap `packageRules` (added in #302) silently did **not** suppress their targets — the recreated #303/#304 still proposed SteamKit2 2.5.0/3.4.0, OpenApi 3.x, etc. Root-caused by running the rules through Renovate's own lookup engine (`renovate --platform=local --dry-run=lookup`).

## Root cause

`allowedVersions` was being evaluated under the **default `nuget` versioning scheme**, which silently no-ops for packages whose published version list interleaves prereleases. SteamKit2's list contains `2.5.0-beta.*` and `3.0.0-alpha.*` between the current and target versions; under `nuget` versioning the range comparison fell through (the debug log shows `Falling back to npm semver syntax for allowedVersions`), so `2.5.0` and `3.4.0` were still proposed. The same scheme worked fine for clean-versioned packages (e.g. Testcontainers), which is why it looked package-specific.

Separately, the SteamKit2 rule used a bare `"2.4.1"`, which semver reads as a `>=` floor (the opposite of a pin).

## Fix

- Add `"versioning": "semver"` to all four rules — semver evaluates the range correctly even with interleaved prereleases.
- Pin SteamKit2 with `"=2.4.1"` (exact), not bare `"2.4.1"`.

## Verified via local lookup against this `renovate.json`

- **SteamKit2** `=2.4.1` → 0 updates (2.5.0 and 3.4.0 suppressed)
- **Microsoft.OpenApi** `<2.0.0` → keeps 1.6.29 minor, blocks 3.x
- **Microsoft.NET.Test.Sdk** `<18.0.0` → keeps 17.14.1 patch, blocks 18.x
- **SixLabors.ImageSharp** `<4.0.0` → 4.0 suppressed
- `tools/steam-service` SteamKit2 (on 3.x) stays updatable
- Full-log leak sweep: no forbidden target version survives

After merge, recreate (close + delete branch) the open dotnet PRs so Renovate re-renders them with the working pins.

## Note for future nuget pins

Always set `"versioning": "semver"` alongside `allowedVersions` for nuget rules, and verify with `renovate --platform=local --dry-run=lookup` — the default `nuget` scheme can silently no-op the constraint.