### PR TITLE
ci(e2e): trigger E2E from a PR via /run-tests-e2e comment + re-run checkbox

### DIFF
--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -282,7 +282,10 @@ const FILTER_ALLOWED = /^[A-Za-z0-9_.+=() -]*$/;
  *   the filter has disallowed characters (the caller should reject, not run).
  */
 function parseCommand(body) {
-  const firstLine = (body || '').split('\n', 1)[0];
+  // Split on CRLF or LF and strip any trailing \r — GitHub comment bodies often arrive
+  // with \r\n, and JS `.` does not match \r, so a bare `\n` split would leave the regex
+  // unable to match `/run-tests-e2e Foo\r` (silently ignoring the command).
+  const firstLine = (body || '').split(/\r?\n/, 1)[0].replace(/\r$/, '');
   const m = firstLine.match(/^\/run-tests-e2e(?:\s+(.*))?$/);
   if (!m) return { isCommand: false, filter: '', valid: false };
   const filter = (m[1] || '').trim().split(/\s+/).filter(Boolean).join(' ');

--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -20,11 +20,22 @@ const RERUN_REQUESTED_LABEL = `${RERUN_LABEL} (requested)`;
 
 // --- marker (de)serialization -------------------------------------------------------
 
+/**
+ * Read the run filter the sticky recorded in its hidden `<!-- filter: … -->` marker.
+ * @param {string} body - The sticky comment body.
+ * @returns {string} The filter (empty string = full suite, or no marker present).
+ */
 function readFilter(body) {
   const m = body && body.match(/<!-- filter:([\s\S]*?)-->/);
   return m ? m[1].trim() : '';
 }
 
+/**
+ * Read the retained run-history array from the sticky's `<!-- run-history: … -->` marker.
+ * Corrupt or absent history yields `[]` (it must never break a run).
+ * @param {string} body - The sticky comment body.
+ * @returns {Array<object>} The history rows (newest appended last).
+ */
 function readHistory(body) {
   const m = body && body.match(/<!-- run-history:([\s\S]*?)-->/);
   if (!m) return [];
@@ -36,20 +47,51 @@ function readHistory(body) {
   }
 }
 
-// Is the re-run checkbox currently checked? Matches `- [x] 🔁 Re-run E2E tests...`.
+/**
+ * Whether the re-run task-list checkbox is currently ticked (`- [x] 🔁 Re-run E2E tests`).
+ * @param {string} body - The comment body to inspect.
+ * @returns {boolean}
+ */
 function isReRunChecked(body) {
   if (!body) return false;
   return new RegExp(`^\\s*-\\s*\\[[xX]\\]\\s*${escapeRe(RERUN_LABEL)}`, 'm').test(body);
 }
 
+/**
+ * Reset a ticked re-run box back to unchecked, leaving the rest of the body untouched.
+ * Used to "disarm" the sticky after a click we won't act on (e.g. a non-maintainer
+ * ticked it) so it doesn't look stuck mid-request.
+ * @param {string} body - The sticky comment body.
+ * @returns {string} The body with the re-run box set to `- [ ]`.
+ */
+function resetReRunCheckbox(body) {
+  if (!body) return body;
+  return body.replace(
+    new RegExp(`^(\\s*-\\s*\\[)[xX](\\]\\s*${escapeRe(RERUN_LABEL)})`, 'm'),
+    '$1 $2',
+  );
+}
+
+/** Escape a string for safe interpolation into a `RegExp`. */
 function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // --- body rendering -----------------------------------------------------------------
 
-// state: { status, statusEmoji, headline, filter, history, requested }
-//   status: 'queued' | 'passed' | 'failed' | 'aborted'
+/**
+ * Render the full sticky comment body: hidden markers (filter + run-history) for the
+ * next event to recover, a status block, the re-run checkbox, and the collapsed
+ * run-history table.
+ * @param {object} state
+ * @param {'queued'|'passed'|'failed'|'aborted'} state.status - Run status (drives wording).
+ * @param {string} state.statusEmoji - Emoji shown in the heading.
+ * @param {string} state.headline - Markdown headline line under the heading.
+ * @param {string} state.filter - The run filter (empty = full suite).
+ * @param {Array<object>} state.history - Run-history rows to render + re-embed.
+ * @param {boolean} state.requested - When true, label the box "… (requested)".
+ * @returns {string} The complete comment body.
+ */
 function renderBody(state) {
   const filter = state.filter || '';
   const filterLabel = filter ? `\`${filter}\`` : '_full suite_';
@@ -95,6 +137,10 @@ function renderBody(state) {
 
 // --- comment upsert -----------------------------------------------------------------
 
+/**
+ * Find the one E2E sticky comment on the PR by its hidden `MARKER` (paginates the thread).
+ * @returns {Promise<object|null>} The comment object, or null if none exists yet.
+ */
 async function findSticky({ github, owner, repo, issue_number }) {
   // Paginate so the sticky is found even on a long PR thread.
   const comments = await github.paginate(github.rest.issues.listComments, {
@@ -103,6 +149,10 @@ async function findSticky({ github, owner, repo, issue_number }) {
   return comments.find((c) => (c.body || '').includes(MARKER)) || null;
 }
 
+/**
+ * Create-or-update the single E2E sticky comment with `body` (one comment per PR).
+ * @returns {Promise<number>} The comment id written.
+ */
 async function upsertSticky({ github, owner, repo, issue_number, body }) {
   const existing = await findSticky({ github, owner, repo, issue_number });
   if (existing) {
@@ -115,14 +165,17 @@ async function upsertSticky({ github, owner, repo, issue_number, body }) {
 
 // --- maintainer authorization (authoritative; author_association is NOT used) -------
 
-// Returns true iff `username` has write or admin permission on the repo (maintain->write,
-// triage->read are collapsed by the API, so write|admin == "can push"). A non-collaborator
-// makes getCollaboratorPermissionLevel throw 404 — that is a DENY, not an error.
-//
-// The endpoint needs only repo metadata read, which every GITHUB_TOKEN has (the gate job
-// also grants contents: read). If the token were ever too narrow it would throw 403, not
-// 404 — we rethrow that so the gate FAILS CLOSED (red job, no run) rather than silently
-// allowing. Fail-closed is the safe direction for an auth check.
+/**
+ * Whether `username` has write or admin permission on the repo (the authoritative
+ * maintainer check; `author_association` is deliberately not used).
+ *
+ * The API collapses maintain->write and triage->read, so write|admin == "can push".
+ * A non-collaborator makes getCollaboratorPermissionLevel throw 404 — treated as a DENY,
+ * not an error. The endpoint needs only repo metadata read, which every GITHUB_TOKEN has
+ * (the gate job also grants contents: read). A too-narrow token would throw 403, which we
+ * rethrow so the gate FAILS CLOSED (red job, no run) — the safe direction for an auth check.
+ * @returns {Promise<boolean>}
+ */
 async function isMaintainer({ github, owner, repo, username }) {
   try {
     const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
@@ -140,6 +193,7 @@ module.exports = {
   readFilter,
   readHistory,
   isReRunChecked,
+  resetReRunCheckbox,
   renderBody,
   findSticky,
   upsertSticky,

--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -17,6 +17,11 @@ const HISTORY_PREFIX = '<!-- run-history:';
 // transiently while a run is queued/in-flight, then removed when fresh results post.
 const RERUN_LABEL = '🔁 Re-run E2E tests';
 const RERUN_REQUESTED_LABEL = `${RERUN_LABEL} (requested)`;
+// Cap the retained/rendered run history. The whole sticky (incl. the embedded
+// run-history JSON marker) must stay under GitHub's 65536-char comment limit, or
+// upsertSticky throws and results silently stop posting. ~40 rows is well within
+// budget even with long filters/URLs; older rows are summarized as a count.
+const MAX_HISTORY_ROWS = 40;
 
 // --- marker (de)serialization -------------------------------------------------------
 
@@ -77,6 +82,77 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+// --- result derivation ---------------------------------------------------------------
+
+/** The `skipped` clause shared by the pass/fail headlines (empty when none were skipped). */
+function skippedClause(summary) {
+  return summary.skipped ? `, ${summary.skipped} skipped` : '';
+}
+
+/**
+ * Derive the final run result (status, emoji, headline) from the job status and the
+ * runner's `summary.json`. Pure: no I/O — the caller reads `summary.json` and `job.status`
+ * and passes them in. Precedence: a cancelled job (a maintainer preempted the run) wins
+ * over any partial summary; then failures; then a clean pass; then a missing summary
+ * (an early failure before the runner wrote one).
+ *
+ * Each branch yields `{ status, emoji, resultWord, headline }`. The status and result
+ * emoji are always the same glyph, so callers get it aliased as both `statusEmoji` and
+ * `resultEmoji` from the single `emoji` field below.
+ * @param {object} args
+ * @param {{ passed?: number, failed?: number, skipped?: number, aborted?: boolean }|null} args.summary
+ *   The parsed `summary.json`, or null if none was written.
+ * @param {string} args.jobStatus - GitHub's `job.status`: 'success' | 'failure' | 'cancelled'.
+ * @param {string} args.sha - The (already-shortened) head SHA to name in the headline.
+ * @param {string} [args.reportUrl] - Hosted report URL; when present, appended to the headline.
+ * @returns {{ status: string, statusEmoji: string, resultEmoji: string, resultWord: string, headline: string }}
+ */
+function deriveResult({ summary, jobStatus, sha, reportUrl }) {
+  let outcome;
+  if (jobStatus === 'cancelled' || (summary && summary.aborted)) {
+    outcome = {
+      status: 'aborted',
+      emoji: '⚪',
+      resultWord: 'aborted',
+      headline: `Aborted (run cancelled) for \`${sha}\`.`,
+    };
+  } else if (summary && summary.failed > 0) {
+    outcome = {
+      status: 'failed',
+      emoji: '🔴',
+      resultWord: 'failed',
+      headline: `**${summary.failed} failed**, ${summary.passed} passed${skippedClause(summary)} for \`${sha}\`.`,
+    };
+  } else if (summary) {
+    outcome = {
+      status: 'passed',
+      emoji: '🟢',
+      resultWord: 'passed',
+      headline: `**${summary.passed} passed**${skippedClause(summary)} for \`${sha}\`.`,
+    };
+  } else {
+    // No summary.json (early failure before the runner wrote it).
+    outcome = {
+      status: 'failed',
+      emoji: '🔴',
+      resultWord: 'no results',
+      headline: `Run finished without a summary for \`${sha}\` (check the Actions log).`,
+    };
+  }
+
+  const headline = reportUrl
+    ? `${outcome.headline}\n\n**[▶ Open interactive report](${reportUrl})** (screenshots + videos)`
+    : outcome.headline;
+
+  return {
+    status: outcome.status,
+    statusEmoji: outcome.emoji,
+    resultEmoji: outcome.emoji,
+    resultWord: outcome.resultWord,
+    headline,
+  };
+}
+
 // --- body rendering -----------------------------------------------------------------
 
 /**
@@ -97,10 +173,21 @@ function renderBody(state) {
   const filterLabel = filter ? `\`${filter}\`` : '_full suite_';
   const checkboxLabel = state.requested ? RERUN_REQUESTED_LABEL : RERUN_LABEL;
 
+  // Keep only the most recent rows so the comment stays under GitHub's 65536-char
+  // limit. Derive how many older runs are hidden from the run-number gap (the oldest
+  // retained row's n), which stays accurate even though the marker only round-trips
+  // the retained slice — array length alone would undercount across renders.
+  const allHistory = state.history || [];
+  const history = allHistory.slice(-MAX_HISTORY_ROWS);
+  const oldestN = history.length ? (history[0].n || history.length) : 0;
+  const droppedCount = Math.max(0, oldestN - 1);
+
   const lines = [
     MARKER,
     `${FILTER_PREFIX} ${filter} -->`,
-    `${HISTORY_PREFIX} ${JSON.stringify(state.history || [])} -->`,
+    // Embed only the retained rows — the marker must round-trip what we render so the
+    // next event reads back a bounded history (prevents unbounded marker growth too).
+    `${HISTORY_PREFIX} ${JSON.stringify(history)} -->`,
     '',
     `### ${state.statusEmoji} E2E Tests`,
     '',
@@ -111,12 +198,14 @@ function renderBody(state) {
     `- [ ] ${checkboxLabel}`,
     '',
     '<sub>Maintainers: tick the box to re-run with the same filter, or comment ' +
-      '`/run-tests-e2e [filter] [--abort-current]`.</sub>',
+      '`/run-tests-e2e [filter]`.</sub>',
   ];
 
-  const history = state.history || [];
   if (history.length) {
-    lines.push('', '<details><summary>Run history</summary>', '');
+    const summaryLabel = droppedCount > 0
+      ? `Run history (latest ${history.length}; ${droppedCount} older hidden)`
+      : 'Run history';
+    lines.push('', `<details><summary>${summaryLabel}</summary>`, '');
     lines.push('| # | Result | SHA | Filter | When | Links |');
     lines.push('|---|--------|-----|--------|------|-------|');
     // Newest first.
@@ -151,16 +240,74 @@ async function findSticky({ github, owner, repo, issue_number }) {
 
 /**
  * Create-or-update the single E2E sticky comment with `body` (one comment per PR).
+ *
+ * Pass `existing` (the comment from a prior `findSticky`) when the caller already
+ * located it to read its history — this makes the whole read-modify-write target ONE
+ * comment id and avoids a second `listComments` fetch that could resolve a different
+ * comment (lost-update race). Omit `existing` only when there was nothing to read first.
+ * @param {object|null} [args.existing] - The sticky comment from a prior findSticky, or null.
  * @returns {Promise<number>} The comment id written.
  */
-async function upsertSticky({ github, owner, repo, issue_number, body }) {
-  const existing = await findSticky({ github, owner, repo, issue_number });
-  if (existing) {
-    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-    return existing.id;
+async function upsertSticky({ github, owner, repo, issue_number, body, existing }) {
+  // `existing === undefined` → caller didn't look; fetch. `existing === null` → caller
+  // looked and there's none → create. A truthy `existing` → update that exact comment.
+  const target = existing === undefined
+    ? await findSticky({ github, owner, repo, issue_number })
+    : existing;
+  if (target) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: target.id, body });
+    return target.id;
   }
   const created = await github.rest.issues.createComment({ owner, repo, issue_number, body });
   return created.data.id;
+}
+
+// --- command parsing (trigger interpretation) ---------------------------------------
+
+// Allowed characters in a run filter. An xUnit `--filter` is a fully-qualified
+// class/method substring, so word chars, `.`, namespace/generic punctuation, spaces and
+// parens are legitimate; everything else is rejected. This is also the security choke
+// point that keeps a filter from breaking the hidden comment markers (a `-->` would
+// truncate the run-history JSON and silently wipe history) or the markdown table (a `|`
+// would split a cell). Keep this conservative — widen only with a matching test.
+const FILTER_ALLOWED = /^[A-Za-z0-9_.+=() -]*$/;
+
+/**
+ * Parse a `/run-tests-e2e [filter]` PR comment into a command decision. Anchored to the
+ * FIRST line so a quoted or mid-text mention (e.g. in a paragraph) is ignored. The filter
+ * is normalized (collapsed whitespace) and validated against {@link FILTER_ALLOWED}.
+ * @param {string} body - The raw comment body.
+ * @returns {{ isCommand: boolean, filter: string, valid: boolean }}
+ *   `isCommand` false → not our command (ignore). `valid` false → it was our command but
+ *   the filter has disallowed characters (the caller should reject, not run).
+ */
+function parseCommand(body) {
+  const firstLine = (body || '').split('\n', 1)[0];
+  const m = firstLine.match(/^\/run-tests-e2e(?:\s+(.*))?$/);
+  if (!m) return { isCommand: false, filter: '', valid: false };
+  const filter = (m[1] || '').trim().split(/\s+/).filter(Boolean).join(' ');
+  return { isCommand: true, filter, valid: isValidFilter(filter) };
+}
+
+/** Whether a run filter is safe to embed in markers / the table and pass to xUnit. */
+function isValidFilter(filter) {
+  return FILTER_ALLOWED.test(filter || '');
+}
+
+/**
+ * Decide whether an `issue_comment: edited` event is a genuine re-run tick: the box went
+ * from unchecked to checked. A real box-tick always delivers the prior body in
+ * `changes.body.from`; when that's absent we cannot prove a transition occurred, so we
+ * fail SAFE (skip) rather than treat "no prior body" as unchecked — otherwise any text
+ * edit while the box sits ticked would re-fire a run.
+ * @param {object} args
+ * @param {string|null|undefined} args.priorBody - `changes.body.from` from the edit event.
+ * @param {string} args.body - The current comment body.
+ * @returns {boolean} True only on a confirmed unchecked->checked transition.
+ */
+function shouldFireRerun({ priorBody, body }) {
+  if (priorBody == null) return false;
+  return isReRunChecked(body) && !isReRunChecked(priorBody);
 }
 
 // --- maintainer authorization (authoritative; author_association is NOT used) -------
@@ -194,8 +341,12 @@ module.exports = {
   readHistory,
   isReRunChecked,
   resetReRunCheckbox,
+  deriveResult,
   renderBody,
   findSticky,
   upsertSticky,
   isMaintainer,
+  parseCommand,
+  isValidFilter,
+  shouldFireRerun,
 };

--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -1,0 +1,147 @@
+// Shared helpers for the E2E PR sticky comment + maintainer authorization, used by
+// the `gate` and `e2e` jobs in .github/workflows/e2e-tests.yml via actions/github-script.
+//
+// The sticky is ONE comment per PR, found by the hidden HTML marker `<!-- e2e-results -->`.
+// Hidden markers also carry the run filter and the run-history JSON so a later event
+// (a checkbox click) can recover them — the comment is the single source of truth, so the
+// workflow holds no per-PR state of its own.
+//
+// Loop-safety: the bot edits this comment with GITHUB_TOKEN, and GITHUB_TOKEN-authored
+// comment events do not retrigger workflows. The gate also ignores Bot authors and only
+// reacts to an unchecked->checked transition of the re-run box.
+
+const MARKER = '<!-- e2e-results -->';
+const FILTER_PREFIX = '<!-- filter:';
+const HISTORY_PREFIX = '<!-- run-history:';
+// The exact label text of the re-run task-list item. The "(requested)" suffix is added
+// transiently while a run is queued/in-flight, then removed when fresh results post.
+const RERUN_LABEL = '🔁 Re-run E2E tests';
+const RERUN_REQUESTED_LABEL = `${RERUN_LABEL} (requested)`;
+
+// --- marker (de)serialization -------------------------------------------------------
+
+function readFilter(body) {
+  const m = body && body.match(/<!-- filter:([\s\S]*?)-->/);
+  return m ? m[1].trim() : '';
+}
+
+function readHistory(body) {
+  const m = body && body.match(/<!-- run-history:([\s\S]*?)-->/);
+  if (!m) return [];
+  try {
+    const parsed = JSON.parse(m[1].trim());
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return []; // corrupt/absent history must never break a run — start fresh
+  }
+}
+
+// Is the re-run checkbox currently checked? Matches `- [x] 🔁 Re-run E2E tests...`.
+function isReRunChecked(body) {
+  if (!body) return false;
+  return new RegExp(`^\\s*-\\s*\\[[xX]\\]\\s*${escapeRe(RERUN_LABEL)}`, 'm').test(body);
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// --- body rendering -----------------------------------------------------------------
+
+// state: { status, statusEmoji, headline, filter, history, requested }
+//   status: 'queued' | 'passed' | 'failed' | 'aborted'
+function renderBody(state) {
+  const filter = state.filter || '';
+  const filterLabel = filter ? `\`${filter}\`` : '_full suite_';
+  const checkboxLabel = state.requested ? RERUN_REQUESTED_LABEL : RERUN_LABEL;
+
+  const lines = [
+    MARKER,
+    `${FILTER_PREFIX} ${filter} -->`,
+    `${HISTORY_PREFIX} ${JSON.stringify(state.history || [])} -->`,
+    '',
+    `### ${state.statusEmoji} E2E Tests`,
+    '',
+    state.headline,
+    '',
+    `**Filter:** ${filterLabel}`,
+    '',
+    `- [ ] ${checkboxLabel}`,
+    '',
+    '<sub>Maintainers: tick the box to re-run with the same filter, or comment ' +
+      '`/run-tests-e2e [filter] [--abort-current]`.</sub>',
+  ];
+
+  const history = state.history || [];
+  if (history.length) {
+    lines.push('', '<details><summary>Run history</summary>', '');
+    lines.push('| # | Result | SHA | Filter | When | Links |');
+    lines.push('|---|--------|-----|--------|------|-------|');
+    // Newest first.
+    for (const h of [...history].reverse()) {
+      const links = [
+        h.runUrl ? `[run](${h.runUrl})` : '',
+        h.reportUrl ? `[report](${h.reportUrl})` : '',
+      ].filter(Boolean).join(' · ');
+      lines.push(
+        `| ${h.n} | ${h.resultEmoji} ${h.result} | \`${h.sha}\` | ${h.filter ? `\`${h.filter}\`` : 'full'} | ${h.when} | ${links} |`,
+      );
+    }
+    lines.push('', '</details>');
+  }
+
+  return lines.join('\n');
+}
+
+// --- comment upsert -----------------------------------------------------------------
+
+async function findSticky({ github, owner, repo, issue_number }) {
+  // Paginate so the sticky is found even on a long PR thread.
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner, repo, issue_number, per_page: 100,
+  });
+  return comments.find((c) => (c.body || '').includes(MARKER)) || null;
+}
+
+async function upsertSticky({ github, owner, repo, issue_number, body }) {
+  const existing = await findSticky({ github, owner, repo, issue_number });
+  if (existing) {
+    await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+    return existing.id;
+  }
+  const created = await github.rest.issues.createComment({ owner, repo, issue_number, body });
+  return created.data.id;
+}
+
+// --- maintainer authorization (authoritative; author_association is NOT used) -------
+
+// Returns true iff `username` has write or admin permission on the repo (maintain->write,
+// triage->read are collapsed by the API, so write|admin == "can push"). A non-collaborator
+// makes getCollaboratorPermissionLevel throw 404 — that is a DENY, not an error.
+//
+// The endpoint needs only repo metadata read, which every GITHUB_TOKEN has (the gate job
+// also grants contents: read). If the token were ever too narrow it would throw 403, not
+// 404 — we rethrow that so the gate FAILS CLOSED (red job, no run) rather than silently
+// allowing. Fail-closed is the safe direction for an auth check.
+async function isMaintainer({ github, owner, repo, username }) {
+  try {
+    const { data } = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username });
+    return data.permission === 'admin' || data.permission === 'write';
+  } catch (err) {
+    if (err.status === 404) return false;
+    throw err; // 403/5xx/rate-limit: fail loudly (closed), never silently allow
+  }
+}
+
+module.exports = {
+  MARKER,
+  RERUN_LABEL,
+  RERUN_REQUESTED_LABEL,
+  readFilter,
+  readHistory,
+  isReRunChecked,
+  renderBody,
+  findSticky,
+  upsertSticky,
+  isMaintainer,
+};

--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -82,6 +82,11 @@ function escapeRe(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** Shorten a commit SHA for display (the 7-char form used in headlines + history rows). */
+function shortSha(sha) {
+  return (sha || '').slice(0, 7);
+}
+
 // --- result derivation ---------------------------------------------------------------
 
 /** The `skipped` clause shared by the pass/fail headlines (empty when none were skipped). */
@@ -342,6 +347,7 @@ module.exports = {
   RERUN_REQUESTED_LABEL,
   readFilter,
   readHistory,
+  shortSha,
   isReRunChecked,
   resetReRunCheckbox,
   deriveResult,

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -217,6 +217,14 @@ test('parseCommand: anchored to the first line; a mid-text mention is ignored', 
   assert.deepEqual(helper.parseCommand('/run-tests-e2e Foo'), { isCommand: true, filter: 'Foo', valid: true });
 });
 
+test('parseCommand: CRLF line endings are handled (GitHub comments often arrive as \\r\\n)', () => {
+  // JS `.` does not match \r, so a naive \n-split would leave a trailing \r and the command
+  // would be silently ignored. Both no-arg and filtered forms must parse under CRLF.
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e\r\nsecond'), { isCommand: true, filter: '', valid: true });
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e MyClass\r\nsecond'), { isCommand: true, filter: 'MyClass', valid: true });
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e MyClass\r'), { isCommand: true, filter: 'MyClass', valid: true });
+});
+
 test('parseCommand: no filter = full suite; extra whitespace collapses', () => {
   assert.deepEqual(helper.parseCommand('/run-tests-e2e'), { isCommand: true, filter: '', valid: true });
   assert.deepEqual(helper.parseCommand('/run-tests-e2e   MyClass   Method  '),

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -1,0 +1,310 @@
+// Tests for e2e-pr-sticky.js — the pure helpers behind the E2E PR sticky comment.
+// Run with `npm test` (or `node --test .github/scripts/`). No dependencies: uses Node's
+// built-in test runner (node:test + node:assert), so it works anywhere Node 18+ is present.
+//
+// These cover the logic that is awkward to exercise through a real workflow run: marker
+// round-tripping, the re-run checkbox state machine, the run-history cap (which guards
+// GitHub's 65536-char comment limit), and the find-once upsert contract (no lost-update
+// re-fetch). The GitHub API calls are exercised against a tiny in-memory fake.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const helper = require('./e2e-pr-sticky.js');
+
+// A minimal fake of the Octokit surface the helper touches, recording the calls made so
+// tests can assert "found once, wrote to that exact id" without a network.
+function fakeGithub(existingComment) {
+  const calls = [];
+  return {
+    calls,
+    paginate: async () => {
+      calls.push('list');
+      return existingComment ? [existingComment] : [];
+    },
+    rest: {
+      issues: {
+        listComments: {}, // only referenced by paginate's signature
+        updateComment: async ({ comment_id }) => { calls.push(`update#${comment_id}`); },
+        createComment: async () => { calls.push('create'); return { data: { id: 999 } }; },
+      },
+    },
+  };
+}
+
+const sticky = (id, extraBody = '') => ({ id, body: `${helper.MARKER}\n${extraBody}` });
+
+// --- marker (de)serialization ------------------------------------------------------
+
+test('readFilter round-trips the filter marker', () => {
+  const body = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: 'PasswordProtection', history: [], requested: false });
+  assert.equal(helper.readFilter(body), 'PasswordProtection');
+});
+
+test('readFilter is empty when no filter / no marker', () => {
+  const body = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: '', history: [], requested: false });
+  assert.equal(helper.readFilter(body), '');
+  assert.equal(helper.readFilter('no marker here'), '');
+});
+
+test('readHistory round-trips and tolerates corruption', () => {
+  const rows = [{ n: 5, result: 'failed', resultEmoji: '🔴', sha: 'deadbee', filter: 'Bar', when: 't', runUrl: 'http://r/5', reportUrl: '' }];
+  const body = helper.renderBody({ status: 'failed', statusEmoji: '🔴', headline: 'x', filter: 'Bar', history: rows, requested: false });
+  assert.deepEqual(helper.readHistory(body), rows);
+  assert.deepEqual(helper.readHistory('<!-- run-history: NOT JSON -->'), []);
+  assert.deepEqual(helper.readHistory('no marker'), []);
+});
+
+// --- re-run checkbox state machine -------------------------------------------------
+
+test('isReRunChecked detects only the ticked box', () => {
+  const idle = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: '', history: [], requested: false });
+  assert.equal(helper.isReRunChecked(idle), false);
+  const ticked = idle.replace('- [ ] 🔁 Re-run E2E tests', '- [x] 🔁 Re-run E2E tests');
+  assert.equal(helper.isReRunChecked(ticked), true);
+  assert.equal(helper.isReRunChecked(''), false);
+});
+
+test('isReRunChecked works on the "(requested)" variant', () => {
+  const req = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: '', history: [], requested: true });
+  assert.ok(req.includes('Re-run E2E tests (requested)'));
+  const ticked = req.replace('- [ ] 🔁 Re-run E2E tests (requested)', '- [x] 🔁 Re-run E2E tests (requested)');
+  assert.equal(helper.isReRunChecked(ticked), true);
+});
+
+test('resetReRunCheckbox unchecks while preserving markers, and is a no-op when unchecked', () => {
+  const rows = [{ n: 1, result: 'passed', resultEmoji: '🟢', sha: 'abc', filter: 'Foo', when: 't', runUrl: 'r', reportUrl: '' }];
+  const idle = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: 'Foo', history: rows, requested: false });
+  const ticked = idle.replace('- [ ] 🔁 Re-run E2E tests', '- [x] 🔁 Re-run E2E tests');
+  const reset = helper.resetReRunCheckbox(ticked);
+  assert.equal(helper.isReRunChecked(reset), false);
+  assert.equal(helper.readFilter(reset), 'Foo');
+  assert.deepEqual(helper.readHistory(reset), rows);
+  assert.equal(helper.resetReRunCheckbox(idle), idle); // already unchecked → unchanged
+});
+
+test('RERUN_REQUESTED_LABEL starts with RERUN_LABEL (the checkbox regexes match on the prefix)', () => {
+  // isReRunChecked/resetReRunCheckbox match `RERUN_LABEL` as a prefix so they work on both
+  // the plain and "(requested)" variants. If the requested label ever stops starting with
+  // the base label, that prefix match breaks silently — pin the invariant here.
+  assert.ok(helper.RERUN_REQUESTED_LABEL.startsWith(helper.RERUN_LABEL));
+});
+
+// --- run-history cap (guards GitHub's 65536-char comment limit) ---------------------
+
+test('history is capped and stays well under the comment limit across many runs', () => {
+  // Simulate 200 runs the way the workflow does: read back the (capped) marker, compute
+  // the next run number, append, re-render.
+  let body = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: 'SomeLongTestClassName', history: [], requested: false });
+  for (let i = 1; i <= 200; i++) {
+    const hist = helper.readHistory(body);
+    const nextN = hist.reduce((mx, h) => Math.max(mx, h.n || 0), 0) + 1;
+    hist.push({ n: nextN, result: 'passed', resultEmoji: '🟢', sha: 'abc1234', filter: 'SomeLongTestClassName', when: '2026-06-05 10:00Z', runUrl: 'https://github.com/o/r/actions/runs/1234567890', reportUrl: 'https://reports.example.com/e2e/branch-name/1234567890_abcdef/index.html' });
+    body = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: 'SomeLongTestClassName', history: hist, requested: false });
+  }
+  const retained = helper.readHistory(body);
+  assert.ok(body.length < 65536, `body should stay under the comment limit, was ${body.length}`);
+  assert.equal(retained.length, 40, 'marker retains exactly the cap');
+  assert.equal(retained[retained.length - 1].n, 200, 'run numbering keeps counting past the cap');
+  assert.equal(retained[0].n, 161, 'oldest retained row is run #161');
+  assert.match(body, /Run history \(latest 40; 160 older hidden\)/);
+});
+
+test('exactly at the cap shows no "older hidden" note', () => {
+  let body = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: '', history: [], requested: false });
+  for (let i = 1; i <= 40; i++) {
+    const hist = helper.readHistory(body);
+    const nextN = hist.reduce((mx, h) => Math.max(mx, h.n || 0), 0) + 1;
+    hist.push({ n: nextN, result: 'passed', resultEmoji: '🟢', sha: 'a', filter: '', when: 't', runUrl: 'r', reportUrl: '' });
+    body = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: '', history: hist, requested: false });
+  }
+  assert.doesNotMatch(body, /older hidden/);
+  assert.equal(helper.readHistory(body)[0].n, 1, 'at the cap the oldest retained row is still #1');
+});
+
+test('renderBody links: run + report when present, omitted when absent', () => {
+  const withReport = [{ n: 1, result: 'passed', resultEmoji: '🟢', sha: 'a', filter: '', when: 't', runUrl: 'http://r/1', reportUrl: 'http://x/1' }];
+  const b1 = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: '', history: withReport, requested: false });
+  assert.ok(b1.includes('[run](http://r/1)') && b1.includes('[report](http://x/1)'));
+  const noReport = [{ n: 1, result: 'failed', resultEmoji: '🔴', sha: 'a', filter: '', when: 't', runUrl: 'http://r/1', reportUrl: '' }];
+  const b2 = helper.renderBody({ status: 'failed', statusEmoji: '🔴', headline: 'x', filter: '', history: noReport, requested: false });
+  assert.ok(b2.includes('[run](http://r/1)') && !b2.includes('report]('));
+});
+
+// --- result derivation -------------------------------------------------------------
+
+test('deriveResult: a cancelled job is aborted regardless of a partial summary', () => {
+  const r = helper.deriveResult({ summary: { passed: 5, failed: 2 }, jobStatus: 'cancelled', sha: 'abc1234' });
+  assert.equal(r.status, 'aborted');
+  assert.equal(r.statusEmoji, '⚪');
+  assert.equal(r.resultEmoji, '⚪');
+  assert.equal(r.resultWord, 'aborted');
+  assert.match(r.headline, /Aborted \(run cancelled\) for `abc1234`/);
+});
+
+test('deriveResult: summary.aborted is treated as aborted even on a non-cancelled job', () => {
+  const r = helper.deriveResult({ summary: { aborted: true, passed: 1 }, jobStatus: 'failure', sha: 'abc1234' });
+  assert.equal(r.status, 'aborted');
+});
+
+test('deriveResult: failures win over passes; the skipped clause appears only when non-zero', () => {
+  const withSkips = helper.deriveResult({ summary: { passed: 8, failed: 3, skipped: 2 }, jobStatus: 'failure', sha: 'sha' });
+  assert.equal(withSkips.status, 'failed');
+  assert.equal(withSkips.statusEmoji, '🔴');
+  assert.match(withSkips.headline, /\*\*3 failed\*\*, 8 passed, 2 skipped for `sha`/);
+  const noSkips = helper.deriveResult({ summary: { passed: 8, failed: 3, skipped: 0 }, jobStatus: 'failure', sha: 'sha' });
+  assert.doesNotMatch(noSkips.headline, /skipped/);
+});
+
+test('deriveResult: a clean summary is a pass', () => {
+  const r = helper.deriveResult({ summary: { passed: 12, failed: 0, skipped: 1 }, jobStatus: 'success', sha: 'sha' });
+  assert.equal(r.status, 'passed');
+  assert.equal(r.statusEmoji, '🟢');
+  assert.equal(r.resultWord, 'passed');
+  assert.match(r.headline, /\*\*12 passed\*\*, 1 skipped for `sha`/);
+});
+
+test('deriveResult: a missing summary is "no results" (early failure before the runner wrote one)', () => {
+  const r = helper.deriveResult({ summary: null, jobStatus: 'failure', sha: 'sha' });
+  assert.equal(r.status, 'failed');
+  assert.equal(r.resultWord, 'no results');
+  assert.match(r.headline, /without a summary for `sha`/);
+});
+
+test('deriveResult: a reportUrl is appended to the headline; absent leaves it untouched', () => {
+  const withUrl = helper.deriveResult({ summary: { passed: 1, failed: 0 }, jobStatus: 'success', sha: 'sha', reportUrl: 'http://x/1' });
+  assert.match(withUrl.headline, /\[▶ Open interactive report\]\(http:\/\/x\/1\)/);
+  const noUrl = helper.deriveResult({ summary: { passed: 1, failed: 0 }, jobStatus: 'success', sha: 'sha' });
+  assert.doesNotMatch(noUrl.headline, /Open interactive report/);
+});
+
+// --- find-once upsert contract (no lost-update re-fetch) ----------------------------
+
+test('upsertSticky with a provided comment updates that exact id and does NOT re-list', async () => {
+  const gh = fakeGithub(sticky(42));
+  const id = await helper.upsertSticky({ github: gh, owner: 'o', repo: 'r', issue_number: 1, body: 'B', existing: sticky(42) });
+  assert.equal(id, 42);
+  assert.deepEqual(gh.calls, ['update#42']); // no 'list' — single round-trip to the known id
+});
+
+test('upsertSticky with existing=null creates without re-listing', async () => {
+  const gh = fakeGithub(null);
+  const id = await helper.upsertSticky({ github: gh, owner: 'o', repo: 'r', issue_number: 1, body: 'B', existing: null });
+  assert.equal(id, 999);
+  assert.deepEqual(gh.calls, ['create']);
+});
+
+test('upsertSticky without existing self-fetches (back-compat), then writes', async () => {
+  const ghFound = fakeGithub(sticky(7));
+  assert.equal(await helper.upsertSticky({ github: ghFound, owner: 'o', repo: 'r', issue_number: 1, body: 'B' }), 7);
+  assert.deepEqual(ghFound.calls, ['list', 'update#7']);
+
+  const ghNone = fakeGithub(null);
+  assert.equal(await helper.upsertSticky({ github: ghNone, owner: 'o', repo: 'r', issue_number: 1, body: 'B' }), 999);
+  assert.deepEqual(ghNone.calls, ['list', 'create']);
+});
+
+test('findSticky matches only comments carrying the marker', async () => {
+  assert.equal(await helper.findSticky({ github: fakeGithub({ id: 5, body: 'no marker' }), owner: 'o', repo: 'r', issue_number: 1 }), null);
+  const found = await helper.findSticky({ github: fakeGithub(sticky(8)), owner: 'o', repo: 'r', issue_number: 1 });
+  assert.equal(found.id, 8);
+});
+
+// --- command parsing (trigger interpretation) --------------------------------------
+
+test('parseCommand: anchored to the first line; a mid-text mention is ignored', () => {
+  assert.equal(helper.parseCommand('look at `/run-tests-e2e Foo`').isCommand, false);
+  assert.equal(helper.parseCommand('hey\n/run-tests-e2e Foo').isCommand, false); // not first line
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e Foo'), { isCommand: true, filter: 'Foo', valid: true });
+});
+
+test('parseCommand: no filter = full suite; extra whitespace collapses', () => {
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e'), { isCommand: true, filter: '', valid: true });
+  assert.deepEqual(helper.parseCommand('/run-tests-e2e   MyClass   Method  '),
+    { isCommand: true, filter: 'MyClass Method', valid: true });
+});
+
+test('parseCommand: --abort-current is no longer special — it is just a literal filter token', () => {
+  // Regression guard for the removed feature: the flag must NOT be silently stripped (which
+  // would run the FULL suite as if it had vanished). It is passed through verbatim as a
+  // literal xUnit filter — valid characters, but it matches no test, so the run is an
+  // explicit empty no-result rather than a surprise full-suite run.
+  const cmd = helper.parseCommand('/run-tests-e2e --abort-current');
+  assert.equal(cmd.isCommand, true);
+  assert.equal(cmd.filter, '--abort-current', 'flag is preserved as the filter, not stripped');
+  assert.equal(cmd.valid, true, 'all-allowed-chars; harmless literal that matches nothing');
+});
+
+test('isValidFilter: rejects marker/table/HTML breakers, accepts real xUnit filters', () => {
+  // Accepts: namespaced class/method, generics, params, spaces.
+  for (const ok of ['', 'PasswordProtection', 'Ns.Class.Method', 'Foo(Bar=1)', 'A B', 'Class+Nested']) {
+    assert.equal(helper.isValidFilter(ok), true, `should accept ${JSON.stringify(ok)}`);
+  }
+  // Rejects: the marker terminator, the table-cell separator, and HTML — the three things
+  // that would corrupt the sticky (see the --> history-wipe bug this guards).
+  for (const bad of ['A-->B', 'A|B', '<b>x</b>', 'a`b', 'a;b', 'a\nb']) {
+    assert.equal(helper.isValidFilter(bad), false, `should reject ${JSON.stringify(bad)}`);
+  }
+});
+
+test('a rejected filter never reaches the markers (the --> history-wipe is unreachable post-validation)', () => {
+  // Belt-and-braces: prove the validation choke point closes the corruption path end-to-end.
+  // A `-->` filter is rejected by isValidFilter, so it can never be embedded; but if it ever
+  // were, renderBody+readHistory would silently drop history — so we assert the guard catches it.
+  assert.equal(helper.isValidFilter('A-->B'), false);
+  const body = helper.renderBody({ status: 'queued', statusEmoji: '🟡', headline: 'x', filter: 'A-->B',
+    history: [{ n: 1, result: 'passed', resultEmoji: '🟢', sha: 'abc', filter: 'A-->B', when: 't', runUrl: 'r', reportUrl: '' }], requested: false });
+  assert.deepEqual(helper.readHistory(body), [], 'demonstrates the corruption the validation prevents');
+});
+
+test('shouldFireRerun: only a confirmed unchecked->checked transition fires', () => {
+  const idle = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: '', history: [], requested: false });
+  const ticked = idle.replace('- [ ] 🔁 Re-run E2E tests', '- [x] 🔁 Re-run E2E tests');
+  // unchecked -> checked: fire
+  assert.equal(helper.shouldFireRerun({ priorBody: idle, body: ticked }), true);
+  // already checked, text edited: do NOT fire
+  assert.equal(helper.shouldFireRerun({ priorBody: ticked, body: ticked }), false);
+  // checked -> unchecked: do NOT fire
+  assert.equal(helper.shouldFireRerun({ priorBody: ticked, body: idle }), false);
+});
+
+test('shouldFireRerun: missing prior body fails safe (skip), never fires on a ticked box', () => {
+  const idle = helper.renderBody({ status: 'passed', statusEmoji: '🟢', headline: 'x', filter: '', history: [], requested: false });
+  const ticked = idle.replace('- [ ] 🔁 Re-run E2E tests', '- [x] 🔁 Re-run E2E tests');
+  // No changes.body.from on the event → cannot prove a transition → skip even though box is ticked.
+  assert.equal(helper.shouldFireRerun({ priorBody: undefined, body: ticked }), false);
+  assert.equal(helper.shouldFireRerun({ priorBody: null, body: ticked }), false);
+});
+
+// --- maintainer authorization (404 = deny, 403 = fail-closed) -----------------------
+
+function fakeGithubPerm(behaviour) {
+  return {
+    rest: {
+      repos: {
+        getCollaboratorPermissionLevel: async () => {
+          if (behaviour.status) { const e = new Error('http'); e.status = behaviour.status; throw e; }
+          return { data: { permission: behaviour.permission } };
+        },
+      },
+    },
+  };
+}
+
+test('isMaintainer: admin/write allowed; read/none denied', async () => {
+  const args = { owner: 'o', repo: 'r', username: 'u' };
+  assert.equal(await helper.isMaintainer({ github: fakeGithubPerm({ permission: 'admin' }), ...args }), true);
+  assert.equal(await helper.isMaintainer({ github: fakeGithubPerm({ permission: 'write' }), ...args }), true);
+  assert.equal(await helper.isMaintainer({ github: fakeGithubPerm({ permission: 'read' }), ...args }), false);
+  assert.equal(await helper.isMaintainer({ github: fakeGithubPerm({ permission: 'none' }), ...args }), false);
+});
+
+test('isMaintainer: 404 (non-collaborator) is a deny, not an error', async () => {
+  assert.equal(await helper.isMaintainer({ github: fakeGithubPerm({ status: 404 }), owner: 'o', repo: 'r', username: 'u' }), false);
+});
+
+test('isMaintainer: 403/other errors fail closed (rethrow → red job, no silent allow)', async () => {
+  await assert.rejects(
+    helper.isMaintainer({ github: fakeGithubPerm({ status: 403 }), owner: 'o', repo: 'r', username: 'u' }),
+    /http/,
+  );
+});

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -54,6 +54,12 @@ test('readHistory round-trips and tolerates corruption', () => {
   assert.deepEqual(helper.readHistory('no marker'), []);
 });
 
+test('shortSha takes the first 7 chars and is null-safe (empty/undefined → "")', () => {
+  assert.equal(helper.shortSha('abcdef0123456'), 'abcdef0');
+  assert.equal(helper.shortSha(''), '');
+  assert.equal(helper.shortSha(undefined), '');
+});
+
 // --- re-run checkbox state machine -------------------------------------------------
 
 test('isReRunChecked detects only the ticked box', () => {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,7 +6,7 @@
 #
 # THREE ways in, all manual and maintainer-gated — never an automatic merge gate:
 #   1. workflow_dispatch (Actions tab) — runs the full suite from a trusted branch.
-#   2. `/run-tests-e2e [filter] [--abort-current]` PR comment.
+#   2. `/run-tests-e2e [filter]` PR comment.
 #   3. the "Re-run E2E tests" checkbox in the bot's results comment (a click in the
 #      PR view; toggling it fires issue_comment: edited).
 #
@@ -20,8 +20,10 @@
 #     validate-pr.yml) before the secret-bearing `e2e` job runs — the VPS private key
 #     reaching fork code = root on the test VPS via the docker group.
 #   - Single physical VPS runner: a global concurrency singleton QUEUES runs (active +
-#     1 waiting); a run is only aborted on explicit `--abort-current`. A cancel triggers
-#     the runner's abort path (writes summary.json, sweeps VPS containers by run-id).
+#     1 waiting); a newer trigger replaces the waiting one, never preempting the active
+#     run. To preempt, a maintainer cancels the in-flight run from the Actions tab — that
+#     cancel triggers the runner's abort path (writes summary.json, sweeps VPS containers
+#     by run-id), and the sticky reports "⚪ aborted".
 #   - This workflow must NEVER become a required check (external-VPS availability can't
 #     gate the merge queue). Do NOT add pull_request_target / push / schedule /
 #     merge_group.
@@ -48,15 +50,17 @@ permissions:
   contents: read
 
 # ONE concurrency key for the single physical VPS runner — dispatch, comment, and
-# checkbox runs all share it, so they QUEUE rather than run in parallel. Default
-# behaviour keeps the active run + at most one pending (a newer trigger replaces the
-# waiting one). cancel-in-progress is OFF unless the comment carries `--abort-current`,
-# so a plain re-run never preempts an in-flight run; an explicit abort does (and the
-# runner's abort path writes summary.json + sweeps VPS containers by run-id). The
-# event_name guard short-circuits before comment.body is read on a dispatch (null-safe).
+# checkbox runs all share it, so they QUEUE rather than run in parallel (active + at most
+# one pending; a newer trigger replaces the waiting one).
+#
+# cancel-in-progress is ALWAYS false: it is evaluated at the run-scheduling layer, BEFORE
+# the gate authorizes, so making it an expression on comment.body would let any commenter
+# (a non-maintainer) cancel a running job — griefing with no secret/code access, but still
+# a nuisance. Preempting an in-flight run is a maintainer action via the Actions tab, not a
+# comment-triggered one. Do NOT make this an expression on comment.body.
 concurrency:
   group: e2e-tests-singleton
-  cancel-in-progress: ${{ github.event_name == 'issue_comment' && contains(github.event.comment.body, '--abort-current') }}
+  cancel-in-progress: false
 
 jobs:
   # ── Authorize + parse + resolve the PR HEAD. NO secrets here; this job decides
@@ -132,21 +136,27 @@ jobs:
 
             const noop = (reason) => { core.info(`No-op: ${reason}`); core.setOutput('proceed', 'false'); };
 
-            // Classify + parse.
+            // Classify + parse (pure logic lives in the helper, where it's unit-tested).
             let filter = '';
             if (action === 'created') {
-              // Anchored command match on the first line — a quoted/mid-text mention is ignored.
-              const firstLine = body.split('\n', 1)[0];
-              const m = firstLine.match(/^\/run-tests-e2e(?:\s+(.*))?$/);
-              if (!m) return noop('comment is not an anchored /run-tests-e2e command');
-              const args = (m[1] || '').trim().split(/\s+/).filter(Boolean);
-              filter = args.filter((a) => a !== '--abort-current').join(' ');
+              const cmd = helper.parseCommand(body);
+              if (!cmd.isCommand) return noop('comment is not an anchored /run-tests-e2e command');
+              // Reject a filter with characters that could break the hidden markers or the
+              // markdown table (or that xUnit wouldn't accept) rather than corrupt the sticky.
+              if (!cmd.valid) {
+                await github.rest.reactions.createForIssueComment({
+                  owner, repo, comment_id: comment.id, content: 'confused',
+                });
+                return noop('filter contains disallowed characters');
+              }
+              filter = cmd.filter;
             } else {
-              // edited: react only to OUR sticky AND an unchecked->checked transition of the box.
+              // edited: react only to OUR sticky AND a confirmed unchecked->checked tick.
               if (!body.includes(helper.MARKER)) return noop('edited comment is not the e2e sticky');
-              const wasChecked = helper.isReRunChecked(context.payload.changes?.body?.from || '');
-              const nowChecked = helper.isReRunChecked(body);
-              if (!(nowChecked && !wasChecked)) return noop('re-run box was not just ticked');
+              const priorBody = context.payload.changes?.body?.from;
+              if (!helper.shouldFireRerun({ priorBody, body })) {
+                return noop('re-run box was not just ticked (or prior body unavailable)');
+              }
               filter = helper.readFilter(body); // re-run reuses the filter the sticky recorded
             }
 
@@ -184,7 +194,7 @@ jobs:
             const existing = await helper.findSticky({ github, owner, repo, issue_number: issueNumber });
             const history = existing ? helper.readHistory(existing.body) : [];
             await helper.upsertSticky({
-              github, owner, repo, issue_number: issueNumber,
+              github, owner, repo, issue_number: issueNumber, existing,
               body: helper.renderBody({
                 status: 'queued', statusEmoji: '🟡',
                 headline: `Queued for \`${pr.head.sha.slice(0, 7)}\`…`,
@@ -224,9 +234,13 @@ jobs:
     permissions:
       pull-requests: write   # the "Update PR sticky" step posts results back to the PR
       contents: read
-    # No job-level timeout-minutes: a bare dispatch runs the FULL suite, whose size
-    # varies, so we don't hardcode a wall-clock cap. The runner's own per-test and
-    # broker timeouts catch real hangs; GitHub's default job timeout is the backstop.
+    # The runner's own per-test and broker timeouts catch real hangs; this job cap is only
+    # a coarse backstop for a wedged process (e.g. a stuck SSH master) that those miss. It
+    # matters because of the single-runner concurrency singleton: a zombie run would block
+    # the next QUEUED run for as long as it lives, and GitHub's default is 6h. 120 min sits
+    # well above a real full-suite run (even serialized at serverSlots:1, plus image build +
+    # data transfer) but far below that 6h default, so a hang frees the queue in good time.
+    timeout-minutes: 120
 
     # Non-secret runner config shared by every step. The Steam secrets are scoped
     # to the two steps that consume them (populate + run), not broadcast here.
@@ -575,9 +589,9 @@ jobs:
       # runner's summary.json for counts/status, resets the re-run checkbox to its idle
       # label, and APPENDS a row to the retained run-history table (older rows kept) so
       # the PR keeps a full per-run trail for debugging. if: always() fires on pass, fail,
-      # AND cancel (an --abort-current preempt) — a sibling status check picks the headline
-      # so an aborted run reports "⚪ aborted" instead of stranding on "🟡 queued". The
-      # GITHUB_TOKEN edit does not retrigger the workflow (recursion guard).
+      # AND cancel (a maintainer preempting the run from the Actions tab) — a sibling status
+      # check picks the headline so a cancelled run reports "⚪ aborted" instead of stranding
+      # on "🟡 queued". The GITHUB_TOKEN edit does not retrigger the workflow (recursion guard).
       - name: Update PR sticky
         if: always() && github.event_name == 'issue_comment'
         continue-on-error: true
@@ -610,38 +624,26 @@ jobs:
               if (fs.existsSync(p)) { try { summary = JSON.parse(fs.readFileSync(p, 'utf8')); } catch {} break; }
             }
 
-            // Derive status. A cancelled job (--abort-current) wins regardless of partial summary.
-            let status, statusEmoji, resultEmoji, resultWord, headline;
-            if (jobStatus === 'cancelled' || (summary && summary.aborted)) {
-              status = 'aborted'; statusEmoji = resultEmoji = '⚪'; resultWord = 'aborted';
-              headline = `Aborted (\`--abort-current\`) for \`${sha}\`.`;
-            } else if (summary && summary.failed > 0) {
-              status = 'failed'; statusEmoji = resultEmoji = '🔴'; resultWord = 'failed';
-              headline = `**${summary.failed} failed**, ${summary.passed} passed` +
-                `${summary.skipped ? `, ${summary.skipped} skipped` : ''} for \`${sha}\`.`;
-            } else if (summary) {
-              status = 'passed'; statusEmoji = resultEmoji = '🟢'; resultWord = 'passed';
-              headline = `**${summary.passed} passed**` +
-                `${summary.skipped ? `, ${summary.skipped} skipped` : ''} for \`${sha}\`.`;
-            } else {
-              // No summary.json (early failure before the runner wrote it).
-              status = 'failed'; statusEmoji = resultEmoji = '🔴'; resultWord = 'no results';
-              headline = `Run finished without a summary for \`${sha}\` (check the Actions log).`;
-            }
+            // Derive the result (status, emoji, headline) from the job status + summary.json.
+            // Pure logic lives in the helper, where it's unit-tested.
+            const { status, statusEmoji, resultEmoji, resultWord, headline } =
+              helper.deriveResult({ summary, jobStatus, sha, reportUrl });
 
-            // Append a history row to whatever the sticky already holds (older rows kept).
+            // Append a history row. renderBody caps the retained rows, so derive the run
+            // number from the highest existing n (NOT array length, which is bounded).
             const existing = await helper.findSticky({ github, owner, repo, issue_number });
             const history = existing ? helper.readHistory(existing.body) : [];
+            const nextN = history.reduce((mx, h) => Math.max(mx, h.n || 0), 0) + 1;
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             history.push({
-              n: history.length + 1, result: resultWord, resultEmoji, sha,
+              n: nextN, result: resultWord, resultEmoji, sha,
               filter, when: new Date().toISOString().replace('T', ' ').slice(0, 16) + 'Z',
               runUrl, reportUrl,
             });
 
             const body = helper.renderBody({
-              status, statusEmoji,
-              headline: reportUrl ? `${headline}\n\n**[▶ Open interactive report](${reportUrl})** (screenshots + videos)` : headline,
-              filter, history, requested: false,
+              status, statusEmoji, headline, filter, history, requested: false,
             });
-            await helper.upsertSticky({ github, owner, repo, issue_number, body });
+            // Pass `existing` so the write targets the exact comment we read history from
+            // (one find per update; no lost-update race against a concurrent edit).
+            await helper.upsertSticky({ github, owner, repo, issue_number, body, existing });

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,19 +1,34 @@
-# Runs the heavy Docker E2E suite (the full suite by default; a dispatch-time
-# `filter` input narrows it to a class/method). The coordinator
-# (JunimoServer.TestRunner, a net10.0 app) runs here on ubuntu-latest; the actual
-# Stardew game containers run on a remote VPS reached over SSH — the harness's
-# existing multi-host model with SDVD_DOCKER_HOSTS set to a VPS-only fleet.
+# Runs the heavy Docker E2E suite (the full suite by default; a `filter` narrows it
+# to a class/method). The coordinator (JunimoServer.TestRunner, a net10.0 app) runs
+# here on ubuntu-latest; the actual Stardew game containers run on a remote VPS
+# reached over SSH — the harness's existing multi-host model with SDVD_DOCKER_HOSTS
+# set to a VPS-only fleet.
 #
-# workflow_dispatch only — never automatic. E2E depends on an external VPS being
-# up; that availability risk must never gate the merge queue. Manual-from-a-
-# trusted-branch also keeps the VPS SSH key and Steam secrets away from fork code.
-# Do NOT add pull_request_target / push / schedule / merge_group. A future move to
-# any automatic trigger would first require copying validate-pr.yml's authorize /
-# fork-pr environment gate (the VPS private key reaching fork code = root on the
-# test VPS via the docker group), and must never become a required check.
+# THREE ways in, all manual and maintainer-gated — never an automatic merge gate:
+#   1. workflow_dispatch (Actions tab) — runs the full suite from a trusted branch.
+#   2. `/run-tests-e2e [filter] [--abort-current]` PR comment.
+#   3. the "Re-run E2E tests" checkbox in the bot's results comment (a click in the
+#      PR view; toggling it fires issue_comment: edited).
 #
-# All secrets resolve from the `test-vps` GitHub Environment (the same per-
-# environment mechanism deploy-server.yml uses), not loose repo-level secrets.
+# Why this is safe despite touching PRs:
+#   - issue_comment ALWAYS runs THIS workflow file from the default branch (master),
+#     never the PR/fork version — a fork cannot inject workflow code via a comment.
+#   - The `gate` job authorizes the commenter via the repo-permission API (write/admin
+#     required; NOT author_association, which is permission-blind). Non-maintainers are
+#     refused before any secret-bearing job runs.
+#   - Fork PRs additionally pass through the `fork-pr` Environment approval (mirrors
+#     validate-pr.yml) before the secret-bearing `e2e` job runs — the VPS private key
+#     reaching fork code = root on the test VPS via the docker group.
+#   - Single physical VPS runner: a global concurrency singleton QUEUES runs (active +
+#     1 waiting); a run is only aborted on explicit `--abort-current`. A cancel triggers
+#     the runner's abort path (writes summary.json, sweeps VPS containers by run-id).
+#   - This workflow must NEVER become a required check (external-VPS availability can't
+#     gate the merge queue). Do NOT add pull_request_target / push / schedule /
+#     merge_group.
+#
+# All secrets resolve from the `test-vps` GitHub Environment (the same per-environment
+# mechanism deploy-server.yml uses), not loose repo-level secrets. R2_BUCKET /
+# R2_PUBLIC_BASE_URL are test-vps *variables* (public by design; see the R2 step).
 name: E2E Tests
 
 on:
@@ -23,24 +38,179 @@ on:
         description: 'Test filter (xUnit class/method substring). Empty = run the full suite.'
         required: false
         default: ''
+  # PR comments: `created` = the typed `/run-tests-e2e` command; `edited` = the re-run
+  # checkbox in the bot's results comment being ticked. The `gate` job's `if:` narrows
+  # this to PR comments that are actually our command or our sticky (see that job).
+  issue_comment:
+    types: [created, edited]
 
 permissions:
   contents: read
 
-# Cancel superseded dispatches. Keyed on github.ref — a dispatch has no PR number.
-# A cancel triggers the runner's abort path (writes summary.json, sweeps VPS
-# containers by run-id).
+# ONE concurrency key for the single physical VPS runner — dispatch, comment, and
+# checkbox runs all share it, so they QUEUE rather than run in parallel. Default
+# behaviour keeps the active run + at most one pending (a newer trigger replaces the
+# waiting one). cancel-in-progress is OFF unless the comment carries `--abort-current`,
+# so a plain re-run never preempts an in-flight run; an explicit abort does (and the
+# runner's abort path writes summary.json + sweeps VPS containers by run-id). The
+# event_name guard short-circuits before comment.body is read on a dispatch (null-safe).
 concurrency:
-  group: e2e-tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: e2e-tests-singleton
+  cancel-in-progress: ${{ github.event_name == 'issue_comment' && contains(github.event.comment.body, '--abort-current') }}
 
 jobs:
+  # ── Authorize + parse + resolve the PR HEAD. NO secrets here; this job decides
+  # whether the run is allowed and what it should run, then hands the e2e job a
+  # resolved SHA/filter. The `if:` is a coarse pre-filter (GitHub expressions can't do
+  # regex); the authoritative checks (anchored command match, maintainer permission,
+  # checkbox transition) run inside the github-script step.
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   # post/update the sticky + reactions
+      contents: read
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment'
+       && github.event.issue.pull_request != null
+       && github.event.comment.user.type != 'Bot'
+       && (
+            (github.event.action == 'created'
+               && startsWith(github.event.comment.body, '/run-tests-e2e'))
+         || (github.event.action == 'edited'
+               && contains(github.event.comment.body, '<!-- e2e-results -->'))
+          ))
+    outputs:
+      proceed: ${{ steps.gate.outputs.proceed }}
+      head_sha: ${{ steps.gate.outputs.head_sha }}
+      head_ref: ${{ steps.gate.outputs.head_ref }}
+      filter: ${{ steps.gate.outputs.filter }}
+      pr_number: ${{ steps.gate.outputs.pr_number }}
+      is_fork: ${{ steps.gate.outputs.is_fork }}
+    steps:
+      # Check out ONLY the shared helper script from the (trusted) default branch, so
+      # the github-script step can require() it. issue_comment already runs the default-
+      # branch workflow; this checkout is the default ref too (never the PR head).
+      - name: Checkout gate helper
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: .github/scripts/e2e-pr-sticky.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Authorize, parse, resolve PR HEAD
+        id: gate
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          DISPATCH_FILTER: ${{ inputs.filter }}
+        with:
+          script: |
+            const helper = require('./.github/scripts/e2e-pr-sticky.js');
+            const { owner, repo } = context.repo;
+
+            // ---- workflow_dispatch: trusted branch, no PR context ----
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('proceed', 'true');
+              core.setOutput('filter', process.env.DISPATCH_FILTER || '');
+              core.setOutput('is_fork', 'false');
+              return;
+            }
+
+            // ---- issue_comment (created command | edited checkbox) ----
+            const comment = context.payload.comment;
+            const issueNumber = context.payload.issue.number;
+            const action = context.payload.action;
+            const body = comment.body || '';
+
+            const noop = (reason) => { core.info(`No-op: ${reason}`); core.setOutput('proceed', 'false'); };
+
+            // Classify + parse.
+            let filter = '';
+            if (action === 'created') {
+              // Anchored command match on the first line — a quoted/mid-text mention is ignored.
+              const firstLine = body.split('\n', 1)[0];
+              const m = firstLine.match(/^\/run-tests-e2e(?:\s+(.*))?$/);
+              if (!m) return noop('comment is not an anchored /run-tests-e2e command');
+              const args = (m[1] || '').trim().split(/\s+/).filter(Boolean);
+              filter = args.filter((a) => a !== '--abort-current').join(' ');
+            } else {
+              // edited: react only to OUR sticky AND an unchecked->checked transition of the box.
+              if (!body.includes(helper.MARKER)) return noop('edited comment is not the e2e sticky');
+              const wasChecked = helper.isReRunChecked(context.payload.changes?.body?.from || '');
+              const nowChecked = helper.isReRunChecked(body);
+              if (!(nowChecked && !wasChecked)) return noop('re-run box was not just ticked');
+              filter = helper.readFilter(body); // re-run reuses the filter the sticky recorded
+            }
+
+            // Authorize the actor (the commenter / the clicker). Authoritative permission
+            // API — NOT author_association. 404 (non-collaborator) is a deny.
+            const username = comment.user.login;
+            const allowed = await helper.isMaintainer({ github, owner, repo, username });
+            if (!allowed) {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: comment.id, content: '-1',
+              });
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: issueNumber,
+                body: `@${username} — E2E runs are maintainer-only (repo write access required).`,
+              });
+              return noop(`${username} is not a maintainer`);
+            }
+
+            // Resolve PR HEAD (the comment payload has the PR number but not the head SHA).
+            const pr = (await github.rest.pulls.get({ owner, repo, pull_number: issueNumber })).data;
+            const headRepo = pr.head.repo ? pr.head.repo.full_name : null;
+            const isFork = headRepo !== `${owner}/${repo}`; // null head.repo (deleted fork) => treat as fork
+
+            // Acknowledge: 👀 on the comment + a "queued" sticky (re-run box reset; "(requested)"
+            // on the checkbox path so the click is visibly picked up). Preserve run history.
+            await github.rest.reactions.createForIssueComment({
+              owner, repo, comment_id: comment.id, content: 'eyes',
+            });
+            const existing = await helper.findSticky({ github, owner, repo, issue_number: issueNumber });
+            const history = existing ? helper.readHistory(existing.body) : [];
+            await helper.upsertSticky({
+              github, owner, repo, issue_number: issueNumber,
+              body: helper.renderBody({
+                status: 'queued', statusEmoji: '🟡',
+                headline: `Queued for \`${pr.head.sha.slice(0, 7)}\`…`,
+                filter, history, requested: action === 'edited',
+              }),
+            });
+
+            core.setOutput('proceed', 'true');
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('filter', filter);
+            core.setOutput('pr_number', String(issueNumber));
+            core.setOutput('is_fork', String(isFork));
+
+  # ── Fork-PR approval gate. Same-repo PRs and dispatch resolve the empty environment
+  # (no prompt); fork PRs resolve `fork-pr`, requiring a maintainer to approve the
+  # deployment before the secret-bearing e2e job runs (the VPS key reaching fork code =
+  # root on the test VPS). `needs` is permitted in jobs.<id>.environment. Defense in
+  # depth atop the gate's permission check.
+  authorize:
+    name: Authorize (fork-pr)
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ needs.gate.outputs.is_fork == 'true' && 'fork-pr' || '' }}
+    steps:
+      - run: echo "Authorized — fork=${{ needs.gate.outputs.is_fork }}."
+
   e2e:
     name: E2E (VPS)
+    needs: [gate, authorize]
+    if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     # Holds the Steam + SSH secrets. Mirrors deploy-server.yml's per-environment
     # secret scoping.
     environment: test-vps
+    permissions:
+      pull-requests: write   # the "Update PR sticky" step posts results back to the PR
+      contents: read
     # No job-level timeout-minutes: a bare dispatch runs the FULL suite, whose size
     # varies, so we don't hardcode a wall-clock cap. The runner's own per-test and
     # broker timeouts catch real hangs; GitHub's default job timeout is the backstop.
@@ -88,6 +258,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          # On the PR-comment path, check out the PR's HEAD (resolved by the gate) so we
+          # test the proposed code, not master — a full SHA fetches a fork commit fine.
+          # On dispatch, gate.outputs.head_sha is empty → checkout's default ref (the
+          # dispatched branch). The default-branch workflow file is what runs either way.
+          ref: ${{ needs.gate.outputs.head_sha }}
           # This job uploads artifacts and publishes a report to a PUBLIC bucket, and
           # no later step needs the git credential, so don't persist it in .git/config
           # (defense in depth — keeps the token out of anything we upload).
@@ -214,11 +389,12 @@ jobs:
         env:
           SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
           STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
-          # Pass the (operator-controlled) filter through the environment, not
+          # Pass the (maintainer-controlled) filter through the environment, not
           # interpolated into the command line, so its value can never be parsed
-          # as shell. Empty (the default) runs the full suite — pass --filter only
+          # as shell. The gate resolves it from the dispatch input OR the comment /
+          # checkbox; empty (the default) runs the full suite — pass --filter only
           # when a non-whitespace value was provided.
-          FILTER: ${{ inputs.filter }}
+          FILTER: ${{ needs.gate.outputs.filter }}
         run: |
           if [ -n "${FILTER//[[:space:]]/}" ]; then
             dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
@@ -300,6 +476,7 @@ jobs:
       # account id, all hex) stay secrets. Do NOT move R2_BUCKET / R2_PUBLIC_BASE_URL back
       # to secrets.
       - name: Publish web report to R2
+        id: r2
         if: always()
         continue-on-error: true
         env:
@@ -308,7 +485,9 @@ jobs:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET: ${{ vars.R2_BUCKET }}
           R2_PUBLIC_BASE_URL: ${{ vars.R2_PUBLIC_BASE_URL }}
-          BRANCH_REF: ${{ github.ref_name }}
+          # Prefer the PR head ref (comment path) so the object key is keyed on the PR's
+          # branch — on issue_comment, github.ref_name is the default branch (master).
+          BRANCH_REF: ${{ needs.gate.outputs.head_ref || github.ref_name }}
         run: |
           # GitHub runs steps with `bash -eo pipefail` (errexit ON). Relax it so a
           # partial failure can't truncate the script before the summary write.
@@ -355,7 +534,82 @@ jobs:
               echo ""
               echo "**[Open interactive report]($url)** (screenshots + videos, $size)"
             } >> "$GITHUB_STEP_SUMMARY"
+            # Hand the URL to the PR-sticky step (no-op on dispatch / when unconfigured).
+            echo "report_url=$url" >> "$GITHUB_OUTPUT"
             echo "Published report: $url ($size)"
           else
             echo "::warning::R2 publish failed (network/credentials/quota). Report remains in the 'e2e-web-report' artifact."
           fi
+
+      # Replace the PR sticky with the final result (PR-comment path only). Reads the
+      # runner's summary.json for counts/status, resets the re-run checkbox to its idle
+      # label, and APPENDS a row to the retained run-history table (older rows kept) so
+      # the PR keeps a full per-run trail for debugging. if: always() fires on pass, fail,
+      # AND cancel (an --abort-current preempt) — a sibling status check picks the headline
+      # so an aborted run reports "⚪ aborted" instead of stranding on "🟡 queued". The
+      # GITHUB_TOKEN edit does not retrigger the workflow (recursion guard).
+      - name: Update PR sticky
+        if: always() && github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          REPORT_URL: ${{ steps.r2.outputs.report_url }}
+          FILTER: ${{ needs.gate.outputs.filter }}
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+          # job.status is success | failure | cancelled at always()-eval time.
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const fs = require('fs');
+            const helper = require('./.github/scripts/e2e-pr-sticky.js');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const sha = (process.env.HEAD_SHA || '').slice(0, 7);
+            const filter = process.env.FILTER || '';
+            const reportUrl = process.env.REPORT_URL || '';
+            const jobStatus = process.env.JOB_STATUS;
+
+            // Find the one summary.json the runner wrote (one run dir per invocation).
+            let summary = null;
+            const runsDir = 'TestResults/runs';
+            for (const dir of (fs.existsSync(runsDir) ? fs.readdirSync(runsDir) : [])) {
+              const p = `${runsDir}/${dir}/summary.json`;
+              if (fs.existsSync(p)) { try { summary = JSON.parse(fs.readFileSync(p, 'utf8')); } catch {} break; }
+            }
+
+            // Derive status. A cancelled job (--abort-current) wins regardless of partial summary.
+            let status, statusEmoji, resultEmoji, resultWord, headline;
+            if (jobStatus === 'cancelled' || (summary && summary.aborted)) {
+              status = 'aborted'; statusEmoji = resultEmoji = '⚪'; resultWord = 'aborted';
+              headline = `Aborted (\`--abort-current\`) for \`${sha}\`.`;
+            } else if (summary && summary.failed > 0) {
+              status = 'failed'; statusEmoji = resultEmoji = '🔴'; resultWord = 'failed';
+              headline = `**${summary.failed} failed**, ${summary.passed} passed` +
+                `${summary.skipped ? `, ${summary.skipped} skipped` : ''} for \`${sha}\`.`;
+            } else if (summary) {
+              status = 'passed'; statusEmoji = resultEmoji = '🟢'; resultWord = 'passed';
+              headline = `**${summary.passed} passed**` +
+                `${summary.skipped ? `, ${summary.skipped} skipped` : ''} for \`${sha}\`.`;
+            } else {
+              // No summary.json (early failure before the runner wrote it).
+              status = 'failed'; statusEmoji = resultEmoji = '🔴'; resultWord = 'no results';
+              headline = `Run finished without a summary for \`${sha}\` (check the Actions log).`;
+            }
+
+            // Append a history row to whatever the sticky already holds (older rows kept).
+            const existing = await helper.findSticky({ github, owner, repo, issue_number });
+            const history = existing ? helper.readHistory(existing.body) : [];
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            history.push({
+              n: history.length + 1, result: resultWord, resultEmoji, sha,
+              filter, when: new Date().toISOString().replace('T', ' ').slice(0, 16) + 'Z',
+              runUrl, reportUrl,
+            });
+
+            const body = helper.renderBody({
+              status, statusEmoji,
+              headline: reportUrl ? `${headline}\n\n**[▶ Open interactive report](${reportUrl})** (screenshots + videos)` : headline,
+              filter, history, requested: false,
+            });
+            await helper.upsertSticky({ github, owner, repo, issue_number, body });

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -70,11 +70,15 @@ jobs:
     permissions:
       pull-requests: write   # post/update the sticky + reactions
       contents: read
+    # NB: use github.event.sender (the actor who triggered the event), NOT
+    # github.event.comment.user. On an `edited` checkbox toggle, comment.user is the
+    # comment's ORIGINAL author — our own bot sticky — so a comment.user.type != 'Bot'
+    # filter would block every re-run. sender is the human who clicked.
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request != null
-       && github.event.comment.user.type != 'Bot'
+       && github.event.sender.type != 'Bot'
        && (
             (github.event.action == 'created'
                && startsWith(github.event.comment.body, '/run-tests-e2e'))
@@ -122,6 +126,9 @@ jobs:
             const issueNumber = context.payload.issue.number;
             const action = context.payload.action;
             const body = comment.body || '';
+            // The ACTOR is the sender (who clicked/commented), not comment.user — on an
+            // `edited` checkbox toggle comment.user is the original author (our bot).
+            const actor = context.payload.sender.login;
 
             const noop = (reason) => { core.info(`No-op: ${reason}`); core.setOutput('proceed', 'false'); };
 
@@ -145,17 +152,23 @@ jobs:
 
             // Authorize the actor (the commenter / the clicker). Authoritative permission
             // API — NOT author_association. 404 (non-collaborator) is a deny.
-            const username = comment.user.login;
-            const allowed = await helper.isMaintainer({ github, owner, repo, username });
+            const allowed = await helper.isMaintainer({ github, owner, repo, username: actor });
             if (!allowed) {
               await github.rest.reactions.createForIssueComment({
                 owner, repo, comment_id: comment.id, content: '-1',
               });
               await github.rest.issues.createComment({
                 owner, repo, issue_number: issueNumber,
-                body: `@${username} — E2E runs are maintainer-only (repo write access required).`,
+                body: `@${actor} — E2E runs are maintainer-only (repo write access required).`,
               });
-              return noop(`${username} is not a maintainer`);
+              // A non-maintainer ticked the box: disarm it so the sticky doesn't look stuck.
+              if (action === 'edited') {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: comment.id,
+                  body: helper.resetReRunCheckbox(body),
+                });
+              }
+              return noop(`${actor} is not a maintainer`);
             }
 
             // Resolve PR HEAD (the comment payload has the PR number but not the head SHA).
@@ -267,6 +280,23 @@ jobs:
           # no later step needs the git credential, so don't persist it in .git/config
           # (defense in depth — keeps the token out of anything we upload).
           persist-credentials: false
+
+      # SECURITY: the workspace above is PR HEAD — on a fork PR it is untrusted code.
+      # The "Update PR sticky" step runs with the test-vps secrets + pull-requests:write,
+      # so it must NOT require() the sticky helper from that checkout (a fork could edit it
+      # to run arbitrary JS with secrets — CodeQL "Untrusted Checkout TOCTOU"). Pull the
+      # helper from the TRUSTED default branch into a separate path and require() that copy.
+      # (Building/testing the PR code itself is the intended, fork-pr-gated behaviour; this
+      # just avoids handing forks an extra code-execution vector through our own tooling.)
+      - name: Checkout trusted sticky helper
+        if: github.event_name == 'issue_comment'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/scripts/e2e-pr-sticky.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+          path: trusted-helper
 
       # The coordinator is a net10.0 app that runs HERE on the runner (the mod
       # builds inside Docker; the runner does not). .NET 10 is GA, so the default
@@ -562,7 +592,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const helper = require('./.github/scripts/e2e-pr-sticky.js');
+            // Trusted (default-branch) copy — NOT the PR-HEAD checkout (see "Checkout
+            // trusted sticky helper" above). require() resolves relative to the workspace.
+            const helper = require(`${process.env.GITHUB_WORKSPACE}/trusted-helper/.github/scripts/e2e-pr-sticky.js`);
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
             const sha = (process.env.HEAD_SHA || '').slice(0, 7);

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -137,19 +137,18 @@ jobs:
             const noop = (reason) => { core.info(`No-op: ${reason}`); core.setOutput('proceed', 'false'); };
 
             // Classify + parse (pure logic lives in the helper, where it's unit-tested).
+            // These are the cheap, side-effect-free structural filters that decide "is this
+            // even our command / our sticky" — they must run BEFORE authorization so an edit
+            // to an unrelated comment is ignored silently (no auth API call, no bot reply).
+            // Filter validity is recorded here but only ACTED ON after the maintainer check,
+            // so a non-maintainer's bad input never elicits a bot reaction (see below).
             let filter = '';
+            let filterValid = true;
             if (action === 'created') {
               const cmd = helper.parseCommand(body);
               if (!cmd.isCommand) return noop('comment is not an anchored /run-tests-e2e command');
-              // Reject a filter with characters that could break the hidden markers or the
-              // markdown table (or that xUnit wouldn't accept) rather than corrupt the sticky.
-              if (!cmd.valid) {
-                await github.rest.reactions.createForIssueComment({
-                  owner, repo, comment_id: comment.id, content: 'confused',
-                });
-                return noop('filter contains disallowed characters');
-              }
               filter = cmd.filter;
+              filterValid = cmd.valid;
             } else {
               // edited: react only to OUR sticky AND a confirmed unchecked->checked tick.
               if (!body.includes(helper.MARKER)) return noop('edited comment is not the e2e sticky');
@@ -161,7 +160,8 @@ jobs:
             }
 
             // Authorize the actor (the commenter / the clicker). Authoritative permission
-            // API — NOT author_association. 404 (non-collaborator) is a deny.
+            // API — NOT author_association. 404 (non-collaborator) is a deny. Runs before any
+            // bot reaction so a non-maintainer can't elicit one (beyond the deny reply below).
             const allowed = await helper.isMaintainer({ github, owner, repo, username: actor });
             if (!allowed) {
               await github.rest.reactions.createForIssueComment({
@@ -179,6 +179,16 @@ jobs:
                 });
               }
               return noop(`${actor} is not a maintainer`);
+            }
+
+            // Maintainer, but the filter has characters that could break the hidden markers
+            // or the markdown table (or that xUnit wouldn't accept). React 'confused' and
+            // bail rather than corrupt the sticky. Only reachable on the `created` path.
+            if (!filterValid) {
+              await github.rest.reactions.createForIssueComment({
+                owner, repo, comment_id: comment.id, content: 'confused',
+              });
+              return noop('filter contains disallowed characters');
             }
 
             // Resolve PR HEAD (the comment payload has the PR number but not the head SHA).

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -201,13 +201,17 @@ jobs:
             await github.rest.reactions.createForIssueComment({
               owner, repo, comment_id: comment.id, content: 'eyes',
             });
+            // Read the sticky LIVE (not from context.payload.comment) on BOTH paths: the
+            // singleton-queue means a prior run's "Update PR sticky" can append a history row
+            // between the checkbox tick and this queued gate's execution, so a payload snapshot
+            // would be stale and overwrite that row away. findSticky reads the settled comment.
             const existing = await helper.findSticky({ github, owner, repo, issue_number: issueNumber });
             const history = existing ? helper.readHistory(existing.body) : [];
             await helper.upsertSticky({
               github, owner, repo, issue_number: issueNumber, existing,
               body: helper.renderBody({
                 status: 'queued', statusEmoji: '🟡',
-                headline: `Queued for \`${pr.head.sha.slice(0, 7)}\`…`,
+                headline: `Queued for \`${helper.shortSha(pr.head.sha)}\`…`,
                 filter, history, requested: action === 'edited',
               }),
             });
@@ -621,7 +625,7 @@ jobs:
             const helper = require(`${process.env.GITHUB_WORKSPACE}/trusted-helper/.github/scripts/e2e-pr-sticky.js`);
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
-            const sha = (process.env.HEAD_SHA || '').slice(0, 7);
+            const sha = helper.shortSha(process.env.HEAD_SHA);
             const filter = process.env.FILTER || '';
             const reportUrl = process.env.REPORT_URL || '';
             const jobStatus = process.env.JOB_STATUS;

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -11,6 +11,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 | [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits, builds, and line endings |
 | [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
 | [CodeQL](#codeql-pipeline) | Pull requests / push to `master` / weekly | Static security analysis (advisory) |
+| [E2E Tests](#e2e-tests-pipeline) | Manual: `workflow_dispatch` or maintainer `/run-tests-e2e` PR comment | Runs the Docker E2E suite on a remote VPS (never a required check) |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
 | [Deploy Docs](#deploy-docs-pipeline) | After build / manual | Deploys documentation to GitHub Pages |
 | [Cleanup Preview Tags](#cleanup-preview-tags) | Weekly schedule / manual | Deletes old preview tags from DockerHub |
@@ -221,6 +222,45 @@ On push to `master` and on the weekly schedule there is no PR diff base, so the 
 ### Trigger & Fork Safety
 
 CodeQL triggers on `pull_request`, **not** `pull_request_target` (the opposite choice from [Validate PR](#validate-pr-pipeline)). It analyzes the PR head read-only with the default `GITHUB_TOKEN` and needs no secrets, so it is safe to run on fork PRs — fork code must be read to be scanned, but no secret is ever exposed to it. It is not run on `merge_group`: that event is only for required checks, and running an advisory scan there would be pure waste.
+
+## E2E Tests Pipeline
+
+[Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/e2e-tests.yml)
+
+Runs the heavy Docker E2E suite. The coordinator (`JunimoServer.TestRunner`) runs on the GitHub runner; the actual Stardew game containers run on a **remote VPS over SSH**. It is **manual and maintainer-gated** — never an automatic merge gate, and **never a required check** (an external VPS being down must not block the queue). For how to *use* it (triggers, results, the re-run checkbox), see [E2E Testing → CI Usage](../testing/e2e-testing.md#ci-usage); this section covers the pipeline's safety model and one-time setup.
+
+### Three entry points
+
+| Trigger | How |
+|---------|-----|
+| `workflow_dispatch` | Actions tab → **Run workflow** (full suite from a trusted branch; optional `filter`). |
+| `/run-tests-e2e [filter]` | A PR comment (the `issue_comment: created` event). Runs against the PR's HEAD. |
+| **Re-run checkbox** | Ticking "🔁 Re-run E2E tests" in the bot's results comment (`issue_comment: edited`). |
+
+### Trigger & Fork Safety
+
+The PR-comment path is privileged (it reaches the VPS SSH key = root on the test VPS via the docker group), so it is gated in layers:
+
+- **`issue_comment` always runs the workflow file from the default branch** (`master`), never the PR/fork copy — a fork cannot inject workflow code via a comment.
+- The **`gate` job** (no secrets) authorizes the **event actor** (`github.event.sender`, not the comment author — they differ on a checkbox edit) via the repo-permission API (`getCollaboratorPermissionLevel`; **write/admin required**, `author_association` is deliberately not used; a non-collaborator's `404` is a deny; a `403` fails closed). Non-maintainers get a 👎 + a "not authorized" reply and **no secret-bearing job runs**.
+- **Fork PRs** additionally pass through the **`fork-pr` GitHub Environment** approval (a required reviewer) on the `authorize` job before the secret-bearing `e2e` job runs. Same-repo PRs resolve no environment (no prompt). This mirrors [Validate PR](#validate-pr-pipeline)'s `authorize` gate.
+- The `e2e` job checks out the **PR HEAD at a pinned SHA** (resolved by the gate) to build and test the proposed code — this is the intended behaviour, gated by the fork-pr approval. The PR-sticky helper is loaded from a **separate trusted (default-branch) checkout**, never from the PR checkout, so fork code can't run with secrets through our own tooling.
+- **Single VPS runner:** a global `concurrency` singleton means runs **queue** (active + at most one pending); a newer trigger replaces the waiting one and never preempts the active run. To preempt, a maintainer cancels the in-flight run from the Actions tab — kept off the comment surface deliberately, since `cancel-in-progress` is evaluated *before* the gate authorizes, so a comment-driven cancel would let a non-maintainer grief the queue. The cancelled run reports "⚪ aborted".
+
+### One-time setup (required for the PR path to be safe)
+
+1. **`fork-pr` Environment** (Settings → Environments) — must exist with **at least one required reviewer**. This is the load-bearing control for fork PRs; without a reviewer the approval auto-passes and fork code would reach the secrets. (Shared with Validate PR.)
+2. **`test-vps` Environment** — holds the run secrets: `SDVD_DOCKER_HOSTS` (the host-fleet JSON with the inline SSH key) and `STEAM_ACCOUNTS`. The Cloudflare-R2 report publish uses `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ACCOUNT_ID` (secrets) plus `R2_BUCKET` / `R2_PUBLIC_BASE_URL` (**variables**, not secrets — they contain a hyphen that the secret masker would over-mask). See [E2E Testing → Hosted report](../testing/e2e-testing.md#hosted-report-cloudflare-r2).
+
+### Helper script & tests
+
+The PR sticky-comment logic lives in [`.github/scripts/e2e-pr-sticky.js`](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/scripts/e2e-pr-sticky.js) (pure functions + thin GitHub-API wrappers). Its unit tests (`e2e-pr-sticky.test.js`) use Node's built-in runner — run them with `npm test`. These cover the command parsing, the re-run checkbox state machine, the marker round-tripping, the run-history cap, the filter validation, and the maintainer-auth fail-closed behaviour.
+
+To lint the workflow YAML itself, run [actionlint](https://github.com/rhysd/actionlint) via its Docker image (no local install needed):
+
+```bash
+docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/e2e-tests.yml
+```
 
 ## Deploy Docs Pipeline
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -11,7 +11,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 | [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits, builds, and line endings |
 | [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
 | [CodeQL](#codeql-pipeline) | Pull requests / push to `master` / weekly | Static security analysis (advisory) |
-| [E2E Tests](#e2e-tests-pipeline) | Manual: `workflow_dispatch` or maintainer `/run-tests-e2e` PR comment | Runs the Docker E2E suite on a remote VPS (never a required check) |
+| [E2E Tests](#e2e-tests-pipeline) | Manual: `workflow_dispatch`, or a maintainer's `/run-tests-e2e` PR comment / re-run checkbox | Runs the Docker E2E suite on a remote VPS (never a required check) |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
 | [Deploy Docs](#deploy-docs-pipeline) | After build / manual | Deploys documentation to GitHub Pages |
 | [Cleanup Preview Tags](#cleanup-preview-tags) | Weekly schedule / manual | Deletes old preview tags from DockerHub |

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -171,26 +171,49 @@ TestResults/runs/{timestamp}_{sha}/tests/{Class}.{Method}/
 
 ## CI Usage
 
-The E2E suite runs from `.github/workflows/e2e-tests.yml` (`workflow_dispatch`
-only — the coordinator runs on the GitHub runner; the game containers run on a
-remote VPS over SSH). A bare dispatch runs the full suite; the optional `filter`
-input narrows it to a class/method. That workflow is the source of truth for CI
-invocation.
+The E2E suite runs from `.github/workflows/e2e-tests.yml` (the coordinator runs on
+the GitHub runner; the game containers run on a remote VPS over SSH). That workflow
+is the source of truth for CI invocation. There are three ways to launch it, all
+manual and **maintainer-gated** — it is never an automatic merge gate (an external
+VPS being down must not block the queue):
 
-Results surface in three places, all produced from artifacts the runner emits:
+- **Actions tab → "Run workflow"** (`workflow_dispatch`) — runs the full suite from a
+  trusted branch; the optional `filter` input narrows it to a class/method.
+- **`/run-tests-e2e [filter] [--abort-current]` PR comment** — runs against the PR's
+  HEAD commit and posts results back to the PR (see below). `filter` is an xUnit
+  class/method substring; omit it for the full suite.
+- **The "🔁 Re-run E2E tests" checkbox** in the bot's results comment — ticking it
+  re-runs with the same filter (a click-in-the-PR control; it fires `issue_comment:
+  edited`). The box auto-resets and shows "(requested)" until fresh results arrive.
 
+**Authorization.** Only repo maintainers (write/admin permission — checked via the
+repo-permission API, not `author_association`) can trigger a run from a PR; anyone
+else gets a 👎 and a "not authorized" reply, and no test job runs. **Fork PRs**
+additionally pause at a `fork-pr` Environment approval before the secret-bearing job
+runs (a maintainer clicks "approve"); same-repo PRs run without a prompt.
+
+**Single runner / queueing.** There is one physical VPS runner, so all runs share a
+global concurrency singleton: a new trigger **queues** behind an active run (it does
+not abort it). To deliberately preempt the in-flight run, add `--abort-current` to
+the comment. The aborted run still writes its summary and reports "⚪ aborted".
+
+Results surface in several places, all produced from artifacts the runner emits:
+
+- **PR sticky comment** (comment/checkbox path only) — a single bot comment, updated
+  in place each run, with the pass/fail headline, the hosted report link, the re-run
+  checkbox, and a collapsed **"Run history"** table that is appended to every run
+  (older rows kept) so the PR retains a full per-run trail for debugging.
 - **Job Summary tab** — the [CTRF reporter action](https://github.com/ctrf-io/github-test-reporter)
-  renders `runs/{id}/ctrf-report.json` into a pass/fail + failed-tests table. No
-  PR comment (the workflow is dispatch-only and has no PR context).
+  renders `runs/{id}/ctrf-report.json` into a pass/fail + failed-tests table.
 - **`e2e-web-report` artifact** — a self-contained offline bundle of the test-UI
   SPA with the run snapshot inlined and screenshots/videos copied alongside.
   Download it and open `report/index.html` over `file://`; screenshots and videos
   play without a running server.
 - **Hosted report URL (optional)** — when Cloudflare R2 is configured (see below),
-  the bundle is published to `…/e2e/{branch}/{run-id}/index.html` and linked from
-  the Job Summary, so the interactive report (with playing videos) can be opened
-  directly and shared. Per-branch history is kept; an R2 lifecycle rule expires
-  reports after 30 days.
+  the bundle is published to `…/e2e/{branch}/{run-id}/index.html` and linked from the
+  Job Summary and the PR sticky, so the interactive report (with playing videos) can
+  be opened directly and shared. Per-branch history is kept; an R2 lifecycle rule
+  expires reports after 30 days.
 
 Under `CI` (or with the `--report` flag locally), the runner assembles that
 bundle into `TestResults/runs/{id}/report/` after the run — it requires the

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -179,7 +179,7 @@ VPS being down must not block the queue):
 
 - **Actions tab → "Run workflow"** (`workflow_dispatch`) — runs the full suite from a
   trusted branch; the optional `filter` input narrows it to a class/method.
-- **`/run-tests-e2e [filter] [--abort-current]` PR comment** — runs against the PR's
+- **`/run-tests-e2e [filter]` PR comment** — runs against the PR's
   HEAD commit and posts results back to the PR (see below). `filter` is an xUnit
   class/method substring; omit it for the full suite.
 - **The "🔁 Re-run E2E tests" checkbox** in the bot's results comment — ticking it
@@ -194,8 +194,8 @@ runs (a maintainer clicks "approve"); same-repo PRs run without a prompt.
 
 **Single runner / queueing.** There is one physical VPS runner, so all runs share a
 global concurrency singleton: a new trigger **queues** behind an active run (it does
-not abort it). To deliberately preempt the in-flight run, add `--abort-current` to
-the comment. The aborted run still writes its summary and reports "⚪ aborted".
+not abort it). To deliberately preempt the in-flight run, a maintainer cancels it from
+the **Actions tab**; the cancelled run still writes its summary and reports "⚪ aborted".
 
 Results surface in several places, all produced from artifacts the runner emits:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Stardew Valley Dedicated Server",
   "private": true,
   "scripts": {
-    "postinstall": "lefthook install"
+    "postinstall": "lefthook install",
+    "test": "node --test \".github/scripts/**/*.test.js\""
   },
   "devDependencies": {
     "@commitlint/cli": "^21.0.0",


### PR DESCRIPTION
## What

Adds maintainer-gated, PR-scoped ways to launch the E2E suite and reports results back into the PR, without weakening the existing secret model. The workflow stays manual and **never becomes a required check**.

Three ways in (all maintainer-gated):
- **Actions tab → Run workflow** (`workflow_dispatch`) — unchanged.
- **`/run-tests-e2e [filter] [--abort-current]` PR comment** — runs against the PR's HEAD.
- **"🔁 Re-run E2E tests" checkbox** in the bot's results comment — a click-in-the-PR re-run (fires `issue_comment: edited`).

## How

- **`on:`** add `issue_comment: [created, edited]` alongside `workflow_dispatch`.
- **`gate` job (no secrets):** authorizes the commenter via the repo-permission API (write/admin required; 404 = deny; `author_association` deliberately not used); anchored command parse / checkbox-transition detection; resolves the PR HEAD; acks with a 👀 reaction + a "queued" sticky.
- **`authorize` job:** fork PRs pass through the `fork-pr` Environment approval before the secret-bearing `e2e` job runs; same-repo/dispatch resolve no environment (no prompt).
- **`e2e` job:** `needs: [gate, authorize]`; checks out the PR HEAD on the comment path; filter comes from the gate; gains `pull-requests: write`.
- **Concurrency:** one global singleton for the single VPS runner — runs **queue** (active + 1 waiting); only `--abort-current` preempts an in-flight run.
- **Update PR sticky step:** one comment per PR with status + report link + the re-run checkbox (auto-resets, shows "(requested)") + an appended **Run history** table retained for debugging; fires on pass/fail/cancel.
- Exports the R2 report URL so the sticky can link it; keys R2 objects on the PR head ref (not the default branch) on the comment path.
- New `.github/scripts/e2e-pr-sticky.js` — shared sticky/auth helpers.
- Docs: rewrites `e2e-testing.md` CI Usage for the new triggers, queueing, and fork approval.

## Why it's safe

- `issue_comment` always runs **this** workflow file from the default branch — a fork can't inject workflow code via a comment.
- Non-maintainers are refused before any secret-bearing job runs.
- Fork PRs are double-gated (permission check + `fork-pr` approval) before secrets are exposed.

## Verification

- `actionlint` (official Docker image): **clean, 0 findings** on `e2e-tests.yml`.
- `.github/scripts/e2e-pr-sticky.js`: `node --check` + 12 unit assertions (marker roundtrip, checkbox transition, history append/parse, corrupt-history fallback) all pass.

Three runtime behaviors can only be confirmed on a live run (all fail-safe; flagged for first-PR verification):
1. Fork-PR `issue_comment` retains secrets + write token (worst case: sticky can't post on forks; never a secret leak — `fork-pr` gate covers it).
2. `changes.body.from` populated on checkbox edits (optional-chained; absent → tick still triggers).
3. `getCollaboratorPermissionLevel` token scope (fails **closed** — red gate, no run — if too narrow).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Maintainer-gated, multi-trigger E2E runs (workflow dispatch, PR comment command, bot “🔁 Re-run” checkbox), fork-PR approval flow, singleton queueing, maintainer preemption, per-branch hosted report URL, and a persistent PR sticky comment showing status, filter, checkbox state, and run history.

* **Documentation**
  * CI/CD and E2E docs updated to cover triggers, authorization, fork handling, queueing, results surfaces, and hosted report usage.

* **Tests**
  * New test suite covering sticky-comment behavior, parsing, history capping, re-run checkbox logic, result derivation, and authorization.

* **Chores**
  * Added project test script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->