### PR TITLE
ci: exempt GitHub suggestion-batch commits from commitlint

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,10 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  // GitHub's "Apply suggestions from code review" button generates a fixed,
+  // non-conventional subject that the UI does not let you customize. Exempt it
+  // so batch-applying review suggestions doesn't fail the commit lint. The
+  // repo squash-merges into master, so these subjects never reach the changelog.
+  ignores: [(message) => message.startsWith('Apply suggestions from code review')],
   rules: {
     // Match the types defined in release-please-config.json
     'type-enum': [


### PR DESCRIPTION
## Problem

GitHub's **"Apply suggestions from code review"** button creates a commit with a fixed, non-conventional subject (`Apply suggestions from code review`) that the GitHub UI does not let you customize. The per-commit commitlint check in `validate-pr.yml` (`npx commitlint --from base --to head`) rejects it with `type-empty` / `subject-empty`, failing CI through no fault of the contributor. This recurs every time anyone uses the button (e.g. PR #301).

## Fix

- Add a commitlint `ignores` predicate exempting the `Apply suggestions from code review` subject.
- All other commits remain strictly linted (verified: a non-conventional message still fails).
- Per-commit linting is kept (rather than switching to PR-title-only), preserving the release-please changelog guarantee.

## Verification

- `Apply suggestions from code review` message → passes (0 problems).
- `broken no type` message → still fails (`type-empty`, `subject-empty`).

## Follow-up

Once merged, re-trigger PR #301's checks (push an update or close/reopen); `validate-pr.yml` checks out the base-repo config, so #301 will pass without a history rewrite.