### PR TITLE
fix(chat): tag server-originated messages by script so non-Latin text renders (#259)

### DIFF
--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -459,10 +459,9 @@ namespace JunimoServer.Services.CabinManager
                     // Block all human players from the farmhouse - it's reserved for the server host
                     if (!roleService.IsServerHost(farmer))
                     {
-                        Game1.Multiplayer.sendChatMessage(
-                            LocalizedContentManager.CurrentLanguageCode,
-                            "Can't enter main building, porting to your own cabin",
-                            farmer.UniqueMultiplayerID
+                        Helper.SendPrivateMessage(
+                            farmer.UniqueMultiplayerID,
+                            "Can't enter main building, porting to your own cabin"
                         );
 
                         farmer.WarpHome();

--- a/mod/JunimoServer/Util/ChatLanguageDetector.cs
+++ b/mod/JunimoServer/Util/ChatLanguageDetector.cs
@@ -1,0 +1,86 @@
+using StardewValley;
+
+namespace JunimoServer.Util
+{
+    /// <summary>
+    /// Infers the chat <see cref="LocalizedContentManager.LanguageCode"/> a message should be
+    /// tagged with from the script of its text, so the receiving client loads a font that can
+    /// render the glyphs. A SpriteFont renders only its baked glyphs; tagging a Cyrillic/CJK/Thai
+    /// message with the wrong language loads a font without those glyphs and draws boxes.
+    ///
+    /// Only languages whose <c>SmallFont</c> ships a distinct (non-Latin) glyph set need detection.
+    /// The Latin-script locales in vanilla's font set (pt, es, de, fr, it, tr, hu) share the same
+    /// glyph coverage as en, so Latin text resolves to en — identical to the prior behavior.
+    /// Mirrors vanilla's available font set (LocalizedContentManager.LanguageCodeString).
+    /// </summary>
+    public static class ChatLanguageDetector
+    {
+        /// <summary>
+        /// Returns the LanguageCode whose baked font covers the message's script. Scans the whole
+        /// string so the Han/Kana ambiguity resolves correctly (kana proves Japanese even when Han
+        /// appears first). Latin text, punctuation, and empty/null input resolve to en.
+        /// </summary>
+        public static LocalizedContentManager.LanguageCode DetectLanguage(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return LocalizedContentManager.LanguageCode.en;
+            }
+
+            var hasCyrillic = false;
+            var hasHangul = false;
+            var hasKana = false;
+            var hasHan = false;
+            var hasThai = false;
+
+            foreach (var c in text)
+            {
+                if (c >= 0x0400 && c <= 0x04FF) // Cyrillic
+                {
+                    hasCyrillic = true;
+                }
+                else if ((c >= 0xAC00 && c <= 0xD7A3) || (c >= 0x1100 && c <= 0x11FF)) // Hangul syllables / jamo
+                {
+                    hasHangul = true;
+                }
+                else if ((c >= 0x3040 && c <= 0x309F) || (c >= 0x30A0 && c <= 0x30FF)) // Hiragana / Katakana
+                {
+                    hasKana = true;
+                }
+                else if (c >= 0x4E00 && c <= 0x9FFF) // CJK Unified Ideographs (Han)
+                {
+                    hasHan = true;
+                }
+                else if (c >= 0x0E00 && c <= 0x0E7F) // Thai
+                {
+                    hasThai = true;
+                }
+            }
+
+            // Precedence: unambiguous scripts first. Kana outranks Han because Han is shared between
+            // Japanese and Chinese — kana disambiguates a Han-bearing string to Japanese.
+            if (hasKana)
+            {
+                return LocalizedContentManager.LanguageCode.ja;
+            }
+            if (hasHangul)
+            {
+                return LocalizedContentManager.LanguageCode.ko;
+            }
+            if (hasCyrillic)
+            {
+                return LocalizedContentManager.LanguageCode.ru;
+            }
+            if (hasThai)
+            {
+                return LocalizedContentManager.LanguageCode.th;
+            }
+            if (hasHan)
+            {
+                return LocalizedContentManager.LanguageCode.zh;
+            }
+
+            return LocalizedContentManager.LanguageCode.en;
+        }
+    }
+}

--- a/mod/JunimoServer/Util/ModHelperExtensions.cs
+++ b/mod/JunimoServer/Util/ModHelperExtensions.cs
@@ -43,13 +43,13 @@ namespace JunimoServer.Util
         public static void SendPublicMessage(this IModHelper helper, string msg)
         {
             helper.GetMultiplayer()
-                .sendChatMessage(LocalizedContentManager.CurrentLanguageCode, msg, Multiplayer.AllPlayers);
+                .sendChatMessage(ChatLanguageDetector.DetectLanguage(msg), msg, Multiplayer.AllPlayers);
         }
 
         public static void SendPrivateMessage(this IModHelper helper, long uniqueMultiplayerId, string msg)
         {
             helper.GetMultiplayer()
-                .sendChatMessage(LocalizedContentManager.CurrentLanguageCode, msg, uniqueMultiplayerId);
+                .sendChatMessage(ChatLanguageDetector.DetectLanguage(msg), msg, uniqueMultiplayerId);
         }
 
         public static int GetCurrentNumCabins(this IModHelper helper)


### PR DESCRIPTION
Fixes #259.

## Problem

Chat the **server** sends to clients — Discord relay, festival announcements, command replies, auth prompts, cabin/system notices — rendered non-Latin text (Cyrillic, CJK, Thai) as empty boxes on every client. In-game chat typed by human players was unaffected.

## Root cause

Stardew picks the chat font solely from the `LanguageCode` tag attached to each message at send time (`ChatMessage.draw` → `ChatBox.messageFont(language)` → `Game1.content.Load<SpriteFont>("Fonts\SmallFont", language)`), with no per-glyph fallback and no broad multi-script font. A real player's client tags each outgoing message with that player's language, so receivers load a matching font. The server's send primitives instead hardcoded `LocalizedContentManager.CurrentLanguageCode` — always `en` on the headless server — so Cyrillic loaded the English font and drew boxes.

Relayed messages (e.g. Discord) carry no sender language, so the only source of truth for "the right font per text" is the message text's own script.

## Changes

- **Add `ChatLanguageDetector.DetectLanguage(string)`** — infers the `LanguageCode` from the text's Unicode script via direct range checks: Cyrillic → `ru`, Hangul → `ko`, Kana → `ja`, Han → `zh`, Thai → `th`, else `en`. Scans the whole string with Kana-outranks-Han precedence so a Han-bearing Japanese sentence resolves to `ja` (Han is shared between Japanese and Chinese).
- **`ModHelperExtensions.SendPublicMessage` / `SendPrivateMessage`** — tag via the detector instead of `CurrentLanguageCode`. Every caller (Discord relay, festival announcements, all commands, API sends, auth replies) benefits with no per-site change.
- **`CabinManagerService`** — route the one direct `Game1.Multiplayer.sendChatMessage` bypass through `Helper.SendPrivateMessage` so it shares the same detector-tagged path (single source of truth).

Latin text resolves to `en`, identical to prior behavior — no behavior change for existing English messages.

## Relationship to #336

This makes the language **tag** correct. For the glyphs to actually be present, the operator must keep the relevant localized fonts via `STEAM_KEEP_LANGUAGES` (#336). Both halves are required; #336 supplied the fonts, this supplies the correct tag.

## Validation

- Mod builds clean (0 warnings, 0 errors).
- The **real compiled** `DetectLanguage` was exercised against a version-matched stub of the game assembly (no MonoGame needed) — 13/13 cases pass, including Han/Kana disambiguation (`日本語のテスト` → `ja`), decorated Cyrillic (`(Web) Bob: Привет` → `ru`), empty/null → `en`, Thai → `th`, and emoji surrogate pairs → `en`.

Not yet exercised: the end-to-end visual gate (send Cyrillic from Discord with `STEAM_KEEP_LANGUAGES=ru-RU`, confirm glyphs not boxes render on a client via VNC). That requires a live server run and is the final acceptance test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Private messages now used for farmhouse access restriction notifications.

* **Improvements**
  * Chat messages automatically detect language based on character content for proper multilingual display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->