### PR TITLE
fix: server-stuck LoopingCueManager NRE (#249) + localized font crash (#260/#259)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,11 @@ VNC_PASSWORD=""
 # Additional Steam accounts for E2E tests (JSON array). See .env.test.example.
 # STEAM_ACCOUNTS='[{"user":"server","pass":"pw"},{"user":"client","pass":"pw"}]'
 
+# Keep localized fonts for these languages so their text renders correctly
+# (default: none — English-only, smallest download). Comma-separated codes:
+# de-DE,es-ES,fr-FR,hu-HU,it-IT,ja-JP,ko-KR,pt-BR,ru-RU,tr-TR,zh-CN,th-TH
+# STEAM_KEEP_LANGUAGES="pt-BR,ru-RU"
+
 # Health check interval in seconds (default: 300)
 # HEALTH_CHECK_SECONDS=300
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       STEAM_USERNAME: "${STEAM_USERNAME:-}"
       STEAM_PASSWORD: "${STEAM_PASSWORD:-}"
       STEAM_REFRESH_TOKEN: "${STEAM_REFRESH_TOKEN:-}"
+      # Comma-separated language codes whose fonts to keep in the download
+      # (e.g. "pt-BR,ru-RU"). Default strips all localized content (English-only).
+      STEAM_KEEP_LANGUAGES: "${STEAM_KEEP_LANGUAGES:-}"
     restart: unless-stopped
 
   # Discord bot for server status display and chat relay

--- a/docs/developers/architecture/steam-auth.md
+++ b/docs/developers/architecture/steam-auth.md
@@ -103,11 +103,34 @@ Refresh tokens are saved to `/data/steam-session/session-{username}.json` and re
 
 The download process skips unnecessary files to reduce download size:
 
-- Large audio files (Wave Bank.xwb ~370MB)
-- Non-English language files (~50MB)
+- Large audio files (Wave Bank.xwb ~370MB) — always stripped (the server runs silent)
+- Non-English language files (~50MB) — stripped by default; opt back in per language
+  with `STEAM_KEEP_LANGUAGES` (see below)
 - Other assets not needed for dedicated server operation
 
 This reduces the download from ~1.5GB to ~600MB.
+
+After filtering, `Content/ContentHashes.json` is pruned to list only the files that
+were actually downloaded. The game checks this manifest (not the filesystem) to decide
+whether an asset exists, so leaving a stripped file listed would make the game attempt
+to load a missing `.xnb` and throw `ContentLoadException`. Pruning keeps the manifest
+honest so the game's built-in localized→English font fallback works.
+
+### Keeping a language's fonts
+
+By default every localized font/content file is stripped and the server falls back to
+the English font, so non-Latin chat (e.g. Cyrillic, CJK) renders as empty boxes on
+clients. To keep a language's fonts in the download — so that language renders
+correctly — set `STEAM_KEEP_LANGUAGES` to a comma-separated list of language codes:
+
+```bash
+STEAM_KEEP_LANGUAGES=pt-BR,ru-RU
+```
+
+Valid codes: `de-DE`, `es-ES`, `fr-FR`, `hu-HU`, `it-IT`, `ja-JP`, `ko-KR`, `pt-BR`,
+`ru-RU`, `tr-TR`, `zh-CN`, `th-TH`. CJK codes (`zh-CN`, `ja-JP`, `ko-KR`) also keep
+their larger font families, so those add more to the image size than the others. An
+unrecognized code is logged as a warning and ignored.
 
 ## CI/CD Usage
 
@@ -134,6 +157,7 @@ STEAM_REFRESH_TOKEN=xxx STEAM_USERNAME=user docker compose run steam-auth downlo
 | `SESSION_DIR` | Token storage directory | /data/steam-session |
 | `GAME_DIR` | Game files directory | /data/game |
 | `FORCE_REDOWNLOAD` | Set to "1" to re-download all files | - |
+| `STEAM_KEEP_LANGUAGES` | Comma-separated language codes whose fonts to keep in the download (e.g. `pt-BR,ru-RU`). Default strips all localized content (English-only). | - |
 
 ### Game Server Container
 

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.DependencyInjection;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
+using StardewValley.Audio;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -145,6 +146,15 @@ namespace JunimoServer
                 original: AccessTools.Method(typeof(GameLocation), nameof(GameLocation.UpdateWhenCurrentLocation)),
                 prefix: new HarmonyMethod(typeof(ModEntry), nameof(UpdateWhenCurrentLocation_Prefix)));
             Monitor.Log("Patched UpdateWhenCurrentLocation with null-safety guard", LogLevel.Trace);
+
+            // Server throws out audio (Wave Bank stripped; DummySoundBank in use). Disable
+            // LoopingCueManager.Update entirely: it only plays/stops ambient location cues
+            // (no game-state effect). On the silent host a null ICue can get cached in its
+            // playingCues dict and NRE on .Stop() every frame, locking the server (issue #249).
+            harmony.Patch(
+                original: AccessTools.Method(typeof(LoopingCueManager), nameof(LoopingCueManager.Update)),
+                prefix: new HarmonyMethod(typeof(ModEntry), nameof(LoopingCueManager_Update_Prefix)));
+            Monitor.Log("Disabled LoopingCueManager.Update (server audio is off)", LogLevel.Trace);
 
             // Keep the display zoom/UI scale pinned in every game mode (the actual resize
             // happens on GameLaunched via DisplaySizing.ApplyFromEnv).
@@ -289,6 +299,14 @@ namespace JunimoServer
         {
             return Game1.player?.currentLocation != null;
         }
+
+        /// <summary>
+        /// Skips LoopingCueManager.Update unconditionally. The server runs without
+        /// audio, so the looping-cue manager has nothing to do; skipping it avoids the
+        /// recurring vanilla NRE (#249) where a null cached ICue in playingCues throws
+        /// on .Stop() in the host update loop.
+        /// </summary>
+        private static bool LoopingCueManager_Update_Prefix() => false;
 
     }
 }

--- a/tools/steam-service/Program.cs
+++ b/tools/steam-service/Program.cs
@@ -50,6 +50,14 @@ string? GetEnvTrimmed(string name)
     return string.IsNullOrEmpty(value) ? null : value;
 }
 
+// STEAM_KEEP_LANGUAGES: comma-separated language codes (e.g. "pt-BR,ru-RU") whose
+// fonts/content to keep in the download. Default (unset) strips all localized content
+// for the smallest image; the server itself runs English-only. An unknown code is
+// warned-and-ignored (not fatal) so a typo can't abort the whole download.
+var keepLanguages = SteamAuthService.ParseKeepLanguages(GetEnvTrimmed("STEAM_KEEP_LANGUAGES"));
+if (keepLanguages.Count > 0)
+    Logger.Log($"[SteamService] Keeping localized content for: {string.Join(", ", keepLanguages)}");
+
 // ============================================================================
 // Account Discovery
 // ============================================================================
@@ -122,7 +130,7 @@ Dictionary<int, SteamAuthService> CreateAccountServices(Dictionary<int, (string 
     var services = new Dictionary<int, SteamAuthService>();
     foreach (var (index, config) in accountConfigs)
     {
-        services[index] = new SteamAuthService(index, config.user, sessionDir, gameDir);
+        services[index] = new SteamAuthService(index, config.user, sessionDir, gameDir, keepLanguages);
     }
     return services;
 }

--- a/tools/steam-service/SteamAuthService.cs
+++ b/tools/steam-service/SteamAuthService.cs
@@ -84,13 +84,15 @@ public class SteamAuthService
     public string? SteamId => _steamClient.SteamID?.ConvertToUInt64().ToString();
     public ulong CurrentLobbyId => _currentLobbyId;
 
-    public SteamAuthService(int accountIndex, string username, string sessionDir, string gameDir)
+    public SteamAuthService(int accountIndex, string username, string sessionDir, string gameDir,
+        IReadOnlyCollection<string>? keepLanguages = null)
     {
         AccountIndex = accountIndex;
         Username = username;
         _sessionDir = Path.Combine(sessionDir, username);
         _gameDir = gameDir;
         _logPrefix = $"[SteamAuth:A{accountIndex}]";
+        _skipPatterns = BuildSkipPatterns(keepLanguages ?? []);
 
         Directory.CreateDirectory(_sessionDir);
         MigrateOldSession(sessionDir);
@@ -910,20 +912,147 @@ public class SteamAuthService
         Logger.Log($"{_logPrefix} Download marker saved (manifest: {manifestId})");
     }
 
-    // Patterns to skip during download (not needed for dedicated server)
-    private static readonly Regex[] SkipPatterns =
+    /// <summary>
+    /// Rewrites Content/ContentHashes.json to list only files actually present on disk,
+    /// dropping entries for assets the download filter stripped. Keeps each surviving
+    /// entry's original hash (no recompute — we only prune). Keys are content-root-relative
+    /// with forward slashes (e.g. "Fonts/SmallFont.pt-BR.xnb"); we join them against
+    /// &lt;downloadDir&gt;/Content to check existence.
+    /// <para>
+    /// The download filter only skips <i>downloading</i> files; it never deletes files
+    /// already on disk. So after a re-download (or a STEAM_KEEP_LANGUAGES change), a
+    /// previously-downloaded localized file may still be present — this keeps its manifest
+    /// entry, which is correct: manifest and filesystem stay in agreement, so the game's
+    /// DoesAssetExist never lies and never crashes. The only effect is that stale files
+    /// aren't reclaimed on reconfigure (a size concern, not a correctness one).
+    /// </para>
+    /// </summary>
+    private void PruneContentManifest(string downloadDir)
+    {
+        var contentDir = Path.Combine(downloadDir, "Content");
+        var manifestPath = Path.Combine(contentDir, "ContentHashes.json");
+        if (!File.Exists(manifestPath))
+        {
+            Logger.Log($"{_logPrefix} ContentHashes.json not found at {manifestPath}; skipping manifest prune");
+            return;
+        }
+
+        Dictionary<string, JsonElement>? entries;
+        try
+        {
+            entries = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(File.ReadAllText(manifestPath));
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"{_logPrefix} WARN: failed to parse ContentHashes.json ({ex.Message}); leaving it unchanged");
+            return;
+        }
+        if (entries == null || entries.Count == 0)
+            return;
+
+        var kept = new Dictionary<string, JsonElement>(entries.Count);
+        foreach (var (key, value) in entries)
+        {
+            // Manifest keys use forward slashes regardless of OS; normalize for the local FS.
+            var localPath = Path.Combine(contentDir, key.Replace('/', Path.DirectorySeparatorChar));
+            if (File.Exists(localPath))
+                kept[key] = value;
+        }
+
+        var removed = entries.Count - kept.Count;
+        if (removed == 0)
+            return;
+
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(kept));
+        Logger.Log($"{_logPrefix} Pruned ContentHashes.json: removed {removed} stripped entries, {kept.Count} remain");
+    }
+
+    // Audio is always stripped — the dedicated server runs silent (no Wave Bank).
+    private static readonly Regex[] WaveBankPatterns =
     [
         new Regex(@"Content/XACT/Wave Bank.xwb", RegexOptions.IgnoreCase | RegexOptions.Compiled),
         new Regex(@"Content/XACT/Wave Bank\(1.4\).xwb", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"Content/Fonts/Chinese.*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"Content/Fonts/Korean.*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"Content/Fonts/Japanese.*", RegexOptions.IgnoreCase | RegexOptions.Compiled),
-        new Regex(@"\.(de-DE|es-ES|fr-FR|hu-HU|it-IT|ja-JP|ko-KR|pt-BR|ru-RU|tr-TR|zh-CN)\.xnb$", RegexOptions.IgnoreCase | RegexOptions.Compiled),
     ];
 
-    private static bool ShouldSkipFile(string fileName)
+    // Every localized content code the game ships (matches LocalizedContentManager
+    // .LanguageCodeString in the decompiled game). A file named "*.{code}.xnb" is a
+    // per-language variant; by default all are stripped to keep the image small.
+    private static readonly string[] AllLanguageCodes =
+        ["de-DE", "es-ES", "fr-FR", "hu-HU", "it-IT", "ja-JP", "ko-KR", "pt-BR", "ru-RU", "tr-TR", "zh-CN", "th-TH"];
+
+    // CJK fonts are large, multi-file families keyed by family name (not a "*.{code}.xnb"
+    // suffix), so a kept CJK language must also un-strip its whole family directory.
+    private static readonly Dictionary<string, string> CjkFontFamilyByCode = new(StringComparer.OrdinalIgnoreCase)
     {
-        foreach (var pattern in SkipPatterns)
+        ["zh-CN"] = "Chinese",
+        ["ja-JP"] = "Japanese",
+        ["ko-KR"] = "Korean",
+    };
+
+    // Built per-instance in the constructor from the operator's STEAM_KEEP_LANGUAGES.
+    private readonly Regex[] _skipPatterns;
+
+    /// <summary>
+    /// Parses a STEAM_KEEP_LANGUAGES value ("pt-BR, ru-RU") into validated language
+    /// codes. Whitespace-tolerant and case-insensitive on each code; unknown codes are
+    /// warned-and-dropped (never throws) so a typo can't abort the download. Returns the
+    /// canonical-cased codes from <see cref="AllLanguageCodes"/>.
+    /// </summary>
+    public static IReadOnlyCollection<string> ParseKeepLanguages(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return [];
+
+        var canonical = AllLanguageCodes.ToDictionary(c => c, StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var token in raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            if (canonical.TryGetValue(token, out var code))
+            {
+                if (!result.Contains(code))
+                    result.Add(code);
+            }
+            else
+            {
+                Logger.Log($"[SteamService] WARN: STEAM_KEEP_LANGUAGES has unknown code '{token}' — ignoring. " +
+                           $"Valid codes: {string.Join(", ", AllLanguageCodes)}");
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Builds the download skip-set: always-stripped audio, plus the per-language
+    /// "*.{code}.xnb" variants and CJK font families for every code NOT in <paramref name="keepLanguages"/>.
+    /// A kept language's font/content files are left in the download (and survive into
+    /// the regenerated manifest) so that language renders correctly on clients.
+    /// </summary>
+    private static Regex[] BuildSkipPatterns(IReadOnlyCollection<string> keepLanguages)
+    {
+        var keep = new HashSet<string>(keepLanguages, StringComparer.OrdinalIgnoreCase);
+        var patterns = new List<Regex>(WaveBankPatterns);
+
+        // Strip CJK font families only for non-kept CJK languages.
+        foreach (var (code, family) in CjkFontFamilyByCode)
+        {
+            if (!keep.Contains(code))
+                patterns.Add(new Regex($@"Content/Fonts/{family}.*", RegexOptions.IgnoreCase | RegexOptions.Compiled));
+        }
+
+        // Strip "*.{code}.xnb" localized variants for every non-kept code.
+        var strippedCodes = AllLanguageCodes.Where(c => !keep.Contains(c)).ToArray();
+        if (strippedCodes.Length > 0)
+        {
+            var alternation = string.Join("|", strippedCodes.Select(Regex.Escape));
+            patterns.Add(new Regex($@"\.({alternation})\.xnb$", RegexOptions.IgnoreCase | RegexOptions.Compiled));
+        }
+
+        return patterns.ToArray();
+    }
+
+    private bool ShouldSkipFile(string fileName)
+    {
+        foreach (var pattern in _skipPatterns)
         {
             if (pattern.IsMatch(fileName))
                 return true;
@@ -1251,6 +1380,14 @@ public class SteamAuthService
             Logger.Log($"{_logPrefix} Total size: {FormatSize(processedBytes)}");
             if (skippedExisting > 0)
                 Logger.Log($"{_logPrefix} Skipped {skippedExisting} existing files (already up to date)");
+
+            // Prune the content manifest to match what we actually downloaded. The game's
+            // LocalizedContentManager.DoesAssetExist checks ContentHashes.json (a manifest),
+            // not the filesystem — so a stripped-but-still-listed asset makes the game think
+            // the file exists, then throw ContentLoadException on the missing on-disk read.
+            // Removing the stale entries lets the game's built-in localized→English fallback
+            // work instead of crashing.
+            PruneContentManifest(downloadDir);
 
             // Save download marker to skip re-download next time
             SaveDownloadMarker(downloadDir, appId, depotId, manifestId, targetOs, totalBytes, totalFiles);


### PR DESCRIPTION
Fixes two open headless-server bugs from the triage. Independent changes (mod vs. steam-service); two commits.

## #249 — `LoopingCueManager` NRE / server stuck

- The issue's stack trace pins a per-frame NRE on the **host** at `LoopingCueManager.cs:35` (`playingCues[item2].Stop(...)`) — a **null cached `ICue`** in `playingCues`, not a null `currentLocation` (that call site is guarded by `if (currentLocation != null)` before `UpdateLocations`) nor `netAudio` (a `readonly` field). It recurs every frame and locks the server.
- The dedicated server runs **without audio** (Wave Bank stripped → `DummySoundBank`), so `LoopingCueManager.Update` — which only starts/stops ambient cues and mutates no game state — has nothing to do.
- **Fix:** Harmony prefix on `LoopingCueManager.Update` returning `false` unconditionally (mirrors the existing `UpdateWhenCurrentLocation_Prefix`). Removes the NRE regardless of which cue went null, plus a secondary `StopAll`/enumeration race. Logs at Trace so it doesn't trip the E2E error detector.

## #260 / #259 — localized font crash + tofu rendering

- Root cause: the download strips localized `.xnb` files but leaves `ContentHashes.json` advertising them. The game checks that **manifest** (not the filesystem) in `DoesAssetExist`, so it reports the asset present, **bypasses its built-in English fallback**, and throws `ContentLoadException` on the missing on-disk read. This hits the **server** too (via the chat-receive `MeasureString` path when a non-English client chats), not just clients.
- **Fix (root cause):** regenerate `ContentHashes.json` after filtering so it lists only files actually on disk — the game's localized→English fallback then works instead of crashing. Resolves the mismatch for every stripped category (fonts, CJK, audio).
- **`STEAM_KEEP_LANGUAGES`:** operators pass language codes (e.g. `pt-BR,ru-RU`) to keep that language's fonts in the download so it renders correctly (#259). Default stays English-only for the smallest image; audio is always stripped. CJK codes also keep their (larger) font families. Unknown codes warn-and-ignore (never abort the download).
- Documented in `steam-auth.md`, `.env.example`, and `docker-compose.yml`.

## Verification

- Both projects build clean (0 new warnings).
- 30 keep-list/parse checks + a manifest-prune round-trip pass (English base survives, localized/CJK/audio stripped by default, kept languages preserved, hashes preserved, slash/case handling correct).

## Not in this PR

- E2E tests for both fixes were investigated and deliberately deferred: #260 can't reproduce in the E2E harness without artificially recreating the manifest/filesystem mismatch (the test `server_game-data` volume is a full Steam install — the strip/prune never runs in the test pipeline), and #249 is intermittent/load-dependent. Runtime gates are documented for manual verification.
- Symbol-safe revival of the `init_patch_dll` audio strip (perf/wastefulness; risks Space Core) — orthogonal to the #249 crash.
- #259's server-relay angle (`SendPublicMessage` stamps the server's English language on relayed messages) — a distinct sender-metadata fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added STEAM_KEEP_LANGUAGES option to selectively retain localized Steam fonts during downloads (defaults to stripping localized content).
  * Download process now prunes asset manifests so removed files won’t be treated as present.

* **Bug Fixes**
  * Prevented server-side audio looping from causing a crash by disabling looping-cue updates on the host.

* **Documentation**
  * Updated docs with language-filtering, allowed language codes, and manifest-pruning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->