### PR TITLE
ci: add CodeQL advanced setup with per-language path scoping

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,107 @@
+# CodeQL advanced setup. Committing this workflow disables the repo's default setup automatically.
+# Two load-bearing trigger choices the reader can't infer from the YAML: it stays ADVISORY (a
+# required check that the per-language matrix skipped would leave PRs stuck "Waiting for status"),
+# and it uses `pull_request`, NOT pull_request_target (it reads fork HEAD read-only, needs no secrets).
+# See docs/developers/contributing/ci-cd.md#codeql-pipeline.
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly full scan (safety net for changes the PR matrix skipped).
+    # Offset from Cleanup Caches (Sun 06:00) and Cleanup Preview Tags (Mon 06:00).
+    - cron: "17 7 * * 3" # Wednesday 07:17 UTC
+
+# Cancel superseded PR runs only. A push/schedule scan on master must never be cancelled
+# mid-upload — doing so would leave a gap in code-scanning history for that commit — so
+# cancel-in-progress is gated to pull_request (where github.ref is the per-PR merge ref).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Detect changed languages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      # JSON array, e.g. ["csharp"] or [] when no analyzable file changed.
+      languages: ${{ steps.select.outputs.languages }}
+    steps:
+      # paths-filter reads the changed-file list via the GitHub API — no checkout needed
+      # (mirrors validate-pr.yml). Skipped off-PR, where Select languages does a full scan.
+      - name: Path filter
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            csharp:
+              - '**/*.cs'
+              - '**/*.csproj'
+              - 'Directory.Build.props'
+            js-ts:
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.js'
+              - '**/*.jsx'
+              - '**/*.vue'
+              - '**/package.json'
+              - '**/tsconfig*.json'
+            actions:
+              - '.github/workflows/**'
+              - '.github/actions/**'
+
+      - name: Select languages
+        id: select
+        env:
+          FULL_SCAN: ${{ github.event_name != 'pull_request' }}
+          CSHARP: ${{ steps.filter.outputs.csharp }}
+          JS_TS: ${{ steps.filter.outputs.js-ts }}
+          ACTIONS: ${{ steps.filter.outputs.actions }}
+        run: |
+          langs=()
+          if [ "$FULL_SCAN" = "true" ] || [ "$CSHARP"  = "true" ]; then langs+=("csharp"); fi
+          if [ "$FULL_SCAN" = "true" ] || [ "$JS_TS"   = "true" ]; then langs+=("javascript-typescript"); fi
+          if [ "$FULL_SCAN" = "true" ] || [ "$ACTIONS" = "true" ]; then langs+=("actions"); fi
+          # jq -cn with --args builds the JSON array directly — correct for 0..n elements
+          # (empty → [], one → ["csharp"]). No temp file, no [""] footgun.
+          languages=$(jq -cn '$ARGS.positional' --args "${langs[@]}")
+          echo "languages=$languages" >> "$GITHUB_OUTPUT"
+
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    needs: changes
+    if: needs.changes.outputs.languages != '[]'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF results to code scanning
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(needs.changes.outputs.languages) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1
+        with:
+          languages: ${{ matrix.language }}
+          # build-mode is only meaningful for csharp (buildless DB, no Docker/dotnet). For the others
+          # the empty string is read as unset by codeql-action, matching GitHub's template.
+          build-mode: ${{ matrix.language == 'csharp' && 'none' || '' }}
+          # query-suite: default (matches today). Consider security-extended later.
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@21eb7f7842f33eafc83782b56fff2a2c43e9696f # v4.36.1

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -10,6 +10,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 | [Build Preview](#build-preview-pipeline) | Push to `master` | Builds and publishes preview Docker images |
 | [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits and builds |
 | [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
+| [CodeQL](#codeql-pipeline) | Pull requests / push to `master` / weekly | Static security analysis (advisory) |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
 | [Deploy Docs](#deploy-docs-pipeline) | After build / manual | Deploys documentation to GitHub Pages |
 | [Cleanup Preview Tags](#cleanup-preview-tags) | Weekly schedule / manual | Deletes old preview tags from DockerHub |
@@ -176,6 +177,49 @@ The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-
 ::: warning
 Both required checks (`Validate Build`, `Validate Commits`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too.
 :::
+
+## CodeQL Pipeline
+
+[Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/codeql.yml)
+
+[CodeQL](https://codeql.github.com/) runs GitHub's static security analysis over the codebase. It is configured as **advanced setup** — a committed workflow that gives full control over languages, triggers, and path filters. The workflow runs on pull requests, on push to `master`, and on a weekly schedule (Wednesday 07:17 UTC).
+
+### Advisory, Not Required
+
+CodeQL is **not** a required status check — a PR merges on `Validate Build` + `Validate Commits` alone, and CodeQL findings surface under **Security → Code scanning** without blocking the merge.
+
+This is deliberate. The pipeline uses per-language path scoping (below), so a PR that touches no analyzable source runs **zero** analyze jobs. A *required* check that never reports leaves a PR stuck on "Expected — Waiting for status", so the path-scoping optimization is only safe while CodeQL stays advisory.
+
+::: warning
+If CodeQL is ever promoted to a required check, this pipeline must be revisited: a required check needs a `merge_group` producer (like `validate-merge-group.yml`) and a way to report even when path-scoped out. The current advisory design has neither, on purpose.
+:::
+
+### Languages Analyzed
+
+Three languages are analyzed. C# uses `build-mode: none`, so CodeQL builds its database from source directly with no Docker or `dotnet build`; the other two need no build step at all:
+
+| Language | Covers |
+|----------|--------|
+| `csharp` | The SMAPI mod, shared library, E2E tests, runner, and tools |
+| `javascript-typescript` | The Vue/TypeScript test UI and docs site (JS, TS, and Vue in one unified language) |
+| `actions` | The GitHub Actions workflows themselves |
+
+C/C++ is intentionally excluded: the only `.c`/`.h` files in the repo are deployment shims under `docker/modern/` (`pthread_shim.c`, `steamclient_stub.c`), not application source worth scanning.
+
+### Per-Language Path Scoping
+
+A fast `changes` job runs first and emits a JSON array of just the languages whose files changed in the PR. The `analyze` job consumes that array as its build matrix, so **only the relevant analyze jobs are ever created** — there are no skipped-job rows to read past.
+
+- A PR that touches only a Dockerfile (e.g. a base-image bump) creates **zero** analyze jobs.
+- A `.cs` or `.csproj` change creates only `Analyze (csharp)`.
+- A `package.json`, `.ts`, or `.vue` change creates only `Analyze (javascript-typescript)`.
+- A `.github/workflows/**` change creates only `Analyze (actions)`.
+
+On push to `master` and on the weekly schedule there is no PR diff base, so the `changes` job emits all three languages and the full scan runs — the safety net for anything the per-PR scoping skipped.
+
+### Trigger & Fork Safety
+
+CodeQL triggers on `pull_request`, **not** `pull_request_target` (the opposite choice from [Validate PR](#validate-pr-pipeline)). It analyzes the PR head read-only with the default `GITHUB_TOKEN` and needs no secrets, so it is safe to run on fork PRs — fork code must be read to be scanned, but no secret is ever exposed to it. It is not run on `merge_group`: that event is only for required checks, and running an advisory scan there would be pure waste.
 
 ## Deploy Docs Pipeline
 


### PR DESCRIPTION
Migrates CodeQL from GitHub **Default Setup** to a committed **Advanced Setup** workflow. Committing `codeql.yml` to `master` auto-disables default setup (one cutover, no double-runs).

## Changes

- Add `.github/workflows/codeql.yml` (advanced setup).
- Analyze **csharp**, **javascript-typescript**, and **actions** only — drops `c-cpp` (the only C/C++ files are `docker/modern/` deployment shims, not real source) and the redundant `javascript`/`typescript` duplicates that default setup auto-detected.
- **Per-language path scoping** via a dynamic matrix: a `changes` job emits a JSON array of just the languages whose files changed, and the `analyze` matrix consumes it — so a PR runs only the relevant analyze job(s), and a dep-bump PR touching no analyzable source runs **zero**.
- Keep **push-to-master + weekly scheduled** (Wed 07:17 UTC) full scans as the coverage safety net.
- Keep CodeQL **advisory** (non-required) — a required check skipped by the matrix would leave PRs stuck on "Waiting for status".
- Use `pull_request` (not `pull_request_target`): reads fork HEAD read-only, needs no secrets, fork-safe. Not run on `merge_group` (it isn't required).
- `cancel-in-progress` gated to `pull_request` so a push/schedule scan on `master` is never cancelled mid-upload.
- `build-mode: none` only for csharp (buildless DB, no Docker/dotnet); unset for the others, matching GitHub's template.
- Pin `github/codeql-action@v4.36.1` (node24, consistent with the repo's existing node24 actions) and `dorny/paths-filter@v4.0.1` (mirrors the existing pin). Renovate's `github-actions` group keeps both updated.
- Document the pipeline in `docs/developers/contributing/ci-cd.md` (Overview row + `## CodeQL Pipeline` section).

## Post-merge verification

- `gh api .../code-scanning/default-setup` should report default setup is no longer `configured` (auto-disabled on merge; if not, disable once in Settings).
- A Renovate Dockerfile-bump PR creates zero `Analyze (...)` jobs; a `.csproj` PR creates only `Analyze (csharp)`; etc.
- The push-to-master run analyzes all three languages.
- Branch protection unchanged — `Validate Commits` + `Validate Build` remain the only required checks.