### PR TITLE
chore: block accidental direct pushes to master via lefthook pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,3 +2,24 @@ commit-msg:
   commands:
     commitlint:
       run: npx commitlint --edit {1}
+
+# Local guard against accidental direct pushes to master.
+#
+# The "master" ruleset requires a PR + approval for the normal case (fork/external PRs).
+# GitHub forbids self-approval, so own PRs rely on an OrganizationAdmin "always" bypass to
+# merge once CI is green. That bypass also silently permits a stray push straight to
+# master — this hook sits below the bypass layer and is the only thing that catches it.
+#
+# `only: ref: master` runs only while master is checked out, so a push from master always
+# fails here. A deliberate direct push means temporarily removing this block by hand.
+pre-push:
+  commands:
+    block-master:
+      only:
+        - ref: master
+      # Single-quoted echoes: lefthook wraps the script in sh -c "...", so embedded
+      # double-quotes would break that outer quoting and swallow the exit code.
+      run: |
+        echo '✋ Direct push to master is blocked — open a PR instead.'
+        echo '   (Deliberate push? Temporarily remove the block-master hook in lefthook.yml.)'
+        exit 1


### PR DESCRIPTION
## Why

The `master` ruleset requires a PR + approval for the normal case (fork / external / contributor PRs). **GitHub forbids approving your own PR**, so own PRs can't satisfy that gate — they rely on an `OrganizationAdmin` `always` bypass to merge once CI is green.

The cost of that bypass: it **also silently permits a stray `git push` straight to master**. That's how the recent accidental direct push slipped through. A **local git pre-push hook sits below the bypass layer**, so it's the only thing that can catch it.

## What

- Adds a lefthook `pre-push` command `block-master`, gated on `only: ref: master`.
- When master is checked out, the command runs and exits 1 → the push is aborted with a message pointing at opening a PR.
- On any other branch it's skipped by condition, so normal feature-branch pushes are unaffected.
- No override env var by design: a deliberate direct push means temporarily removing the block by hand.

The hook installs automatically via the existing `postinstall: lefthook install`; no extra setup for other clones.

## Verification (run locally, nothing pushed during testing)

- On master: `lefthook run pre-push` → prints the block message, `exit status 1`.
- On a feature branch: `block-master (skip) by condition`, exit 0.
- This PR's own push showed `block-master (skip) by condition` — confirming feature-branch pushes proceed.

## Notes

- Single-quoted `echo`s in the `run` script are deliberate: lefthook wraps the script in `sh -c "..."`, so embedded double-quotes break that outer quoting and silently swallow the exit code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Direct pushes to the master branch are now blocked by a client-side pre-push check. When attempting to push to master, users will see informational messages and the push is aborted, so changes must be submitted via the standard pull request workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->