### PR TITLE
fix(tests): keep SDVD_EVENT transport lines out of human-facing output

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -434,7 +434,16 @@ jobs:
           STEAM_ACCOUNTS: ${{ secrets.STEAM_ACCOUNTS }}
         run: |
           docker compose build steam-auth
-          docker compose run --rm -e STEAM_ACCOUNTS steam-auth download
+          # Drop the sidecar's SDVD_EVENT transport lines from this step's log:
+          # they're a machine envelope with no consumer here (unlike the E2E run,
+          # nothing tails/forwards a `docker compose run` stdout). Keep the
+          # human-readable [SteamService] progress lines. grep is the last pipe
+          # stage, so guard the producer's real exit via PIPESTATUS; grep exiting
+          # 1 (every line filtered) must not fail the step.
+          set -o pipefail
+          docker compose run --rm -e STEAM_ACCOUNTS steam-auth download \
+            | { grep -v '^SDVD_EVENT ' || true; }
+          exit "${PIPESTATUS[0]}"
 
       # The whole pipeline in one command. The runner builds all three images
       # in-process (reading STEAM_ACCOUNTS[0] for the Steam --secret login),

--- a/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
@@ -510,13 +510,15 @@ public class GameClientContainer : IAsyncDisposable
         _containerLog?.WriteLine(line);
 
         // Forward any SDVD_EVENT structured event lines (stdout fallback
-        // transport from the test-client mod) to infrastructure.jsonl.
-        SimpleContainerLogStreamer.TryForwardSdvdEvent(line, $"client-{_clientIndex}");
+        // transport from the test-client mod) to infrastructure.jsonl. Once
+        // forwarded, the line is a spent machine envelope — keep it off the
+        // human-facing sinks (UI ticker, operator terminal/CI log) below.
+        var isEvent = SimpleContainerLogStreamer.TryForwardSdvdEvent(line, $"client-{_clientIndex}");
 
         // Emit to UI during startup phases (callback is null post-startup)
-        _startupLogCallback?.Invoke(line);
+        if (!isEvent) _startupLogCallback?.Invoke(line);
 
-        _logCallback?.Invoke(line);
+        if (!isEvent) _logCallback?.Invoke(line);
     }
 
     public async ValueTask DisposeAsync()

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -681,11 +681,15 @@ public class ServerContainer : IAsyncDisposable
         _containerLog?.WriteLine(line);
 
         // Forward any SDVD_EVENT structured event lines (stdout fallback
-        // transport from the mod) to infrastructure.jsonl.
-        SimpleContainerLogStreamer.TryForwardSdvdEvent(line, $"server-{_serverIndex}");
+        // transport from the mod) to infrastructure.jsonl. Once forwarded, the
+        // line is a spent machine envelope — keep it off the UI ticker below.
+        // Error detection still runs unconditionally: a SDVD_EVENT line is JSON,
+        // so SmapiLogLinePrefix never matches it, and leaving the block
+        // unguarded preserves error-continuation accounting exactly.
+        var isEvent = SimpleContainerLogStreamer.TryForwardSdvdEvent(line, $"server-{_serverIndex}");
 
         // Emit to UI during startup phases (callback is null post-startup)
-        _startupLogCallback?.Invoke(line);
+        if (!isEvent) _startupLogCallback?.Invoke(line);
 
         var isNewLogLine = SmapiLogLinePrefix.IsMatch(line);
 

--- a/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
+++ b/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
@@ -79,6 +79,9 @@ public class SharedSteamAuth : IAsyncDisposable
         // Forward any SDVD_EVENT structured event lines from the steam-auth
         // sidecar (e.g. account-login state transitions) to infrastructure.jsonl,
         // and write the human-readable line to the per-container log file.
+        // The return value (was-an-event) is intentionally discarded: this path
+        // has no human-facing sink to keep transport lines off of — container.log
+        // is a verbatim record by design.
         SimpleContainerLogStreamer.TryForwardSdvdEvent(line, "steam-auth-shared");
         _containerLog.WriteLine(line);
     }

--- a/tests/JunimoServer.Tests/Containers/SimpleContainerLogStreamer.cs
+++ b/tests/JunimoServer.Tests/Containers/SimpleContainerLogStreamer.cs
@@ -26,13 +26,17 @@ internal static class SimpleContainerLogStreamer
     /// <param name="line">The raw stdout line, including the <c>SDVD_EVENT </c> prefix.</param>
     /// <param name="forwardedVia">Container of origin (e.g. <c>server-0</c>,
     /// <c>client-2</c>, <c>steam-auth-shared</c>).</param>
-    public static void TryForwardSdvdEvent(string line, string forwardedVia)
+    /// <returns><c>true</c> if the line was a <c>SDVD_EVENT </c> transport line
+    /// (forwarded and now spent) — callers should keep it off human-facing
+    /// sinks; <c>false</c> for ordinary log lines.</returns>
+    public static bool TryForwardSdvdEvent(string line, string forwardedVia)
     {
         const string prefix = "SDVD_EVENT ";
-        if (line.Length <= prefix.Length || !line.StartsWith(prefix, StringComparison.Ordinal)) return;
+        if (line.Length <= prefix.Length || !line.StartsWith(prefix, StringComparison.Ordinal)) return false;
         var jsonTail = line.Substring(prefix.Length);
         InfrastructureEventLog.ForwardRaw(jsonTail, forwardedVia);
         TryAnnotateModPhase(jsonTail, forwardedVia);
+        return true;
     }
 
     /// <summary>


### PR DESCRIPTION
## Problem

`SDVD_EVENT <json>` lines are a machine envelope: in-container producers (server mod, test-client mod, steam-auth sidecar) emit them on stdout, and the harness forwards them to `infrastructure.jsonl`. Once forwarded they're spent — but the harness was *also* passing the raw lines on to human-facing surfaces, polluting:

- the operator's local terminal,
- the CI job log (e.g. ~132 `[Client] client-0 SDVD_EVENT {…}` `http_served` lines per run, inherited from the `dotnet run` step's stderr),
- the startup-UI ticker.

## Fix A — harness consumer-side filter

- `SimpleContainerLogStreamer.TryForwardSdvdEvent` now returns `bool` (was the line a transport line?). Single source of truth for the `SDVD_EVENT ` prefix — no caller re-implements it.
- `GameClientContainer.HandleLine` / `ServerContainer.HandleLine` guard their human-facing sinks (`_logCallback`, `_startupLogCallback`) on `!isEvent`.
- `container.log` writes and the `infrastructure.jsonl` forward stay **unconditional**.
- `ServerContainer`'s error-detection block is left unguarded — a `SDVD_EVENT` line is JSON, never matches the SMAPI prefix, so error-continuation accounting is preserved exactly.
- `SharedSteamAuth` has no human sink; it discards the new return value (documented).

## Fix B — standalone CI step

The lone steam-auth `account_logged_in` line in CI comes from the separate `Populate local game-data volume` step (`docker compose run --rm steam-auth download`) — outside the harness, no consumer for its events. That step now filters `^SDVD_EVENT ` from stdout, preserving the producer's exit status via `PIPESTATUS[0]`. The sidecar emitter itself is unchanged (load-bearing in `serve` mode, where the harness does forward it).

## Scope / non-goals

- `container.log` files are intentionally left **verbatim** (full byte-for-byte record).
- No change to the `SDVD_EVENT`-over-stdout transport or its producers.
- `infrastructure.jsonl` and the forward path are unchanged except for the return type.

## Verification

- `dotnet build` clean (0/0); `TryForwardSdvdEvent` has exactly 3 callers.
- CI-step exit-code logic tested across producer-fail / all-lines-filtered / normal cases.
- Disk artifacts from a local run: `container.log` retains `SDVD_EVENT` lines; `infrastructure.jsonl` still receives `http_served` + `account_logged_in`; **zero** `SDVD_EVENT` in any human-facing run output.
- Terminal/CI stderr surface and Fix B are exercised by the next CI run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test log output filtering to reduce noise and prevent false failures when structured events are present.

* **Tests**
  * Enhanced test infrastructure to properly track and separate structured event logs from regular output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->