### PR TITLE
docs(contributing): stage by path, not `git add .`

### DIFF
--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -62,8 +62,8 @@ We use **GitHub Flow** with automated CI/CD:
 
 3. **Make changes and commit**
    ```bash
-   # Make your changes
-   git add .
+   # Make your changes, then stage them explicitly by path
+   git add path/to/changed-file
    git commit -m "feat: add cabin management system"
    ```
 


### PR DESCRIPTION
Small doc fix: the quick-workflow example used `git add .`, which contradicts the project's git-workflow rule (stage explicitly by path). This aligns the contributing guide with the enforced policy.

It also serves to trigger the `Validate Line Endings` check introduced in #329 for the first time, so it reports a status and becomes selectable in branch-protection required checks.
