### PR TITLE
ci: E2E smoke workflow + surface results (GitHub summary + offline test-web report)

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -29,8 +29,11 @@
 #   clientSlots  required, positive integer.
 #   endpoint     optional. Omit for the local default daemon (Unix socket /
 #                named pipe). Remote: ssh://user@host. Requires OpenSSH on PATH.
-#   sshKey       optional. Path to a private key, `~`-expanded or relative to
-#                the project root. When set, the runner passes
+#   sshKey       optional. Either a path to a private key (`~`-expanded or
+#                relative to the project root), or inline key material — a
+#                "-----BEGIN…" block, which the runner writes to a 0600 temp
+#                file. Inline is for CI, where the whole SDVD_DOCKER_HOSTS JSON
+#                (key included) is one secret. When set, the runner passes
 #                `-i {key} -o IdentitiesOnly=yes` to every ssh invocation for
 #                this host. Omit to fall back to ~/.ssh/config + ssh-agent.
 #   socketPath   optional, remote hosts only. Daemon Unix socket on the remote

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,237 @@
+# Runs the heavy Docker E2E suite as a smoke subset. The coordinator
+# (JunimoServer.TestRunner, a net10.0 app) runs here on ubuntu-latest; the actual
+# Stardew game containers run on a remote VPS reached over SSH — the harness's
+# existing multi-host model with SDVD_DOCKER_HOSTS set to a VPS-only fleet.
+#
+# workflow_dispatch only — never automatic. E2E depends on an external VPS being
+# up; that availability risk must never gate the merge queue. Manual-from-a-
+# trusted-branch also keeps the VPS SSH key and Steam secrets away from fork code.
+# Do NOT add pull_request_target / push / schedule / merge_group. A future move to
+# any automatic trigger would first require copying validate-pr.yml's authorize /
+# fork-pr environment gate (the VPS private key reaching fork code = root on the
+# test VPS via the docker group), and must never become a required check.
+#
+# All secrets resolve from the `test-vps` GitHub Environment (the same per-
+# environment mechanism deploy-server.yml uses), not loose repo-level secrets.
+name: E2E Tests (Smoke)
+
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'Test filter (xUnit class/method substring)'
+        required: false
+        default: 'ServerSettingsTests'
+
+permissions:
+  contents: read
+
+# Cancel superseded dispatches. Keyed on github.ref — a dispatch has no PR number.
+# A cancel triggers the runner's abort path (writes summary.json, sweeps VPS
+# containers by run-id).
+concurrency:
+  group: e2e-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-smoke:
+    name: E2E Smoke (VPS)
+    runs-on: ubuntu-latest
+    # Holds the Steam + SSH secrets. Mirrors deploy-server.yml's per-environment
+    # secret scoping.
+    environment: test-vps
+    # Generous headroom for a cold first run: server + test-client + steam-service
+    # image builds, the one-time ~250 MB game-data stream to the VPS, a remote
+    # server cold-start (slower than local), plus a handful of HTTP asserts.
+    # Tighten toward ~20 once steady-state.
+    timeout-minutes: 30
+
+    # Non-secret runner config shared by every step. The Steam secrets are scoped
+    # to the two steps that consume them (populate + run), not broadcast here.
+    env:
+      CI: "true"
+      # SDVD_IMAGE_TAG=local ⇒ PullPolicy.Never on the VPS (ServerContainer): the
+      # VPS never pulls sdvd/server:local from a registry — the run depends
+      # entirely on ImageDistributor having streamed the freshly-built image to
+      # the VPS daemon (build local → stream → skip-when-digests-match). A
+      # broken/skipped distribution surfaces as a container-create "image not
+      # found" on the VPS, not a pull retry. Keep this `local`.
+      SDVD_IMAGE_TAG: local
+      SDVD_STOP_ON_FAIL: "true"
+      # Rendering + recording knobs, mirrored from the local .env.test so a CI run
+      # behaves like a local `make test` run (watchable video per test). FPS > 0
+      # turns on the in-container draw loop AND the video recorder; on this
+      # gpu:false VPS the recorder uses libx264 software encoding (no NVENC). The
+      # .mp4 clips land under TestResults/runs/ and are uploaded as artifacts.
+      # SDVD_TEST_SCREENSHOTS / SDVD_TEST_TRACING are intentionally unset here
+      # (as in .env.test) so they take their defaults.
+      SERVER_TPS: "5"
+      SERVER_FPS: "5"
+      CLIENT_TPS: "5"
+      CLIENT_FPS: "5"
+      SDVD_TEST_RECORDING: all
+      DISPLAY_WIDTH: "640"
+      DISPLAY_HEIGHT: "360"
+      # Consumed by `make build` as --build-arg BUILD_CONFIGURATION (Makefile),
+      # inherited by the runner's in-process `make build` subprocess. Not read by
+      # any C#. The Makefile default is Debug; pin Release for CI.
+      BUILD_CONFIGURATION: Release
+      # The harness's host-fleet config, verbatim — set as ONE GitHub secret in
+      # the test-vps environment, exactly as you'd put it in .env.test locally.
+      # It carries the whole VPS-only fleet: id / endpoint (ssh://user@host, keep
+      # the VPS on port 22 — SDVD_DOCKER_HOSTS has no port field) / serverSlots /
+      # clientSlots / gpu:false (recording uses libx264 software encode), AND the SSH
+      # private key INLINE in the `sshKey` field (a "-----BEGIN…" block). HostPool
+      # writes inline key material to a 0600 temp file at startup and resolves
+      # `sshKey` to that path, so no key-file step is needed here. Shape the
+      # secret like:
+      #   [{"id":"vps","endpoint":"ssh://sdvd-runner@HOST","serverSlots":1,
+      #     "clientSlots":2,"gpu":false,
+      #     "sshKey":"-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END…-----\n"}]
+      SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # The coordinator is a net10.0 app that runs HERE on the runner (the mod
+      # builds inside Docker; the runner does not). .NET 10 is GA, so the default
+      # quality channel resolves a stable SDK — no preview pin needed.
+      - name: Setup .NET 10.0
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
+        with:
+          dotnet-version: '10.0.x'
+
+      # For the runner's own `make build` (the E2E step), which shells out to
+      # `docker buildx build --load`. There is NO separate image-build step in
+      # this job — the runner builds all three images (server, test-client,
+      # steam-service) in-process.
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      # The Dockerfile uses a BuildKit `--mount=type=cache` for /root/.nuget/packages
+      # that BuildKit does not persist across runs. The cache-dance bridges that:
+      # actions/cache persists a local nuget-cache-mount dir, the inject step seeds
+      # the BuildKit mount from it before the build, and the extract step (after)
+      # writes the updated mount back. Mirrors validate-pr.yml — but with no
+      # `changes`-job gating (this job always builds).
+      - name: Cache NuGet mount
+        id: nuget-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: nuget-cache-mount
+          key: nuget-cache-mount-${{ hashFiles('mod/**/*.csproj', 'tools/steam-service/**/*.csproj', 'Directory.Build.props') }}
+
+      - name: Inject NuGet mount
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          skip-extraction: ${{ steps.nuget-cache.outputs.cache-hit }}
+
+      # Seed known_hosts so the runner's `ssh -M` master is non-interactive. The
+      # master spawns with BatchMode=yes and the default known_hosts file (no
+      # StrictHostKeyChecking override, TunnelManager.SpawnMasterAsync), so an
+      # unknown host key is a hard failure — this keyscan is mandatory, not
+      # cosmetic. The host(s) are parsed out of SDVD_DOCKER_HOSTS itself (strip
+      # the ssh:// scheme and any user@), so there's no separate host secret to
+      # keep in sync. The private key is NOT written here — HostPool materializes
+      # the inline `sshKey` to its own 0600 temp file.
+      #
+      # SECURITY: the jq below extracts ONLY `.endpoint`. Never change it to read
+      # `.sshKey` (or pipe the raw $SDVD_DOCKER_HOSTS to stdout). `jq -r .sshKey`
+      # would emit the DECODED key with real newlines — different bytes than the
+      # registered secret, so GitHub's log masker would NOT redact it, leaking the
+      # private key into public CI logs.
+      - name: Trust VPS host key
+        env:
+          SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          hosts=$(printf '%s' "$SDVD_DOCKER_HOSTS" \
+            | jq -r '.[] | select(.endpoint) | .endpoint' \
+            | sed -E 's#^ssh://##; s#^[^@]*@##')
+          if [ -z "$hosts" ]; then
+            echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS — cannot keyscan." >&2
+            exit 1
+          fi
+          for h in $hosts; do
+            echo "Scanning host key for $h"
+            ssh-keyscan -t rsa,ecdsa,ed25519 "$h" >> ~/.ssh/known_hosts 2>/dev/null
+          done
+          chmod 644 ~/.ssh/known_hosts
+
+      # Populate the LOCAL server_game-data volume — the precondition for
+      # GameDataDistributor, which throws if the local volume is empty (it probes
+      # for /data/StardewValley inside it) and otherwise streams it to the VPS.
+      # STEAM_ACCOUNTS is the single source of Steam credentials: steam-service's
+      # DiscoverAccounts() reads STEAM_ACCOUNTS (JSON) first and only falls back
+      # to bare STEAM_USERNAME/PASSWORD when it's absent (tools/steam-service/
+      # Program.cs). compose doesn't map STEAM_ACCOUNTS into the steam-auth
+      # service, so we forward it with `-e STEAM_ACCOUNTS` (value comes from this
+      # step's env, never the command line) — the CI analogue of `make setup`,
+      # which injects .env.test (carrying STEAM_ACCOUNTS) via --env-from-file.
+      # `download` logs in headlessly (no 2FA on the test accounts → no Steam
+      # Guard) and fills /data/game. COMPOSE_PROJECT_NAME=server pins the volume
+      # name to the hardcoded `server_game-data` (ServerContainerOptions);
+      # IMAGE_VERSION=local makes compose resolve the locally-built
+      # sdvd/steam-service:local rather than the :latest default.
+      - name: Populate local game-data volume
+        env:
+          COMPOSE_PROJECT_NAME: server
+          IMAGE_VERSION: local
+          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
+        run: |
+          docker compose build steam-auth
+          docker compose run --rm -e STEAM_ACCOUNTS steam-auth download
+
+      # The whole pipeline in one command. The runner builds all three images
+      # in-process (reading STEAM_ACCOUNTS[0] for the Steam --secret login),
+      # streams them + the game-data volume to the VPS, then runs the filtered
+      # tests there. --filter is a substring match against the FQ test name, so a
+      # class name runs that class. STEAM_ACCOUNTS is required here from the very
+      # first run — without it the in-process image build fails with a Steam-login
+      # error.
+      - name: Run E2E smoke
+        env:
+          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
+          # Pass the (operator-controlled) filter through the environment, not
+          # interpolated into the command line, so its value can never be parsed
+          # as shell. The input already defaults to ServerSettingsTests; the
+          # fallback covers an explicitly-cleared input.
+          FILTER: ${{ inputs.filter || 'ServerSettingsTests' }}
+        run: |
+          dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
+
+      # After the build (which seeds the BuildKit mount), write the updated NuGet
+      # mount back for actions/cache to save. Gated on cache-miss only — matches
+      # validate-pr.yml; do NOT add `if: always()`.
+      - name: Extract NuGet mount
+        if: steps.nuget-cache.outputs.cache-hit != 'true'
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-dir: nuget-cache-mount
+          cache-map: |
+            {
+              "nuget-cache-mount": "/root/.nuget/packages"
+            }
+          extract: true
+
+      # Per-run artifact tree: summary.json, ctrf-report.json, run-metadata.json,
+      # diagnostics/infrastructure.jsonl, tests/{Class}.{Method}/, containers/...
+      # (TestArtifacts: TestResults/runs/{timestamp}_{sha}/). Always upload so a
+      # failed or aborted run is still inspectable.
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-test-results
+          path: TestResults/runs/
+          if-no-files-found: warn

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -102,6 +102,19 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      # Build the test-UI SPA so the runner can assemble the offline web report
+      # (test-web) from it after the run. The runner's report path (ReportGenerator,
+      # triggered by CI) needs tests/test-ui/dist/index.html to exist; without this
+      # step it no-ops with a "SPA dist not found" warning. Mirrors build-docs.yml's
+      # Bun setup and `make build-test-ui` (bun install && bun run build →
+      # vue-tsc --noEmit && vite build).
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Build test-UI SPA
+        run: bun install && bun run build
+        working-directory: tests/test-ui
+
       # For the runner's own `make build` (the E2E step), which shells out to
       # `docker buildx build --load`. There is NO separate image-build step in
       # this job — the runner builds all three images (server, test-client,
@@ -209,6 +222,24 @@ jobs:
         run: |
           dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
 
+      # Render the run's results into the GitHub job Summary tab from the CTRF
+      # report the runner already emits (TestRunArtifactWriter.WriteCtrfReport →
+      # runs/{id}/ctrf-report.json — exactly one run per CI invocation, so the
+      # glob resolves it unambiguously). summary-report = the pass/fail table;
+      # failed-report = a table of failing tests with their error; test-list-report
+      # = the full per-test list. `summary: true` (the action default) writes to
+      # $GITHUB_STEP_SUMMARY. No PR comment — `pull-request` defaults to false and
+      # this workflow is dispatch-only with no PR context. if: always() so a failed
+      # or aborted run still surfaces its results.
+      - name: Publish CTRF results to job summary
+        if: always()
+        uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1.0.28
+        with:
+          report-path: 'TestResults/runs/**/ctrf-report.json'
+          summary-report: true
+          failed-report: true
+          test-list-report: true
+
       # After the build (which seeds the BuildKit mount), write the updated NuGet
       # mount back for actions/cache to save. Gated on cache-miss only — matches
       # validate-pr.yml; do NOT add `if: always()`.
@@ -234,4 +265,18 @@ jobs:
         with:
           name: e2e-test-results
           path: TestResults/runs/
+          if-no-files-found: warn
+
+      # The self-contained offline test-web bundle (the test-UI SPA + run snapshot
+      # + copied screenshots/videos under report/artifacts/), assembled by the
+      # runner inside the run dir. Uploaded separately so reviewers can grab a
+      # clean, openable report (open report/index.html over file://) without
+      # downloading the multi-GB raw runs/ tree. if-no-files-found: warn covers an
+      # early abort before report assembly (e.g. preflight failure).
+      - name: Upload web report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-web-report
+          path: TestResults/runs/*/report/
           if-no-files-found: warn

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -171,21 +171,26 @@ TestResults/runs/{timestamp}_{sha}/tests/{Class}.{Method}/
 
 ## CI Usage
 
-### GitHub Actions Example
+The E2E smoke suite runs from `.github/workflows/e2e-tests.yml` (`workflow_dispatch`
+only — the coordinator runs on the GitHub runner; the game containers run on a
+remote VPS over SSH). That workflow is the source of truth for CI invocation.
 
-```yaml
-- name: Run E2E Tests
-  env:
-    STEAM_REFRESH_TOKEN: ${{ secrets.STEAM_REFRESH_TOKEN }}
-    SDVD_TEST_SCREENSHOTS: done
-    SDVD_TEST_RECORDING: failure
-    CI: true
-  run: |
-    make setup
-    make test-web-report FILTER=Smoke
-```
+Results surface in two GitHub-native places, both produced from artifacts the
+runner already emits:
 
-The `test-web-report` target generates a static HTML report in `TestResults/report/` that can be uploaded as a CI artifact.
+- **Job Summary tab** — the [CTRF reporter action](https://github.com/ctrf-io/github-test-reporter)
+  renders `runs/{id}/ctrf-report.json` into a pass/fail + failed-tests table. No
+  PR comment (the workflow is dispatch-only and has no PR context).
+- **`e2e-web-report` artifact** — a self-contained offline bundle of the test-UI
+  SPA with the run snapshot inlined and screenshots/videos copied alongside.
+  Download it and open `report/index.html` over `file://`; screenshots and videos
+  play without a running server.
+
+Under `CI` (or with the `--report` flag locally), the runner assembles that
+bundle into `TestResults/runs/{id}/report/` after the run — it requires the
+test-UI SPA to be built first (the workflow runs `bun run build` in
+`tests/test-ui`). Locally, `make test-web-report FILTER=<name>` does the same
+build-then-report in one step.
 
 ## Troubleshooting
 

--- a/docs/developers/testing/remote-host-setup.md
+++ b/docs/developers/testing/remote-host-setup.md
@@ -12,7 +12,7 @@ How to configure `SDVD_DOCKER_HOSTS` for multi-host runs and how `STEAM_ACCOUNTS
 | `serverSlots` | yes | Concurrent server containers this host can run. Combined with other hosts via Hamilton allocation. |
 | `clientSlots` | yes | Concurrent client containers this host can run. Sets the upper bound on how many clients a server on this host can serve concurrently. |
 | `endpoint` | no | `ssh://user@machine` for remote daemons. Omit for the local Docker daemon. |
-| `sshKey` | no | Path to a private key (relative paths anchor at the project root, `~` is expanded). Omit to use `~/.ssh/config` + ssh-agent. |
+| `sshKey` | no | Either a path to a private key (relative paths anchor at the project root, `~` is expanded), or inline key material (a `-----BEGIN…` block, written to a 0600 temp file — used in CI so the whole `SDVD_DOCKER_HOSTS` JSON, key included, can live in one secret). Omit to use `~/.ssh/config` + ssh-agent. |
 | `socketPath` | no | Remote Unix socket path. Defaults to `/var/run/docker.sock` (the standard Docker location). Override for hosts where the daemon listens elsewhere — most commonly macOS Docker Desktop's per-user `~/.docker/run/docker.sock`. Ignored for local entries. |
 | `gpu` | no | `true` if this host has an NVIDIA GPU + Container Toolkit. Defaults to `false`. Per-host so a fleet can mix GPU workstations and CPU-only VPSes. |
 | `concurrentStarts` | no | Cap on simultaneous `docker create+start` calls against this daemon. When omitted, falls back to `SDVD_MAX_CONCURRENT_STARTS` (if set) and otherwise to this host's `serverSlots + clientSlots`. Independent across hosts. |

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -6,6 +6,7 @@ using JunimoServer.Tests.Schema.Events;
 using JunimoServer.Tests.Schema.Json;
 using JunimoServer.TestRunner.IPC;
 using JunimoServer.TestRunner.Rendering;
+using JunimoServer.TestRunner.Rendering.Web;
 using JunimoServer.TestRunner.Setup;
 using JunimoServer.TestRunner.Sinks;
 using System.Diagnostics;
@@ -79,7 +80,7 @@ recorder.SeedRunIdentity(TestArtifacts.RunDir, RunMetadata.RunId!);
 ITestRenderer baseRenderer = mode switch
 {
     OutputMode.LLM => new LLMRenderer(recorder, verbose),
-    OutputMode.Web => new WebRenderer(recorder, generateReport),
+    OutputMode.Web => new WebRenderer(recorder),
     _ => new CIRenderer(verbose)
 };
 
@@ -672,6 +673,14 @@ finally
     {
         Console.Error.WriteLine($"[ArtifactWriter] finally-path write failed: {ex.Message}");
     }
+
+    // Assemble the offline test-web bundle (SPA + run snapshot + copied media)
+    // inside the run dir, so it rides along in the uploaded artifact tree and
+    // opens over file://. One site, every renderer mode — driven by --report or
+    // CI. No-ops with a warning when the SPA hasn't been built. Requires the
+    // final state, so it runs after WriteRunArtifacts.
+    if (generateReport || IsCIEnvironment())
+        ReportGenerator.TryGenerate(recorder.State, TestArtifacts.RunDir);
 
     // Dev-mode Web runs that completed normally: hold the browser open
     // until the operator presses a key (or signals shutdown). Skipped on

--- a/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
@@ -4,12 +4,18 @@ using System.Text.Json;
 namespace JunimoServer.TestRunner.Rendering.Web;
 
 /// <summary>
-/// Generates a self-contained static HTML report by injecting the final test state
-/// into the SPA's index.html. Screenshots are base64-inlined for offline viewing.
-/// TODO: Should this be renamed to HtmlReportGenerator?
+/// Assembles the self-contained offline bundle of the test-UI SPA: copies the
+/// built SPA next to the run's media and injects the final run snapshot as
+/// <c>&lt;script id="test-report-data"&gt;</c>, which the SPA bootstraps from in
+/// report mode (no WebSocket). Screenshots and videos are copied to a sibling
+/// <c>artifacts/</c> directory with relative paths so they resolve over
+/// <c>file://</c>.
 /// </summary>
 public sealed class ReportGenerator
 {
+    /// <summary>Sibling directory (next to index.html) holding copied media.</summary>
+    private const string BundleArtifactsDir = "artifacts";
+
     private readonly TestRunState _state;
     private readonly string _spaDistPath;
     private readonly string _testResultsPath;
@@ -19,6 +25,56 @@ public sealed class ReportGenerator
         _state = state;
         _spaDistPath = spaDistPath;
         _testResultsPath = testResultsPath;
+    }
+
+    /// <summary>
+    /// Single entrypoint for assembling the offline report bundle, called from
+    /// the runner's finally regardless of renderer mode. Resolves the built SPA,
+    /// writes the bundle inside <paramref name="runDir"/> (so it rides along in
+    /// the uploaded per-run artifact tree), and no-ops with a warning when the
+    /// SPA has not been built. Never throws.
+    /// </summary>
+    public static void TryGenerate(TestRunState state, string runDir)
+    {
+        try
+        {
+            var spaDistPath = FindSpaProjectPath() is { } proj ? Path.Combine(proj, "dist") : null;
+            if (spaDistPath == null || !File.Exists(Path.Combine(spaDistPath, "index.html")))
+            {
+                Console.Error.WriteLine(
+                    "WARNING: Report generation skipped. SPA dist not found. Run 'make build-test-ui' first.");
+                return;
+            }
+
+            new ReportGenerator(state, spaDistPath, runDir).Generate();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"WARNING: Report generation failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Locates the test-UI SPA project dir by walking up from the runner's base
+    /// directory (then the cwd) for <c>tests/test-ui/src</c>. Shared with
+    /// mock-data export.
+    /// </summary>
+    public static string? FindSpaProjectPath()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, "tests", "test-ui");
+            if (Directory.Exists(Path.Combine(candidate, "src")))
+                return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        var cwdCandidate = Path.GetFullPath("tests/test-ui");
+        if (Directory.Exists(Path.Combine(cwdCandidate, "src")))
+            return cwdCandidate;
+
+        return null;
     }
 
     public void Generate()
@@ -33,20 +89,24 @@ public sealed class ReportGenerator
         var reportDir = Path.Combine(_testResultsPath, "report");
         Directory.CreateDirectory(reportDir);
 
-        // Copy assets (JS, CSS files)
+        // Copy the SPA (JS, CSS) next to the bundle.
         CopyAssets(reportDir);
 
-        // Build the report HTML
-        var html = File.ReadAllText(indexPath);
-
-        // Get the snapshot and inline screenshots
-        var snapshotJson = GetSnapshotWithInlinedScreenshots();
+        // Copy screenshots + videos into reportDir/artifacts/ and rewrite the
+        // snapshot's paths to that relative location, so both kinds of media
+        // resolve over file:// once Kestrel is gone. (The SPA's screenshotSrc
+        // passes these relative paths through unchanged in report mode.)
+        var snapshotJson = CopyArtifacts(
+            _state.ToSnapshotJson(),
+            Path.Combine(reportDir, BundleArtifactsDir),
+            BundleArtifactsDir,
+            _testResultsPath);
 
         // Inject state JSON using a safe script tag
         // System.Text.Json's default encoder escapes <, >, & (safe against </script> breakout)
         var dataTag = $"<script type=\"application/json\" id=\"test-report-data\">{snapshotJson}</script>";
 
-        // Insert before closing </head> tag
+        var html = File.ReadAllText(indexPath);
         if (html.Contains("</head>"))
         {
             html = html.Replace("</head>", $"{dataTag}\n</head>");
@@ -57,7 +117,7 @@ public sealed class ReportGenerator
             html = dataTag + "\n" + html;
         }
 
-        // Fix asset paths to be relative (report is served from TestResults/report/)
+        // Fix asset paths to be relative (the bundle is opened over file://).
         // Vite outputs paths like /assets/xxx.js; make them ./assets/xxx.js
         html = html.Replace("src=\"/assets/", "src=\"./assets/");
         html = html.Replace("href=\"/assets/", "href=\"./assets/");
@@ -68,80 +128,40 @@ public sealed class ReportGenerator
         Console.Error.WriteLine($"[WebUI] Static report generated: {reportPath}");
     }
 
-    private string GetSnapshotWithInlinedScreenshots()
-    {
-        var snapshotJson = _state.ToSnapshotJson();
-        return InlineScreenshots(snapshotJson, _testResultsPath);
-    }
-
-    /// <summary>
-    /// Replaces absolute screenshot file paths in snapshot JSON with base64 data URIs,
-    /// making the JSON self-contained. Used by report generation for offline viewing.
-    /// </summary>
-    public static string InlineScreenshots(string snapshotJson, string? testResultsPath = null)
-    {
-        try
-        {
-            var paths = CollectArtifactPaths(snapshotJson);
-
-            foreach (var screenshotPath in paths)
-            {
-                // Only inline image files; videos are too large for base64
-                var ext = Path.GetExtension(screenshotPath).ToLowerInvariant();
-                if (ext is not (".png" or ".jpg" or ".jpeg" or ".gif"))
-                    continue;
-
-                var resolvedPath = ResolveArtifactPath(screenshotPath, testResultsPath);
-                if (resolvedPath == null || !File.Exists(resolvedPath))
-                {
-                    Console.Error.WriteLine($"[WebUI] Warning: Screenshot not found: {screenshotPath}");
-                    continue;
-                }
-
-                var fileInfo = new FileInfo(resolvedPath);
-                if (fileInfo.Length > 2 * 1024 * 1024)
-                    Console.Error.WriteLine($"[WebUI] Warning: Large screenshot ({fileInfo.Length / 1024}KB): {resolvedPath}");
-
-                var bytes = File.ReadAllBytes(resolvedPath);
-                var base64 = Convert.ToBase64String(bytes);
-                var mimeType = ext switch
-                {
-                    ".jpg" or ".jpeg" => "image/jpeg",
-                    ".gif" => "image/gif",
-                    _ => "image/png"
-                };
-                var dataUrl = $"data:{mimeType};base64,{base64}";
-
-                // Replace all occurrences of this path in the JSON with the data URL
-                snapshotJson = snapshotJson.Replace(
-                    JsonSerializer.Serialize(screenshotPath),
-                    JsonSerializer.Serialize(dataUrl));
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine($"[WebUI] Warning: Failed to inline screenshots: {ex.Message}");
-        }
-
-        return snapshotJson;
-    }
-
     /// <summary>
     /// Exports artifact files (screenshots and videos) to a directory with content-hashed
     /// filenames and rewrites all paths in the snapshot JSON to relative paths.
-    /// Used by mock data export for frontend development.
+    /// Used by mock data export for frontend development. Replaces the directory's
+    /// contents (mock data is regenerated wholesale each run).
     /// </summary>
     public static string ExportMockArtifacts(string snapshotJson, string mockArtifactsDir, string? testResultsPath = null)
     {
+        if (Directory.Exists(mockArtifactsDir))
+            Directory.Delete(mockArtifactsDir, recursive: true);
+
+        return CopyArtifacts(
+            snapshotJson,
+            mockArtifactsDir,
+            Path.GetFileName(mockArtifactsDir), // "mock-artifacts"
+            testResultsPath);
+    }
+
+    /// <summary>
+    /// Copies every screenshot/video referenced in the snapshot into
+    /// <paramref name="targetDir"/> with a content-hashed filename, then rewrites
+    /// each path in the snapshot JSON to <paramref name="relativePrefix"/>/&lt;hash&gt;.&lt;ext&gt;.
+    /// The shared mechanism behind both the offline report bundle and mock-data
+    /// export — content hashing dedupes identical media across tests.
+    /// </summary>
+    private static string CopyArtifacts(
+        string snapshotJson, string targetDir, string relativePrefix, string? testResultsPath)
+    {
         try
         {
-            if (Directory.Exists(mockArtifactsDir))
-                Directory.Delete(mockArtifactsDir, recursive: true);
-            Directory.CreateDirectory(mockArtifactsDir);
+            Directory.CreateDirectory(targetDir);
 
             var paths = CollectArtifactPaths(snapshotJson);
             var replacements = new Dictionary<string, string>();
-            var dirName = Path.GetFileName(mockArtifactsDir); // "mock-artifacts"
 
             foreach (var originalPath in paths)
             {
@@ -158,8 +178,8 @@ public sealed class ReportGenerator
                 if (string.IsNullOrEmpty(ext)) ext = ".png";
                 var fileName = $"{hash}{ext}";
 
-                File.WriteAllBytes(Path.Combine(mockArtifactsDir, fileName), bytes);
-                replacements[originalPath] = $"{dirName}/{fileName}";
+                File.WriteAllBytes(Path.Combine(targetDir, fileName), bytes);
+                replacements[originalPath] = $"{relativePrefix}/{fileName}";
             }
 
             foreach (var (originalPath, newPath) in replacements)
@@ -176,11 +196,11 @@ public sealed class ReportGenerator
                 snapshotJson = snapshotJson.Replace(escapedOld, escapedNew);
             }
 
-            Console.Error.WriteLine($"[WebUI] Exported {replacements.Count} artifacts to {mockArtifactsDir}");
+            Console.Error.WriteLine($"[WebUI] Exported {replacements.Count} artifacts to {targetDir}");
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[WebUI] Warning: Failed to export mock artifacts: {ex.Message}");
+            Console.Error.WriteLine($"[WebUI] Warning: Failed to copy artifacts: {ex.Message}");
         }
 
         return snapshotJson;

--- a/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
@@ -27,7 +27,6 @@ namespace JunimoServer.TestRunner.Rendering;
 /// </summary>
 public sealed class WebRenderer : RendererBase
 {
-    private readonly bool _generateReport;
     private readonly RunRecorder _recorder;
     private readonly TestRunState _state;
     private readonly Channel<string> _eventChannel = Channel.CreateBounded<string>(
@@ -53,11 +52,10 @@ public sealed class WebRenderer : RendererBase
     private Action<string>? _onCommand;
     public void OnCommand(Action<string> handler) => _onCommand = handler;
 
-    public WebRenderer(RunRecorder recorder, bool generateReport = false) : base(verbose: true)
+    public WebRenderer(RunRecorder recorder) : base(verbose: true)
     {
         _recorder = recorder;
         _state = recorder.State;
-        _generateReport = generateReport;
     }
 
     /// <summary>
@@ -73,7 +71,7 @@ public sealed class WebRenderer : RendererBase
 
     public override async ValueTask InitializeAsync()
     {
-        var spaDistPath = FindSpaProjectPath() is { } proj ? Path.Combine(proj, "dist") : null;
+        var spaDistPath = ReportGenerator.FindSpaProjectPath() is { } proj ? Path.Combine(proj, "dist") : null;
 
         var builder = WebApplication.CreateBuilder(new WebApplicationOptions
         {
@@ -271,27 +269,9 @@ public sealed class WebRenderer : RendererBase
         if (!_recorder.IsRunFinished)
             WriteMockData();
 
-        // Generate static report if requested
-        if (_generateReport || IsCI())
-        {
-            try
-            {
-                var spaDistPath = FindSpaProjectPath() is { } p ? Path.Combine(p, "dist") : null;
-                if (spaDistPath != null)
-                {
-                    var generator = new ReportGenerator(_state, spaDistPath, "TestResults");
-                    generator.Generate();
-                }
-                else
-                {
-                    Console.Error.WriteLine("WARNING: Report generation skipped. SPA dist not found. Run 'make build-test-ui' first.");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"WARNING: Report generation failed: {ex.Message}");
-            }
-        }
+        // The static report bundle is assembled from Program.cs's finally (one
+        // site, runs in every mode incl. CIRenderer) — not here, which only ran
+        // when the renderer was a WebRenderer.
 
         // Drain queued events so post-run events (recordings, late artifacts)
         // reach the browser before we stop accepting new sends.
@@ -502,7 +482,7 @@ public sealed class WebRenderer : RendererBase
         {
             // Write snapshot and artifacts to public/mock-artifacts/ for frontend development.
             // Vite serves public/ as static files, so the dev server can load mock data directly.
-            var projectDir = FindSpaProjectPath();
+            var projectDir = ReportGenerator.FindSpaProjectPath();
             if (projectDir == null) return;
 
             var mockArtifactsDir = Path.Combine(projectDir, "public", "mock-artifacts");
@@ -518,24 +498,6 @@ public sealed class WebRenderer : RendererBase
         {
             Console.Error.WriteLine($"[WebUI] Failed to write mock data: {ex.Message}");
         }
-    }
-
-    private static string? FindSpaProjectPath()
-    {
-        var dir = AppContext.BaseDirectory;
-        for (var i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, "tests", "test-ui");
-            if (Directory.Exists(Path.Combine(candidate, "src")))
-                return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-
-        var cwdCandidate = Path.GetFullPath("tests/test-ui");
-        if (Directory.Exists(Path.Combine(cwdCandidate, "src")))
-            return cwdCandidate;
-
-        return null;
     }
 
     private static bool IsCI()

--- a/tests/JunimoServer.Tests/Infrastructure/HostPool.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/HostPool.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Docker.DotNet;
@@ -17,7 +19,8 @@ namespace JunimoServer.Tests.Infrastructure;
 /// <c>SDVD_DOCKER_HOSTS</c> is a JSON array. Each entry must specify
 /// <c>id</c>, <c>serverSlots</c>, and <c>clientSlots</c>. Optional fields:
 /// <c>endpoint</c> (omit for local daemon, or <c>ssh://user@host</c>),
-/// <c>sshKey</c> (path to a private key; <c>~</c> is expanded), and
+/// <c>sshKey</c> (either a path to a private key — <c>~</c>-expanded — or inline
+/// <c>-----BEGIN…</c> key material, which is written to a 0600 temp file), and
 /// <c>socketPath</c> (remote Unix socket; defaults to <c>/var/run/docker.sock</c>,
 /// override e.g. <c>~/.docker/run/docker.sock</c> for macOS Docker Desktop).
 /// </para>
@@ -199,6 +202,24 @@ public sealed class HostPool : IAsyncDisposable
         return string.IsNullOrEmpty(uri.UserInfo) ? uri.Host : $"{uri.UserInfo}@{uri.Host}";
     }
 
+    /// <summary>
+    /// Resolves a host's <c>sshKey</c> to a file path <c>ssh -i</c> can consume.
+    /// Accepts two forms:
+    /// <list type="bullet">
+    ///   <item><b>Inline key material</b> (the value starts with
+    ///   <c>-----BEGIN</c>): the PEM/OpenSSH-format private key is written to a
+    ///   private (0600) temp file and that path is returned. This is what CI
+    ///   uses — the whole <c>SDVD_DOCKER_HOSTS</c> JSON (key included) lives in
+    ///   one GitHub secret, with no separate key-file step.</item>
+    ///   <item><b>A path</b> (anything else): resolved against the project root
+    ///   (<c>~</c>-expanded, relative paths anchored at the repo so <c>./foo</c>
+    ///   works regardless of the runner's CWD) and required to exist. This is
+    ///   the local-dev form pointing at <c>~/.ssh/&lt;key&gt;</c>.</item>
+    /// </list>
+    /// Either way the result is a filesystem path; every downstream consumer
+    /// (<see cref="DockerHost.SshKeyPath"/>, <see cref="TunnelManager"/>'s
+    /// <c>ssh -i</c>) is path-based and unchanged.
+    /// </summary>
     private static string? ResolveSshKeyPath(string id, string? sshDest, string? sshKey)
     {
         if (string.IsNullOrWhiteSpace(sshKey)) return null;
@@ -207,13 +228,88 @@ public sealed class HostPool : IAsyncDisposable
                 $"SDVD_DOCKER_HOSTS entry '{id}': 'sshKey' is set but 'endpoint' is local. " +
                 "Drop sshKey for local entries.");
 
-        // Relative paths anchor at the project root, not the binary's CWD,
-        // so `./foo` works regardless of how the runner was launched.
+        // Inline PEM/OpenSSH key material (CI passes the key inside the JSON
+        // secret). OpenSSH and PEM private keys begin with a `-----BEGIN` armor
+        // line; a filesystem path never contains one. So a `-----BEGIN`
+        // *anywhere* in the value means inline was intended — match loosely on
+        // Contains (not StartsWith) so a stray leading character can't misroute
+        // the key into the path branch, whose "not found" error would otherwise
+        // echo the key bytes into logs.
+        var looksInline = sshKey.Contains("-----BEGIN", StringComparison.Ordinal);
+        if (looksInline)
+        {
+            if (!sshKey.TrimStart().StartsWith("-----BEGIN", StringComparison.Ordinal))
+                // Inline was intended but the armor isn't at the start (leading
+                // junk / wrong indentation). Fail WITHOUT echoing the key.
+                throw new InvalidOperationException(
+                    $"SDVD_DOCKER_HOSTS entry '{id}': sshKey looks like inline key material " +
+                    "but does not start with '-----BEGIN'. Provide the key with the armor " +
+                    "line first and no leading characters. (Key content omitted from this error.)");
+            return MaterializeInlineKey(id, sshKey);
+        }
+
+        // Otherwise treat as a path. Relative paths anchor at the project root,
+        // not the binary's CWD, so `./foo` works regardless of how the runner
+        // was launched. Safe to echo `sshKey` here — it is a path, not a key.
         var full = Helpers.ProjectRoot.Resolve(sshKey);
         if (!File.Exists(full))
             throw new InvalidOperationException(
-                $"SDVD_DOCKER_HOSTS entry '{id}': sshKey '{sshKey}' does not exist at '{full}'.");
+                $"SDVD_DOCKER_HOSTS entry '{id}': sshKey '{sshKey}' is neither inline key " +
+                $"material (a '-----BEGIN…' block) nor an existing file (resolved to '{full}').");
         return full;
+    }
+
+    /// <summary>
+    /// Writes inline private-key material to a 0600 temp file and returns its
+    /// path. The filename is derived from a hash of the key content so the
+    /// coordinator and the xUnit child — which independently re-parse
+    /// <c>SDVD_DOCKER_HOSTS</c> — converge on the same file rather than racing
+    /// two writes of divergently-named files. A trailing newline is ensured
+    /// because OpenSSH rejects a key file whose final armor line lacks one.
+    /// </summary>
+    private static string MaterializeInlineKey(string id, string keyMaterial)
+    {
+        var normalized = keyMaterial.Replace("\r\n", "\n").TrimEnd('\n') + "\n";
+        var hash = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))
+            .ToLowerInvariant()[..16];
+        var path = Path.Combine(Path.GetTempPath(), $"sdvd-test-sshkey-{hash}");
+
+        // Content-addressed: a matching file from a sibling process (parent +
+        // xUnit child both parse this) or a prior run holds these exact bytes
+        // already. Create-new-only — if it exists, the content is identical, so
+        // reuse it. The file is created 0600 atomically (UnixCreateMode applies
+        // at open(2)), so the key bytes are never momentarily group/world-
+        // readable in the temp dir — no write-then-chmod window.
+        if (File.Exists(path)) return path;
+
+        var options = new FileStreamOptions
+        {
+            Mode = FileMode.CreateNew,
+            Access = FileAccess.Write,
+        };
+        if (!OperatingSystem.IsWindows())
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+
+        try
+        {
+            using var stream = new FileStream(path, options);
+            using var writer = new StreamWriter(stream);
+            writer.Write(normalized);
+        }
+        catch (IOException) when (File.Exists(path))
+        {
+            // A sibling process created it between our Exists check and
+            // CreateNew. Same content — its file is fine.
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            throw new InvalidOperationException(
+                $"SDVD_DOCKER_HOSTS entry '{id}': failed to materialize inline sshKey " +
+                $"to '{path}': {ex.Message}", ex);
+        }
+
+        return path;
     }
 
     /// <summary>

--- a/tests/test-ui/src/composables/useScreenshotCache.ts
+++ b/tests/test-ui/src/composables/useScreenshotCache.ts
@@ -22,6 +22,7 @@ export function useScreenshotCache(): ScreenshotCache {
     if (blobCache.has(artifactPath) || fetchPending.has(artifactPath)) return
     if (artifactPath.startsWith('data:')) return // already inline
     if (artifactPath.startsWith('mock-artifacts/')) return // static files served by Vite
+    if (artifactPath.startsWith('artifacts/')) return // offline report bundle: media sits next to index.html
     fetchPending.add(artifactPath)
     fetch(`/artifacts/${artifactPath}`)
       .then(res => {
@@ -43,6 +44,9 @@ export function useScreenshotCache(): ScreenshotCache {
     if (blobCache.has(path)) return blobCache.get(path)!
     // mock-artifacts/ paths are static files served directly from public/ by Vite
     if (path.startsWith('mock-artifacts/')) return `/${path}`
+    // artifacts/ paths come from the offline report bundle, where media sits
+    // next to index.html — keep them document-relative so they resolve over file://
+    if (path.startsWith('artifacts/')) return path
     return `/artifacts/${path}`
   }
 


### PR DESCRIPTION
Adds the manual E2E smoke workflow (VPS over SSH) and surfaces its results in GitHub.

## Workflow (`cf6bce8`)
- `workflow_dispatch`-only E2E smoke job: coordinator runs on the GitHub runner, game containers run on a remote VPS over SSH. Secrets scoped to the `test-vps` environment. Builds all three images in-process, streams them + game-data to the VPS, runs the filtered suite there.

## Results surfacing (`20a3300`)
- **Job Summary** — the CTRF reporter action (`ctrf-io/github-test-reporter`, SHA-pinned v1.0.28) renders the runner's `ctrf-report.json` into the run's Summary tab (summary / failed / test-list tables). No PR comment — the workflow is dispatch-only with no PR context.
- **Offline test-web report** — consolidated onto the actual test-UI SPA instead of a separate base64 HTML reporter. `ReportGenerator` now assembles an offline bundle (SPA `dist` + inlined run snapshot + copied media) and copies screenshots **and** videos into `report/artifacts/` with relative paths, so both render over `file://`. Reuses the existing `ExportMockArtifacts` copy/hash/rewrite core (one shared mechanism). Driven from `Program.cs` so it runs in CIRenderer mode, written inside the per-run dir.
- `screenshotSrc` passes the relative `artifacts/` paths through unchanged in report mode.
- Workflow builds the test-UI SPA (Bun) so the bundle can be assembled, and uploads it as a separate `e2e-web-report` artifact (clean, openable, without the multi-GB raw `runs/` tree).
- Corrected the stale CI-usage docs section.

## Verification
- `dotnet build` clean (0 warnings); `bun run build` (vue-tsc) clean; workflow YAML valid.
- Real `--report` run on the VPS: 12/12 passed, bundle assembled with `index.html` (relative `./assets/`) + 3 videos copied to `artifacts/`, snapshot media paths rewritten relative, valid report-mode JSON; report renders offline (visually confirmed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated end-to-end (E2E) smoke test workflow triggered manually via GitHub Actions
  * Added support for inline SSH private key material in CI environments (in addition to file paths)
  * Improved offline test report generation with artifact bundling and structured result publishing

* **Documentation**
  * Updated E2E testing documentation with CI workflow and report generation details
  * Clarified SSH key configuration options for remote host setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->