### PR TITLE
fix(ci): base64 STEAM_ACCOUNTS too — finish the multiline-secret log-mangling fix

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -88,8 +88,10 @@ jobs:
       #   [{"id":"vps","endpoint":"ssh://sdvd-runner@HOST","serverSlots":1,
       #     "clientSlots":2,"gpu":false,
       #     "sshKey":"-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END…-----\n"}]
-      # To (re)create the secret:
+      # To (re)create the secrets (STEAM_ACCOUNTS_B64 is the same idea — the Steam
+      # credentials JSON is also base64'd to a single line for the same masking reason):
       #   jq -c --rawfile k key.pem '.[0].sshKey=$k' hosts.json | base64 -w0 | gh secret set SDVD_DOCKER_HOSTS_B64 --env test-vps
+      #   jq -c . steam-accounts.json | base64 -w0 | gh secret set STEAM_ACCOUNTS_B64 --env test-vps
 
     steps:
       - name: Checkout code
@@ -174,7 +176,9 @@ jobs:
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          hosts_json=$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d)
+          # tr -d strips any stray whitespace/newline in the stored secret before decode
+          # (base64 is whitespace-free, so this only removes corruption, not data).
+          hosts_json=$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | tr -d '[:space:]' | base64 -d)
           hosts=$(printf '%s' "$hosts_json" \
             | jq -r '.[] | select(.endpoint) | .endpoint' \
             | sed -E 's#^ssh://##; s#^[^@]*@##')
@@ -209,8 +213,11 @@ jobs:
         env:
           COMPOSE_PROJECT_NAME: server
           IMAGE_VERSION: local
-          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
+          # base64 (single-line) so GitHub registers it atomically — multiline JSON
+          # secrets break log masking (see the SDVD_DOCKER_HOSTS_B64 note above).
+          STEAM_ACCOUNTS_B64: ${{ secrets.STEAM_ACCOUNTS_B64 }}
         run: |
+          export STEAM_ACCOUNTS="$(printf '%s' "$STEAM_ACCOUNTS_B64" | tr -d '[:space:]' | base64 -d)"
           docker compose build steam-auth
           docker compose run --rm -e STEAM_ACCOUNTS steam-auth download
 
@@ -223,17 +230,19 @@ jobs:
       # with a Steam-login error.
       - name: Run E2E suite
         env:
-          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
-          # The base64 host fleet is decoded STEP-LOCALLY below (not $GITHUB_ENV) so
-          # the inline SSH key isn't exposed to other steps.
+          # Both fleet + Steam creds are base64 (single-line) secrets, decoded
+          # STEP-LOCALLY below — never into $GITHUB_ENV (would expose them to other
+          # steps) and never as multiline secrets (would break log masking).
           SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
+          STEAM_ACCOUNTS_B64: ${{ secrets.STEAM_ACCOUNTS_B64 }}
           # Pass the (operator-controlled) filter through the environment, not
           # interpolated into the command line, so its value can never be parsed
           # as shell. Empty (the default) runs the full suite — pass --filter only
           # when a non-whitespace value was provided.
           FILTER: ${{ inputs.filter }}
         run: |
-          export SDVD_DOCKER_HOSTS="$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | base64 -d)"
+          export SDVD_DOCKER_HOSTS="$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | tr -d '[:space:]' | base64 -d)"
+          export STEAM_ACCOUNTS="$(printf '%s' "$STEAM_ACCOUNTS_B64" | tr -d '[:space:]' | base64 -d)"
           if [ -n "${FILTER//[[:space:]]/}" ]; then
             dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
           else


### PR DESCRIPTION
Follow-up to #354. That PR base64'd only `SDVD_DOCKER_HOSTS`, but the CI logs were **still** mangled (`mkdir ***p`, `Build test***UI`, `2026***06***04`) and the host decode failed with `base64: invalid input`.

## Root cause (the part #354 missed)

`STEAM_ACCOUNTS` is **also** a multiline JSON secret. GitHub masks multiline secrets line-by-line and registers the `-` token, so it kept mangling every hyphen in the whole log — independent of the host secret. Multiline secrets are the root cause regardless of which one; **both** must be single-line.

## Fix

- **`STEAM_ACCOUNTS` → `STEAM_ACCOUNTS_B64`** (base64 of the minified JSON), decoded step-locally in its two consumers (game-data populate + the runner). The old multiline `STEAM_ACCOUNTS` secret is deleted from the `test-vps` environment.
- **Harden every `base64 -d` with `tr -d '[:space:]'`** — the prior run's `base64: invalid input` came from a stray newline in the stored secret; stripping whitespace (base64 is whitespace-free) makes the decode robust.
- Both `*_B64` secrets re-set from verified single-line, round-tripped values.

Only single-line secrets now remain in `test-vps`, so GitHub registers each atomically and no sub-token gets masked.

## Verification
- YAML valid; no plain multiline secret refs remain.
- Both b64 values built + round-trip-verified locally (`base64 -d` reproduces the JSON; STEAM decodes to 3 accounts).
- Decode hardening simulated: decodes correctly even with injected stray whitespace.
- **Runtime gate (needs a dispatch):** the `-` mangling is gone (hyphens literal in the log) and the run gets past the keyscan/decode. This is the definitive proof — the prior run failed at exactly those points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal testing infrastructure security by updating credential handling in automated test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->