### PR TITLE
fix(ci): R2 publish guard checked wrong env-var names, always skipped

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -538,6 +538,10 @@ jobs:
         if: always()
         continue-on-error: true
         env:
+          # The credential pair MUST use the AWS_* names: the aws CLI (R2 speaks the S3
+          # API) auto-discovers credentials only from AWS_ACCESS_KEY_ID / _SECRET_ACCESS_KEY.
+          # The rest stay R2_* — they're read by the script by hand. The guard below checks
+          # these env names (AWS_* for creds), not the secret names that feed them.
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
@@ -553,8 +557,9 @@ jobs:
           set +e
 
           # Unconfigured is the EXPECTED opt-out, not an error. Clean skip, green run.
-          if [ -z "${R2_BUCKET:-}" ] || [ -z "${R2_ACCESS_KEY_ID:-}" ] \
-             || [ -z "${R2_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ] \
+          # Check the env-var names defined in `env:` above (AWS_* for the credentials).
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
+             || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ] \
              || [ -z "${R2_PUBLIC_BASE_URL:-}" ]; then
             echo "R2 publish not configured — skipping. The report is still available as the 'e2e-web-report' artifact."
             exit 0


### PR DESCRIPTION
## Problem

The E2E "Publish web report to R2" step has been silently skipping on **every** run since R2 publishing was added in #352 — printing `R2 publish not configured — skipping` regardless of whether the R2 secrets/vars were set.

## Root cause

The "is R2 configured?" guard tested env vars `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY`, but the credentials are exported under their **AWS_*** names (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) so the `aws` CLI auto-discovers them — R2 speaks the S3 API. The `R2_*` credential names were never defined as env vars in the step, so those `-z` tests were always true and the guard tripped unconditionally.

The three config vars (`R2_BUCKET`, `R2_ACCOUNT_ID`, `R2_PUBLIC_BASE_URL`) were named correctly all along; only the two credential checks were wrong.

## Fix

- Point the guard at `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` — the names actually defined in the step's `env:` block.
- Comment the `AWS_*`-vs-`R2_*` split at the env block so the guard and the env block can't silently drift apart again.

Credential flow through the declarative `env:` block (and thus GitHub's secret masking) is unchanged — no secret is moved into shell expansion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD environment variable configuration for report publishing workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->