### PR TITLE
fix(mod): dismiss SpaceCore level-up menu to prevent server freeze

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -40,6 +40,8 @@ namespace JunimoServer.Services.AlwaysOn
 
         private AlwaysOnServerFestivals alwaysOnServerFestivals;
 
+        private readonly AlwaysOnModCompat modCompat;
+
         private readonly AlwaysOnConfig Config;
 
         public AlwaysOnServer(ChatCommandsService chatCommandService, AlwaysOnConfig config, IModHelper helper, IMonitor monitor, Harmony harmony) : base(helper, monitor)
@@ -52,6 +54,9 @@ namespace JunimoServer.Services.AlwaysOn
 
             // Extracted festival logic
             alwaysOnServerFestivals = new AlwaysOnServerFestivals(helper, monitor, chatCommandService, config);
+
+            // Third-party mod compatibility workarounds (kept separate from base-game automation)
+            modCompat = new AlwaysOnModCompat(helper, monitor);
 
             // Re-claim Cabin.inventoryMutex inside vanilla's update method so it can
             // never be observed unlocked by peers — replaces the 60Hz polling that
@@ -200,6 +205,8 @@ namespace JunimoServer.Services.AlwaysOn
             HandleMinigame();
             alwaysOnServerFestivals.HandleFestivalEvents();
             HandleLevelUpMenu();
+            // Third-party mod compatibility (see AlwaysOnModCompat)
+            modCompat.HandleSpaceCoreLevelUpMenu();
             HandleShippingMenu();
             HandlePetChoice();
             HandleCaveChoice();

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnModCompat.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnModCompat.cs
@@ -1,0 +1,78 @@
+using StardewModdingAPI;
+using StardewValley;
+using System;
+
+namespace JunimoServer.Services.AlwaysOn
+{
+    /// <summary>
+    /// Compatibility workarounds for THIRD-PARTY MODS (not base game). Base-game automation lives in
+    /// <see cref="AlwaysOnServer"/>; this class is the bounded home for behavior the server needs only
+    /// because a specific external mod is installed. None of these mods are compile-time dependencies,
+    /// so detection is by runtime type name and interaction is via reflection — both quarantined here so
+    /// they don't bleed into the clean base-game paths. Each member names the specific mod it targets.
+    /// </summary>
+    public class AlwaysOnModCompat
+    {
+        // --- SpaceCore (Luck Skill and other custom-skill mods) ---
+
+        /// <summary>
+        /// SpaceCore's custom level-up menu (<c>SpaceCore.Interface.SkillLevelUpMenu</c>). A separate
+        /// IClickableMenu subclass that does NOT derive from vanilla LevelUpMenu — so the base-game
+        /// <c>HandleLevelUpMenu</c> never matches it. Type name + fields verified stable across SpaceCore
+        /// releases 1.5.7→develop (2021→2025).
+        /// </summary>
+        private const string SpaceCoreLevelUpMenuTypeName = "SpaceCore.Interface.SkillLevelUpMenu";
+
+        private readonly IModHelper _helper;
+        private readonly IMonitor _monitor;
+
+        public AlwaysOnModCompat(IModHelper helper, IMonitor monitor)
+        {
+            _helper = helper;
+            _monitor = monitor;
+        }
+
+        /// <summary>
+        /// Dismiss SpaceCore's custom level-up menu so the headless server isn't frozen by it.
+        ///
+        /// On a dedicated server no one can click OK. The menu sits on <c>Game1.activeClickableMenu</c>,
+        /// and the new-day sequence (<c>Game1._newDayAfterFade</c> / the end-of-night block in
+        /// <c>Game1._update</c>) only pops the next end-of-night menu while <c>activeClickableMenu == null</c>
+        /// — so an undismissed menu stalls the new day permanently (the reported freeze).
+        ///
+        /// Setting <c>isActive = false</c> makes the menu self-close on its next <c>update()</c> (its
+        /// update begins with <c>if (!isActive) { exitThisMenu(); return; }</c>, identical to vanilla),
+        /// which nulls <c>activeClickableMenu</c> and lets the sequence proceed. The farmer keeps the skill
+        /// level (it is derived from persisted XP); only the optional, usually-empty <c>DoLevelPerk</c>
+        /// hook is skipped — the same trade-off the base-game handler makes for professions.
+        ///
+        /// No-op (and zero reflection) when SpaceCore is absent: the type-name check simply never matches.
+        /// Call on the 1 Hz cadence alongside the base-game menu handlers.
+        /// </summary>
+        public void HandleSpaceCoreLevelUpMenu()
+        {
+            var menu = Game1.activeClickableMenu;
+            if (menu == null || menu.GetType().FullName != SpaceCoreLevelUpMenuTypeName)
+            {
+                return;
+            }
+
+            try
+            {
+                _helper.Reflection.GetField<bool>(menu, "isActive").SetValue(false);
+                _helper.Reflection.GetField<bool>(menu, "informationUp").SetValue(false);
+                _monitor.Log("[Automation] Skipping SpaceCore level up menu", LogLevel.Info);
+            }
+            catch (Exception ex)
+            {
+                // Field/type could change in a future SpaceCore version (names verified stable across
+                // every released git source 2021→2025, so unlikely). Recoverable: the menu stays up one
+                // more second and this retries next tick. Log the actual type so a maintainer can re-sync
+                // fast. Never log at Error (poisons E2E error detection — see .claude/rules/debugging.md).
+                _monitor.Log(
+                    $"[Automation] Failed to dismiss SpaceCore level up menu ({menu.GetType().FullName}): {ex.Message}",
+                    LogLevel.Warn);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #258.

## Problem

When a SpaceCore-based skill mod (e.g. [Luck Skill](https://www.nexusmods.com/stardewvalley/mods/28103)) is installed, the server freezes when the host gains a custom-skill level at the start of a new day. The only workaround was to connect via VNC and click OK by hand.

**Root cause:** SpaceCore shows its own `SpaceCore.Interface.SkillLevelUpMenu` — a separate `IClickableMenu` subclass that does **not** derive from vanilla `LevelUpMenu`. The existing `HandleLevelUpMenu` only matches `Game1.activeClickableMenu is LevelUpMenu`, so it never touched the SpaceCore menu. On a headless server nobody can click OK, so the menu stayed on `activeClickableMenu`. The new-day sequence only pops the next end-of-night menu while `activeClickableMenu == null` (`Game1._update`), so an undismissed menu stalls the new day permanently.

## Changes

- Add `AlwaysOnModCompat`, a dedicated sibling class that is the bounded home for third-party-mod compatibility workarounds — keeping them architecturally separated from base-game automation. Mirrors the existing `AlwaysOnFestivals` extraction convention.
- Detect the SpaceCore menu by runtime type name (SpaceCore is not a compile-time dependency) and dismiss it by setting `isActive = false` via reflection. The menu then self-closes on its next `update()` (its update begins with `if (!isActive) { exitThisMenu(); return; }`, identical to vanilla), which nulls `activeClickableMenu` and lets the new day proceed.
- No-op with zero reflection when SpaceCore is absent — the type-name check simply never matches.
- Reflection failure logs at `Warn` (never `Error`, which would poison E2E error detection) and retries on the next tick.
- The farmer keeps the skill level (it is derived from persisted XP); only the optional, usually-empty `DoLevelPerk` hook is skipped — the same trade-off the base-game handler already makes for professions.

## Verification

- `dotnet build mod/JunimoServer/JunimoServer.csproj` — builds clean (0 warnings, 0 errors).
- SpaceCore-side facts (type name `SpaceCore.Interface.SkillLevelUpMenu`, public `isActive`/`informationUp` fields, `update()` opening) verified stable across SpaceCore git tags 1.5.7 → 1.8.1 → develop (2021→2025), no drift.
- Manual repro (dev machine): install SpaceCore + Luck Skill, level the skill during a day, then sleep — the new day starts with no freeze and `[Automation] Skipping SpaceCore level up menu` is logged.

## Out of scope

Auto-granting the SpaceCore skill perk and automating its profession chooser. The base-game handler also skips its equivalent; if wanted later, it should be designed for both paths together rather than bundled into this freeze fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modular compatibility support to better handle third‑party mods during AlwaysOn operation.

* **Bug Fixes**
  * Improved handling to automatically dismiss SpaceCore’s custom level‑up UI so headless server sessions continue without interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->