### PR TITLE
fix(ci): de-secret R2 bucket/URL to stop log-wide hyphen over-masking

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -75,23 +75,14 @@ jobs:
       # inherited by the runner's in-process `make build` subprocess. Not read by
       # any C#. The Makefile default is Debug; pin Release for CI.
       BUILD_CONFIGURATION: Release
-      # The harness's host-fleet config is supplied as SDVD_DOCKER_HOSTS_B64 — the
-      # base64 of the JSON (the same shape as .env.test, but with the SSH private key
-      # INLINE in each `sshKey` field). It is base64-encoded because the inline key is
-      # multiline, and GitHub masks multiline secrets line-by-line — registering the
-      # PEM's `-----` armor would mask every `-` in the whole log (client-0 → client***0,
-      # dates, etc.) while leaving the real IP unmasked. Base64 makes it a single-line
-      # secret that GitHub registers atomically, so nothing in normal logs matches it.
-      # It is decoded STEP-LOCALLY in the two steps that need it (keyscan + runner) —
-      # never into $GITHUB_ENV, which would expose the inline SSH key to every later
-      # step (incl. third-party actions). Shape of the pre-encoding JSON:
+      # The harness's host-fleet config — set as ONE GitHub secret in the test-vps
+      # environment, exactly as in .env.test, with the SSH private key INLINE in each
+      # `sshKey` field (a "-----BEGIN…" block). HostPool materializes the inline key to
+      # a 0600 temp file at startup. Shape:
       #   [{"id":"vps","endpoint":"ssh://sdvd-runner@HOST","serverSlots":1,
       #     "clientSlots":2,"gpu":false,
       #     "sshKey":"-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END…-----\n"}]
-      # To (re)create the secrets (STEAM_ACCOUNTS_B64 is the same idea — the Steam
-      # credentials JSON is also base64'd to a single line for the same masking reason):
-      #   jq -c --rawfile k key.pem '.[0].sshKey=$k' hosts.json | base64 -w0 | gh secret set SDVD_DOCKER_HOSTS_B64 --env test-vps
-      #   jq -c . steam-accounts.json | base64 -w0 | gh secret set STEAM_ACCOUNTS_B64 --env test-vps
+      SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
 
     steps:
       - name: Checkout code
@@ -164,26 +155,20 @@ jobs:
       # keep in sync. The private key is NOT written here — HostPool materializes
       # the inline `sshKey` to its own 0600 temp file.
       #
-      # SECURITY: the base64 host-fleet config is decoded into a STEP-LOCAL shell var
-      # (never $GITHUB_ENV — that would expose the inline SSH key to every later step,
-      # incl. third-party actions). The jq below extracts ONLY `.endpoint`; never read
-      # `.sshKey` or pipe the decoded JSON to stdout — GitHub does NOT mask the decoded
-      # value (only the base64 blob is registered), so printing it would leak the key.
-      # The host is NOT echoed either: it's the VPS IP.
+      # SECURITY: the jq below extracts ONLY `.endpoint`. Never change it to read
+      # `.sshKey` or pipe the raw $SDVD_DOCKER_HOSTS to stdout — that would leak the
+      # inline private key into the log. The host is NOT echoed either: it's the VPS IP.
       - name: Trust VPS host key
         env:
-          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
+          SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
         run: |
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
-          # tr -d strips any stray whitespace/newline in the stored secret before decode
-          # (base64 is whitespace-free, so this only removes corruption, not data).
-          hosts_json=$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | tr -d '[:space:]' | base64 -d)
-          hosts=$(printf '%s' "$hosts_json" \
+          hosts=$(printf '%s' "$SDVD_DOCKER_HOSTS" \
             | jq -r '.[] | select(.endpoint) | .endpoint' \
             | sed -E 's#^ssh://##; s#^[^@]*@##')
           if [ -z "$hosts" ]; then
-            echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS_B64 — cannot keyscan." >&2
+            echo "::error::No ssh:// endpoint found in SDVD_DOCKER_HOSTS — cannot keyscan." >&2
             exit 1
           fi
           count=0
@@ -213,11 +198,8 @@ jobs:
         env:
           COMPOSE_PROJECT_NAME: server
           IMAGE_VERSION: local
-          # base64 (single-line) so GitHub registers it atomically — multiline JSON
-          # secrets break log masking (see the SDVD_DOCKER_HOSTS_B64 note above).
-          STEAM_ACCOUNTS_B64: ${{ secrets.STEAM_ACCOUNTS_B64 }}
+          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
         run: |
-          export STEAM_ACCOUNTS="$(printf '%s' "$STEAM_ACCOUNTS_B64" | tr -d '[:space:]' | base64 -d)"
           docker compose build steam-auth
           docker compose run --rm -e STEAM_ACCOUNTS steam-auth download
 
@@ -230,19 +212,14 @@ jobs:
       # with a Steam-login error.
       - name: Run E2E suite
         env:
-          # Both fleet + Steam creds are base64 (single-line) secrets, decoded
-          # STEP-LOCALLY below — never into $GITHUB_ENV (would expose them to other
-          # steps) and never as multiline secrets (would break log masking).
-          SDVD_DOCKER_HOSTS_B64: ${{ secrets.SDVD_DOCKER_HOSTS_B64 }}
-          STEAM_ACCOUNTS_B64: ${{ secrets.STEAM_ACCOUNTS_B64 }}
+          SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
+          STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
           # Pass the (operator-controlled) filter through the environment, not
           # interpolated into the command line, so its value can never be parsed
           # as shell. Empty (the default) runs the full suite — pass --filter only
           # when a non-whitespace value was provided.
           FILTER: ${{ inputs.filter }}
         run: |
-          export SDVD_DOCKER_HOSTS="$(printf '%s' "$SDVD_DOCKER_HOSTS_B64" | tr -d '[:space:]' | base64 -d)"
-          export STEAM_ACCOUNTS="$(printf '%s' "$STEAM_ACCOUNTS_B64" | tr -d '[:space:]' | base64 -d)"
           if [ -n "${FILTER//[[:space:]]/}" ]; then
             dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
           else
@@ -315,8 +292,13 @@ jobs:
       # lifecycle rule (operator setup), so CI does no pruning.
       #
       # Fully optional and never fails the run: continue-on-error decouples it from the
-      # job result, and the body (below) skips cleanly when the R2_* secrets are unset.
-      # The R2_* values come from the test-vps environment, like the other secrets.
+      # job result, and the body (below) skips cleanly when R2 is unconfigured.
+      # The bucket name and public base URL are NOT secret (the bucket is world-readable
+      # by design) and are stored as test-vps *variables*, not secrets — both contain a
+      # hyphen, and GitHub's secret masker over-masks the `-` substring across the WHOLE
+      # log if they're secrets (turning every `-` into ***). Only the credentials (keys /
+      # account id, all hex) stay secrets. Do NOT move R2_BUCKET / R2_PUBLIC_BASE_URL back
+      # to secrets.
       - name: Publish web report to R2
         if: always()
         continue-on-error: true
@@ -324,8 +306,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          R2_PUBLIC_BASE_URL: ${{ secrets.R2_PUBLIC_BASE_URL }}
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
+          R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
           BRANCH_REF: ${{ github.ref_name }}
         run: |
           # GitHub runs steps with `bash -eo pipefail` (errexit ON). Relax it so a

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -214,7 +214,7 @@ published snapshot is redacted (IPs, Steam credentials, player names, keys maske
 
 One-time setup (Cloudflare dashboard, outside this repo):
 
-1. Create an R2 bucket (e.g. `sdvd-e2e-reports`).
+1. Create an R2 bucket (e.g. `sdvd-test-artifacts`).
 2. Enable **public read** access (managed `r2.dev` subdomain or a custom domain); record
    the public base URL. Do not grant public write — writes use the API token (step 4).
 3. Add an **object-lifecycle rule** on the bucket to expire objects after 30 days
@@ -222,16 +222,23 @@ One-time setup (Cloudflare dashboard, outside this repo):
    reports server-side, so CI does no pruning.
 4. Create an R2 API token scoped to **Object Read & Write** → Access Key ID + Secret.
    This token is the only write path; keep it in the `test-vps` environment, never public.
-5. Add these as secrets in the **`test-vps`** GitHub Environment (same scoping as the
-   other E2E secrets):
+5. In the **`test-vps`** GitHub Environment, add the credentials as **secrets** and the
+   bucket name + public URL as **variables**:
 
    | Secret | Value |
    |--------|-------|
    | `R2_ACCOUNT_ID` | Cloudflare account ID (the `<id>` in the S3 endpoint) |
    | `R2_ACCESS_KEY_ID` | R2 API token access key |
    | `R2_SECRET_ACCESS_KEY` | R2 API token secret |
-   | `R2_BUCKET` | Bucket name (e.g. `sdvd-e2e-reports`) |
+
+   | Variable | Value |
+   |----------|-------|
+   | `R2_BUCKET` | Bucket name (e.g. `sdvd-test-artifacts`) |
    | `R2_PUBLIC_BASE_URL` | Public base URL of the bucket (no trailing slash) |
+
+   The bucket name and URL are **variables, not secrets** — they're public by design, and
+   both contain a hyphen. GitHub's secret masker over-masks the `-` substring across the
+   entire log when these are secrets (turning every `-` into `***`). Keep them as variables.
 
 The publish step runs `aws s3 sync` against R2's S3-compatible endpoint
 (`https://{R2_ACCOUNT_ID}.r2.cloudflarestorage.com`). It is wrapped in


### PR DESCRIPTION
## What

Fixes a CI-log bug where every `-` was masked to `***` (`client-0` → `client***0`, dates, `--flags`, even the runner boot banner).

Root cause (found by bisecting runs — clean at #350, mangled starting #352): two R2 secrets, `R2_BUCKET` (`sdvd-test-artifacts`) and `R2_PUBLIC_BASE_URL` (`https://pub-….r2.dev`), each contain a hyphen, and GitHub's `SecretMasker` over-masks the `-` substring across the whole log. It was **not** a multiline-secret problem (an earlier base64 detour, now fully reverted) and **not** a secret whose value is `-`.

## Changes

- Move `R2_BUCKET` / `R2_PUBLIC_BASE_URL` from secrets to `test-vps` **variables** (`vars.*`, which aren't masked). They're public by design, so they were never sensitive.
- Revert the base64 detour: `SDVD_DOCKER_HOSTS` / `STEAM_ACCOUNTS` are back to direct secrets — drop the `*_B64` indirection, the `tr -d` / `base64 -d` decode lines, and their comments.
- Keep credentials (`R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ACCOUNT_ID`) as secrets; keep the keyscan IP-leak fix and the R2 optional-skip guard.
- `docs/e2e-testing.md`: split R2 setup into secrets (creds) vs variables (bucket/URL) with the masking rationale; consistent example bucket name.

## GitHub env state (already applied out of band)

`test-vps` env now has `R2_BUCKET` / `R2_PUBLIC_BASE_URL` as **variables**; secrets are `R2_ACCESS_KEY_ID` / `R2_ACCOUNT_ID` / `R2_SECRET_ACCESS_KEY` / `SDVD_DOCKER_HOSTS` / `STEAM_ACCOUNTS`; the `*_B64` secrets are deleted.

## Verification

- `dotnet build` of the TestRunner: clean (0 warnings, 0 errors).
- Static cross-surface check: no lingering `secrets.R2_BUCKET` / `secrets.R2_PUBLIC_BASE_URL`, no `_B64` / `base64 -d` / `tr -d` residue; secrets-vs-variables split consistent across workflow + docs.
- **Runtime: not yet proven.** Confirming the fix requires one `workflow_dispatch` showing literal hyphens un-mangled in the log.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated E2E testing setup documentation with revised Cloudflare R2 configuration guidance.

* **Chores**
  * Improved CI/CD workflow credential and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->