### PR TITLE
fix(ci): stop CI-log mangling (base64 host secret) + scrub VPS IP from E2E logs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -76,23 +76,46 @@ jobs:
       # inherited by the runner's in-process `make build` subprocess. Not read by
       # any C#. The Makefile default is Debug; pin Release for CI.
       BUILD_CONFIGURATION: Release
-      # The harness's host-fleet config, verbatim — set as ONE GitHub secret in
-      # the test-vps environment, exactly as you'd put it in .env.test locally.
-      # It carries the whole VPS-only fleet: id / endpoint (ssh://user@host, keep
-      # the VPS on port 22 — SDVD_DOCKER_HOSTS has no port field) / serverSlots /
-      # clientSlots / gpu:false (recording uses libx264 software encode), AND the SSH
-      # private key INLINE in the `sshKey` field (a "-----BEGIN…" block). HostPool
-      # writes inline key material to a 0600 temp file at startup and resolves
-      # `sshKey` to that path, so no key-file step is needed here. Shape the
-      # secret like:
+      # The harness's host-fleet config is supplied as SDVD_DOCKER_HOSTS_B64 — the
+      # base64 of the JSON (the same shape as .env.test, but with the SSH private key
+      # INLINE in each `sshKey` field). It is base64-encoded because the inline key is
+      # multiline, and GitHub masks multiline secrets line-by-line — registering the
+      # PEM's `-----` armor would mask every `-` in the whole log (client-0 → client***0,
+      # dates, etc.) while leaving the real IP unmasked. Base64 makes it a single-line
+      # secret that GitHub registers atomically, so nothing in normal logs matches it.
+      # The "Decode host fleet" step (below) restores SDVD_DOCKER_HOSTS into $GITHUB_ENV
+      # for the keyscan + runner steps. Shape of the pre-encoding JSON:
       #   [{"id":"vps","endpoint":"ssh://sdvd-runner@HOST","serverSlots":1,
       #     "clientSlots":2,"gpu":false,
       #     "sshKey":"-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END…-----\n"}]
-      SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
+      # To (re)create the secret:
+      #   jq -c --rawfile k key.pem '.[0].sshKey=$k' hosts.json | base64 -w0 | gh secret set SDVD_DOCKER_HOSTS_B64 --env test-vps
 
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Decode the base64 host-fleet config into SDVD_DOCKER_HOSTS for the keyscan +
+      # runner steps. Written to $GITHUB_ENV via the heredoc form (multiline-safe),
+      # NOT echoed to the log. The decoded JSON carries the inline SSH key with real
+      # newlines; GitHub does NOT auto-mask it (only the registered base64 blob is
+      # masked, never derived values) — so it MUST NEVER be printed. Do not add an
+      # `echo`/`cat` of $SDVD_DOCKER_HOSTS anywhere; the keyscan step's jq already
+      # extracts only `.endpoint`.
+      - name: Decode host fleet
+        env:
+          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
+        run: |
+          if [ -z "$SDVD_DOCKER_HOSTS_B64" ]; then
+            echo "::error::SDVD_DOCKER_HOSTS_B64 is not set in the test-vps environment." >&2
+            exit 1
+          fi
+          {
+            echo 'SDVD_DOCKER_HOSTS<<__SDVD_HOSTS_EOF__'
+            printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d
+            echo
+            echo '__SDVD_HOSTS_EOF__'
+          } >> "$GITHUB_ENV"
 
       # The coordinator is a net10.0 app that runs HERE on the runner (the mod
       # builds inside Docker; the runner does not). .NET 10 is GA, so the default
@@ -157,13 +180,12 @@ jobs:
       # the inline `sshKey` to its own 0600 temp file.
       #
       # SECURITY: the jq below extracts ONLY `.endpoint`. Never change it to read
-      # `.sshKey` (or pipe the raw $SDVD_DOCKER_HOSTS to stdout). `jq -r .sshKey`
-      # would emit the DECODED key with real newlines — different bytes than the
-      # registered secret, so GitHub's log masker would NOT redact it, leaking the
-      # private key into public CI logs.
+      # `.sshKey` (or pipe the raw $SDVD_DOCKER_HOSTS to stdout) — the decoded JSON
+      # carries the private key with real newlines, which GitHub does NOT mask (only
+      # the base64 blob is registered), so printing it would leak the key. The host
+      # is NOT echoed either: it's the VPS IP, which would otherwise show in the log.
+      # SDVD_DOCKER_HOSTS comes from $GITHUB_ENV (the Decode host fleet step).
       - name: Trust VPS host key
-        env:
-          SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
@@ -174,10 +196,12 @@ jobs:
             echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS — cannot keyscan." >&2
             exit 1
           fi
+          count=0
           for h in $hosts; do
-            echo "Scanning host key for $h"
             ssh-keyscan -t rsa,ecdsa,ed25519 "$h" >> ~/.ssh/known_hosts 2>/dev/null
+            count=$((count + 1))
           done
+          echo "Scanned host keys for $count host(s)."
           chmod 644 ~/.ssh/known_hosts
 
       # Populate the LOCAL server_game-data volume — the precondition for

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,6 +93,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # This job uploads artifacts and publishes a report to a PUBLIC bucket, and
+          # no later step needs the git credential, so don't persist it in .git/config
+          # (defense in depth — keeps the token out of anything we upload).
+          persist-credentials: false
 
       # Decode the base64 host-fleet config into SDVD_DOCKER_HOSTS for the keyscan +
       # runner steps. Written to $GITHUB_ENV via the heredoc form (multiline-safe),

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -82,8 +82,9 @@ jobs:
       # PEM's `-----` armor would mask every `-` in the whole log (client-0 → client***0,
       # dates, etc.) while leaving the real IP unmasked. Base64 makes it a single-line
       # secret that GitHub registers atomically, so nothing in normal logs matches it.
-      # The "Decode host fleet" step (below) restores SDVD_DOCKER_HOSTS into $GITHUB_ENV
-      # for the keyscan + runner steps. Shape of the pre-encoding JSON:
+      # It is decoded STEP-LOCALLY in the two steps that need it (keyscan + runner) —
+      # never into $GITHUB_ENV, which would expose the inline SSH key to every later
+      # step (incl. third-party actions). Shape of the pre-encoding JSON:
       #   [{"id":"vps","endpoint":"ssh://sdvd-runner@HOST","serverSlots":1,
       #     "clientSlots":2,"gpu":false,
       #     "sshKey":"-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END…-----\n"}]
@@ -98,28 +99,6 @@ jobs:
           # no later step needs the git credential, so don't persist it in .git/config
           # (defense in depth — keeps the token out of anything we upload).
           persist-credentials: false
-
-      # Decode the base64 host-fleet config into SDVD_DOCKER_HOSTS for the keyscan +
-      # runner steps. Written to $GITHUB_ENV via the heredoc form (multiline-safe),
-      # NOT echoed to the log. The decoded JSON carries the inline SSH key with real
-      # newlines; GitHub does NOT auto-mask it (only the registered base64 blob is
-      # masked, never derived values) — so it MUST NEVER be printed. Do not add an
-      # `echo`/`cat` of $SDVD_DOCKER_HOSTS anywhere; the keyscan step's jq already
-      # extracts only `.endpoint`.
-      - name: Decode host fleet
-        env:
-          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
-        run: |
-          if [ -z "$SDVD_DOCKER_HOSTS_B64" ]; then
-            echo "::error::SDVD_DOCKER_HOSTS_B64 is not set in the test-vps environment." >&2
-            exit 1
-          fi
-          {
-            echo 'SDVD_DOCKER_HOSTS<<__SDVD_HOSTS_EOF__'
-            printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d
-            echo
-            echo '__SDVD_HOSTS_EOF__'
-          } >> "$GITHUB_ENV"
 
       # The coordinator is a net10.0 app that runs HERE on the runner (the mod
       # builds inside Docker; the runner does not). .NET 10 is GA, so the default
@@ -183,21 +162,24 @@ jobs:
       # keep in sync. The private key is NOT written here — HostPool materializes
       # the inline `sshKey` to its own 0600 temp file.
       #
-      # SECURITY: the jq below extracts ONLY `.endpoint`. Never change it to read
-      # `.sshKey` (or pipe the raw $SDVD_DOCKER_HOSTS to stdout) — the decoded JSON
-      # carries the private key with real newlines, which GitHub does NOT mask (only
-      # the base64 blob is registered), so printing it would leak the key. The host
-      # is NOT echoed either: it's the VPS IP, which would otherwise show in the log.
-      # SDVD_DOCKER_HOSTS comes from $GITHUB_ENV (the Decode host fleet step).
+      # SECURITY: the base64 host-fleet config is decoded into a STEP-LOCAL shell var
+      # (never $GITHUB_ENV — that would expose the inline SSH key to every later step,
+      # incl. third-party actions). The jq below extracts ONLY `.endpoint`; never read
+      # `.sshKey` or pipe the decoded JSON to stdout — GitHub does NOT mask the decoded
+      # value (only the base64 blob is registered), so printing it would leak the key.
+      # The host is NOT echoed either: it's the VPS IP.
       - name: Trust VPS host key
+        env:
+          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          hosts=$(printf '%s' "$SDVD_DOCKER_HOSTS" \
+          hosts_json=$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d)
+          hosts=$(printf '%s' "$hosts_json" \
             | jq -r '.[] | select(.endpoint) | .endpoint' \
             | sed -E 's#^ssh://##; s#^[^@]*@##')
           if [ -z "$hosts" ]; then
-            echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS — cannot keyscan." >&2
+            echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS_B64 — cannot keyscan." >&2
             exit 1
           fi
           count=0
@@ -242,13 +224,17 @@ jobs:
       - name: Run E2E suite
         env:
           STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
+          # The base64 host fleet is decoded STEP-LOCALLY below (not $GITHUB_ENV) so
+          # the inline SSH key isn't exposed to other steps.
+          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
           # Pass the (operator-controlled) filter through the environment, not
           # interpolated into the command line, so its value can never be parsed
           # as shell. Empty (the default) runs the full suite — pass --filter only
-          # when a value was provided.
+          # when a non-whitespace value was provided.
           FILTER: ${{ inputs.filter }}
         run: |
-          if [ -n "$FILTER" ]; then
+          export SDVD_DOCKER_HOSTS="$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d)"
+          if [ -n "${FILTER//[[:space:]]/}" ]; then
             dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
           else
             dotnet run --project ./tests/JunimoServer.TestRunner

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,5 @@
-# Runs the heavy Docker E2E suite as a smoke subset. The coordinator
+# Runs the heavy Docker E2E suite (the full suite by default; a dispatch-time
+# `filter` input narrows it to a class/method). The coordinator
 # (JunimoServer.TestRunner, a net10.0 app) runs here on ubuntu-latest; the actual
 # Stardew game containers run on a remote VPS reached over SSH — the harness's
 # existing multi-host model with SDVD_DOCKER_HOSTS set to a VPS-only fleet.
@@ -13,15 +14,15 @@
 #
 # All secrets resolve from the `test-vps` GitHub Environment (the same per-
 # environment mechanism deploy-server.yml uses), not loose repo-level secrets.
-name: E2E Tests (Smoke)
+name: E2E Tests
 
 on:
   workflow_dispatch:
     inputs:
       filter:
-        description: 'Test filter (xUnit class/method substring)'
+        description: 'Test filter (xUnit class/method substring). Empty = run the full suite.'
         required: false
-        default: 'ServerSettingsTests'
+        default: ''
 
 permissions:
   contents: read
@@ -34,17 +35,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-smoke:
-    name: E2E Smoke (VPS)
+  e2e:
+    name: E2E (VPS)
     runs-on: ubuntu-latest
     # Holds the Steam + SSH secrets. Mirrors deploy-server.yml's per-environment
     # secret scoping.
     environment: test-vps
-    # Generous headroom for a cold first run: server + test-client + steam-service
-    # image builds, the one-time ~250 MB game-data stream to the VPS, a remote
-    # server cold-start (slower than local), plus a handful of HTTP asserts.
-    # Tighten toward ~20 once steady-state.
-    timeout-minutes: 30
+    # No job-level timeout-minutes: a bare dispatch runs the FULL suite, whose size
+    # varies, so we don't hardcode a wall-clock cap. The runner's own per-test and
+    # broker timeouts catch real hangs; GitHub's default job timeout is the backstop.
 
     # Non-secret runner config shared by every step. The Steam secrets are scoped
     # to the two steps that consume them (populate + run), not broadcast here.
@@ -230,21 +229,25 @@ jobs:
 
       # The whole pipeline in one command. The runner builds all three images
       # in-process (reading STEAM_ACCOUNTS[0] for the Steam --secret login),
-      # streams them + the game-data volume to the VPS, then runs the filtered
-      # tests there. --filter is a substring match against the FQ test name, so a
-      # class name runs that class. STEAM_ACCOUNTS is required here from the very
-      # first run — without it the in-process image build fails with a Steam-login
-      # error.
-      - name: Run E2E smoke
+      # streams them + the game-data volume to the VPS, then runs the tests there.
+      # --filter is a substring match against the FQ test name (a class name runs
+      # that class); with no filter the full suite runs. STEAM_ACCOUNTS is required
+      # here from the very first run — without it the in-process image build fails
+      # with a Steam-login error.
+      - name: Run E2E suite
         env:
           STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
           # Pass the (operator-controlled) filter through the environment, not
           # interpolated into the command line, so its value can never be parsed
-          # as shell. The input already defaults to ServerSettingsTests; the
-          # fallback covers an explicitly-cleared input.
-          FILTER: ${{ inputs.filter || 'ServerSettingsTests' }}
+          # as shell. Empty (the default) runs the full suite — pass --filter only
+          # when a value was provided.
+          FILTER: ${{ inputs.filter }}
         run: |
-          dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
+          if [ -n "$FILTER" ]; then
+            dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
+          else
+            dotnet run --project ./tests/JunimoServer.TestRunner
+          fi
 
       # Render the runner's ctrf-report.json (TestRunArtifactWriter.WriteCtrfReport,
       # one per CI invocation) into the job Summary tab. summary-report = pass/fail

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -171,9 +171,11 @@ TestResults/runs/{timestamp}_{sha}/tests/{Class}.{Method}/
 
 ## CI Usage
 
-The E2E smoke suite runs from `.github/workflows/e2e-tests.yml` (`workflow_dispatch`
+The E2E suite runs from `.github/workflows/e2e-tests.yml` (`workflow_dispatch`
 only — the coordinator runs on the GitHub runner; the game containers run on a
-remote VPS over SSH). That workflow is the source of truth for CI invocation.
+remote VPS over SSH). A bare dispatch runs the full suite; the optional `filter`
+input narrows it to a class/method. That workflow is the source of truth for CI
+invocation.
 
 Results surface in three places, all produced from artifacts the runner emits:
 

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -437,7 +437,7 @@ try
         if (result.Error != null)
         {
             renderer.OnSetupStep(new SetupStepEvent(SetupCategory, $"Cleanup {result.HostId}",
-                SetupStepStatus.Warning, $"{result.Error.GetType().Name}: {result.Error.Message}"));
+                SetupStepStatus.Warning, $"{result.Error.GetType().Name}: {ScrubForLog(result.Error.Message)}"));
         }
         else
         {
@@ -485,9 +485,10 @@ try
 }
 catch (Exception ex)
 {
-    Console.Error.WriteLine($"[ImageBuild] Parent-side build failed: {ex.Message}");
-    InfrastructureEventLog.Emit("run_aborted", new { cause = "image_build", message = ex.Message });
-    parentBuildProgress.PhaseCompleted("Docker Images", false, ex.Message);
+    var buildMsg = ScrubForLog(ex.Message);
+    Console.Error.WriteLine($"[ImageBuild] Parent-side build failed: {buildMsg}");
+    InfrastructureEventLog.Emit("run_aborted", new { cause = "image_build", message = buildMsg });
+    parentBuildProgress.PhaseCompleted("Docker Images", false, buildMsg);
     recorder.SetAbortReason("image_build");
     recorder.WriteRunArtifacts();
     await renderer.DisposeAsync();
@@ -643,12 +644,13 @@ try
 }
 catch (Exception ex)
 {
-    JunimoServer.Tests.Fixtures.TestSummaryFixture.Instance?.SetAborted(ex.Message);
+    var runMsg = ScrubForLog(ex.Message);
+    JunimoServer.Tests.Fixtures.TestSummaryFixture.Instance?.SetAborted(runMsg);
     JunimoServer.Tests.Helpers.InfrastructureEventLog.Emit("run_aborted", new
     {
         cause = "exception",
         exceptionType = ex.GetType().Name,
-        message = ex.Message
+        message = runMsg
     });
     recorder.SetAbortReason("exception");
     throw;

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -394,8 +394,10 @@ try
     using var preflightCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
     foreach (var host in hostPool.Hosts)
     {
+        // Detail is "remote"/"local" only — never host.SshDestination (the VPS
+        // user@IP), which the CIRenderer prints to the public CI log.
         renderer.OnSetupStep(new SetupStepEvent(SetupCategory, $"Preflight {host.Id}",
-            SetupStepStatus.Started, host.SshDestination ?? "local"));
+            SetupStepStatus.Started, host.SshDestination != null ? "remote" : "local"));
     }
     await hostPool.PreflightAsync(tunnelManager, preflightCts.Token);
     foreach (var host in hostPool.Hosts)
@@ -407,9 +409,10 @@ try
 }
 catch (Exception ex)
 {
-    Console.Error.WriteLine($"[HostPool] Preflight failed: {ex.Message}");
-    InfrastructureEventLog.Emit("run_aborted", new { cause = "host_preflight", message = ex.Message });
-    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Preflight", false, ex.Message));
+    var preflightMsg = ScrubForLog(ex.Message);
+    Console.Error.WriteLine($"[HostPool] Preflight failed: {preflightMsg}");
+    InfrastructureEventLog.Emit("run_aborted", new { cause = "host_preflight", message = preflightMsg });
+    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Preflight", false, preflightMsg));
     recorder.SetAbortReason("preflight");
     recorder.WriteRunArtifacts();
     await renderer.DisposeAsync();
@@ -426,7 +429,7 @@ try
     foreach (var host in hostPool.Hosts)
     {
         renderer.OnSetupStep(new SetupStepEvent(SetupCategory, $"Cleanup {host.Id}",
-            SetupStepStatus.Started, host.SshDestination ?? "local"));
+            SetupStepStatus.Started, host.SshDestination != null ? "remote" : "local"));
     }
     await foreach (var result in JunimoServer.Tests.Helpers.EmergencyCleanup
         .SweepStaleResourcesAsync(hostPool.Hosts))
@@ -449,8 +452,9 @@ try
 }
 catch (Exception ex)
 {
-    Console.Error.WriteLine($"[Cleanup] Stale-resource sweep failed: {ex.Message}");
-    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Cleanup leftovers", false, ex.Message));
+    var cleanupMsg = ScrubForLog(ex.Message);
+    Console.Error.WriteLine($"[Cleanup] Stale-resource sweep failed: {cleanupMsg}");
+    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Cleanup leftovers", false, cleanupMsg));
     // Don't abort the run — sweep failure is recoverable; the run can still
     // execute against whatever leftover state exists, and process-exit cleanup
     // will mop up at the end.
@@ -516,9 +520,10 @@ try
 }
 catch (Exception ex)
 {
-    Console.Error.WriteLine($"[ImageTransfer] aborted: {ex.Message}");
-    InfrastructureEventLog.Emit("run_aborted", new { cause = "image_transfer_exception", message = ex.Message });
-    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Image distribution", false, ex.Message));
+    var transferMsg = ScrubForLog(ex.Message);
+    Console.Error.WriteLine($"[ImageTransfer] aborted: {transferMsg}");
+    InfrastructureEventLog.Emit("run_aborted", new { cause = "image_transfer_exception", message = transferMsg });
+    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Image distribution", false, transferMsg));
     recorder.SetAbortReason("image_transfer_exception");
     recorder.WriteRunArtifacts();
     await renderer.DisposeAsync();
@@ -554,9 +559,10 @@ try
 }
 catch (Exception ex)
 {
-    Console.Error.WriteLine($"[GameData] aborted: {ex.Message}");
-    InfrastructureEventLog.Emit("run_aborted", new { cause = "game_data_transfer_exception", message = ex.Message });
-    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Game data distribution", false, ex.Message));
+    var gameDataMsg = ScrubForLog(ex.Message);
+    Console.Error.WriteLine($"[GameData] aborted: {gameDataMsg}");
+    InfrastructureEventLog.Emit("run_aborted", new { cause = "game_data_transfer_exception", message = gameDataMsg });
+    renderer.OnSetupPhaseCompleted(new SetupPhaseCompletedEvent(SetupCategory, "Game data distribution", false, gameDataMsg));
     recorder.SetAbortReason("game_data_transfer_exception");
     recorder.WriteRunArtifacts();
     await renderer.DisposeAsync();
@@ -728,6 +734,15 @@ static bool IsCIEnvironment()
     => Environment.GetEnvironmentVariable("CI") != null
        || Environment.GetEnvironmentVariable("GITHUB_ACTIONS") != null
        || Environment.GetEnvironmentVariable("TF_BUILD") != null;
+
+/// <summary>
+/// Masks secrets/infra out of a free-text setup error before it reaches the CI log —
+/// preflight/transfer exceptions carry SSH stderr that can embed the VPS host/IP. Delegates
+/// to the same <see cref="ReportRedactor"/> + <see cref="CollectKnownSecrets"/> used for the
+/// published report, so masking is consistent everywhere (e.g. <c>***.***.***.188</c>).
+/// </summary>
+static string ScrubForLog(string message)
+    => ReportRedactor.Scrub(message, CollectKnownSecrets());
 
 /// <summary>
 /// Collects the sensitive values the runner knows, for the report redactor to mask out


### PR DESCRIPTION
## Problem

The E2E CI logs were mangled — every `-` replaced with `***` (`client-0`→`client***0`, `2026-06-04`, `vps-1`, `-->`) — while the real VPS IP showed **unmasked**. So GitHub's masking was backwards: it shredded benign text and let the actual secret through.

**Root cause:** `SDVD_DOCKER_HOSTS` is a multiline secret (it embeds the inline SSH private key). GitHub masks multiline secrets line-by-line and tokenizes the PEM `-----` armor, registering the hyphen as a mask pattern → every `-` in the whole log gets `***`'d. The IP isn't masked because it's a mid-JSON-string substring. GitHub's own guidance: don't wrap a secret in a JSON/YAML blob (redaction needs an exact match); base64-encoding a multiline secret to a single line is the canonical fix (actions/runner#161).

## Fix

**1. Root cause — base64 the host-fleet secret**
- `SDVD_DOCKER_HOSTS` → `SDVD_DOCKER_HOSTS_B64` (base64 of the JSON, single line → GitHub registers it atomically → no more `-` mangling). Already re-set in the `test-vps` environment.
- New **Decode host fleet** step base64-decodes into `$GITHUB_ENV` via the multiline-safe heredoc form (never echoed — the decoded JSON carries the key, which GitHub does NOT auto-mask, so it must never be printed). Old job/step `env` dropped; keyscan no longer echoes the host; secret-shape comment updated.

**2. Separately — stop the VPS IP reaching CI logs** (now visible once `-` masking is gone)
- Setup-step detail → `"remote"`/`"local"` (not `host.SshDestination`) at preflight + cleanup.
- Setup error messages (preflight / cleanup / image-transfer / game-data) scrubbed via `ScrubForLog`, which reuses `ReportRedactor` + the known-secret set — consistent with the published report (`***.***.***.188`). Catches host/IP embedded in infra exceptions (e.g. `HostPool.PreflightAsync`) at the `Program.cs` error boundary.

## Verification

- Both projects build clean (net6.0 mod, net10.0 runner).
- base64 round-trips byte-identical (single-line); the `$GITHUB_ENV` heredoc round-trips byte-identical for single-line **and** multiline values; the decoded JSON's `jq`/keyscan extraction still works.
- The compiled `ReportRedactor` masks real SSH error messages (incl. the exact `HostPool.PreflightAsync` shape) → `(s***8) … ***.***.***.188`, `vps-1` preserved, no leak.
- **Runtime gates (need a dispatch):** `-` mangling gone (hyphens literal in the log); decoded value never printed (grep for `BEGIN OPENSSH` → zero); runner still connects; IP not in logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now runs the full E2E suite by default when no filter is provided, accepts base64-encoded host-fleet data decoded at runtime, and consolidates host-key scanning output to reduce per-host noise.
* **Tests**
  * Test-runner logging now consistently redacts sensitive host/IP and exception details across setup, distribution, cleanup, and abort/error reports.
* **Documentation**
  * Updated E2E CI usage guidance to reflect workflow dispatch, filtering behavior, and remote-run coordination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->