### PR TITLE
fix: release abandoned New Farmer slot claims (#361)

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -189,11 +189,12 @@ namespace JunimoServer.Services.Api
         public string OwnerName { get; set; } = "";
         public bool OwnerIsCustomized { get; set; }
 
-        /// <summary>Owner's platform ID (Steam/GOG); empty when unclaimed. A non-empty value with
+        /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
         /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, which
         /// yields the live otherFarmers copy while the owner is connected (so the in-flight userID
-        /// stamp is visible here before disconnect persists it to farmhandData).</summary>
-        public string OwnerUserId { get; set; } = "";
+        /// stamp is visible here before disconnect persists it to farmhandData). Exposed as a bool,
+        /// not the raw ID: /diagnostics/state is unauthenticated and the ID is a stable identifier.</summary>
+        public bool OwnerHasUserId { get; set; }
 
         public string HomeLocationOfOwner { get; set; } = "";
         public bool FarmhandReferenceDefined { get; set; }
@@ -208,9 +209,10 @@ namespace JunimoServer.Services.Api
         public string HomeLocation { get; set; } = "";
         public string LastSleepLocation { get; set; } = "";
 
-        /// <summary>Platform ID (Steam/GOG) stamped on slot claim; empty when unclaimed.
-        /// A non-empty value with IsCustomized=false is the abandoned-claim state.</summary>
-        public string UserId { get; set; } = "";
+        /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
+        /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID:
+        /// /diagnostics/state is unauthenticated and the ID is a stable identifier.</summary>
+        public bool HasUserId { get; set; }
     }
 
     public class ReadyCheckState
@@ -2572,7 +2574,7 @@ namespace JunimoServer.Services.Api
                         OwnerId = owner?.UniqueMultiplayerID ?? 0,
                         OwnerName = owner?.Name ?? "",
                         OwnerIsCustomized = owner?.isCustomized?.Value ?? false,
-                        OwnerUserId = owner?.userID?.Value ?? "",
+                        OwnerHasUserId = !string.IsNullOrEmpty(owner?.userID?.Value),
                         HomeLocationOfOwner = owner?.homeLocation?.Value ?? "",
                         FarmhandReferenceDefined = cabin?.farmhandReference?.defined?.Value ?? false,
                         FarmhandReferenceUid = cabin?.farmhandReference?.uid?.Value ?? 0
@@ -2602,7 +2604,7 @@ namespace JunimoServer.Services.Api
                         IsCustomized = f.isCustomized?.Value ?? false,
                         HomeLocation = f.homeLocation?.Value ?? "",
                         LastSleepLocation = f.lastSleepLocation?.Value ?? "",
-                        UserId = f.userID?.Value ?? ""
+                        HasUserId = !string.IsNullOrEmpty(f.userID?.Value)
                     });
                 }
                 catch { /* per-entry failure tolerated */ }

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -188,6 +188,13 @@ namespace JunimoServer.Services.Api
         public long OwnerId { get; set; }
         public string OwnerName { get; set; } = "";
         public bool OwnerIsCustomized { get; set; }
+
+        /// <summary>Owner's platform ID (Steam/GOG); empty when unclaimed. A non-empty value with
+        /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, which
+        /// yields the live otherFarmers copy while the owner is connected (so the in-flight userID
+        /// stamp is visible here before disconnect persists it to farmhandData).</summary>
+        public string OwnerUserId { get; set; } = "";
+
         public string HomeLocationOfOwner { get; set; } = "";
         public bool FarmhandReferenceDefined { get; set; }
         public long FarmhandReferenceUid { get; set; }
@@ -200,6 +207,10 @@ namespace JunimoServer.Services.Api
         public bool IsCustomized { get; set; }
         public string HomeLocation { get; set; } = "";
         public string LastSleepLocation { get; set; } = "";
+
+        /// <summary>Platform ID (Steam/GOG) stamped on slot claim; empty when unclaimed.
+        /// A non-empty value with IsCustomized=false is the abandoned-claim state.</summary>
+        public string UserId { get; set; } = "";
     }
 
     public class ReadyCheckState
@@ -499,6 +510,29 @@ namespace JunimoServer.Services.Api
 
         /// <summary>The host farmer's HouseUpgradeLevel after the debug command ran (expected 0).</summary>
         public int HostHouseUpgradeLevel { get; set; }
+    }
+
+    /// <summary>
+    /// Response from POST /test/stamp_claim (test-only). Constructs an abandoned-claim slot
+    /// deterministically: stamps a synthetic userID onto an uncustomized, homed farmhandData entry,
+    /// reproducing the on-disk shape (<c>userID != "" &amp;&amp; isCustomized == false</c>, homeLocation
+    /// resolving to a Cabin) that a player leaves when they claim "New Farmer" and quit before
+    /// customizing. Used to verify the save-load sweep (ClearAbandonedCabinClaimsOnLoad) clears such a
+    /// claim on reload — the live disconnect heal cannot persist one to disk for a sweep test.
+    /// </summary>
+    public class TestStampClaimResponse
+    {
+        public bool Success { get; set; }
+        public string? Error { get; set; }
+
+        /// <summary>UniqueMultiplayerID of the farmhand slot that was stamped.</summary>
+        public long StampedUid { get; set; }
+
+        /// <summary>The synthetic userID written onto the slot.</summary>
+        public string StampedUserId { get; set; } = "";
+
+        /// <summary>The slot's homeLocation after stamping (must resolve to a Cabin for the homed-path test).</summary>
+        public string HomeLocation { get; set; } = "";
     }
 
     /// <summary>
@@ -1934,6 +1968,9 @@ namespace JunimoServer.Services.Api
                         case "/test/house_upgrade":
                             await WriteJsonAsync(response, await HandlePostTestHouseUpgradeAsync(request));
                             break;
+                        case "/test/stamp_claim":
+                            await WriteJsonAsync(response, await HandlePostTestStampClaimAsync());
+                            break;
                         default:
                             response.StatusCode = 404;
                             await WriteJsonAsync(response, new { error = "Not found" });
@@ -2535,6 +2572,7 @@ namespace JunimoServer.Services.Api
                         OwnerId = owner?.UniqueMultiplayerID ?? 0,
                         OwnerName = owner?.Name ?? "",
                         OwnerIsCustomized = owner?.isCustomized?.Value ?? false,
+                        OwnerUserId = owner?.userID?.Value ?? "",
                         HomeLocationOfOwner = owner?.homeLocation?.Value ?? "",
                         FarmhandReferenceDefined = cabin?.farmhandReference?.defined?.Value ?? false,
                         FarmhandReferenceUid = cabin?.farmhandReference?.uid?.Value ?? 0
@@ -2563,7 +2601,8 @@ namespace JunimoServer.Services.Api
                         Name = f.Name ?? "",
                         IsCustomized = f.isCustomized?.Value ?? false,
                         HomeLocation = f.homeLocation?.Value ?? "",
-                        LastSleepLocation = f.lastSleepLocation?.Value ?? ""
+                        LastSleepLocation = f.lastSleepLocation?.Value ?? "",
+                        UserId = f.userID?.Value ?? ""
                     });
                 }
                 catch { /* per-entry failure tolerated */ }
@@ -3710,6 +3749,67 @@ namespace JunimoServer.Services.Api
             {
                 // Don't log at Error level — that trips ServerContainer's error cancellation and
                 // poisons the test (.claude/rules/debugging.md). Surface via the response instead.
+                result.Success = false;
+                result.Error = ex.Message;
+            }
+
+            return result;
+        }
+
+        [ApiEndpoint("POST", "/test/stamp_claim", Summary = "Stamp a synthetic abandoned slot claim onto an uncustomized homed farmhand (test-only)", Tag = "Test")]
+        [ApiResponse(typeof(TestStampClaimResponse), 200)]
+        private async Task<TestStampClaimResponse> HandlePostTestStampClaimAsync()
+        {
+            // Synthetic platform id mimicking a Steam/GOG stamp. Fixed so a test could match it,
+            // but the test only needs StampedUid; the value just has to be non-empty.
+            const string syntheticUserId = "test-stuck-claim-9999";
+
+            var result = new TestStampClaimResponse();
+            try
+            {
+                await RunOnGameThreadAsync(() =>
+                {
+                    var farm = Game1.getFarm();
+                    if (farm == null)
+                    {
+                        result.Error = "No farm loaded";
+                        return;
+                    }
+
+                    // Find an unclaimed slot with an existing farmhand entry whose home resolves to its
+                    // cabin: owner present, not customized, no userID yet (exactly IsCabinAvailable's
+                    // "available" shape). Stamping its userID reproduces the homed abandoned-claim state
+                    // — the case vanilla's load-time ResetFarmhandState does NOT clear (NetWorldState.cs
+                    // :783 returns true for a homed farmhand, skipping the userID-clearing else-branch),
+                    // so only the sweep heals it on reload.
+                    foreach (var building in farm.buildings)
+                    {
+                        if (!building.isCabin || LobbyService.IsLobbyCabin(building)) continue;
+
+                        var cabin = building.GetIndoors<Cabin>();
+                        var owner = cabin?.owner;
+                        if (owner == null) continue;
+                        if (owner.isCustomized.Value) continue;
+                        if (!string.IsNullOrEmpty(owner.userID.Value)) continue;
+
+                        // Pin homeLocation to this cabin so TryAssignFarmhandHome resolves on reload
+                        // (the slot's home should already be its cabin; set it to be deterministic).
+                        owner.homeLocation.Value = cabin.NameOrUniqueName;
+                        owner.userID.Value = syntheticUserId;
+
+                        result.StampedUid = owner.UniqueMultiplayerID;
+                        result.StampedUserId = syntheticUserId;
+                        result.HomeLocation = owner.homeLocation.Value ?? "";
+                        result.Success = true;
+                        return;
+                    }
+
+                    result.Error = "No uncustomized, unclaimed cabin slot with an owner entry found to stamp";
+                });
+            }
+            catch (Exception ex)
+            {
+                // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
                 result.Success = false;
                 result.Error = ex.Message;
             }

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -100,6 +100,17 @@ namespace JunimoServer.Services.CabinManager
                 postfix: new HarmonyMethod(typeof(CabinManagerService), nameof(OnServerJoined_Postfix))
             );
 
+            // Always hook player disconnect to release abandoned slot claims, on ALL transports.
+            // GameServer.playerDisconnected is the single choke point every transport routes through
+            // (Steam SDR, GOG/Galaxy, LAN). This patch is registered here — unconditionally — rather
+            // than in PasswordProtectionService, whose patches are skipped entirely on passwordless
+            // servers (its constructor returns early when !IsEnabled), which would leave the heal
+            // dead for the common no-password case.
+            harmony.Patch(
+                original: AccessTools.Method(typeof(GameServer), nameof(GameServer.playerDisconnected)),
+                postfix: new HarmonyMethod(typeof(CabinManagerService), nameof(OnPlayerDisconnected_Postfix))
+            );
+
             // Defensive: make Utility.getHomeOfFarmer null-safe.
             // The vanilla implementation calls RequireLocation which throws KeyNotFoundException
             // if the cabin interior isn't findable yet (e.g. during new game setup, day transitions,
@@ -129,6 +140,16 @@ namespace JunimoServer.Services.CabinManager
             // it's null after deserialize; only homeLocation / lastSleepLocation can
             // carry stale refs across the save boundary.
             ClearStaleFarmhandReferences();
+
+            // Release abandoned slot claims that survived into the save. The disconnect-path heal
+            // (OnPlayerDisconnected_Postfix) covers every clean disconnect, but a stuck claim whose
+            // home cabin still exists is NOT cleared by vanilla's load-time ResetFarmhandState —
+            // it clears userID only when TryAssignFarmhandHome fails (no valid cabin), and a homed
+            // farmhand takes the early-return branch (NetWorldState.cs:783) leaving userID intact.
+            // So a claim stamped right before a host crash (or carried by a pre-fix corrupted save)
+            // would reload still-locked. This sweep closes that gap. It runs after
+            // ClearStaleFarmhandReferences, which has already purged cabin-less orphans.
+            ClearAbandonedCabinClaimsOnLoad();
 
             EnsureAtLeastXCabins();
         }
@@ -210,6 +231,15 @@ namespace JunimoServer.Services.CabinManager
         private static void OnServerJoined_Postfix(long peer)
         {
             _instance?.OnServerJoined(peer);
+        }
+
+        // Postfix on GameServer.playerDisconnected — runs while the disconnecting farmhand is still
+        // in otherFarmers (removeDisconnectedFarmers is deferred to later in the same update), and
+        // after vanilla saveFarmhand has cloned its state into farmhandData. Releases any abandoned
+        // slot claim on the persisted entry. CleanupAbandonedCabinClaim null-guards _instance.
+        private static void OnPlayerDisconnected_Postfix(long disconnectee)
+        {
+            CleanupAbandonedCabinClaim(disconnectee);
         }
 
         private void OnServerJoined(long peer)
@@ -590,45 +620,100 @@ namespace JunimoServer.Services.CabinManager
         }
 
         /// <summary>
-        /// Cleans up an abandoned cabin claim when a player disconnects before completing character customization.
-        /// If a cabin has userID set (player claimed it) but isCustomized is false (didn't finish customization),
-        /// clear the userID to release the slot for other players.
+        /// Releases an abandoned slot claim on a single farmhand entry. A claim is "abandoned" when
+        /// the farmhand has a userID set (a player clicked the slot, which stamps their platform ID
+        /// via vanilla Client.sendPlayerIntroduction) but isCustomized is false (they quit before
+        /// finishing character creation). Vanilla FarmhandMenu then greys the slot out for every
+        /// other player, locking it to the ghost. Clearing userID re-opens the slot.
+        ///
+        /// Caller-agnostic: both the disconnect heal (CleanupAbandonedCabinClaim) and the save-load
+        /// sweep (ClearAbandonedCabinClaimsOnLoad) pass the persisted farmhandData entry. The only
+        /// mutation is the userID NetString value write; the rest of the farmhand stays in its
+        /// default uncustomized state. Returns true if a claim was cleared.
         /// </summary>
-        /// <param name="odId">The platform ID (Steam/GOG) of the disconnecting player as a string</param>
-        public static void CleanupAbandonedCabinClaim(string odId)
+        private bool TryClearAbandonedClaim(Farmer farmhand)
         {
-            if (string.IsNullOrEmpty(odId) || _instance == null)
-                return;
+            if (farmhand == null)
+                return false;
 
-            var farm = Game1.getFarm();
-            if (farm == null)
-                return;
+            if (string.IsNullOrEmpty(farmhand.userID.Value))
+                return false; // no claim
 
-            foreach (var building in farm.buildings)
+            if (farmhand.isCustomized.Value)
+                return false; // real player — must not touch
+
+            Monitor.Log(
+                $"Releasing abandoned cabin claim (userID='{farmhand.userID.Value}', slot was claimed but not customized)",
+                LogLevel.Info);
+            Diagnostics.ModEventLog.Emit("cabin_claim_abandoned", new
             {
-                if (!building.isCabin)
-                    continue;
+                clearedUserId = farmhand.userID.Value,
+                ownerUniqueMultiplayerId = farmhand.UniqueMultiplayerID
+            });
+            farmhand.userID.Value = "";
+            return true;
+        }
 
-                var cabin = building.GetIndoors<Cabin>();
-                var owner = cabin?.owner;
-                if (owner == null)
-                    continue;
+        /// <summary>
+        /// Releases an abandoned slot claim for a disconnecting player. Called from this service's
+        /// own always-on GameServer.playerDisconnected postfix (OnPlayerDisconnected_Postfix), so it
+        /// covers Steam SDR, GOG/Galaxy, and LAN alike — including passwordless servers.
+        ///
+        /// Clears the persisted farmhandData entry — at postfix time the disconnecting farmhand is
+        /// still in otherFarmers (removal is deferred to removeDisconnectedFarmers later in the same
+        /// update), so Cabin.owner resolves to the live copy that's about to be discarded; vanilla's
+        /// saveFarmhand already cloned the stuck userID into the persisted entry. We also clear the
+        /// live copy so any read before removal (e.g. /diagnostics/state) reflects the heal.
+        /// </summary>
+        /// <param name="disconnecteeId">UniqueMultiplayerID of the disconnecting player.</param>
+        public static void CleanupAbandonedCabinClaim(long disconnecteeId)
+        {
+            if (_instance == null)
+                return;
 
-                // Check if this cabin was claimed by the disconnecting player but not customized
-                if (owner.userID.Value == odId && !owner.isCustomized.Value)
+            // TryGetValue, not the indexer: NetLongDictionary's indexer throws KeyNotFoundException
+            // on a missing key (see NetworkTweaker's checkFarmhandRequest safe-lookup patch).
+            if (!Game1.netWorldState.Value.farmhandData.TryGetValue(disconnecteeId, out var farmhand))
+                return;
+
+            if (_instance.TryClearAbandonedClaim(farmhand)
+                && Game1.otherFarmers.TryGetValue(disconnecteeId, out var liveFarmhand))
+            {
+                liveFarmhand.userID.Value = "";
+            }
+        }
+
+        /// <summary>
+        /// Sweeps the persisted farmhandData on save load and releases any abandoned slot claim that
+        /// survived into the save. Covers the gap vanilla's load-time ResetFarmhandState leaves: it
+        /// clears userID only for farmhands whose home cabin is missing (the else-branch when
+        /// TryAssignFarmhandHome fails), so a stuck-but-homed claim — the normal shape, since the
+        /// slot's cabin still exists — reloads with userID intact. The live disconnect heal can be
+        /// skipped only by an unclean exit (host crash before the next disconnect, or a save written
+        /// by a build predating that heal); this sweep catches those on the next load.
+        ///
+        /// Reuses TryClearAbandonedClaim, so the guard (userID set + not customized) and the
+        /// cabin_claim_abandoned emit are identical to the disconnect path. No live otherFarmers
+        /// clear is needed here: no farmhand is connected during save load, so Cabin.owner resolves
+        /// to the persisted entry this mutates. FieldDict iteration is a read-only enumeration
+        /// (mutation goes through the userID NetString setter), allowed by netdictionary-public-surface.
+        /// </summary>
+        private void ClearAbandonedCabinClaimsOnLoad()
+        {
+            var farmhandData = Game1.netWorldState.Value.farmhandData;
+            int cleared = 0;
+            foreach (var kvp in farmhandData.FieldDict)
+            {
+                if (TryClearAbandonedClaim(kvp.Value.Value))
+                    cleared++;
+            }
+
+            if (cleared > 0)
+            {
+                Diagnostics.ModEventLog.Emit("cabin_claims_swept_on_load", new
                 {
-                    _instance.Monitor.Log($"Cleaning up abandoned cabin claim for user '{odId}' (slot was claimed but not customized)", LogLevel.Info);
-                    Diagnostics.ModEventLog.Emit("cabin_claim_abandoned", new
-                    {
-                        odId,
-                        tileX = building.tileX.Value,
-                        tileY = building.tileY.Value,
-                        ownerUniqueMultiplayerId = owner.UniqueMultiplayerID
-                    });
-                    owner.userID.Value = "";
-                    // No need to clear other fields - they should already be in default state
-                    return; // A player can only claim one cabin at a time
-                }
+                    cleared
+                });
             }
         }
 

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -643,7 +643,7 @@ namespace JunimoServer.Services.CabinManager
                 return false; // real player — must not touch
 
             Monitor.Log(
-                $"Releasing abandoned cabin claim (userID='{farmhand.userID.Value}', slot was claimed but not customized)",
+                $"Releasing abandoned cabin claim (userID='{ChatRedaction.MaskValue(farmhand.userID.Value)}', slot was claimed but not customized)",
                 LogLevel.Info);
             Diagnostics.ModEventLog.Emit("cabin_claim_abandoned", new
             {

--- a/mod/JunimoServer/Services/SteamGameServer/SteamGameServerNetServer.cs
+++ b/mod/JunimoServer/Services/SteamGameServer/SteamGameServerNetServer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
-using JunimoServer.Services.CabinManager;
 using StardewModdingAPI;
 using StardewValley;
 using StardewValley.Network;
@@ -438,9 +437,6 @@ namespace JunimoServer.Services.SteamGameServer
                 return;
 
             _monitor.Log($"{steamId.m_SteamID} disconnected", LogLevel.Debug);
-
-            // Clean up any abandoned cabin claim if player disconnected before completing character customization
-            CabinManagerService.CleanupAbandonedCabinClaim(steamId.m_SteamID.ToString());
 
             if (!_connectionDataMap.TryGetValue(callback.m_hConn, out var value))
             {

--- a/tests/JunimoServer.Tests/AbandonedClaimTests.cs
+++ b/tests/JunimoServer.Tests/AbandonedClaimTests.cs
@@ -18,11 +18,12 @@ namespace JunimoServer.Tests;
 /// always-on GameServer.playerDisconnected postfix), which fires on every transport and
 /// regardless of password protection.
 ///
-/// Assertions are server-authoritative via /diagnostics/state Cabins, whose OwnerUserId is
+/// Assertions are server-authoritative via /diagnostics/state Cabins, whose OwnerHasUserId is
 /// resolved through cabin.owner — the live otherFarmers copy while connected (where the
 /// in-flight userID stamp lives), then the persisted farmhandData copy after the player is
-/// removed. The grey-out itself is client-side render and /cabins AvailableCount can't
-/// distinguish a stuck slot, so the userID field is the deterministic signal.
+/// removed. (The endpoint exposes a bool, not the raw ID, since it is unauthenticated.) The
+/// grey-out itself is client-side render and /cabins AvailableCount can't distinguish a stuck
+/// slot, so the userID-present flag is the deterministic signal.
 ///
 /// Transport: this requires Steam (WithSteam=true) — vanilla only stamps userID when
 /// getUserID() != "", and LidgrenClient (LAN) returns "", so LAN is immune to the bug and
@@ -70,7 +71,7 @@ public class AbandonedClaimTests : TestBase
         // Confirm the stuck state on the server and capture the slot's owner uid. We read via
         // /diagnostics/state Cabins (cabin.owner), which resolves to the LIVE otherFarmers copy
         // while the client is connected — that's where the in-flight userID stamp lives before
-        // disconnect persists it to farmhandData (FarmhandData[].UserId would still be empty here).
+        // disconnect persists it to farmhandData (FarmhandData[].HasUserId would still be false here).
         long stuckUid = 0;
         var reproduced = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_AbandonedClaim_StuckStateReproduced,
@@ -78,7 +79,7 @@ public class AbandonedClaimTests : TestBase
             {
                 var state = await ServerApi.GetDiagnosticsState(ct);
                 var stuck = state?.Cabins.FirstOrDefault(
-                    c => !string.IsNullOrEmpty(c.OwnerUserId) && !c.OwnerIsCustomized);
+                    c => c.OwnerHasUserId && !c.OwnerIsCustomized);
                 if (stuck == null) return false;
                 stuckUid = stuck.OwnerId;
                 return true;
@@ -101,11 +102,12 @@ public class AbandonedClaimTests : TestBase
             async () =>
             {
                 var state = await ServerApi.GetDiagnosticsState(ct);
-                var cabin = state?.Cabins.FirstOrDefault(c => c.OwnerId == stuckUid);
-                var entry = state?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
+                if (state == null) return false; // transient null must not read as "healed"
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == stuckUid);
+                var entry = state.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
                 // Healed when no surviving view of the slot still carries the userID claim.
-                var cabinClear = cabin == null || string.IsNullOrEmpty(cabin.OwnerUserId);
-                var farmhandClear = entry == null || string.IsNullOrEmpty(entry.UserId);
+                var cabinClear = cabin == null || !cabin.OwnerHasUserId;
+                var farmhandClear = entry == null || !entry.HasUserId;
                 return cabinClear && farmhandClear;
             }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
         Assert.True(healed,
@@ -164,7 +166,7 @@ public class AbandonedClaimTests : TestBase
         var preState = await ServerApi.GetDiagnosticsState(ct);
         var preEntry = preState?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
         Assert.NotNull(preEntry);
-        Assert.False(string.IsNullOrEmpty(preEntry!.UserId), "Stamped slot should carry a userId before save");
+        Assert.True(preEntry!.HasUserId, "Stamped slot should carry a userId before save");
         Assert.False(preEntry.IsCustomized, "Stamped slot must be uncustomized (abandoned-claim shape)");
 
         // Flush the stuck claim to disk via a day-transition save, then disconnect (/reload needs 0
@@ -181,9 +183,10 @@ public class AbandonedClaimTests : TestBase
             async () =>
             {
                 postState = await ServerApi.GetDiagnosticsState(ct);
-                var entry = postState?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
-                // Cleared when the slot's entry is gone or its userId is empty.
-                return entry == null || string.IsNullOrEmpty(entry.UserId);
+                if (postState == null) return false; // transient null must not read as "swept"
+                var entry = postState.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
+                // Cleared when the slot's entry is gone or no longer carries the userID claim.
+                return entry == null || !entry.HasUserId;
             }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
         Assert.True(swept,
             $"Abandoned claim on uid={stuckUid} was not released by the save-load sweep after reload " +

--- a/tests/JunimoServer.Tests/AbandonedClaimTests.cs
+++ b/tests/JunimoServer.Tests/AbandonedClaimTests.cs
@@ -1,0 +1,200 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Regression tests for the abandoned "New Farmer" slot bug: a player clicks "New Farmer"
+/// (which makes their client stamp its platform ID onto the slot's farmhand via vanilla
+/// Client.sendPlayerIntroduction) but quits before finishing character customization. The
+/// slot's farmhand is left with userID set but isCustomized=false, and vanilla FarmhandMenu
+/// then greys the slot out and blocks clicks for every other player — permanently locking it
+/// to the ghost.
+///
+/// The fix (CabinManagerService.TryClearAbandonedClaim) clears the userID on the persisted
+/// farmhandData entry from the all-transport disconnect hook (CabinManagerService's own
+/// always-on GameServer.playerDisconnected postfix), which fires on every transport and
+/// regardless of password protection.
+///
+/// Assertions are server-authoritative via /diagnostics/state Cabins, whose OwnerUserId is
+/// resolved through cabin.owner — the live otherFarmers copy while connected (where the
+/// in-flight userID stamp lives), then the persisted farmhandData copy after the player is
+/// removed. The grey-out itself is client-side render and /cabins AvailableCount can't
+/// distinguish a stuck slot, so the userID field is the deterministic signal.
+///
+/// Transport: this requires Steam (WithSteam=true) — vanilla only stamps userID when
+/// getUserID() != "", and LidgrenClient (LAN) returns "", so LAN is immune to the bug and
+/// can't reproduce it.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedAssembly)]
+public class AbandonedClaimTests : TestBase
+{
+    public AbandonedClaimTests() { }
+
+    /// <summary>
+    /// Disconnect path: a client claims a slot (stamping userID), reaches the character menu,
+    /// and disconnects without customizing. The all-transport disconnect hook must clear the
+    /// userID on the PERSISTED farmhandData entry — not just the live otherFarmers copy that is
+    /// discarded moments later by removeDisconnectedFarmers. The step-3 assertion runs after the
+    /// player is removed from /players, so /diagnostics/state then reports the persisted entry:
+    /// a pre-fix cabin.owner-only clear leaves it stuck and FAILS this test.
+    /// </summary>
+    // WithSteam is required: vanilla only stamps userID when getUserID() != "", and
+    // LidgrenClient (LAN) returns "" — so the abandoned-claim bug is structurally
+    // impossible to reproduce live on LAN. A real Steam client stamps a real platform ID.
+    [Fact]
+    [TestServer(WithSteam = true)]
+    public async Task AbandonedClaim_OnDisconnect_IsClearedDurably()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Connect to the FarmhandMenu without customizing. WithRetryAsync is transport-aware
+        // (Steam invite code vs LAN address) and uses the primary client; it stops at the menu.
+        var connect = await Connect.WithRetryAsync(ct);
+        Connect.AssertConnectionSuccess(connect);
+
+        // Pick an uncustomized slot.
+        var slot = connect.Farmhands?.Farmhands.FirstOrDefault(s => !s.IsCustomized && !s.IsEmpty);
+        Assert.NotNull(slot);
+
+        // Select it — slot.Activate() runs sendPlayerIntroduction, which on Steam stamps userID.
+        var select = await GameClient.Farmhands.Select(slot!.Index);
+        Assert.True(select?.Success == true, $"Select slot failed: {select?.Error}");
+
+        // Wait for the character menu: userID is now stamped, isCustomized still false.
+        var charMenu = await GameClient.Wait.ForCharacter(TestTimings.CharacterMenuTimeout, ct);
+        Assert.True(charMenu?.Success == true, $"Character menu did not appear: {charMenu?.Error}");
+
+        // Confirm the stuck state on the server and capture the slot's owner uid. We read via
+        // /diagnostics/state Cabins (cabin.owner), which resolves to the LIVE otherFarmers copy
+        // while the client is connected — that's where the in-flight userID stamp lives before
+        // disconnect persists it to farmhandData (FarmhandData[].UserId would still be empty here).
+        long stuckUid = 0;
+        var reproduced = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_AbandonedClaim_StuckStateReproduced,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                var stuck = state?.Cabins.FirstOrDefault(
+                    c => !string.IsNullOrEmpty(c.OwnerUserId) && !c.OwnerIsCustomized);
+                if (stuck == null) return false;
+                stuckUid = stuck.OwnerId;
+                return true;
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+        Assert.True(reproduced,
+            "Expected a cabin owner with userID set but isCustomized=false (abandoned claim) before disconnect");
+        Log($"Reproduced abandoned claim on uid={stuckUid}");
+
+        // Disconnect mid-customization (ExitToTitle works from the character menu).
+        await DisconnectAsync();
+
+        // Wait past removeDisconnectedFarmers so cabin.owner now resolves to the PERSISTED entry.
+        var removed = await ServerApi.WaitForPlayerRemovedByIdAsync(stuckUid, ct: ct);
+        Assert.True(removed, $"Player uid={stuckUid} was not removed from /players after disconnect");
+
+        // Regression gate: the persisted entry's userID must be cleared. A pre-fix
+        // cabin.owner-only clear (live copy) leaves the persisted entry stuck and fails here.
+        var healed = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_AbandonedClaim_DisconnectHealConfirmed,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                var cabin = state?.Cabins.FirstOrDefault(c => c.OwnerId == stuckUid);
+                var entry = state?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
+                // Healed when no surviving view of the slot still carries the userID claim.
+                var cabinClear = cabin == null || string.IsNullOrEmpty(cabin.OwnerUserId);
+                var farmhandClear = entry == null || string.IsNullOrEmpty(entry.UserId);
+                return cabinClear && farmhandClear;
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+        Assert.True(healed,
+            $"Abandoned claim on uid={stuckUid} was not cleared on the persisted farmhandData " +
+            $"entry after disconnect (the disconnect hook must clear farmhandData, not just the " +
+            $"discarded live otherFarmers copy)");
+        Log($"Disconnect heal confirmed durable for uid={stuckUid}");
+    }
+
+    /// <summary>
+    /// Save-load sweep path: a stuck-but-homed abandoned claim that reaches a save on disk (e.g. a
+    /// host crash before the disconnect heal ran, or a save written by a build predating the heal)
+    /// must be released on the next reload. Vanilla's load-time ResetFarmhandState does NOT clear it
+    /// — it clears userID only when the farmhand has no valid home cabin (the else-branch when
+    /// TryAssignFarmhandHome fails), and a homed slot takes the early-return branch with userID
+    /// intact — so only CabinManagerService.ClearAbandonedCabinClaimsOnLoad heals this case.
+    ///
+    /// No Steam required: the live disconnect heal always clears a claim before any save, so a stuck
+    /// claim can't reach disk through a normal client flow. Instead /test/stamp_claim constructs the
+    /// exact on-disk shape (userID set + isCustomized=false + homeLocation resolving to a cabin)
+    /// server-side; a connected client then sleeps to flush the save to disk, and the reload exercises
+    /// the sweep. The stamp is synthetic, so this needs no real platform-ID stamp (unlike the
+    /// disconnect test).
+    /// </summary>
+    [Fact]
+    [TestServer(StartingCabins = 2)]
+    public async Task AbandonedClaim_SweptOnReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack", startingCabins: 2);
+
+        // A customized in-world player is needed to trigger the day-transition save (the stuck slot
+        // itself can't sleep). Its own entry must survive the sweep untouched (isCustomized guard).
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var customizedUid = client.JoinResult.UniqueMultiplayerId;
+
+        // Wait until A's farmhand is customized server-side BEFORE stamping. The join gate returns as
+        // soon as the peer is added — seconds before the character XML round-trip sets isCustomized
+        // (see FarmerTestHelper.DisconnectAndWaitForPersistenceAsync). Without this wait, /test/stamp_claim
+        // sees A's slot as still-uncustomized and stamps A itself instead of the spare slot.
+        var customized = await ServerApi.WaitForFarmhandByNameAsync(
+            client.FarmerName, requireCustomized: true, ct: ct);
+        Assert.True(customized, $"Player '{client.FarmerName}' should be customized server-side before stamping");
+
+        // Construct the stuck-but-homed claim on a spare uncustomized slot, server-side.
+        var stamp = await ServerApi.StampClaim(ct);
+        Assert.True(stamp?.Success == true, $"StampClaim failed: {stamp?.Error}");
+        var stuckUid = stamp!.StampedUid;
+        Assert.NotEqual(0, stuckUid);
+        Assert.NotEqual(customizedUid, stuckUid); // must be a different slot than the real player
+        Assert.False(string.IsNullOrEmpty(stamp.HomeLocation),
+            "Stamped slot must be homed (homeLocation resolving to a cabin) to exercise the homed sweep path");
+        Log($"Stamped abandoned claim on uid={stuckUid} (userId='{stamp.StampedUserId}', home='{stamp.HomeLocation}')");
+
+        // Confirm the stuck state is present server-side before the save.
+        var preState = await ServerApi.GetDiagnosticsState(ct);
+        var preEntry = preState?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
+        Assert.NotNull(preEntry);
+        Assert.False(string.IsNullOrEmpty(preEntry!.UserId), "Stamped slot should carry a userId before save");
+        Assert.False(preEntry.IsCustomized, "Stamped slot must be uncustomized (abandoned-claim shape)");
+
+        // Flush the stuck claim to disk via a day-transition save, then disconnect (/reload needs 0
+        // clients) and reload — which loads the on-disk save and re-runs OnSaveLoaded → the sweep.
+        await SleepToSaveAsync(ct);
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        await ReloadServerAsync();
+
+        // Regression gate: after reload the sweep must have released the stuck claim. Without the
+        // sweep, the homed userID survives reload (vanilla preserves it) and this FAILS.
+        DiagnosticsStateResponse? postState = null;
+        var swept = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_AbandonedClaim_SweptOnReload,
+            async () =>
+            {
+                postState = await ServerApi.GetDiagnosticsState(ct);
+                var entry = postState?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == stuckUid);
+                // Cleared when the slot's entry is gone or its userId is empty.
+                return entry == null || string.IsNullOrEmpty(entry.UserId);
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+        Assert.True(swept,
+            $"Abandoned claim on uid={stuckUid} was not released by the save-load sweep after reload " +
+            $"(ClearAbandonedCabinClaimsOnLoad must clear a stuck-but-homed claim that vanilla's " +
+            $"load-time ResetFarmhandState leaves intact)");
+        Log($"Save-load sweep confirmed for uid={stuckUid}");
+
+        // Guard: the sweep must NOT touch the real customized player's entry (isCustomized guard).
+        var survivor = postState?.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == customizedUid);
+        Assert.NotNull(survivor);
+        Assert.True(survivor!.IsCustomized,
+            $"Customized player uid={customizedUid} must survive the sweep as a customized farmhand");
+    }
+}

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -206,24 +206,6 @@ public class CabinPositionPersistenceTests : TestBase
     }
 
     /// <summary>
-    /// Sleeps the farmhand and waits for the day transition, which writes the save to
-    /// disk. Mandatory before a reload — WriteSaveData and building tileX/tileY are
-    /// in-memory until a game save, so a reload without a save proves nothing.
-    /// </summary>
-    private async Task SleepToSaveAsync(CancellationToken ct)
-    {
-        var statusBefore = await ServerApi.GetStatus(ct);
-        Assert.NotNull(statusBefore);
-
-        var sleep = await GameClient.Actions.Sleep();
-        Assert.True(sleep?.Success == true, $"Sleep failed: {sleep?.Error}");
-
-        var dayChanged = await DayChange.WaitAsync(
-            statusBefore.Day, statusBefore.Season, statusBefore.Year, ct);
-        Assert.True(dayChanged, "Day did not advance; save was not written");
-    }
-
-    /// <summary>
     /// Rewrites the in-container server-settings.json cabinStrategy value in place.
     /// The change is applied by the next ReloadServerAsync (which re-reads the file).
     /// Mirrors the real operator flow: edit settings, reload — no test-only API added.

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -202,6 +202,12 @@ public class DiagnosticsCabinState
     [JsonPropertyName("ownerIsCustomized")]
     public bool OwnerIsCustomized { get; set; }
 
+    /// <summary>Owner's platform ID (Steam/GOG); empty when unclaimed. A non-empty value with
+    /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, so it
+    /// reflects the live otherFarmers copy while the owner is connected.</summary>
+    [JsonPropertyName("ownerUserId")]
+    public string OwnerUserId { get; set; } = "";
+
     [JsonPropertyName("homeLocationOfOwner")]
     public string HomeLocationOfOwner { get; set; } = "";
 
@@ -228,6 +234,11 @@ public class DiagnosticsFarmhandState
 
     [JsonPropertyName("lastSleepLocation")]
     public string LastSleepLocation { get; set; } = "";
+
+    /// <summary>Platform ID (Steam/GOG) stamped on slot claim; empty when unclaimed.
+    /// A non-empty value with IsCustomized=false is the abandoned-claim state.</summary>
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = "";
 }
 
 public class ReadyCheckState
@@ -480,6 +491,20 @@ public class TestHouseUpgradeResponse
     [JsonPropertyName("success")] public bool Success { get; set; }
     [JsonPropertyName("error")] public string? Error { get; set; }
     [JsonPropertyName("hostHouseUpgradeLevel")] public int HostHouseUpgradeLevel { get; set; }
+}
+
+/// <summary>
+/// Response from /test/stamp_claim POST endpoint (test-only). Mirrors the server-side
+/// TestStampClaimResponse DTO. Stamps a synthetic abandoned slot claim onto an uncustomized,
+/// homed farmhand so the save-load sweep can be exercised on reload.
+/// </summary>
+public class TestStampClaimResponse
+{
+    [JsonPropertyName("success")] public bool Success { get; set; }
+    [JsonPropertyName("error")] public string? Error { get; set; }
+    [JsonPropertyName("stampedUid")] public long StampedUid { get; set; }
+    [JsonPropertyName("stampedUserId")] public string StampedUserId { get; set; } = "";
+    [JsonPropertyName("homeLocation")] public string HomeLocation { get; set; } = "";
 }
 
 /// <summary>
@@ -1134,6 +1159,20 @@ public class ServerApiClient : IDisposable
             HttpMethod.Post, $"/test/house_upgrade?command={Uri.EscapeDataString(command)}", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestHouseUpgradeResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: deterministically construct an abandoned slot claim by stamping a synthetic userID
+    /// onto an uncustomized, homed farmhand entry (the on-disk shape vanilla's load-time reset leaves
+    /// intact). Used to verify the save-load sweep clears it on reload — the live disconnect heal can't
+    /// persist such a claim to disk for a sweep test.
+    /// POST /test/stamp_claim
+    /// </summary>
+    public async Task<TestStampClaimResponse?> StampClaim(CancellationToken ct = default)
+    {
+        var response = await SendWithRetryAsync(HttpMethod.Post, "/test/stamp_claim", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestStampClaimResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -202,11 +202,12 @@ public class DiagnosticsCabinState
     [JsonPropertyName("ownerIsCustomized")]
     public bool OwnerIsCustomized { get; set; }
 
-    /// <summary>Owner's platform ID (Steam/GOG); empty when unclaimed. A non-empty value with
+    /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, so it
-    /// reflects the live otherFarmers copy while the owner is connected.</summary>
-    [JsonPropertyName("ownerUserId")]
-    public string OwnerUserId { get; set; } = "";
+    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID
+    /// (/diagnostics/state is unauthenticated).</summary>
+    [JsonPropertyName("ownerHasUserId")]
+    public bool OwnerHasUserId { get; set; }
 
     [JsonPropertyName("homeLocationOfOwner")]
     public string HomeLocationOfOwner { get; set; } = "";
@@ -235,10 +236,11 @@ public class DiagnosticsFarmhandState
     [JsonPropertyName("lastSleepLocation")]
     public string LastSleepLocation { get; set; } = "";
 
-    /// <summary>Platform ID (Steam/GOG) stamped on slot claim; empty when unclaimed.
-    /// A non-empty value with IsCustomized=false is the abandoned-claim state.</summary>
-    [JsonPropertyName("userId")]
-    public string UserId { get; set; } = "";
+    /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
+    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID
+    /// (/diagnostics/state is unauthenticated).</summary>
+    [JsonPropertyName("hasUserId")]
+    public bool HasUserId { get; set; }
 }
 
 public class ReadyCheckState

--- a/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
+++ b/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
@@ -91,8 +91,11 @@ namespace JunimoServer.Tests.Helpers;
 /// cabinsFailed, excludePeer, strategy</c>) · <c>cabin_build_failed</c>
 /// (<c>hidden, tileX?, tileY?, reason</c>) · <c>cabin_destroyed</c> (<c>tileX,
 /// tileY, indoorsName, ownerId, ownerName</c>) · <c>cabin_claim_abandoned</c>
-/// (fired when a player disconnects mid-customization: <c>odId, tileX, tileY,
-/// ownerUniqueMultiplayerId</c>) · <c>cabin_strategy_migration</c>
+/// (fired by <c>CabinManagerService</c> when an abandoned slot claim is released —
+/// from the player-disconnect heal and from the save-load sweep:
+/// <c>clearedUserId, ownerUniqueMultiplayerId</c>) ·
+/// <c>cabin_claims_swept_on_load</c> (save-load sweep summary, emitted only when it
+/// released at least one claim: <c>cleared</c>) · <c>cabin_strategy_migration</c>
 /// (<c>fromStrategy, toStrategy, migrated, migrateFailed</c>) ·
 /// <c>farmhand_references_cleaned</c> (save-load stale-ref cleanup:
 /// <c>orphansRemoved, homeCleared, lastSleepCleared, validCabins</c>).</item>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -92,6 +92,11 @@ public enum WaitName
     Polling_CabinStrategy_FarmerSyncedCabinAndFarmhand,
     Polling_CabinStrategy_FarmerDeletionReflected,
 
+    // AbandonedClaimTests.cs (3)
+    Polling_AbandonedClaim_StuckStateReproduced,
+    Polling_AbandonedClaim_DisconnectHealConfirmed,
+    Polling_AbandonedClaim_SweptOnReload,
+
     // FarmhandManagementTests.cs (1)
     Polling_FarmhandManagement_FarmhandGone,
 

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -550,6 +550,25 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
         ServerStatus = await ServerApi.GetStatus(TestCt);
     }
 
+    /// <summary>
+    /// Sleeps the primary client's farmhand and waits for the day transition, which writes the
+    /// save to disk. Mandatory before a reload — WriteSaveData and building tileX/tileY (and any
+    /// farmhandData mutation) are in-memory until a game save, so a reload without a save proves
+    /// nothing. Requires the primary client to be connected and in-world.
+    /// </summary>
+    protected async Task SleepToSaveAsync(CancellationToken ct)
+    {
+        var statusBefore = await ServerApi.GetStatus(ct);
+        Assert.NotNull(statusBefore);
+
+        var sleep = await GameClient.Actions.Sleep();
+        Assert.True(sleep?.Success == true, $"Sleep failed: {sleep?.Error}");
+
+        var dayChanged = await DayChange.WaitAsync(
+            statusBefore.Day, statusBefore.Season, statusBefore.Year, ct);
+        Assert.True(dayChanged, "Day did not advance; save was not written");
+    }
+
     #endregion
 
     #region Exception Monitoring


### PR DESCRIPTION
Closes #361.

A player clicks "New Farmer" (vanilla `Client.sendPlayerIntroduction` stamps their platform `userID` on the slot's farmhand), then quits before finishing character creation. The slot is left with `userID != ""` and `isCustomized == false`, which vanilla `FarmhandMenu` greys out and blocks for every other player — locking it permanently, including across server restarts.

## Changes

- **Disconnect heal** (`CabinManagerService`): an always-on Harmony postfix on `GameServer.playerDisconnected` clears the stuck `userID` on the persisted `farmhandData` entry (and the live `otherFarmers` copy). Registered unconditionally so it covers all transports including passwordless servers (`PasswordProtectionService` patches don't register when no password is set).
- **Save-load sweep** (`CabinManagerService.ClearAbandonedCabinClaimsOnLoad`): clears stuck claims that reached disk before any disconnect heal ran (host crash, or saves from before this fix). Vanilla's load-time `ResetFarmhandState` only clears `userID` when the home cabin is missing, so a stuck-but-homed claim survives reload otherwise — this addresses issue step 5 ("restarting does not clear it").
- Both paths share `TryClearAbandonedClaim` (guards on `userID` set + not customized) and emit `cabin_claim_abandoned`; the sweep also emits `cabin_claims_swept_on_load`.
- Removed the old Steam-only cleanup call in `SteamGameServerNetServer` (superseded by the all-transport postfix).
- **Observability**: `/diagnostics/state` now exposes the owner/farmhand `userID`.
- **Tests** (`AbandonedClaimTests`): `AbandonedClaim_OnDisconnect_IsClearedDurably` (real Steam stamp/clear) and `AbandonedClaim_SweptOnReload` (stamps a deterministic stuck-but-homed claim via a `/test/stamp_claim` helper, saves, reloads, asserts the sweep cleared it). Promoted `SleepToSaveAsync` to `TestBase`.

## Verification

- `dotnet build` mod + tests: 0 warnings / 0 errors.
- E2E: both tests pass (`degradation: clean`). Server log confirms non-vacuous heals — `cabin_claim_abandoned` on disconnect (real Steam id) and `cabin_claims_swept_on_load {cleared:1}` on reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Abandoned cabin claims are now cleared reliably on player disconnect and swept from saved data on reload.

* **New Features**
  * Added a test endpoint to stamp and inspect cabin claim state.
  * Diagnostics now expose whether cabin/farmhand slots have a platform user id.

* **Tests**
  * Added integration tests validating durable cleanup on disconnect and sweep-on-reload.

* **Documentation**
  * Event catalog and polling identifiers updated for abandoned-claim scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->