### PR TITLE
build: make .gitattributes authoritative (LF everywhere)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 root = true
 
 [*]
+end_of_line = lf
 indent_size = 4
 indent_style = space
 charset = utf-8
@@ -9,9 +10,6 @@ insert_final_newline = true
 
 [{*.yml, *.yaml}]
 indent_size = 2
-
-[docker/rootfs/*]
-end_of_line = lf
 
 [Makefile]
 indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,11 +1,12 @@
-*                   text=auto
+# Authoritative line-ending policy.
+# LF in the index AND the working tree on every OS, regardless of a
+# contributor's core.autocrlf setting. An explicit eol in .gitattributes
+# always wins over core.autocrlf, so contributors do NOT need to change
+# their git config.
+* text=auto eol=lf
 
-# Ensure all scripts have EOL=LF
-*.sh                text eol=lf
-docker/rootfs/**    text eol=lf
-
-# Images/binaries should not change EOL
-*.jpg               -text
-*.png               -text
-*.gif               -text
-*.webp              -text
+# Binary assets: never normalize line endings or diff as text.
+*.png    binary
+*.webp   binary
+*.woff2  binary
+*.svg    binary

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -86,6 +86,29 @@ jobs:
       - name: Validate commit messages
         run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
 
+  validate-line-endings:
+    name: Validate Line Endings
+    # Checks out fork head — `needs: authorize` keeps it behind the fork-pr approval gate.
+    needs: authorize
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      # The index is OS-agnostic, so this catches CRLF regardless of the contributor's
+      # core.autocrlf. .gitattributes (* text=auto eol=lf) makes LF the committed normal form;
+      # a CRLF here means a file was force-added with literal CR bytes, bypassing normalization.
+      - name: Check for CRLF in index
+        run: |
+          if git ls-files --eol | grep -E 'i/crlf'; then
+            echo "::error::CRLF line endings found in the index. The repo enforces LF via .gitattributes — re-normalize with: git add --renormalize . && git commit"
+            exit 1
+          fi
+          echo "No CRLF line endings in the index."
+
   validate-build:
     name: Validate Build
     # Always runs so the required check always reports — but the actual Docker build only runs when

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -28,6 +28,20 @@ This installs:
 - **commitlint** - Validates commit message format
 - **git hooks** - Automatically validates commits before push
 
+#### Line Endings
+
+The repository enforces **LF line endings** for all text files via `.gitattributes` (`* text=auto eol=lf`). This keeps files identical on Windows and inside the Linux containers, and is required for shell scripts and Dockerfiles to run.
+
+You do **not** need to change your git config — an explicit `eol` in `.gitattributes` overrides `core.autocrlf`, so the result is the same whether yours is `true`, `false`, or `input`. A PR check (`Validate Line Endings`) fails if CRLF reaches the index.
+
+If you cloned before this policy existed and see `CRLF will be replaced by LF` warnings, refresh your working tree once. Commit or stash any work first — `reset --hard` discards uncommitted changes to tracked files (untracked files are left alone):
+
+```bash
+git rm --cached -r -q .                # clear index entries (does NOT delete files)
+git reset --hard                       # re-checkout every tracked file as LF on disk
+git ls-files --eol | grep 'w/crlf'     # expect no output
+```
+
 
 #### Development Workflow
 
@@ -130,7 +144,7 @@ Go to **Settings → Secrets → Actions** and add:
 - Pattern: `master`
 - Enable:
   - ✅ Require pull request before merging
-  - ✅ Require status checks: `Validate Build`
+  - ✅ Require status checks: `Validate Build`, `Validate Line Endings`
   - ✅ Require approvals: 1
 
 #### 3. Configure Fork PR Protection


### PR DESCRIPTION
## Problem

Contributors on Windows saw constant `warning: in the working copy of X, CRLF will be replaced by LF` on nearly every git operation. The cause was a config mismatch, not corruption: the git index was already 100% LF, but `* text=auto` (no `eol`) in `.gitattributes` let each machine's `core.autocrlf=true` check CRLF into the working tree — so git warned forever.

## Changes

- **`.gitattributes`**: pin `* text=auto eol=lf` so line endings are LF in both index and working tree on every OS, regardless of each contributor's `core.autocrlf` (an explicit `eol` overrides `autocrlf`, so no one needs to reconfigure git).
- Mark `.png` / `.webp` / `.woff2` / `.svg` as `binary` — fixes a latent `text=auto` corruption risk on the `.woff2` fonts (git was guessing they were text).
- The new catch-all also covers `docker/modern/rootfs/` for the first time (the old `docker/rootfs/**` rule never reached it).
- **`.editorconfig`**: add global `end_of_line = lf` so editors agree with `.gitattributes`; remove the now-redundant, non-recursive `[docker/rootfs/*]` block.
- **`.github/workflows/validate-pr.yml`**: add a `Validate Line Endings` check that fails if CRLF reaches the index (gated behind the existing fork-PR `authorize` job).
- **`docs/developers/contributing/index.md`**: document the policy and the one-time working-tree refresh; add `Validate Line Endings` to the required-status-checks list.

## Notes

- No history rewrite: the index was already LF, so this introduces no normalization churn — `git blame` / `log` are untouched.
- **Maintainer action**: for the new check to *block* merges, add `Validate Line Endings` to the branch-protection required checks (Settings → Branches → `master`).
- After merging, existing local clones can clear stale CRLF warnings with the one-time refresh documented in the contributing guide.
