### PR TITLE
ci: add Validate Line Endings producer to merge-queue workflow

### DIFF
--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -3,9 +3,10 @@
 # here — hence no `authorize` gate and no environment, unlike validate-pr.yml. This is a separate
 # file rather than a trigger added to validate-pr.yml on purpose: the merge_group payload has no
 # `github.event.pull_request.*` fields, and one workflow per event keeps one required check per
-# name. Both required checks (`Validate Build`, `Validate Commits`) are reproduced here under the
-# same names: a required check with no merge_group producer leaves every queued PR stuck in
-# AWAITING_CHECKS until timeout. See docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
+# name. All three required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`)
+# are reproduced here under the same names: a required check with no merge_group producer leaves
+# every queued PR stuck in AWAITING_CHECKS until timeout. See
+# docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
 name: Validate Merge Group
 
 on:
@@ -76,6 +77,27 @@ jobs:
 
       - name: Validate commit messages
         run: npx commitlint --from ${{ github.event.merge_group.base_sha }} --to ${{ github.event.merge_group.head_sha }} --verbose
+
+  validate-line-endings:
+    name: Validate Line Endings
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout queue branch
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.merge_group.head_sha }}
+
+      # The index is OS-agnostic, so this catches CRLF regardless of the contributor's
+      # core.autocrlf. .gitattributes (* text=auto eol=lf) makes LF the committed normal form;
+      # a CRLF here means a file was force-added with literal CR bytes, bypassing normalization.
+      - name: Check for CRLF in index
+        run: |
+          if git ls-files --eol | grep -E 'i/crlf'; then
+            echo "::error::CRLF line endings found in the index. The repo enforces LF via .gitattributes — re-normalize with: git add --renormalize . && git commit"
+            exit 1
+          fi
+          echo "No CRLF line endings in the index."
 
   validate-build:
     name: Validate Build

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -8,7 +8,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 |----------|---------|---------|
 | [Build Release](#build-release-pipeline) | Merge release candidate PR to `master` | Creates releases and publishes stable Docker images |
 | [Build Preview](#build-preview-pipeline) | Push to `master` | Builds and publishes preview Docker images |
-| [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits and builds |
+| [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits, builds, and line endings |
 | [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
 | [CodeQL](#codeql-pipeline) | Pull requests / push to `master` / weekly | Static security analysis (advisory) |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
@@ -131,8 +131,9 @@ The validation pipeline runs on every pull request targeting `master`. It ensure
 
 - **Commit messages** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - **Docker build** - Ensures the image builds successfully (without pushing)
+- **Line endings** - Fails if a file with CRLF line endings reached the index, bypassing the LF normalization `.gitattributes` enforces
 
-These surface as two required status checks — `Validate Build` and `Validate Commits` — that must pass before a PR can merge.
+These surface as three required status checks — `Validate Build`, `Validate Commits`, and `Validate Line Endings` — that must pass before a PR can merge.
 
 ### Trigger & Security Model
 
@@ -172,10 +173,10 @@ A PR sitting in the queue shows **`AWAITING_CHECKS`** while its merge-group buil
 
 ### Why Validate Merge Group is a separate workflow
 
-The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-pipeline) does not respond to (it triggers on `pull_request_target`). The merge queue requires the same `Validate Build` and `Validate Commits` checks to report **on the merge-group ref**, so `validate-merge-group.yml` reproduces both under the same names. It runs the same commitlint and Docker build, but without the `authorize` gate — merge-group code is already approved and runs from the base repository, so there is no fork-secret exposure to gate.
+The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-pipeline) does not respond to (it triggers on `pull_request_target`). The merge queue requires the same `Validate Build`, `Validate Commits`, and `Validate Line Endings` checks to report **on the merge-group ref**, so `validate-merge-group.yml` reproduces all three under the same names. It runs the same commitlint, Docker build, and line-ending scan, but without the `authorize` gate — merge-group code is already approved and runs from the base repository, so there is no fork-secret exposure to gate.
 
 ::: warning
-Both required checks (`Validate Build`, `Validate Commits`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too.
+All three required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too.
 :::
 
 ## CodeQL Pipeline
@@ -186,7 +187,7 @@ Both required checks (`Validate Build`, `Validate Commits`) must have a `merge_g
 
 ### Advisory, Not Required
 
-CodeQL is **not** a required status check — a PR merges on `Validate Build` + `Validate Commits` alone, and CodeQL findings surface under **Security → Code scanning** without blocking the merge.
+CodeQL is **not** a required status check — a PR merges on `Validate Build` + `Validate Commits` + `Validate Line Endings` alone, and CodeQL findings surface under **Security → Code scanning** without blocking the merge.
 
 This is deliberate. The pipeline uses per-language path scoping (below), so a PR that touches no analyzable source runs **zero** analyze jobs. A *required* check that never reports leaves a PR stuck on "Expected — Waiting for status", so the path-scoping optimization is only safe while CodeQL stays advisory.
 

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -144,7 +144,7 @@ Go to **Settings → Secrets → Actions** and add:
 - Pattern: `master`
 - Enable:
   - ✅ Require pull request before merging
-  - ✅ Require status checks: `Validate Build`, `Validate Line Endings`
+  - ✅ Require status checks: `Validate Build`, `Validate Commits`, `Validate Line Endings`
   - ✅ Require approvals: 1
 
 #### 3. Configure Fork PR Protection


### PR DESCRIPTION
## Problem

Queued PRs get stuck in `AWAITING_CHECKS` until the merge queue's 60-minute timeout (e.g. #301).

The `master` ruleset requires three status checks — `Validate Build`, `Validate Commits`, and `Validate Line Endings` (the last added 2026-06-02). The merge queue validates each PR via the `merge_group` event, so every required check needs a `merge_group` producer. But `validate-merge-group.yml` only reproduced `Validate Build` and `Validate Commits`. When `Validate Line Endings` was promoted to required, no merge-group producer was added — so the queue waits forever for a check that never reports. The workflow's own header comment warns about exactly this trap.

## Changes

- Add a `validate-line-endings` job to `validate-merge-group.yml`, mirroring the PR-side job (same `git ls-files --eol | grep i/crlf` index scan), checking out the `merge_group` head sha, without the `authorize` gate (queue code is already approved)
- Update the workflow header comment to cover all three required checks
- Sync `ci-cd.md` — overview table, validate-pr section, merge-queue section + warning, and CodeQL note — to list three required checks instead of two
- Fix the branch-protection checklist in `index.md` (it was missing `Validate Commits`)

## Merge note

Because `validate-merge-group.yml` only takes effect from the version on `master`, this fix cannot merge *through* the currently-broken queue. Merge with an **admin bypass**, or temporarily drop `Validate Line Endings` from the ruleset's required-checks list, merge, then re-add it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added line endings validation check to the CI/CD pipeline to detect and prevent CRLF line ending issues.
  * Updated contributor documentation to reflect new validation requirements and branch protection settings for the master branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->