### PR TITLE
fix(cabin): persist /cabin-placed position across restart (#64)

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -612,6 +612,13 @@ namespace JunimoServer.Services.Api
 
         /// <summary>Individual cabin details.</summary>
         public List<CabinInfo> Cabins { get; set; } = new();
+
+        /// <summary>
+        /// UniqueMultiplayerIDs of players who have an explicitly-placed cabin position
+        /// recorded (via the cabin command). These cabins are exempt from the
+        /// MoveToStack / strategy-migration sweep. Cleared when the farmhand is deleted.
+        /// </summary>
+        public List<long> SavedPositionPlayerIds { get; set; } = new();
     }
 
     /// <summary>
@@ -719,6 +726,21 @@ namespace JunimoServer.Services.Api
     public class NewGameResponse
     {
         /// <summary>Whether the new game was created successfully.</summary>
+        public bool Success { get; set; }
+
+        /// <summary>Message describing the result.</summary>
+        public string? Message { get; set; }
+
+        /// <summary>Error message if the operation failed.</summary>
+        public string? Error { get; set; }
+    }
+
+    /// <summary>
+    /// Response from POST /reload.
+    /// </summary>
+    public class ReloadResponse
+    {
+        /// <summary>Whether the world reloaded successfully.</summary>
         public bool Success { get; set; }
 
         /// <summary>Message describing the result.</summary>
@@ -1880,6 +1902,9 @@ namespace JunimoServer.Services.Api
                             break;
                         case "/newgame":
                             await HandlePostNewGameAsync(request, response);
+                            break;
+                        case "/reload":
+                            await HandlePostReloadAsync(response);
                             break;
                         case "/test/set_date":
                             await WriteJsonAsync(response, await HandlePostTestSetDateAsync(request));
@@ -3195,7 +3220,8 @@ namespace JunimoServer.Services.Api
                 TotalCount = snap.CabinTotalCount,
                 AssignedCount = snap.CabinAssignedCount,
                 AvailableCount = snap.CabinAvailableCount,
-                Cabins = snap.Cabins
+                Cabins = snap.Cabins,
+                SavedPositionPlayerIds = _cabinManager.Data.PlayerCabinPositions.Keys.ToList()
             };
         }
 
@@ -4060,6 +4086,108 @@ namespace JunimoServer.Services.Api
                 {
                     Success = false,
                     Error = $"New game creation failed: {ex.Message}"
+                });
+            }
+        }
+
+        [ApiEndpoint("POST", "/reload", Summary = "Re-read server-settings.json and reload the active world (no restart)", Tag = "Server")]
+        [ApiResponse(typeof(ReloadResponse), 200, Description = "World reloaded successfully")]
+        private async Task HandlePostReloadAsync(HttpListenerResponse response)
+        {
+            // Validate no clients are connected — reload returns to title and would
+            // disconnect everyone (same precondition as /newgame).
+            int connectedClients = 0;
+            try
+            {
+                await RunOnGameThreadAsync(() =>
+                {
+                    connectedClients = Game1.otherFarmers.Count;
+                });
+            }
+            catch
+            {
+                // Game thread unavailable; allow the attempt anyway
+            }
+
+            if (connectedClients > 0)
+            {
+                response.StatusCode = 409;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = $"Cannot reload while {connectedClients} client(s) are connected. Disconnect all players first."
+                });
+                return;
+            }
+
+            var gameManager = GameManagerService.Instance;
+            if (gameManager == null)
+            {
+                response.StatusCode = 503;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = "Game manager not initialized yet"
+                });
+                return;
+            }
+
+            Monitor.Log("[API] World reload requested", LogLevel.Info);
+
+            // Call RequestReloadSave on the game thread (sets flags + ExitToTitle).
+            // The returned Task completes when the world has finished reloading.
+            Task? reloadTask = null;
+            try
+            {
+                await RunOnGameThreadAsync(() =>
+                {
+                    reloadTask = gameManager.RequestReloadSave();
+                });
+            }
+            catch (Exception ex)
+            {
+                response.StatusCode = 500;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = $"Failed to initiate reload: {ex.Message}"
+                });
+                return;
+            }
+
+            // Wait for the reload to complete (ExitToTitle → title screen → LoadSave → ready).
+            try
+            {
+                using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(120));
+                var timeoutTask = Task.Delay(Timeout.Infinite, timeoutCts.Token);
+                var completed = await Task.WhenAny(reloadTask!, timeoutTask);
+
+                if (completed == reloadTask)
+                {
+                    await reloadTask!; // Propagate any exception from LoadSave
+                    await WriteJsonAsync(response, new ReloadResponse
+                    {
+                        Success = true,
+                        Message = "World reloaded"
+                    });
+                    return;
+                }
+
+                // Timeout
+                response.StatusCode = 504;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = "World reload timed out (120s)"
+                });
+            }
+            catch (Exception ex)
+            {
+                response.StatusCode = 500;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = $"World reload failed: {ex.Message}"
                 });
             }
         }

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -4095,7 +4095,10 @@ namespace JunimoServer.Services.Api
         private async Task HandlePostReloadAsync(HttpListenerResponse response)
         {
             // Validate no clients are connected — reload returns to title and would
-            // disconnect everyone (same precondition as /newgame).
+            // disconnect everyone. Fail closed: if the count can't be read because the
+            // game thread is busy, treat it as transient (503) rather than assuming 0
+            // connected, which could silently disconnect active players if the thread
+            // recovers before the reload fires.
             int connectedClients = 0;
             try
             {
@@ -4104,9 +4107,16 @@ namespace JunimoServer.Services.Api
                     connectedClients = Game1.otherFarmers.Count;
                 });
             }
-            catch
+            catch (Exception ex)
             {
-                // Game thread unavailable; allow the attempt anyway
+                Monitor.Log($"[API] Reload precheck could not read connected-client count: {ex.Message}", LogLevel.Warn);
+                response.StatusCode = 503;
+                await WriteJsonAsync(response, new ReloadResponse
+                {
+                    Success = false,
+                    Error = "Cannot verify connected clients right now (game thread busy, likely a day transition or save sync). Retry after a few seconds."
+                });
+                return;
             }
 
             if (connectedClients > 0)

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -3918,8 +3918,12 @@ namespace JunimoServer.Services.Api
                 }
             }
 
-            // Remove from cabin manager tracking
-            if (_cabinManager.Data.AllPlayerIdsEverJoined.Remove(farmhandId))
+            // Remove from cabin manager tracking. PlayerCabinPositions shares the
+            // farmhand's lifecycle, so clear its intent entry here too — otherwise a
+            // deleted player's position record leaks into the save indefinitely.
+            var removedEverJoined = _cabinManager.Data.AllPlayerIdsEverJoined.Remove(farmhandId);
+            var removedPosition = _cabinManager.Data.PlayerCabinPositions.TryRemove(farmhandId, out _);
+            if (removedEverJoined || removedPosition)
             {
                 _cabinManager.Data.Write();
                 Monitor.Log($"Removed farmhand from cabin tracking", LogLevel.Debug);

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerData.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerData.cs
@@ -1,5 +1,6 @@
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace JunimoServer.Services.CabinManager
@@ -9,6 +10,15 @@ namespace JunimoServer.Services.CabinManager
         public Vector2? DefaultCabinLocation = null;
 
         public HashSet<long> AllPlayerIdsEverJoined = new HashSet<long>();
+
+        /// <summary>
+        /// Positions of cabins a player has explicitly moved via the /cabin command,
+        /// keyed by the owner's UniqueMultiplayerID. This records that the placement
+        /// was intentional so the MoveToStack / strategy-switch bulk movers don't
+        /// sweep it back into the hidden stack on the next load. The position itself
+        /// persists via the building's own tileX/tileY; this map only records intent.
+        /// </summary>
+        public ConcurrentDictionary<long, Vector2> PlayerCabinPositions = new ConcurrentDictionary<long, Vector2>();
 
         private const string _storageDataKey = "JunimoHost.CabinManager.data";
 
@@ -27,6 +37,7 @@ namespace JunimoServer.Services.CabinManager
             CabinManagerData Data = Helper.Data.ReadSaveData<CabinManagerData>(_storageDataKey) ?? new CabinManagerData(Helper, Monitor);
             DefaultCabinLocation = Data.DefaultCabinLocation;
             AllPlayerIdsEverJoined = Data.AllPlayerIdsEverJoined;
+            PlayerCabinPositions = Data.PlayerCabinPositions ?? new ConcurrentDictionary<long, Vector2>();
         }
 
         public void Write()

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -267,9 +267,10 @@ namespace JunimoServer.Services.CabinManager
             }
             else if (!fromUsesHidden && toUsesHidden)
             {
-                // None → Stacked: move visible cabins to hidden stack (exclude lobby/editing cabins)
+                // None → Stacked: move visible cabins to hidden stack (exclude lobby/editing
+                // cabins and any cabin a player explicitly placed via /cabin)
                 var visibleCabins = farm.buildings
-                    .Where(b => b.isCabin && !b.IsInHiddenStack() && !b.IsLobbyOrEditing())
+                    .Where(b => b.isCabin && !b.IsInHiddenStack() && !b.IsLobbyOrEditing() && !HasSavedPosition(b))
                     .ToList();
 
                 foreach (var cabin in visibleCabins)
@@ -293,6 +294,18 @@ namespace JunimoServer.Services.CabinManager
         #endregion
 
         #region Existing Cabin Import Handling
+
+        /// <summary>
+        /// True if the cabin's owner has explicitly placed it via the /cabin command.
+        /// Such a cabin must not be pulled back into the hidden stack by the bulk
+        /// movers (MoveToStack / strategy migration). This distinguishes a /cabin-placed
+        /// cabin from an imported-but-claimed one, which MoveToStack should still sweep.
+        /// </summary>
+        private bool HasSavedPosition(Building cabin)
+        {
+            var ownerId = cabin.GetIndoors<Cabin>()?.owner?.UniqueMultiplayerID ?? 0;
+            return ownerId != 0 && Data.PlayerCabinPositions.ContainsKey(ownerId);
+        }
 
         private void SyncExistingCabins()
         {
@@ -334,7 +347,7 @@ namespace JunimoServer.Services.CabinManager
             // Handle ExistingCabinBehavior for stacked strategies
             if (options.UsesHiddenCabins && options.Data.ExistingCabinBehavior == ExistingCabinBehavior.MoveToStack)
             {
-                var visibleCabins = allCabins.Where(b => !b.IsInHiddenStack() && !b.IsLobbyOrEditing()).ToList();
+                var visibleCabins = allCabins.Where(b => !b.IsInHiddenStack() && !b.IsLobbyOrEditing() && !HasSavedPosition(b)).ToList();
                 if (visibleCabins.Count > 0)
                 {
                     Monitor.Log($"MoveToStack: relocating {visibleCabins.Count} visible cabin(s) to hidden stack", LogLevel.Info);

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -2,6 +2,7 @@ using JunimoServer.Services.CabinManager;
 using JunimoServer.Services.ChatCommands;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Util;
+using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewValley;
 
@@ -39,15 +40,24 @@ namespace JunimoServer.Services.Commands
 
 
                     // TODO:
-                    // a) When cabin was relocated out of the stack, move a dummy/placeholder/other cabin in place of the stack location
-                    // b) Add checks to prevent placing cabin out-of-bounds, over trees, buildings etc.
-                    // c) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
+                    // a) Add checks to prevent placing cabin out-of-bounds, over trees, buildings etc.
+                    // b) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
                     //  - 'cabin move [direction=top|right|bottom|left]': Start "ghost" mode, manipulate LocationIntroduction package to show building as ghost without updating warp targets etc?
                     //  - 'cabin cancel': Cancel the move, reset to position from before the ghost mode
                     //  - 'cabin confirm': Confirm the move, update warp targets etc
 
-                    // Place cabin on the right-hand side the farmer
-                    cabin.Relocate(farmer.Tile.X + 1, farmer.Tile.Y);
+                    // Place cabin on the right-hand side of the farmer
+                    var newPosition = new Vector2(farmer.Tile.X + 1, farmer.Tile.Y);
+
+                    // Record the player's intent BEFORE relocating. The building's
+                    // tileX/tileY is what persists the position to the save; this map
+                    // only records that the move was intentional, so the MoveToStack /
+                    // strategy-switch bulk movers don't sweep it back into the hidden
+                    // stack on the next load.
+                    cabinService.Data.PlayerCabinPositions[msg.SourceFarmer] = newPosition;
+                    cabinService.Data.Write();
+
+                    cabin.Relocate(newPosition.ToPoint());
                 }
             );
         }

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -175,6 +175,9 @@ namespace JunimoServer.Services.GameManager
                 }
                 catch (Exception ex)
                 {
+                    // Reset startup so the next tick retries ConditionallyStartGame instead
+                    // of early-returning on _gameStarted and parking the server at title.
+                    _gameStarted = false;
                     Monitor.Log($"World reload failed: {ex}", LogLevel.Warn);
                     _reloadCompletion?.TrySetException(ex);
                 }

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -79,6 +79,9 @@ namespace JunimoServer.Services.GameManager
         /// </summary>
         public Task RequestReloadSave()
         {
+            // Reload returns to title intentionally. Flag it so AlwaysOn.OnReturnedToTitle
+            // treats this as expected instead of logging a critical (test-poisoning) error.
+            IsNewGamePending = true;
             _pendingReload = true;
             _reloadCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _gameStarted = false;
@@ -147,6 +150,9 @@ namespace JunimoServer.Services.GameManager
             if (_pendingReload)
             {
                 _pendingReload = false;
+                // Clear here (not only on success) so a failed reload doesn't leave the
+                // intent flag stuck true, which would mask a later genuine crash-to-title.
+                IsNewGamePending = false;
                 try
                 {
                     Monitor.Log("Reloading current world from API request", LogLevel.Info);
@@ -160,7 +166,7 @@ namespace JunimoServer.Services.GameManager
                 }
                 catch (Exception ex)
                 {
-                    Monitor.Log($"World reload failed: {ex}", LogLevel.Error);
+                    Monitor.Log($"World reload failed: {ex}", LogLevel.Warn);
                     _reloadCompletion?.TrySetException(ex);
                 }
                 _reloadCompletion = null;

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -1,5 +1,6 @@
 using JunimoServer.Services.GameCreator;
 using JunimoServer.Services.GameLoader;
+using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Settings;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -15,6 +16,7 @@ namespace JunimoServer.Services.GameManager
         private readonly GameCreatorService _gameCreatorService;
         private readonly GameLoaderService _gameLoaderService;
         private readonly ServerSettingsLoader _settings;
+        private readonly PersistentOptions _options;
 
         private bool _titleLaunched = false;
         private bool _gameStarted = false;
@@ -24,6 +26,10 @@ namespace JunimoServer.Services.GameManager
         // New game creation via API
         private NewGameConfig? _pendingNewGameConfig;
         private TaskCompletionSource<bool>? _newGameCompletion;
+
+        // Reload-current-world via API (apply settings + reload, no process restart)
+        private bool _pendingReload;
+        private TaskCompletionSource<bool>? _reloadCompletion;
 
         /// <summary>
         /// Whether a new game creation has been requested via the API.
@@ -37,11 +43,12 @@ namespace JunimoServer.Services.GameManager
         /// </summary>
         internal static GameManagerService? Instance { get; private set; }
 
-        public GameManagerService(GameCreatorService gameCreator, GameLoaderService gameLoader, ServerSettingsLoader settings, IModHelper helper, IMonitor monitor) : base(helper, monitor)
+        public GameManagerService(GameCreatorService gameCreator, GameLoaderService gameLoader, ServerSettingsLoader settings, PersistentOptions options, IModHelper helper, IMonitor monitor) : base(helper, monitor)
         {
             _gameCreatorService = gameCreator;
             _gameLoaderService = gameLoader;
             _settings = settings;
+            _options = options;
             Instance = this;
         }
 
@@ -61,6 +68,25 @@ namespace JunimoServer.Services.GameManager
             _lastNullCodeTime = null;
             Game1.ExitToTitle();
             return _newGameCompletion.Task;
+        }
+
+        /// <summary>
+        /// Re-reads server-settings.json and reloads the current world in-process
+        /// (no container restart). Applies any runtime settings change — notably a
+        /// CabinStrategy switch, which the cabin manager migrates on the next save load.
+        /// MUST be called on the game thread (via RunOnGameThreadAsync).
+        /// Returns a Task that completes when the world has finished reloading.
+        /// </summary>
+        public Task RequestReloadSave()
+        {
+            _pendingReload = true;
+            _reloadCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _gameStarted = false;
+            _titleLaunched = false;
+            _healthCheckTimer = 0;
+            _lastNullCodeTime = null;
+            Game1.ExitToTitle();
+            return _reloadCompletion.Task;
         }
 
         public override void Entry()
@@ -114,6 +140,32 @@ namespace JunimoServer.Services.GameManager
             }
 
             _gameStarted = true;
+
+            // If a reload was requested via the API, re-read settings and reload the
+            // current world. RecaptureAndSync makes a CabinStrategy change detectable
+            // by the cabin manager on the SaveLoaded that LoadSave triggers.
+            if (_pendingReload)
+            {
+                _pendingReload = false;
+                try
+                {
+                    Monitor.Log("Reloading current world from API request", LogLevel.Info);
+                    _settings.Reload();
+                    _options.RecaptureAndSync(_settings);
+                    if (!_gameLoaderService.LoadSave())
+                    {
+                        throw new InvalidOperationException("LoadSave returned false (no loadable save found)");
+                    }
+                    _reloadCompletion?.TrySetResult(true);
+                }
+                catch (Exception ex)
+                {
+                    Monitor.Log($"World reload failed: {ex}", LogLevel.Error);
+                    _reloadCompletion?.TrySetException(ex);
+                }
+                _reloadCompletion = null;
+                return;
+            }
 
             // If a new game was requested via the API, use the provided config
             if (_pendingNewGameConfig != null)

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -79,6 +79,15 @@ namespace JunimoServer.Services.GameManager
         /// </summary>
         public Task RequestReloadSave()
         {
+            // Coalesce overlapping requests: a second /reload while one is in flight would
+            // otherwise replace _reloadCompletion and orphan the first caller until its 120s
+            // timeout. Always invoked on the game thread (via RunOnGameThreadAsync), so this
+            // check-and-act needs no lock. Returns the in-flight task to the late caller.
+            if (_pendingReload && _reloadCompletion != null)
+            {
+                return _reloadCompletion.Task;
+            }
+
             // Reload returns to title intentionally. Flag it so AlwaysOn.OnReturnedToTitle
             // treats this as expected instead of logging a critical (test-poisoning) error.
             IsNewGamePending = true;

--- a/mod/JunimoServer/Services/PersistentOption/PersistentOptions.cs
+++ b/mod/JunimoServer/Services/PersistentOption/PersistentOptions.cs
@@ -23,12 +23,21 @@ namespace JunimoServer.Services.PersistentOption
         {
             _helper = helper;
             Data = helper.Data.ReadGlobalData<PersistentOptionsSaveData>(SaveKey) ?? new PersistentOptionsSaveData();
+            RecaptureAndSync(settings);
+        }
 
-            // Capture persisted strategy before overwriting with settings file values
+        /// <summary>
+        /// Captures the currently-persisted strategy as PreviousCabinStrategy, then
+        /// overwrites Data from the current settings file. Called on construction and
+        /// again on a runtime /reload so a CabinStrategy change is detected by
+        /// CabinManagerService.DetectAndMigrateStrategyChange without a process restart.
+        /// </summary>
+        public void RecaptureAndSync(ServerSettingsLoader settings)
+        {
+            // Persisted value = the strategy the cabins are currently arranged for.
             PreviousCabinStrategy = Data.CabinStrategy;
 
-            // Sync runtime settings from settings file on construction so services
-            // always see the current values
+            // Sync runtime settings from the settings file so services see current values.
             SyncFromSettings(settings);
         }
 

--- a/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
@@ -12,7 +12,7 @@ namespace JunimoServer.Services.Settings
     /// </summary>
     public class ServerSettingsLoader
     {
-        private readonly ServerSettings _settings;
+        private ServerSettings _settings;
         private readonly string _settingsPath;
         private readonly IMonitor _monitor;
 
@@ -78,6 +78,16 @@ namespace JunimoServer.Services.Settings
         #endregion
 
         #region Runtime setters
+
+        /// <summary>
+        /// Re-reads the settings file from disk, picking up any changes made since
+        /// startup. Used by the in-process reload path so an operator can edit
+        /// server-settings.json and apply it without a process restart.
+        /// </summary>
+        public void Reload()
+        {
+            _settings = LoadOrCreate();
+        }
 
         public void SetVerboseLogging(bool value)
         {

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -1,0 +1,243 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Containers;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Regression tests for issue #64 — a cabin moved via /cabin must keep its position
+/// across a save+reload. The bug lived in the save-load bulk movers
+/// (CabinManagerService.SyncExistingCabins / MigrateCabins), which swept every
+/// visible cabin back into the hidden stack on OnSaveLoaded with no exemption for an
+/// intentionally-placed cabin.
+///
+/// These tests exercise the real persistence path: move a cabin, sleep to write the
+/// save, then reload the world in-process via POST /reload (which re-fires
+/// OnSaveLoaded). A plain assertion after /cabin without a reload would pass even with
+/// the bug present, so every persistence test reloads.
+///
+/// Exclusive + a fresh game per test (like CabinStrategyNoneTests) so the farm starts
+/// clean and assertions can be scoped to our single farmer.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedAssembly, Exclusive = true, ExistingCabinBehavior = "MoveToStack")]
+public class CabinPositionPersistenceTests : TestBase
+{
+    public CabinPositionPersistenceTests() { }
+
+    public override async ValueTask DisposeAsync()
+    {
+        // Reset the shared server to a clean default game so the MoveToStack config
+        // and any moved cabins don't leak into sibling tests.
+        if (Lease != null)
+        {
+            try { await CreateNewGameOnServerAsync(farmType: 0); }
+            catch (Exception ex) { LogWarning($"Server reset failed during cleanup: {ex.Message}"); }
+        }
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Core bug (#64), merge gate: a /cabin-placed cabin under MoveToStack keeps its
+    /// position after a save+reload instead of being swept back to the hidden stack.
+    /// </summary>
+    [Fact]
+    public async Task MoveToStack_PlacedCabinSurvivesReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        Log($"Cabin placed at ({movedTile.X},{movedTile.Y}) for '{client.FarmerName}'");
+
+        await SleepToSaveAsync(ct);
+        // Disconnect before reload: /reload returns 409 while a client is connected.
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        await ReloadServerAsync();
+
+        var afterReload = await GetOurCabinAsync(ownerId, ct);
+        Assert.False(afterReload.IsHidden,
+            $"Cabin reverted to hidden stack after reload (at {afterReload.TileX},{afterReload.TileY})");
+        Assert.Equal(movedTile, (afterReload.TileX, afterReload.TileY));
+        Log($"Cabin survived reload at ({afterReload.TileX},{afterReload.TileY})");
+    }
+
+    /// <summary>
+    /// Over-fix guard: with NO /cabin move, an unclaimed visible cabin is still swept
+    /// into the hidden stack on reload under MoveToStack. Proves the HasSavedPosition
+    /// exemption didn't break the sweep's real job.
+    /// </summary>
+    [Fact]
+    public async Task MoveToStack_UnclaimedCabinSweptOnReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // None strategy starts cabins at real, visible map positions. After switching
+        // to CabinStack + MoveToStack and reloading, those unclaimed cabins (no /cabin
+        // intent) must be pulled into the hidden stack.
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None", startingCabins: 2);
+
+        var before = await ServerApi.GetCabins(ct);
+        Assert.NotNull(before);
+        var visibleUnclaimed = before.Cabins.Where(c => !c.IsHidden && !c.IsAssigned).ToList();
+        Assert.True(visibleUnclaimed.Count > 0,
+            "Expected at least one visible unclaimed cabin under None strategy");
+        Log($"Before reload: {visibleUnclaimed.Count} visible unclaimed cabin(s)");
+
+        await SwitchCabinStrategyAsync("CabinStack", ct);
+        await ReloadServerAsync();
+
+        var after = await ServerApi.GetCabins(ct);
+        Assert.NotNull(after);
+        var stillVisibleUnclaimed = after.Cabins.Count(c => !c.IsHidden && !c.IsAssigned && c.Type != "Lobby");
+        Assert.Equal(0, stillVisibleUnclaimed);
+        Log($"After reload: unclaimed cabins swept to hidden stack ({after.Cabins.Count(c => c.IsHidden)} hidden)");
+    }
+
+    /// <summary>
+    /// Second bug path: the strategy-switch migration (MigrateCabins, None→CabinStack)
+    /// must also respect a /cabin-placed cabin.
+    /// </summary>
+    [Fact]
+    public async Task StrategySwitch_NoneToCabinStack_PlacedCabinSurvives()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        Log($"Cabin placed at ({movedTile.X},{movedTile.Y}) under None for '{client.FarmerName}'");
+
+        await SleepToSaveAsync(ct);
+        // Disconnect before reload: /reload returns 409 while a client is connected.
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        await SwitchCabinStrategyAsync("CabinStack", ct);
+        await ReloadServerAsync();
+
+        var afterReload = await GetOurCabinAsync(ownerId, ct);
+        Assert.False(afterReload.IsHidden,
+            $"Cabin swept by None→CabinStack migration (at {afterReload.TileX},{afterReload.TileY})");
+        Assert.Equal(movedTile, (afterReload.TileX, afterReload.TileY));
+        Log($"Cabin survived strategy switch at ({afterReload.TileX},{afterReload.TileY})");
+    }
+
+    /// <summary>
+    /// Deleting a farmhand clears its saved-position intent. After !cabin, the owner's
+    /// id appears in /cabins SavedPositionPlayerIds; after the farmhand is deleted, it
+    /// is gone (ExecuteFarmhandDeletion removes PlayerCabinPositions[ownerId]). No
+    /// reload needed — the intent map is observable directly.
+    /// </summary>
+    [Fact]
+    public async Task Deletion_ClearsSavedPositionIntent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        await MoveCabinViaCommandAsync(ownerId, ct);
+
+        // Intent is recorded for this owner.
+        var withIntent = await ServerApi.GetCabins(ct);
+        Assert.NotNull(withIntent);
+        Assert.Contains(ownerId, withIntent.SavedPositionPlayerIds);
+        Log($"Intent recorded for owner {ownerId}");
+
+        // Delete the farmhand; this must also clear PlayerCabinPositions[ownerId].
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        var deleteResult = await ServerApi.WaitForFarmhandDeletedByNameAsync(client.FarmerName, ct: ct);
+        Assert.True(deleteResult?.Success, $"Delete should succeed: {deleteResult?.Error ?? "timeout"}");
+        Farmers.CreatedFarmers.RemoveAll(f => f.Uid == ownerId);
+
+        var afterDelete = await ServerApi.GetCabins(ct);
+        Assert.NotNull(afterDelete);
+        Assert.DoesNotContain(ownerId, afterDelete.SavedPositionPlayerIds);
+        Log($"Intent cleared for deleted owner {ownerId}");
+    }
+
+    #region Helpers
+
+    /// <summary>
+    /// Warps the farmer to the Farm and runs the !cabin command, then returns the
+    /// resulting master cabin tile read from /cabins. The tile is captured (not
+    /// predicted) so the test never assumes a warp landing tile or map position.
+    /// </summary>
+    private async Task<(int X, int Y)> MoveCabinViaCommandAsync(long ownerId, CancellationToken ct)
+    {
+        // !cabin requires the farmer to be on the Farm. The exact tile doesn't matter —
+        // we read the resulting cabin position back from /cabins.
+        var warp = await GameClient.Actions.Warp("Farm", 64, 15);
+        Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
+        await GameClient.WaitForLocationAsync("Farm", ct: ct);
+
+        var before = await GetOurCabinAsync(ownerId, ct);
+
+        // Resend on each poll: the !cabin handler checks the SERVER's view of the
+        // farmer location, which can lag the client-side warp by a tick. Resending
+        // until the move lands self-heals that race without a fixed sleep.
+        CabinInfoResponse? moved = null;
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinStrategy_OurCabinAssigned,
+            async () =>
+            {
+                await GameClient.SendChat("!cabin");
+                moved = await GetOurCabinAsync(ownerId, ct);
+                return !moved.IsHidden && (moved.TileX, moved.TileY) != (before.TileX, before.TileY);
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+
+        Assert.True(ok, "Cabin did not move out of the hidden stack after !cabin");
+        return (moved!.TileX, moved.TileY);
+    }
+
+    /// <summary>
+    /// Sleeps the farmhand and waits for the day transition, which writes the save to
+    /// disk. Mandatory before a reload — WriteSaveData and building tileX/tileY are
+    /// in-memory until a game save, so a reload without a save proves nothing.
+    /// </summary>
+    private async Task SleepToSaveAsync(CancellationToken ct)
+    {
+        var statusBefore = await ServerApi.GetStatus(ct);
+        Assert.NotNull(statusBefore);
+
+        var sleep = await GameClient.Actions.Sleep();
+        Assert.True(sleep?.Success == true, $"Sleep failed: {sleep?.Error}");
+
+        var dayChanged = await DayChange.WaitAsync(
+            statusBefore.Day, statusBefore.Season, statusBefore.Year, ct);
+        Assert.True(dayChanged, "Day did not advance; save was not written");
+    }
+
+    /// <summary>
+    /// Rewrites the in-container server-settings.json cabinStrategy value in place.
+    /// The change is applied by the next ReloadServerAsync (which re-reads the file).
+    /// Mirrors the real operator flow: edit settings, reload — no test-only API added.
+    /// Uses sed (jq is not in the server image); the settings writer emits one
+    /// "cabinStrategy": "..." line, so a keyed substitution is unambiguous.
+    /// </summary>
+    private async Task SwitchCabinStrategyAsync(string strategy, CancellationToken ct)
+    {
+        var script =
+            $"sed -i 's/\"cabinStrategy\": \"[^\"]*\"/\"cabinStrategy\": \"{strategy}\"/' {ServerContainer.SettingsPath}";
+        var result = await Server.Container.ExecAsync(new[] { "sh", "-c", script }, ct);
+        Assert.True(result.ExitCode == DockerExitCodes.Success,
+            $"Failed to rewrite settings cabinStrategy: {result.Stderr}");
+        Log($"Switched in-container cabinStrategy to {strategy}");
+    }
+
+    private async Task<CabinInfoResponse> GetOurCabinAsync(long ownerId, CancellationToken ct)
+    {
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        var ours = cabins.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+        Assert.NotNull(ours);
+        return ours;
+    }
+
+    #endregion
+}

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -155,9 +155,19 @@ public class CabinPositionPersistenceTests : TestBase
         Assert.True(deleteResult?.Success, $"Delete should succeed: {deleteResult?.Error ?? "timeout"}");
         Farmers.CreatedFarmers.RemoveAll(f => f.Uid == ownerId);
 
-        var afterDelete = await ServerApi.GetCabins(ct);
-        Assert.NotNull(afterDelete);
-        Assert.DoesNotContain(ownerId, afterDelete.SavedPositionPlayerIds);
+        // /cabins is snapshot-backed, so the cleared intent can lag the deletion by a
+        // snapshot tick. Poll until the owner is gone instead of asserting immediately.
+        CabinsResponse? afterDelete = null;
+        var cleared = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinStrategy_FarmerDeletionReflected,
+            async () =>
+            {
+                afterDelete = await ServerApi.GetCabins(ct);
+                return afterDelete != null
+                    && !afterDelete.SavedPositionPlayerIds.Contains(ownerId);
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+
+        Assert.True(cleared, $"Saved-position intent was not cleared for deleted owner {ownerId}");
         Log($"Intent cleared for deleted owner {ownerId}");
     }
 

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -623,6 +623,9 @@ public class CabinsResponse
 
     [JsonPropertyName("cabins")]
     public List<CabinInfoResponse> Cabins { get; set; } = new();
+
+    [JsonPropertyName("savedPositionPlayerIds")]
+    public List<long> SavedPositionPlayerIds { get; set; } = new();
 }
 
 /// <summary>
@@ -1341,6 +1344,19 @@ public class ServerApiClient : IDisposable
 
         var content = JsonContent.Create(body);
         var response = await _httpClient.PostAsync("/newgame", content, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<NewGameResponse>(ct);
+    }
+
+    /// <summary>
+    /// Re-reads server-settings.json and reloads the active world in-process (no
+    /// container restart). Applies any runtime settings change (e.g. CabinStrategy)
+    /// and fires the mod's SaveLoaded path. The response shape matches /newgame.
+    /// POST /reload
+    /// </summary>
+    public async Task<NewGameResponse?> ReloadAsync(CancellationToken ct = default)
+    {
+        var response = await _httpClient.PostAsync("/reload", content: null, ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<NewGameResponse>(ct);
     }

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1356,7 +1356,10 @@ public class ServerApiClient : IDisposable
     /// </summary>
     public async Task<NewGameResponse?> ReloadAsync(CancellationToken ct = default)
     {
-        var response = await _httpClient.PostAsync("/reload", content: null, ct);
+        // Reload runs during title/save transitions, where the game thread is most
+        // likely busy and the server returns a transient 503. Go through the retry
+        // helper so those are retried transparently like every other mutating call.
+        var response = await SendWithRetryAsync(HttpMethod.Post, "/reload", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<NewGameResponse>(ct);
     }

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -62,6 +62,9 @@ public class ServerContainer : IAsyncDisposable
     public const int ContainerGamePort = 24642;
     public const string ContainerGamePortUdp = "24642/udp";
 
+    /// <summary>In-container path of the server settings file (injected at create, re-read by /reload).</summary>
+    public const string SettingsPath = "/config/server-settings.json";
+
     /// <summary>
     /// Mapped host ports (available after StartAsync).
     /// </summary>
@@ -250,8 +253,8 @@ public class ServerContainer : IAsyncDisposable
             // Inject settings via the Testcontainers tar API so no host temp
             // file is involved (and so remote-host runs work without uploading
             // a path that doesn't exist on the daemon side).
-            .WithResourceMapping(settingsBytes, "/config/server-settings.json")
-            .WithEnvironment("SETTINGS_PATH", "/config/server-settings.json")
+            .WithResourceMapping(settingsBytes, SettingsPath)
+            .WithEnvironment("SETTINGS_PATH", SettingsPath)
             .WithEnvironment("API_ENABLED", "true")
             .WithEnvironment("API_PORT", ContainerApiPort.ToString())
             // Performance/test settings

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -986,6 +986,44 @@ internal sealed class ManagedServer : IAsyncDisposable
     }
 
     /// <summary>
+    /// Re-reads server-settings.json and reloads the active world via the API,
+    /// suspending health checks during the title→reload transition. Used by tests
+    /// that need OnSaveLoaded to re-run (e.g. cabin-position persistence).
+    /// </summary>
+    public async Task ReloadAsync(CancellationToken ct = default)
+    {
+        SuspendHealthChecks();
+        try
+        {
+            using var api = Server.CreateApiClient();
+
+            var result = await api.ReloadAsync(ct);
+            if (result?.Success != true)
+                throw new InvalidOperationException($"Reload failed: {result?.Error ?? "unknown"}");
+
+            // Verify the server is actually back online
+            var status = await api.WaitForServerOnline(
+                timeout: TimeSpan.FromSeconds(120),
+                pollInterval: TimeSpan.FromSeconds(2),
+                cancellationToken: ct,
+                requireInviteCode: Server.Options.WithSteam);
+
+            if (status == null)
+            {
+                ct.ThrowIfCancellationRequested();
+                throw new TimeoutException("Server did not come back online after reload");
+            }
+
+            Server.ClearErrors();
+            TestLog.Server($"{_displayLabel} world reloaded");
+        }
+        finally
+        {
+            ResumeHealthChecks();
+        }
+    }
+
+    /// <summary>
     /// Disposal path for poisoned servers. Releases the environment slot
     /// immediately so a replacement can start, then waits for active leases
     /// to drain (so tests can finish their artifacts phase against the

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
@@ -94,6 +94,15 @@ public sealed class ResourceLease : IAsyncDisposable
     }
 
     /// <summary>
+    /// Re-reads settings and reloads the current world, suspending health checks
+    /// during the transition.
+    /// </summary>
+    public async Task ReloadAsync(CancellationToken ct = default)
+    {
+        await _managed.ReloadAsync(ct);
+    }
+
+    /// <summary>
     /// Current reference count on the underlying managed server.
     /// </summary>
     internal int RefCount => _managed.RefCount;

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
@@ -13,7 +13,7 @@ public sealed record ResourceRequirements(
     int StartingCabins, int MaxPlayers, int Clients,
     string CabinStrategy, bool AllowIpConnections,
     IsolationMode Isolation, string? TestClassName, string? TestMethodName,
-    bool Exclusive = false)
+    bool Exclusive = false, string ExistingCabinBehavior = "KeepExisting")
 {
     private static int _perTestCounter;
 
@@ -50,7 +50,7 @@ public sealed record ResourceRequirements(
     private string ComputeConfigHash()
     {
         var configString = $"{Password}|{FarmType}|{WithSteam}|{StartingCabins}" +
-                          $"|{MaxPlayers}|{CabinStrategy}|{AllowIpConnections}";
+                          $"|{MaxPlayers}|{CabinStrategy}|{AllowIpConnections}|{ExistingCabinBehavior}";
         var bytes = Encoding.UTF8.GetBytes(configString);
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
@@ -72,7 +72,7 @@ public sealed record ResourceRequirements(
         AllowIpConnections: attr.WithSteam ? attr.AllowIpConnections : true,
         Isolation: attr.Isolation, TestClassName: testClassName,
         TestMethodName: testMethodName,
-        Exclusive: attr.Exclusive);
+        Exclusive: attr.Exclusive, ExistingCabinBehavior: attr.ExistingCabinBehavior);
 
     /// <summary>
     /// Convenience factory for FarmMapTypeTests Theory parameters.
@@ -96,6 +96,7 @@ public sealed record ResourceRequirements(
             StartingCabins = StartingCabins,
             MaxPlayers = MaxPlayers,
             CabinStrategy = CabinStrategy,
+            ExistingCabinBehavior = ExistingCabinBehavior,
             AllowIpConnections = AllowIpConnections,
             WithSteam = WithSteam
         };

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -533,6 +533,23 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
         ServerStatus = await ServerApi.GetStatus(TestCt);
     }
 
+    /// <summary>
+    /// Re-reads server-settings.json and reloads the current world in-process (no
+    /// container restart), re-running the mod's OnSaveLoaded path. Suspends health
+    /// checks during the transition and waits for the server to come back online.
+    /// Only valid when the test has an active server lease.
+    /// </summary>
+    protected async Task ReloadServerAsync()
+    {
+        if (Lease == null)
+            throw new InvalidOperationException("No server lease. Call AcquireServerAsync() first.");
+
+        await Lease.ReloadAsync(TestCt);
+
+        // Refresh the cached server status
+        ServerStatus = await ServerApi.GetStatus(TestCt);
+    }
+
     #endregion
 
     #region Exception Monitoring

--- a/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
@@ -17,6 +17,7 @@ public class TestServerAttribute : Attribute
     private int? _maxPlayers;
     private int? _clients;
     private string? _cabinStrategy;
+    private string? _existingCabinBehavior;
     private bool? _allowIpConnections;
     private IsolationMode? _isolation;
     private int? _priority;
@@ -40,6 +41,7 @@ public class TestServerAttribute : Attribute
     public int MaxPlayers { get => _maxPlayers ?? Math.Max(10, StartingCabins + 1); set => _maxPlayers = value; }
     public int Clients { get => _clients ?? 1; set => _clients = value; }
     public string CabinStrategy { get => _cabinStrategy ?? "CabinStack"; set => _cabinStrategy = value; }
+    public string ExistingCabinBehavior { get => _existingCabinBehavior ?? "KeepExisting"; set => _existingCabinBehavior = value; }
     public bool AllowIpConnections { get => _allowIpConnections ?? false; set => _allowIpConnections = value; }
     public IsolationMode Isolation { get => _isolation ?? IsolationMode.SharedClass; set => _isolation = value; }
 
@@ -98,6 +100,7 @@ public class TestServerAttribute : Attribute
         merged._startingCabins = method._startingCabins ?? _startingCabins;
         merged._maxPlayers = method._maxPlayers ?? _maxPlayers;
         merged._cabinStrategy = method._cabinStrategy ?? _cabinStrategy;
+        merged._existingCabinBehavior = method._existingCabinBehavior ?? _existingCabinBehavior;
         merged._allowIpConnections = method._allowIpConnections ?? _allowIpConnections;
         merged._isolation = method._isolation ?? _isolation;
         merged._priority = method._priority ?? _priority;


### PR DESCRIPTION
Fixes #64 — a cabin moved with `!cabin` reverted to its default location after a host restart.

## Root cause
- The `!cabin` command relocates the master cabin to a real tile; `tileX/tileY` are `NetInt`/`[XmlElement]`, so the position already persists to the save.
- Two save-load bulk movers swept *every* visible cabin back into the hidden stack on `OnSaveLoaded`, with no exemption for an intentionally-placed cabin: `SyncExistingCabins` (under `ExistingCabinBehavior=MoveToStack`) and `MigrateCabins` (on a `None → CabinStack/FarmhouseStack` strategy switch).
- The original "always reverts" behavior for the default config was already fixed by #149's `IsInHiddenStack()` guard; these two paths were what remained.

## Fix
- Record per-player intent in `CabinManagerData.PlayerCabinPositions` (keyed by `UniqueMultiplayerID`) when `!cabin` runs.
- Add a `HasSavedPosition` exemption to both bulk-mover filters so a `!cabin`-placed cabin is never swept. Imported-but-claimed cabins are still swept under `MoveToStack` (intended scope).
- Clear the intent entry in `ExecuteFarmhandDeletion` so a deleted player's record doesn't leak into the save.

## New capability: in-process world reload (`POST /reload`)
Needed to test the on-disk persistence path without a container restart; also useful to operators (apply a `server-settings.json` change live, no `docker restart`).
- `ServerSettingsLoader.Reload()` re-reads settings at runtime.
- `PersistentOptions.RecaptureAndSync()` factors the constructor's capture-previous-strategy + sync so a `CabinStrategy` change is detected on reload.
- `GameManagerService.RequestReloadSave()`: `ExitToTitle` → re-sync → `LoadSave`, symmetric to `RequestNewGame`.
- `POST /reload` (parameterless): apply current settings and reload the active world.
- `/cabins` exposes `SavedPositionPlayerIds` so the per-player intent map is observable.

## Tests
`CabinPositionPersistenceTests` (4, all green on real infra):
- `MoveToStack`: `!cabin`-placed cabin survives save+reload (the bug line).
- `None → CabinStack` strategy switch: placed cabin survives migration.
- `MoveToStack`: unclaimed cabin still swept (over-fix guard).
- Deletion clears the saved-position intent.

Test harness additions: `ReloadAsync`/`ReloadServerAsync`, and an `ExistingCabinBehavior` knob on `[TestServer]` (threaded through the config hash + container settings).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /reload to reload the active world in-process with structured success/error feedback.
  * Cabins GET now exposes saved-position owner IDs so explicitly placed cabins are tracked.
  * Server settings can be reloaded at runtime.

* **Bug Fixes**
  * Deleting a farmhand now clears their saved cabin-position intent and only saves cabin-manager data when changes occur.

* **Tests**
  * Added integration tests for cabin placement persistence, strategy migrations, deletion behavior, and reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->