### PR TITLE
fix(host): complete overnight FarmEvents that hang the headless host (#242)

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -66,6 +66,15 @@ namespace JunimoServer.Services.AlwaysOn
                 original: AccessTools.Method(typeof(Cabin), nameof(Cabin.updateEvenIfFarmerIsntHere)),
                 postfix: new HarmonyMethod(typeof(CabinOverrides), nameof(CabinOverrides.UpdateEvenIfFarmerIsntHere_Postfix))
             );
+
+            // Force-complete the Mr. Qi mystery-box overnight cutscene on the host. Its completion gate
+            // lives in draw() rather than tickUpdate(), so on a headless host (draws gated/desynced) it
+            // never converges and the new day never starts. See QiPlaneEventOverrides.
+            QiPlaneEventOverrides.Initialize(monitor);
+            harmony.Patch(
+                original: AccessTools.Method(typeof(StardewValley.Events.QiPlaneEvent), nameof(StardewValley.Events.QiPlaneEvent.tickUpdate)),
+                postfix: new HarmonyMethod(typeof(QiPlaneEventOverrides), nameof(QiPlaneEventOverrides.TickUpdate_Postfix))
+            );
         }
 
         // TODO: Rename to OnStart, OnLoad or whatever fits best.. need to double-check
@@ -201,6 +210,7 @@ namespace JunimoServer.Services.AlwaysOn
             }
 
             HandleDialogueBox();
+            HandleOvernightNamingMenu();
             HandleSkippableEvent();
             HandleMinigame();
             alwaysOnServerFestivals.HandleFestivalEvents();
@@ -224,6 +234,7 @@ namespace JunimoServer.Services.AlwaysOn
 
             HandleAutoPause();
             HandleAutoSleep();
+            HandleStuckFarmEvent();
 
             alwaysOnServerFestivals.HandleFestivalStart();
             alwaysOnServerFestivals.HandleFestivalLeave();
@@ -533,6 +544,80 @@ namespace JunimoServer.Services.AlwaysOn
                 Game1.CurrentEvent.skipEvent();
                 Game1.CurrentEvent.receiveMouseClick(1, 2);
             }
+        }
+
+        /// <summary>
+        /// Auto-name the baby during the overnight BirthingEvent / PlayerCoupleBirthingEvent. Those
+        /// events open a <see cref="NamingMenu"/> and only complete once a name is submitted; the menu
+        /// is not a DialogueBox, so <see cref="HandleDialogueBox"/> can't dismiss it, and a headless
+        /// host has no one to type a name — the overnight transition hangs forever. We supply a vanilla
+        /// random name (the same source the menu pre-fills), which runs the event's real side effects
+        /// (creates the Child NPC) and lets the new day proceed. Scoped to an active overnight farm
+        /// event so no other NamingMenu use is touched.
+        /// </summary>
+        private void HandleOvernightNamingMenu()
+        {
+            if (!IsAutomating || Game1.farmEvent == null)
+            {
+                return;
+            }
+
+            if (Game1.activeClickableMenu is not NamingMenu naming)
+            {
+                return;
+            }
+
+            var name = Dialogue.randomName();
+            naming.textBox.Text = name;
+            naming.textBoxEnter(naming.textBox);
+            Monitor.Log($"Auto-named overnight baby '{name}' to unblock the host.", LogLevel.Info);
+        }
+
+        // Tracks how long the current Game1.farmEvent has been active (game-time, framerate-independent).
+        // Reset when farmEvent clears. Used by HandleStuckFarmEvent to surface modded/unknown overnight
+        // events that never complete on a headless host.
+        private double _farmEventActiveMs;
+        private bool _stuckFarmEventLogged;
+
+        /// <summary>
+        /// Watchdog for overnight farm events that never complete on a headless host. The known
+        /// headless-hangers are handled directly — <see cref="QiPlaneEventOverrides"/> force-completes
+        /// the Mr. Qi mystery box, and <see cref="HandleOvernightNamingMenu"/> auto-names births — so
+        /// those resolve before this fires. For an unknown/modded <c>FarmEvent</c> still stuck well past
+        /// any vanilla event's natural duration, log once at Warn with its type so we can see what's
+        /// hanging. We deliberately do NOT force-complete unknown types: skipping their tickUpdate would
+        /// bypass their makeChangesToLocation side effects and could corrupt the save.
+        /// </summary>
+        private void HandleStuckFarmEvent()
+        {
+            if (Game1.farmEvent == null)
+            {
+                _farmEventActiveMs = 0.0;
+                _stuckFarmEventLogged = false;
+                return;
+            }
+
+            if (!Game1.IsMasterGame)
+            {
+                return;
+            }
+
+            _farmEventActiveMs += Game1.currentGameTime?.ElapsedGameTime.TotalMilliseconds ?? 0.0;
+
+            // Fire only well after the QiPlane fallback so a healthy or already-handled event never
+            // trips this — anything still stuck past here is an event we don't auto-complete.
+            const double StuckThresholdMs = QiPlaneEventOverrides.FallbackThresholdMs + 15000.0;
+            if (_stuckFarmEventLogged || _farmEventActiveMs < StuckThresholdMs)
+            {
+                return;
+            }
+
+            _stuckFarmEventLogged = true;
+            var type = Game1.farmEvent.GetType().Name;
+            Monitor.Log(
+                $"Overnight farm event '{type}' has not completed after {_farmEventActiveMs / 1000.0:0}s " +
+                "of game-time — the host may be stuck. Not force-completing it, since skipping its " +
+                "tickUpdate would bypass any makeChangesToLocation side effects.", LogLevel.Warn);
         }
 
         /// <summary>

--- a/mod/JunimoServer/Services/AlwaysOnServer/QiPlaneEventOverrides.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/QiPlaneEventOverrides.cs
@@ -1,0 +1,72 @@
+using Microsoft.Xna.Framework;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Events;
+
+namespace JunimoServer.Services.AlwaysOn
+{
+    /// <summary>
+    /// Force-completes the Mr. Qi mystery-box overnight cutscene (<see cref="QiPlaneEvent"/>) on the
+    /// host. Unlike every other overnight <c>FarmEvent</c>, QiPlaneEvent's completion gate
+    /// (<c>finalFadeTimer &gt; 4000</c>) is advanced inside its <c>draw()</c>, not its
+    /// <c>tickUpdate()</c> — so when the headless host's draw cadence is gated/throttled/desynced from
+    /// the per-tick update pump, the gate never converges and <c>tickUpdate</c> returns false forever.
+    /// The new day never starts and clients hang on "Waiting for the host's event to finish."
+    ///
+    /// The postfix accumulates <see cref="GameTime.ElapsedGameTime"/> (game-time, not wall-clock and not
+    /// draw-coupled) per event instance and forces <c>tickUpdate</c> to return true once the event has
+    /// run longer than it ever would with healthy draws. This is framerate-independent: with draws
+    /// running normally the event self-completes first and the postfix is a no-op; otherwise the
+    /// fallback fires and the vanilla completion block (warp-to-bed + save) runs unchanged.
+    /// </summary>
+    public static class QiPlaneEventOverrides
+    {
+        private static IMonitor _monitor;
+
+        private static QiPlaneEvent _trackedInstance;
+        private static double _accumulatedMs;
+        private static bool _forcedThisInstance;
+
+        /// <summary>
+        /// Game-time the event may run before we force completion. Natural draw-driven completion is
+        /// ~15-25s of game-time; 30s sits above that so a host with a healthy draw cadence always
+        /// self-completes first (postfix no-op), while a host where draws never advance the gate still
+        /// escapes after 30s of accumulated game-time. tickUpdate runs every update tick regardless of
+        /// draws, so this elapses quickly in wall-clock on a stuck host. The stuck-farm-event watchdog
+        /// (<c>AlwaysOnServer.HandleStuckFarmEvent</c>) keys its own threshold off this so the two stay
+        /// ordered (watchdog fires only well after this).
+        /// </summary>
+        public const double FallbackThresholdMs = 30000.0;
+
+        public static void Initialize(IMonitor monitor) => _monitor = monitor;
+
+        /// <summary>
+        /// Harmony postfix for <see cref="QiPlaneEvent.tickUpdate"/>. Forces the event to complete on
+        /// the host after the game-time fallback threshold if its draw-driven gate never converged.
+        /// </summary>
+        // ReSharper disable once InconsistentNaming
+        public static void TickUpdate_Postfix(QiPlaneEvent __instance, GameTime time, ref bool __result)
+        {
+            if (!Game1.IsMasterGame) return;   // only the host runs the completion block + newDaySync
+            if (__result) return;              // event self-completed (draws were healthy) — nothing to do
+
+            // Reset the accumulator when a new event instance starts ticking.
+            if (!ReferenceEquals(__instance, _trackedInstance))
+            {
+                _trackedInstance = __instance;
+                _accumulatedMs = 0.0;
+                _forcedThisInstance = false;
+            }
+            if (_forcedThisInstance) return;
+
+            _accumulatedMs += time.ElapsedGameTime.TotalMilliseconds;
+            if (_accumulatedMs < FallbackThresholdMs) return;
+
+            _forcedThisInstance = true;
+            __result = true;
+            _monitor?.Log(
+                "QiPlaneEvent (Mr. Qi mystery box) did not self-complete — forcing overnight completion " +
+                "so the new day can start.", LogLevel.Info);
+        }
+    }
+}

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -447,6 +447,16 @@ namespace JunimoServer.Services.Api
     }
 
     /// <summary>
+    /// Response from /test/farmevent (test-only: queue an overnight FarmEvent for the next night).
+    /// </summary>
+    public class TestFarmEventResponse
+    {
+        public bool Success { get; set; }
+        public string? Error { get; set; }
+        public string? Type { get; set; }
+    }
+
+    /// <summary>
     /// Body for POST /test/saver_crop. Mutates an existing CropSaver entry in
     /// place. Optional fields are skipped when null. Used by E2E tests to
     /// pre-arm extraDays past CropSaver.OnDayEnd's branch-1 floor without
@@ -1873,6 +1883,9 @@ namespace JunimoServer.Services.Api
                             break;
                         case "/test/set_date":
                             await WriteJsonAsync(response, await HandlePostTestSetDateAsync(request));
+                            break;
+                        case "/test/farmevent":
+                            await WriteJsonAsync(response, await HandlePostTestFarmEventAsync(request));
                             break;
                         case "/test/saver_crop":
                             await WriteJsonAsync(response, await HandlePostTestSaverCropAsync(request));
@@ -3502,6 +3515,33 @@ namespace JunimoServer.Services.Api
                 Day = body.Day,
                 Year = body.Year
             };
+        }
+
+        [ApiEndpoint("POST", "/test/farmevent", Summary = "Queue an overnight FarmEvent for the next night (test-only)", Tag = "Test")]
+        [ApiResponse(typeof(TestFarmEventResponse), 200)]
+        private async Task<TestFarmEventResponse> HandlePostTestFarmEventAsync(HttpListenerRequest request)
+        {
+            // Game1.farmEventOverride is consumed by _newDayAfterFade as the fallback when no random
+            // farm event is picked (decompiled Game1.cs:8588), so this deterministically queues the
+            // event for the next overnight transition without seeding mail or stats.
+            var type = request.QueryString["type"]?.ToLowerInvariant() ?? "qiplane";
+
+            StardewValley.Events.FarmEvent? farmEvent = type switch
+            {
+                "qiplane" => new StardewValley.Events.QiPlaneEvent(),
+                _ => null
+            };
+
+            if (farmEvent == null)
+            {
+                return new TestFarmEventResponse { Success = false, Error = $"Unknown farm event type '{type}' (supported: qiplane)" };
+            }
+
+            await RunOnGameThreadAsync(() => Game1.farmEventOverride = farmEvent);
+
+            Monitor.Log($"Queued overnight farm event '{type}' for the next night via test API", LogLevel.Info);
+
+            return new TestFarmEventResponse { Success = true, Type = type };
         }
 
         [ApiEndpoint("POST", "/test/saver_crop", Summary = "Mutate a CropSaver entry (test-only)", Tag = "Test")]

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -457,6 +457,21 @@ public class TestSetDateResponse
 }
 
 /// <summary>
+/// Response from /test/farmevent POST endpoint (test-only).
+/// </summary>
+public class TestFarmEventResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+}
+
+/// <summary>
 /// Response from /test/saver_crop POST endpoint (test-only).
 /// </summary>
 public class TestSaverCropResponse
@@ -1079,6 +1094,18 @@ public class ServerApiClient : IDisposable
             () => JsonContent.Create(new { season, day, year }));
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestSetDateResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: queue an overnight FarmEvent (e.g. the Mr. Qi mystery box) for the next night.
+    /// POST /test/farmevent?type=qiplane
+    /// </summary>
+    public async Task<TestFarmEventResponse?> QueueFarmEvent(string type, CancellationToken ct = default)
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post, $"/test/farmevent?type={type}", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestFarmEventResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/HostAutomationTests.cs
+++ b/tests/JunimoServer.Tests/HostAutomationTests.cs
@@ -305,7 +305,9 @@ public class HostAutomationTests : TestBase
         var ct = TestContext.Current.CancellationToken;
         await Farmers.ConnectNewAsync(ct: ct);
 
-        var initialFps = (await ServerApi.GetRendering(ct))?.Fps ?? 0;
+        var initialRendering = await ServerApi.GetRendering(ct);
+        Assert.NotNull(initialRendering);
+        var initialFps = initialRendering.Fps;
 
         try
         {
@@ -340,7 +342,10 @@ public class HostAutomationTests : TestBase
         finally
         {
             // Restore the server's render rate so the shared server isn't left at the test's FPS.
-            await ServerApi.SetServerFps(initialFps, ct);
+            // Use a fresh cleanup token (not ct) so the restore still runs if the test was cancelled
+            // mid-body — otherwise a timeout would leave the shared server stuck at the test's FPS.
+            using var cleanupCts = new CancellationTokenSource(TestTimings.CleanupTimeout);
+            await ServerApi.SetServerFps(initialFps, cleanupCts.Token);
         }
     }
 

--- a/tests/JunimoServer.Tests/HostAutomationTests.cs
+++ b/tests/JunimoServer.Tests/HostAutomationTests.cs
@@ -286,4 +286,62 @@ public class HostAutomationTests : TestBase
             $"Expected a new day but still on {seasonBefore} {dayBefore}, Year {yearBefore}");
     }
 
+    /// <summary>
+    /// Regression for issue #242: the Mr. Qi mystery-box overnight cutscene (QiPlaneEvent) hangs the
+    /// host, so the new day never starts. QiPlaneEvent's completion gate is advanced in its draw(),
+    /// not its tickUpdate(), so on a headless host (draws gated/desynced) it never converges.
+    /// QiPlaneEventOverrides force-completes it via a framerate-independent game-time fallback.
+    ///
+    /// Runs across an FPS matrix because the fix must NOT assume a particular SERVER_FPS — the bug
+    /// reporter was on unbounded FPS. The day must advance whether rendering is disabled (0) or capped.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(5)]
+    [InlineData(1)]
+    [TestServer(Exclusive = true)]
+    public async Task HostCompletesQiPlaneEvent_AcrossFpsMatrix(int fps)
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await Farmers.ConnectNewAsync(ct: ct);
+
+        var initialFps = (await ServerApi.GetRendering(ct))?.Fps ?? 0;
+
+        try
+        {
+            var fpsResult = await ServerApi.SetServerFps(fps, ct);
+            Assert.True(fpsResult?.Success, $"SetServerFps({fps}) failed: {fpsResult?.Error}");
+
+            // Queue the Mr. Qi mystery-box event for the next overnight transition.
+            var queueResult = await ServerApi.QueueFarmEvent("qiplane", ct);
+            Assert.NotNull(queueResult);
+            Assert.True(queueResult.Success, $"QueueFarmEvent failed: {queueResult.Error}");
+
+            var statusBefore = await ServerApi.GetStatus(ct);
+            Assert.NotNull(statusBefore);
+            var dayBefore = statusBefore.Day;
+            var seasonBefore = statusBefore.Season;
+            var yearBefore = statusBefore.Year;
+            Log($"Before sleep (fps={fps}): {seasonBefore} {dayBefore}, Year {yearBefore}");
+
+            // Sleep the farmhand; the host auto-sleeps and runs the overnight QiPlaneEvent.
+            var sleepResult = await GameClient.Actions.Sleep();
+            Assert.True(sleepResult?.Success, $"Sleep action failed: {sleepResult?.Error}");
+
+            // Without the fix the overnight transition hangs here (QiPlaneEvent never completes) and
+            // this times out. With the fix the game-time fallback completes the event and the day starts.
+            var (dayChanged, disconnected) = await DayChange.WaitAsync(
+                dayBefore, seasonBefore, yearBefore, checkConnection: true, ct);
+
+            Assert.False(disconnected, "Farmhand disconnected during the QiPlaneEvent overnight wait");
+            Assert.True(dayChanged,
+                $"Day should advance after the host completes the overnight QiPlaneEvent (fps={fps})");
+        }
+        finally
+        {
+            // Restore the server's render rate so the shared server isn't left at the test's FPS.
+            await ServerApi.SetServerFps(initialFps, ct);
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #242.

## Problem

The dedicated server hangs during the overnight transition when the Mr. Qi mystery-box cutscene fires. The host gets stuck and clients show "Waiting for the host's event to finish." — the new day never starts.

**Root cause:** The cutscene is `QiPlaneEvent`, a `Game1.farmEvent` run during the overnight `_newDayAfterFade` sequence. Its completion gate (`finalFadeTimer > 4000`) is advanced **only inside `draw()`**, not `tickUpdate()`. On the headless host the draw cadence is gated/throttled/desynced from the per-tick update pump, so the gate never converges and `tickUpdate` returns false forever. QiPlaneEvent is unique here — every other overnight FarmEvent advances its timer inside `tickUpdate` and self-completes.

Investigating surfaced a second, related headless hang: `BirthingEvent` / `PlayerCoupleBirthingEvent` open a `NamingMenu` to name the baby, which is not a `DialogueBox`, so the existing dialogue-clicker can't dismiss it and the host hangs with no one to type a name.

## Changes

- **`QiPlaneEventOverrides`**: Harmony postfix on `QiPlaneEvent.tickUpdate` that force-completes the event after a framerate-independent game-time fallback (30s), letting the vanilla completion block (warp-to-bed + save) run. With healthy draws the event self-completes first and the postfix is a no-op.
- **`AlwaysOnServer.HandleOvernightNamingMenu`**: auto-names the baby during overnight birthing events via the vanilla random-name source, running the event's real side effects (creates the Child NPC) and letting the day proceed.
- **`AlwaysOnServer.HandleStuckFarmEvent`**: log-only watchdog that surfaces unknown/modded overnight FarmEvents still stuck past the QiPlane fallback. Deliberately does not force-complete unknown types (would bypass their `makeChangesToLocation` side effects and risk save corruption). Its threshold is derived from the QiPlane fallback so the two stay ordered.
- **Test-only `POST /test/farmevent` endpoint** + `ServerApiClient.QueueFarmEvent` to deterministically queue an overnight event via `Game1.farmEventOverride` (no mail/stat seeding).
- **Regression test** `HostCompletesQiPlaneEvent_AcrossFpsMatrix` running across `SERVER_FPS` 0/5/1, asserting the day advances in every case (the bug reporter was on unbounded FPS, so the fix must not assume a framerate).

## Verification

3/3 E2E cases pass. The server container log confirms the forced-completion path fires on the headless `fps=0` case (the production scenario) — not natural completion — so the test genuinely exercises the fix.

## Notes

- The fix forces `tickUpdate` to return true rather than nulling `Game1.farmEvent` directly, so the vanilla warp + `showEndOfNightStuff` save chain runs unchanged.
- It does not pre-seed `sawQiPlane` mail, so the event still fires normally and an operator watching with rendering enabled sees the full animation.
- All new logging is at Info/Warn (never Error, which would poison E2E tests via the server's error-detection regex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Mr. Qi mystery-box overnight cutscene hang so the day now progresses reliably (handles desynced/throttled hosts).
  * Improved overnight automation to auto-submit generated names when births occur on a headless host.
  * Added detection and one-time logging for farm events that remain active beyond expected thresholds to aid troubleshooting.

* **Tests**
  * Added an integration regression test ensuring overnight cutscene completion across varied server performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->