### PR TITLE
feat(ci): redact secrets/infra from the public E2E report + publish to R2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -222,17 +222,17 @@ jobs:
         run: |
           dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
 
-      # Render the run's results into the GitHub job Summary tab from the CTRF
-      # report the runner already emits (TestRunArtifactWriter.WriteCtrfReport →
-      # runs/{id}/ctrf-report.json — exactly one run per CI invocation, so the
-      # glob resolves it unambiguously). summary-report = the pass/fail table;
-      # failed-report = a table of failing tests with their error; test-list-report
-      # = the full per-test list. `summary: true` (the action default) writes to
-      # $GITHUB_STEP_SUMMARY. No PR comment — `pull-request` defaults to false and
-      # this workflow is dispatch-only with no PR context. if: always() so a failed
-      # or aborted run still surfaces its results.
+      # Render the runner's ctrf-report.json (TestRunArtifactWriter.WriteCtrfReport,
+      # one per CI invocation) into the job Summary tab. summary-report = pass/fail
+      # table, failed-report = failing tests + errors, test-list-report = full list;
+      # `summary: true` (action default) targets $GITHUB_STEP_SUMMARY. No PR comment —
+      # dispatch-only workflow has no PR context. The action defaults exit-on-no-files
+      # and exit-on-fail to false, so a missing report (early abort) or failing tests
+      # never fail this step; continue-on-error covers an unexpected action error too.
+      # if: always() surfaces results from failed/aborted runs.
       - name: Publish CTRF results to job summary
         if: always()
+        continue-on-error: true
         uses: ctrf-io/github-test-reporter@0f299074936c32ccaab5be5230511f6b2b9080aa # v1.0.28
         with:
           report-path: 'TestResults/runs/**/ctrf-report.json'
@@ -280,3 +280,73 @@ jobs:
           name: e2e-web-report
           path: TestResults/runs/*/report/
           if-no-files-found: warn
+
+      # Publish the offline web report to Cloudflare R2 for a real, linkable URL
+      # (GitHub artifacts aren't URL-addressable — the report can't be viewed without
+      # downloading the zip). Served at {R2_PUBLIC_BASE_URL}/e2e/{branch}/{run-id}/
+      # index.html; per-branch history expires after 30 days via an R2 bucket
+      # lifecycle rule (operator setup), so CI does no pruning.
+      #
+      # Fully optional and never fails the run: continue-on-error decouples it from the
+      # job result, and the body (below) skips cleanly when the R2_* secrets are unset.
+      # The R2_* values come from the test-vps environment, like the other secrets.
+      - name: Publish web report to R2
+        if: always()
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
+          BRANCH_REF: ${{ github.ref_name }}
+        run: |
+          # GitHub runs steps with `bash -eo pipefail` (errexit ON). Relax it so a
+          # partial failure can't truncate the script before the summary write.
+          # continue-on-error above is the job-level guarantee; this keeps the body going.
+          set +e
+
+          # Unconfigured is the EXPECTED opt-out, not an error. Clean skip, green run.
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${R2_ACCESS_KEY_ID:-}" ] \
+             || [ -z "${R2_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ] \
+             || [ -z "${R2_PUBLIC_BASE_URL:-}" ]; then
+            echo "R2 publish not configured — skipping. The report is still available as the 'e2e-web-report' artifact."
+            exit 0
+          fi
+
+          # Don't assume the runner image ships the AWS CLI forever.
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "::warning::aws CLI not found on runner — skipping R2 publish (report still in the artifact)."
+            exit 0
+          fi
+
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+          # Exactly one run per CI invocation, so the glob resolves a single report dir.
+          report_dir=$(find TestResults/runs/*/report -maxdepth 0 -type d 2>/dev/null | head -n1 || true)
+          if [ -z "$report_dir" ]; then
+            echo "No report bundle to publish (run aborted before assembly?) — skipping."
+            exit 0
+          fi
+
+          # Sanitize the branch for use as an object-key prefix (slashes -> dashes).
+          branch=$(printf '%s' "$BRANCH_REF" | tr '/' '-')
+          run_id=$(basename "$(dirname "$report_dir")")
+          key="e2e/${branch}/${run_id}"
+
+          # sync sets each object's Content-Type from its extension (so index.html
+          # renders rather than downloads). 30-day retention is a one-time R2 bucket
+          # lifecycle rule (operator setup), not a per-run prune here.
+          if aws s3 sync "$report_dir" "s3://${R2_BUCKET}/${key}" \
+               --endpoint-url "$endpoint" --no-progress; then
+            size=$(du -sh "$report_dir" | cut -f1)
+            url="${R2_PUBLIC_BASE_URL%/}/${key}/index.html"
+            {
+              echo "### E2E Web Report"
+              echo ""
+              echo "**[Open interactive report]($url)** (screenshots + videos, $size)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "Published report: $url ($size)"
+          else
+            echo "::warning::R2 publish failed (network/credentials/quota). Report remains in the 'e2e-web-report' artifact."
+          fi

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -175,8 +175,7 @@ The E2E smoke suite runs from `.github/workflows/e2e-tests.yml` (`workflow_dispa
 only — the coordinator runs on the GitHub runner; the game containers run on a
 remote VPS over SSH). That workflow is the source of truth for CI invocation.
 
-Results surface in two GitHub-native places, both produced from artifacts the
-runner already emits:
+Results surface in three places, all produced from artifacts the runner emits:
 
 - **Job Summary tab** — the [CTRF reporter action](https://github.com/ctrf-io/github-test-reporter)
   renders `runs/{id}/ctrf-report.json` into a pass/fail + failed-tests table. No
@@ -185,12 +184,75 @@ runner already emits:
   SPA with the run snapshot inlined and screenshots/videos copied alongside.
   Download it and open `report/index.html` over `file://`; screenshots and videos
   play without a running server.
+- **Hosted report URL (optional)** — when Cloudflare R2 is configured (see below),
+  the bundle is published to `…/e2e/{branch}/{run-id}/index.html` and linked from
+  the Job Summary, so the interactive report (with playing videos) can be opened
+  directly and shared. Per-branch history is kept; an R2 lifecycle rule expires
+  reports after 30 days.
 
 Under `CI` (or with the `--report` flag locally), the runner assembles that
 bundle into `TestResults/runs/{id}/report/` after the run — it requires the
 test-UI SPA to be built first (the workflow runs `bun run build` in
 `tests/test-ui`). Locally, `make test-web-report FILTER=<name>` does the same
 build-then-report in one step.
+
+### Hosted report (Cloudflare R2)
+
+The hosted-report URL is **optional**: with none of the `R2_*` secrets set, the
+publish step skips cleanly and the run stays green — the `e2e-web-report` artifact
+is always the fallback. GitHub Pages is deliberately not used (its ~1 GB limit is
+smaller than a single recording-heavy run, and the docs already own the Pages site).
+R2 gives 10 GB free with zero egress fees, so videos stream without cost.
+
+The bucket is **public-read, token-write**: reads are world-readable (anyone with the
+link opens the report), but uploads require the write token (only CI has it). The
+published snapshot is redacted (IPs, Steam credentials, player names, keys masked — see
+"Redaction" below), but because the bucket is public, treat it as a hard rule that
+**secrets must never be logged in the first place**.
+
+One-time setup (Cloudflare dashboard, outside this repo):
+
+1. Create an R2 bucket (e.g. `sdvd-e2e-reports`).
+2. Enable **public read** access (managed `r2.dev` subdomain or a custom domain); record
+   the public base URL. Do not grant public write — writes use the API token (step 4).
+3. Add an **object-lifecycle rule** on the bucket to expire objects after 30 days
+   (scope it to the `e2e/` prefix). This is the retention mechanism — R2 deletes old
+   reports server-side, so CI does no pruning.
+4. Create an R2 API token scoped to **Object Read & Write** → Access Key ID + Secret.
+   This token is the only write path; keep it in the `test-vps` environment, never public.
+5. Add these as secrets in the **`test-vps`** GitHub Environment (same scoping as the
+   other E2E secrets):
+
+   | Secret | Value |
+   |--------|-------|
+   | `R2_ACCOUNT_ID` | Cloudflare account ID (the `<id>` in the S3 endpoint) |
+   | `R2_ACCESS_KEY_ID` | R2 API token access key |
+   | `R2_SECRET_ACCESS_KEY` | R2 API token secret |
+   | `R2_BUCKET` | Bucket name (e.g. `sdvd-e2e-reports`) |
+   | `R2_PUBLIC_BASE_URL` | Public base URL of the bucket (no trailing slash) |
+
+The publish step runs `aws s3 sync` against R2's S3-compatible endpoint
+(`https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com`). It is wrapped in
+`continue-on-error: true` with internal config/credential guards, so a missing or
+broken R2 never fails the test run.
+
+### Redaction
+
+The published report inlines captured server logs, so it is redacted in two layers
+(defense-in-depth) before reaching the public URL:
+
+- **At the mod source** — `ChatRedaction.MaskIp`/`MaskValue` mask the server's IP banner,
+  the public-IP log line, the Steam SDR ID, invite codes, and player names where the mod
+  logs them. Values are masked in place (`46.38.238.188` → `***.***.***.188`,
+  `secret` → `s***t`) so the diagnostic shape survives.
+- **At the report boundary** — `ReportRedactor.Scrub` runs over the whole snapshot before
+  publishing: it masks values the runner knows exactly (the VPS host/IP from
+  `SDVD_DOCKER_HOSTS`, Steam credentials from `STEAM_ACCOUNTS`) plus high-confidence
+  patterns (private-key blocks, `/run/secrets`, `password=`/`token=` assignments,
+  `user@host`). It deliberately does **not** mask bare IPs by regex (a version string like
+  `Unix 6.1.0.17` is indistinguishable from an IP) — those are caught at the mod source
+  and by the known-value set. If redaction ever yields invalid JSON, the report is not
+  published (fail-closed).
 
 ## Troubleshooting
 

--- a/mod/JunimoServer.Shared/ChatRedaction.cs
+++ b/mod/JunimoServer.Shared/ChatRedaction.cs
@@ -2,8 +2,68 @@ using System;
 
 namespace JunimoServer.Shared
 {
+    /// <summary>
+    /// In-place masking for values that must not appear verbatim in logs or in the
+    /// (publicly published) E2E report. Masks preserve shape so "a value was here"
+    /// stays visible: an IP keeps its last octet, a generic value keeps first+last char.
+    ///
+    /// <para><c>MaskIp</c>/<c>MaskValue</c> are duplicated in the test runner's
+    /// <c>ReportRedactor</c> (net10.0, can't reference this net6.0 + game-DLL project).
+    /// Keep the two in sync; a future dependency-free shared library would let both consume
+    /// one implementation.</para>
+    /// </summary>
     public static class ChatRedaction
     {
+        /// <summary>
+        /// Masks an IP address, keeping the last segment so it reads as an IP:
+        /// IPv4 <c>46.38.238.188</c> → <c>***.***.***.188</c>, IPv6 keeps the last hextet.
+        /// Loopback / unspecified addresses (<c>127.0.0.1</c>, <c>0.0.0.0</c>, <c>::1</c>,
+        /// <c>::</c>) are not sensitive and returned unchanged. Non-IP input is returned
+        /// as-is (callers may pass <c>"n/a"</c>).
+        /// </summary>
+        public static string MaskIp(string ip)
+        {
+            if (string.IsNullOrEmpty(ip)) return ip;
+            switch (ip)
+            {
+                case "127.0.0.1":
+                case "0.0.0.0":
+                case "::1":
+                case "::":
+                    return ip;
+            }
+
+            if (ip.IndexOf(':') >= 0)
+            {
+                // IPv6: keep the last non-empty hextet.
+                var parts = ip.Split(':');
+                var last = "";
+                for (var i = parts.Length - 1; i >= 0; i--)
+                {
+                    if (parts[i].Length > 0) { last = parts[i]; break; }
+                }
+                return last.Length > 0 ? "***:***:…:" + last : ip;
+            }
+
+            var octets = ip.Split('.');
+            if (octets.Length == 4)
+                return "***.***.***." + octets[3];
+
+            return ip;
+        }
+
+        /// <summary>
+        /// Masks a value to <c>first***last</c>, hiding the middle while keeping its
+        /// presence and rough length-class visible. Values of length ≤2 collapse to
+        /// <c>***</c> (too short to reveal a hint). Empty input is returned unchanged.
+        /// </summary>
+        public static string MaskValue(string value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            if (value.Length <= 2) return "***";
+            return $"{value[0]}***{value[value.Length - 1]}";
+        }
+
         /// <summary>
         /// Redacts the password argument in <c>!login &lt;password&gt;</c> so chat text
         /// can be safely written to logs and structured event streams.

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -8,6 +8,7 @@ using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Roles;
 using JunimoServer.Services.ServerOptim;
 using JunimoServer.Services.Settings;
+using JunimoServer.Shared;
 using JunimoServer.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -3830,7 +3831,7 @@ namespace JunimoServer.Services.Api
                 }
 
                 _roleService.AssignAdmin(farmer.UniqueMultiplayerID);
-                Monitor.Log($"Admin role granted to '{farmer.Name}' (ID: {farmer.UniqueMultiplayerID}) via API", LogLevel.Info);
+                Monitor.Log($"Admin role granted to '{ChatRedaction.MaskValue(farmer.Name)}' (ID: {farmer.UniqueMultiplayerID}) via API", LogLevel.Info);
 
                 result = new RoleGrantResponse
                 {
@@ -3914,7 +3915,7 @@ namespace JunimoServer.Services.Api
 
                     var resolvedName = targetFarmhand.Name ?? string.Empty;
                     ExecuteFarmhandDeletion(targetFarmhand.UniqueMultiplayerID, resolvedName);
-                    Monitor.Log($"Deleted farmhand '{resolvedName}' (ID: {targetFarmhand.UniqueMultiplayerID})", LogLevel.Info);
+                    Monitor.Log($"Deleted farmhand '{ChatRedaction.MaskValue(resolvedName)}' (ID: {targetFarmhand.UniqueMultiplayerID})", LogLevel.Info);
                     result = new FarmhandResponse
                     {
                         Success = true,
@@ -3966,7 +3967,7 @@ namespace JunimoServer.Services.Api
             if (targetCabin != null)
             {
                 _cabinManager.DestroyCabin(cabinBuilding);
-                Monitor.Log($"Destroyed cabin for farmhand '{farmhandName}'", LogLevel.Debug);
+                Monitor.Log($"Destroyed cabin for farmhand '{ChatRedaction.MaskValue(farmhandName)}'", LogLevel.Debug);
             }
             else
             {
@@ -3983,16 +3984,16 @@ namespace JunimoServer.Services.Api
                             && cabin.farmhandReference.uid.Value == farmhandId)
                         {
                             cabin.farmhandReference.Value = null;
-                            Monitor.Log($"Cleared dangling farmhandReference on cabin '{cabin.NameOrUniqueName}' for farmhand '{farmhandName}' (id={farmhandId})", LogLevel.Warn);
+                            Monitor.Log($"Cleared dangling farmhandReference on cabin '{cabin.NameOrUniqueName}' for farmhand '{ChatRedaction.MaskValue(farmhandName)}' (id={farmhandId})", LogLevel.Warn);
                         }
                     }
 
-                    Monitor.Log($"No cabin found for farmhand '{farmhandName}', removing from farmhandData directly", LogLevel.Warn);
+                    Monitor.Log($"No cabin found for farmhand '{ChatRedaction.MaskValue(farmhandName)}', removing from farmhandData directly", LogLevel.Warn);
                     Game1.netWorldState.Value.farmhandData.Remove(farmhandId);
                 }
                 else
                 {
-                    Monitor.Log($"Farmhand '{farmhandName}' already deleted (no cabin or farmhandData found)", LogLevel.Debug);
+                    Monitor.Log($"Farmhand '{ChatRedaction.MaskValue(farmhandName)}' already deleted (no cabin or farmhandData found)", LogLevel.Debug);
                     return;
                 }
             }

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -4,6 +4,7 @@ using JunimoServer.Services.MessageInterceptors;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Roles;
 using JunimoServer.Services.ServerOptim;
+using JunimoServer.Shared;
 using JunimoServer.Util;
 using Microsoft.Xna.Framework;
 using Netcode;
@@ -174,13 +175,13 @@ namespace JunimoServer.Services.CabinManager
                 {
                     if (homeStale)
                     {
-                        Monitor.Log($"Cleared stale homeLocation '{home}' from farmhand '{f.Name}' (id={f.UniqueMultiplayerID}) at save load", LogLevel.Debug);
+                        Monitor.Log($"Cleared stale homeLocation '{home}' from farmhand '{ChatRedaction.MaskValue(f.Name)}' (id={f.UniqueMultiplayerID}) at save load", LogLevel.Debug);
                         f.homeLocation.Value = "";
                         homeCleared++;
                     }
                     if (lastSleepStale)
                     {
-                        Monitor.Log($"Cleared stale lastSleepLocation '{lastSleep}' from farmhand '{f.Name}' (id={f.UniqueMultiplayerID}) at save load", LogLevel.Debug);
+                        Monitor.Log($"Cleared stale lastSleepLocation '{lastSleep}' from farmhand '{ChatRedaction.MaskValue(f.Name)}' (id={f.UniqueMultiplayerID}) at save load", LogLevel.Debug);
                         f.lastSleepLocation.Value = null;
                         lastSleepCleared++;
                     }
@@ -777,7 +778,7 @@ namespace JunimoServer.Services.CabinManager
             if (ownerId != 0 && farmhandData.FieldDict.ContainsKey(ownerId))
             {
                 Monitor.Log(
-                    $"Cabin owner {ownerId} ('{ownerName}') still in farmhandData after Cabin.DeleteFarmhand; " +
+                    $"Cabin owner {ownerId} ('{ChatRedaction.MaskValue(ownerName)}') still in farmhandData after Cabin.DeleteFarmhand; " +
                     $"not removing to preserve investigability",
                     LogLevel.Warn);
             }

--- a/mod/JunimoServer/Services/NetworkTweaks/DesyncKicker.cs
+++ b/mod/JunimoServer/Services/NetworkTweaks/DesyncKicker.cs
@@ -1,4 +1,5 @@
 using JunimoServer.Services.Lobby;
+using JunimoServer.Shared;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -111,7 +112,7 @@ namespace JunimoServer.Services.NetworkTweaks
                         Game1.player.team.endOfNightStatus.GetStatusText(farmer.UniqueMultiplayerID) != "ready"
                     ))
                     {
-                        _monitor.Log($"Kicking {farmer.Name} because they aren't ready");
+                        _monitor.Log($"Kicking {ChatRedaction.MaskValue(farmer.Name)} because they aren't ready");
                         Game1.server.kick(farmer.UniqueMultiplayerID);
                     }
                 });

--- a/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
+++ b/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
@@ -793,7 +793,7 @@ namespace JunimoServer.Services.PasswordProtection
                         var cabin = building.GetIndoors<Cabin>();
                         if (cabin != null && cabin.NameOrUniqueName == homeLocation)
                         {
-                            _monitor.Log($"[Auth] FindPlayerCabin: primary lookup failed for '{player.Name}' (id={playerId}), " +
+                            _monitor.Log($"[Auth] FindPlayerCabin: primary lookup failed for '{ChatRedaction.MaskValue(player.Name)}' (id={playerId}), " +
                                 $"found via homeLocation fallback: {homeLocation}", LogLevel.Warn);
                             return cabin;
                         }

--- a/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
+++ b/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
@@ -245,20 +245,20 @@ namespace JunimoServer.Services.PasswordProtection
             }
 
             _instance._monitor.Log(
-                $"[Auth] Clearing homeLocation '{home}' ({reason}) for '{farmer.Name}' (id={farmer.UniqueMultiplayerID})",
+                $"[Auth] Clearing homeLocation '{home}' ({reason}) for '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID})",
                 LogLevel.Info);
             farmer.homeLocation.Value = "";
 
             if (Game1.netWorldState.Value.TryAssignFarmhandHome(farmer))
             {
                 _instance._monitor.Log(
-                    $"[Auth] Reassigned '{farmer.Name}' (id={farmer.UniqueMultiplayerID}) to real cabin: homeLocation='{farmer.homeLocation.Value}'",
+                    $"[Auth] Reassigned '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID}) to real cabin: homeLocation='{farmer.homeLocation.Value}'",
                     LogLevel.Info);
             }
             else
             {
                 _instance._monitor.Log(
-                    $"[Auth] TryAssignFarmhandHome failed for '{farmer.Name}' (id={farmer.UniqueMultiplayerID}) - no available cabin",
+                    $"[Auth] TryAssignFarmhandHome failed for '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID}) - no available cabin",
                     LogLevel.Warn);
             }
         }
@@ -307,7 +307,7 @@ namespace JunimoServer.Services.PasswordProtection
 
             var isNewPlayer = !farmer.Value.isCustomized.Value;
             var playerType = isNewPlayer ? "new" : "returning";
-            _monitor.Log($"[Auth] {farmer.Value.Name} ({playerType}) connecting", LogLevel.Debug);
+            _monitor.Log($"[Auth] {ChatRedaction.MaskValue(farmer.Value.Name)} ({playerType}) connecting", LogLevel.Debug);
 
             // Create auth tracking
             var authData = new PlayerAuthData(farmerId)
@@ -808,7 +808,7 @@ namespace JunimoServer.Services.PasswordProtection
             if (player != null && Game1.netWorldState.Value.TryAssignFarmhandHome(player))
             {
                 _monitor.Log($"[Auth] FindPlayerCabin: recovered via TryAssignFarmhandHome " +
-                    $"for '{player.Name}' (id={playerId}), homeLocation now '{player.homeLocation.Value}'", LogLevel.Warn);
+                    $"for '{ChatRedaction.MaskValue(player.Name)}' (id={playerId}), homeLocation now '{player.homeLocation.Value}'", LogLevel.Warn);
 
                 foreach (var building in farm.buildings)
                 {
@@ -844,7 +844,7 @@ namespace JunimoServer.Services.PasswordProtection
                 var ownerName = ind?.owner?.Name;
                 var ownerId = ind?.owner?.UniqueMultiplayerID;
                 var isLobby = LobbyService.IsLobbyCabin(c);
-                _monitor.Log($"[Auth]   Cabin '{ind?.NameOrUniqueName}': refDefined={refDefined}, refUid={refUid}, owner='{ownerName}' (id={ownerId}), isLobby={isLobby}", LogLevel.Error);
+                _monitor.Log($"[Auth]   Cabin '{ind?.NameOrUniqueName}': refDefined={refDefined}, refUid={refUid}, owner='{ChatRedaction.MaskValue(ownerName)}' (id={ownerId}), isLobby={isLobby}", LogLevel.Error);
             }
             var inFarmhandData = Game1.netWorldState.Value.farmhandData.FieldDict.ContainsKey(playerId);
             var inOtherFarmers = Game1.otherFarmers.ContainsKey(playerId);

--- a/mod/JunimoServer/Services/SteamGameServer/SteamGameServerService.cs
+++ b/mod/JunimoServer/Services/SteamGameServer/SteamGameServerService.cs
@@ -1,5 +1,6 @@
 using System;
 using HarmonyLib;
+using JunimoServer.Shared;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -169,11 +170,11 @@ namespace JunimoServer.Services.SteamGameServer
             _monitor.Log($"Connected to Steam servers!", LogLevel.Info);
             _monitor.Log($"Server Steam ID: {_serverSteamId.m_SteamID}", LogLevel.Info);
 
-            // Log the public IP if available
+            // Log the public IP if available (masked — captured into the public report).
             var publicIp = Steamworks.SteamGameServer.GetPublicIP();
             if (publicIp.IsSet())
             {
-                _monitor.Log($"Server public IP: {publicIp}", LogLevel.Info);
+                _monitor.Log($"Server public IP: {ChatRedaction.MaskIp(publicIp.ToString())}", LogLevel.Info);
             }
 
             // Check relay network status

--- a/mod/JunimoServer/Util/ServerBanner.cs
+++ b/mod/JunimoServer/Util/ServerBanner.cs
@@ -1,4 +1,5 @@
 using JunimoServer.Services.SteamGameServer;
+using JunimoServer.Shared;
 using StardewModdingAPI;
 using StardewValley.SDKs.GogGalaxy;
 using System.Collections.Generic;
@@ -48,27 +49,32 @@ namespace JunimoServer.Util
 
             var networkingLines = GetNetworkingStatus();
 
+            // IPs are masked: the banner is captured into the public E2E report, so it
+            // must not disclose the host's real addresses (keep the last octet for shape).
             var bannerLines = new List<string>
             {
                 $"JunimoServer {version}",
                 "",
-                $"✓ Local:   {NetworkHelper.GetIpAddressLocal()}",
-                $"{externalIcon} Network: {externalIpValue}",
+                $"✓ Local:   {ChatRedaction.MaskIp(NetworkHelper.GetIpAddressLocal().ToString())}",
+                $"{externalIcon} Network: {ChatRedaction.MaskIp(externalIpValue)}",
                 "",
             };
 
             bannerLines.AddRange(networkingLines);
             bannerLines.Add("");
 
+            // Invite codes let anyone join, so they're masked in the banner (which is
+            // captured into the public report). The real code is still served verbatim
+            // via /tmp/invite-code.txt and the API for legitimate clients.
             if (SteamGameServerService.IsInitialized && inviteCode != null)
             {
                 var baseCode = inviteCode.Length > 1 ? inviteCode.Substring(1) : inviteCode;
-                bannerLines.Add($"Invite Code (Steam): {GalaxyNetHelper.SteamInvitePrefix}{baseCode}");
-                bannerLines.Add($"Invite Code (GOG):   {GalaxyNetHelper.GalaxyInvitePrefix}{baseCode}");
+                bannerLines.Add($"Invite Code (Steam): {GalaxyNetHelper.SteamInvitePrefix}{ChatRedaction.MaskValue(baseCode)}");
+                bannerLines.Add($"Invite Code (GOG):   {GalaxyNetHelper.GalaxyInvitePrefix}{ChatRedaction.MaskValue(baseCode)}");
             }
             else
             {
-                bannerLines.Add($"Invite Code: {inviteCode ?? "n/a"}");
+                bannerLines.Add($"Invite Code: {(inviteCode != null ? ChatRedaction.MaskValue(inviteCode) : "n/a")}");
             }
 
             monitor.LogBanner(bannerLines.ToArray());
@@ -81,8 +87,10 @@ namespace JunimoServer.Util
             // Steam GameServer (SDR) status
             if (SteamGameServerService.IsInitialized)
             {
+                // Masked: the SDR ID identifies the hosting Steam account and the banner
+                // is captured into the public report.
                 var steamId = SteamGameServerService.ServerSteamId.m_SteamID;
-                lines.Add($"✓ Steam SDR: {steamId}");
+                lines.Add($"✓ Steam SDR: {ChatRedaction.MaskValue(steamId.ToString())}");
             }
             else
             {

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -680,7 +680,7 @@ finally
     // CI. No-ops with a warning when the SPA hasn't been built. Requires the
     // final state, so it runs after WriteRunArtifacts.
     if (generateReport || IsCIEnvironment())
-        ReportGenerator.TryGenerate(recorder.State, TestArtifacts.RunDir);
+        ReportGenerator.TryGenerate(recorder.State, TestArtifacts.RunDir, CollectKnownSecrets());
 
     // Dev-mode Web runs that completed normally: hold the browser open
     // until the operator presses a key (or signals shutdown). Skipped on
@@ -728,6 +728,44 @@ static bool IsCIEnvironment()
     => Environment.GetEnvironmentVariable("CI") != null
        || Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null
        || Environment.GetEnvironmentVariable("TF_BUILD") != null;
+
+/// <summary>
+/// Collects the sensitive values the runner knows, for the report redactor to mask out
+/// of the published (public) snapshot: Steam credentials from <c>STEAM_ACCOUNTS</c> and
+/// each remote host's <c>user@host</c> + bare host from <see cref="HostPool"/>. Best-effort
+/// — any failure yields an empty set (the redactor's regex pass still runs).
+/// </summary>
+static IReadOnlyCollection<string> CollectKnownSecrets()
+{
+    var secrets = new HashSet<string>(StringComparer.Ordinal);
+
+    try
+    {
+        var accountsJson = Environment.GetEnvironmentVariable("STEAM_ACCOUNTS");
+        foreach (var account in JunimoServer.Tests.Schema.Json.UserConfigJson.ParseArrayStrict("STEAM_ACCOUNTS", accountsJson))
+        {
+            foreach (var field in new[] { "user", "pass", "refreshToken" })
+                if (account?[field]?.GetValue<string>() is { Length: > 0 } v)
+                    secrets.Add(v);
+        }
+    }
+    catch { /* malformed STEAM_ACCOUNTS — rely on regex + host values */ }
+
+    try
+    {
+        foreach (var host in HostPool.Instance.Hosts)
+        {
+            if (string.IsNullOrEmpty(host.SshDestination)) continue;
+            secrets.Add(host.SshDestination);                       // user@host
+            var at = host.SshDestination.IndexOf('@');
+            if (at >= 0 && at < host.SshDestination.Length - 1)
+                secrets.Add(host.SshDestination[(at + 1)..]);       // bare host / IP
+        }
+    }
+    catch { /* host pool unavailable — rely on regex + steam values */ }
+
+    return secrets;
+}
 
 /// <summary>
 /// Unwrap a <see cref="RendererDispatchGuard"/> to its inner renderer for type

--- a/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
@@ -19,12 +19,15 @@ public sealed class ReportGenerator
     private readonly TestRunState _state;
     private readonly string _spaDistPath;
     private readonly string _testResultsPath;
+    private readonly IReadOnlyCollection<string> _knownSecrets;
 
-    public ReportGenerator(TestRunState state, string spaDistPath, string testResultsPath)
+    public ReportGenerator(TestRunState state, string spaDistPath, string testResultsPath,
+        IReadOnlyCollection<string> knownSecrets)
     {
         _state = state;
         _spaDistPath = spaDistPath;
         _testResultsPath = testResultsPath;
+        _knownSecrets = knownSecrets;
     }
 
     /// <summary>
@@ -32,9 +35,10 @@ public sealed class ReportGenerator
     /// the runner's finally regardless of renderer mode. Resolves the built SPA,
     /// writes the bundle inside <paramref name="runDir"/> (so it rides along in
     /// the uploaded per-run artifact tree), and no-ops with a warning when the
-    /// SPA has not been built. Never throws.
+    /// SPA has not been built. <paramref name="knownSecrets"/> are masked out of the
+    /// published snapshot (see <see cref="ReportRedactor"/>). Never throws.
     /// </summary>
-    public static void TryGenerate(TestRunState state, string runDir)
+    public static void TryGenerate(TestRunState state, string runDir, IReadOnlyCollection<string> knownSecrets)
     {
         try
         {
@@ -46,7 +50,7 @@ public sealed class ReportGenerator
                 return;
             }
 
-            new ReportGenerator(state, spaDistPath, runDir).Generate();
+            new ReportGenerator(state, spaDistPath, runDir, knownSecrets).Generate();
         }
         catch (Exception ex)
         {
@@ -77,15 +81,10 @@ public sealed class ReportGenerator
         return null;
     }
 
-    public void Generate()
+    // Assumes the SPA index.html exists — TryGenerate (the only caller) verifies it.
+    private void Generate()
     {
         var indexPath = Path.Combine(_spaDistPath, "index.html");
-        if (!File.Exists(indexPath))
-        {
-            Console.Error.WriteLine("WARNING: Report generation skipped. index.html not found in SPA dist.");
-            return;
-        }
-
         var reportDir = Path.Combine(_testResultsPath, "report");
         Directory.CreateDirectory(reportDir);
 
@@ -101,6 +100,21 @@ public sealed class ReportGenerator
             Path.Combine(reportDir, BundleArtifactsDir),
             BundleArtifactsDir,
             _testResultsPath);
+
+        // Redact secrets/infra before the snapshot is published to the public report.
+        // Runs after the media-path rewrite so the artifacts/<hash> paths are preserved.
+        snapshotJson = ReportRedactor.Scrub(snapshotJson, _knownSecrets);
+
+        // Fail closed: if redaction somehow produced invalid JSON, do NOT publish the
+        // bundle (an unredacted fallback could leak). Masked output can't break JSON by
+        // construction, so this is a backstop that should never trip.
+        try { using var _ = JsonDocument.Parse(snapshotJson); }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine(
+                $"WARNING: Report generation aborted — redacted snapshot is not valid JSON ({ex.Message}). Not publishing.");
+            return;
+        }
 
         // Inject state JSON using a safe script tag
         // System.Text.Json's default encoder escapes <, >, & (safe against </script> breakout)

--- a/tests/JunimoServer.TestRunner/Rendering/Web/ReportRedactor.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/ReportRedactor.cs
@@ -1,0 +1,123 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace JunimoServer.TestRunner.Rendering.Web;
+
+/// <summary>
+/// Redaction boundary for the published E2E report. The report bundle inlines the
+/// full run snapshot (captured container logs, error text, diagnostics) and is served
+/// from a <b>public</b> URL, so any secret or infrastructure detail in that text must be
+/// masked before publishing.
+///
+/// <para>Strategy is layered by confidence to avoid false positives (a bare-IPv4 regex
+/// would corrupt benign version strings like <c>Unix 6.1.0.17</c>):</para>
+/// <list type="number">
+///   <item>Known-value pass — literal replacement of values the runner actually knows
+///   (VPS host/IP, Steam credentials), longest-first. Zero ambiguity.</item>
+///   <item>High-confidence regex — shapes that don't collide with benign text: private-key
+///   blocks, <c>/run/secrets</c> snippets, <c>key=value</c> secret assignments, SSH
+///   <c>user@host</c> destinations.</item>
+/// </list>
+/// <para>No broad bare-IP regex here: IPs are masked at the mod source
+/// (<c>ChatRedaction.MaskIp</c>); a real infra IP that still reaches the report is caught
+/// by the known-value pass.</para>
+///
+/// <para>The <c>MaskIp</c>/<c>MaskValue</c> helpers duplicate
+/// <c>mod/JunimoServer.Shared/ChatRedaction.cs</c> (the mod is net6.0 + references the game
+/// DLL, so the net10.0 runner can't reference it). Keep the two in sync; a future
+/// dependency-free shared library would let both consume one implementation.</para>
+/// </summary>
+public static class ReportRedactor
+{
+    // Private-key PEM blocks (any "BEGIN ... PRIVATE KEY" ... "END ... PRIVATE KEY").
+    private static readonly Regex PrivateKeyBlock = new(
+        @"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+        RegexOptions.Singleline | RegexOptions.Compiled);
+
+    // `password=value`, `pass=...`, `token=...`, `secret=...`, `key=...` (value up to a
+    // quote, whitespace, or shell separator). Keeps the key, masks the value.
+    private static readonly Regex SecretAssignment = new(
+        @"(?<key>\b(?:password|passwd|pass|token|secret|api[_-]?key|access[_-]?key)\b\s*[=:]\s*)(?<val>[^\s""'`&|;]+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    // `/run/secrets/<name>` paths and the `$(cat /run/secrets/<name>)` snippet.
+    private static readonly Regex RunSecrets = new(
+        @"/run/secrets/[A-Za-z0-9_.-]+",
+        RegexOptions.Compiled);
+
+    // SSH-style user@host destinations (host is a hostname or IPv4).
+    private static readonly Regex SshDestination = new(
+        @"\b[A-Za-z0-9._-]+@(?:\d{1,3}(?:\.\d{1,3}){3}|[A-Za-z0-9.-]+\.[A-Za-z]{2,})\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns <paramref name="snapshotJson"/> with sensitive values masked in place.
+    /// Masked output stays within <c>[A-Za-z0-9*.:@_-]</c>, so it never introduces a quote
+    /// or backslash and the JSON (incl. the rewritten <c>artifacts/&lt;hash&gt;</c> media
+    /// paths) remains valid. Must run <b>after</b> the media-path rewrite.
+    /// </summary>
+    public static string Scrub(string snapshotJson, IReadOnlyCollection<string> knownSecrets)
+    {
+        if (string.IsNullOrEmpty(snapshotJson))
+            return snapshotJson;
+
+        var result = snapshotJson;
+
+        // 1. Known values — longest-first so e.g. "user@host" is masked before the bare
+        //    "host" substring it contains.
+        foreach (var secret in knownSecrets.Where(s => s.Length >= 3).OrderByDescending(s => s.Length))
+        {
+            var masked = LooksLikeIp(secret) ? MaskIp(secret) : MaskValue(secret);
+            result = result.Replace(secret, masked);
+        }
+
+        // 2. High-confidence regex.
+        result = PrivateKeyBlock.Replace(result, "-----BEGIN PRIVATE KEY----- [redacted] -----END PRIVATE KEY-----");
+        result = RunSecrets.Replace(result, "/run/secrets/***");
+        result = SshDestination.Replace(result, m => MaskValue(m.Value));
+        result = SecretAssignment.Replace(result, m => m.Groups["key"].Value + MaskValue(m.Groups["val"].Value));
+
+        return result;
+    }
+
+    private static bool LooksLikeIp(string value)
+    {
+        if (value.IndexOf(':') >= 0) return true; // candidate IPv6
+        var octets = value.Split('.');
+        return octets.Length == 4 && octets.All(o => int.TryParse(o, out var n) && n is >= 0 and <= 255);
+    }
+
+    // --- Masking helpers (mirror ChatRedaction; see class remarks) ---
+
+    /// <summary>IPv4 → <c>***.***.***.last</c>, IPv6 → <c>***:***:…:lastHextet</c>; loopback kept.</summary>
+    private static string MaskIp(string ip)
+    {
+        switch (ip)
+        {
+            case "127.0.0.1":
+            case "0.0.0.0":
+            case "::1":
+            case "::":
+                return ip;
+        }
+
+        if (ip.IndexOf(':') >= 0)
+        {
+            var parts = ip.Split(':');
+            for (var i = parts.Length - 1; i >= 0; i--)
+                if (parts[i].Length > 0) return "***:***:…:" + parts[i];
+            return ip;
+        }
+
+        var octets = ip.Split('.');
+        return octets.Length == 4 ? "***.***.***." + octets[3] : ip;
+    }
+
+    /// <summary>Generic value → <c>first***last</c>; length ≤2 → <c>***</c>.</summary>
+    private static string MaskValue(string value)
+    {
+        if (string.IsNullOrEmpty(value)) return value;
+        if (value.Length <= 2) return "***";
+        return $"{value[0]}***{value[value.Length - 1]}";
+    }
+}


### PR DESCRIPTION
Builds on #350 (E2E report surfacing). The web report can be published to a **public** Cloudflare R2 URL and inlines captured server logs — a review of a real bundle found the VPS public IP (×12) and a `/run/secrets` snippet. This redacts secrets/infra defense-in-depth and adds the R2 publish step.

## Redaction (two layers, mask-in-place: `1.2.3.4 → ***.***.***.4`, `secret → s***t`)

**Mod source** — `ChatRedaction.MaskIp`/`MaskValue`, applied at display-only sites (no functional consumer; the real invite code still flows via `/tmp/invite-code.txt` + API):
- `ServerBanner` (local/external IP, invite code, Steam SDR ID), `SteamGameServerService` (public-IP log), `PasswordProtectionService` + `DesyncKicker` (player names).

**Report boundary** — new `ReportRedactor.Scrub` over the snapshot before publish:
- Known-value literal replace (VPS host/IP from `SDVD_DOCKER_HOSTS`, Steam creds from `STEAM_ACCOUNTS`, longest-first) + high-confidence regex (private-key blocks, `/run/secrets`, `password=`/`token=`, `user@host`).
- **No bare-IP regex** — a version string like `Unix 6.1.0.17` is indistinguishable from an IP; IPs are caught at mod source + the known-value set.
- JSON-safe; **fail-closed** (invalid JSON after scrub → report not published).

## R2 publish
- Uploads `report/` to `e2e/{branch}/{run-id}/` with a Job-Summary link; **public-read, token-write** bucket; 30-day retention via an R2 lifecycle rule.
- Fully optional: `continue-on-error` + config-skip when `R2_*` secrets are unset — never fails the run.

## Notes
- `MaskIp`/`MaskValue` are duplicated runner-side (net10.0 can't reference the net6.0 mod project); both copies note a future shared lib would consolidate them.
- One-time operator setup required: create the R2 bucket (public-read, lifecycle rule) and add the 5 `R2_*` secrets to the `test-vps` environment. Until then the publish step cleanly no-ops.

## Verification
- Mod (net6.0) + runner (net10.0) build clean.
- The compiled `ReportRedactor` run against a real snapshot masks the VPS IP and Steam username while leaving `6.1.0.17` intact, JSON valid, `artifacts/` paths untouched.
- Live mod-source redaction (masked values in a fresh run) pending a `--report` E2E.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * E2E test reports can optionally be published to Cloudflare R2 with shareable hosted links added to job summaries; publishing is non-fatal if it fails.

* **Improvements**
  * Reports and server/test logs now redact sensitive data (IPs, short secrets, player names) with multi-layer scrubbing and fail-closed validation for published snapshots.

* **Documentation**
  * Updated E2E testing docs to cover hosted report setup, publish behavior, retention, and redaction details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->