### PR TITLE
perf(ci): containerd image store + richer E2E image-transfer progress

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -296,6 +296,14 @@ jobs:
       SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
 
     steps:
+      # containerd image store makes `docker save` emit compressed OCI blobs
+      # (~60% smaller), shrinking the E2E image transfer. Must be the first step.
+      - name: Set up Docker with containerd image store
+        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
+        with:
+          daemon-config: |
+            { "features": { "containerd-snapshotter": true } }
+
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:

--- a/tests/JunimoServer.TestRunner/Distribution/GameDataDistributor.cs
+++ b/tests/JunimoServer.TestRunner/Distribution/GameDataDistributor.cs
@@ -161,9 +161,11 @@ public sealed class GameDataDistributor : IDisposable
                     bytesSent = bytes,
                     elapsedMs = sw.ElapsedMilliseconds
                 });
-                Console.Error.WriteLine($"[GameData] {host.Id}: {FormatMb(bytes)} sent in {sw.Elapsed.TotalSeconds:F1}s");
+                Console.Error.WriteLine(FormattableString.Invariant(
+                    $"[GameData] {host.Id}: {FormatMb(bytes)} sent in {sw.Elapsed.TotalSeconds:F1}s"));
                 renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, host.Id,
-                    SetupStepStatus.Completed, $"{FormatMb(bytes)} in {sw.Elapsed.TotalSeconds:F1}s"));
+                    SetupStepStatus.Completed,
+                    FormattableString.Invariant($"{FormatMb(bytes)} in {sw.Elapsed.TotalSeconds:F1}s")));
                 return new TransferResult(host.Id, true, Skipped: false, Error: null);
             }
             catch (OperationCanceledException) { throw; }
@@ -177,7 +179,7 @@ public sealed class GameDataDistributor : IDisposable
                     var delay = delays[Math.Min(attempt, delays.Length - 1)];
                     renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, host.Id,
                         SetupStepStatus.InProgress,
-                        $"attempt {attempt} failed ({ex.Message}); retrying in {delay.TotalSeconds:F0}s"));
+                        FormattableString.Invariant($"attempt {attempt} failed ({ex.Message}); retrying in {delay.TotalSeconds:F0}s")));
                     try { await Task.Delay(delay, ct); }
                     catch (OperationCanceledException) { throw; }
                 }
@@ -392,7 +394,10 @@ public sealed class GameDataDistributor : IDisposable
             progress.PollByteProgress();
     }
 
-    private static string FormatMb(long bytes) => $"{bytes / 1024.0 / 1024.0:F1} MB";
+    // Invariant culture — these strings land in CI logs and the WebUI; a locale's
+    // "," decimal would mangle them per-runner.
+    private static string FormatMb(long bytes) =>
+        FormattableString.Invariant($"{bytes / 1024.0 / 1024.0:F1} MB");
 
     /// <summary>
     /// Read-only stream decorator that increments a byte counter on every read.
@@ -489,7 +494,8 @@ public sealed class GameDataDistributor : IDisposable
                     bytesSent,
                     elapsedMs = _startedAt.ElapsedMilliseconds,
                 });
-                var detail = $"transferring game files {FormatMb(bytesSent)} ({rateMbPerSec:F1} MB/s, {_startedAt.Elapsed.TotalSeconds:F0}s)";
+                var detail = FormattableString.Invariant(
+                    $"transferring game files {FormatMb(bytesSent)} ({rateMbPerSec:F1} MB/s, {_startedAt.Elapsed.TotalSeconds:F0}s)");
                 Console.Error.WriteLine($"[GameData] {_hostId}: {detail}");
                 _renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, _hostId,
                     SetupStepStatus.InProgress, detail));

--- a/tests/JunimoServer.TestRunner/Distribution/ImageDistributor.cs
+++ b/tests/JunimoServer.TestRunner/Distribution/ImageDistributor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using System.Text.Json;
 using Docker.DotNet;
 using Docker.DotNet.Models;
 using JunimoServer.Tests.Helpers;
@@ -13,8 +14,8 @@ namespace JunimoServer.TestRunner.Distribution;
 /// Builds Docker images once on the coordinator and transfers them to remote
 /// hosts via Docker.DotNet over the per-host <c>ssh -N -L</c> daemon-socket
 /// tunnel that <see cref="TunnelManager"/> opens during preflight. Skips hosts
-/// whose Docker daemon already holds an image with a matching ID. Local hosts
-/// are no-ops — the image is already on the same daemon.
+/// whose Docker daemon already holds every image with matching layer digests.
+/// Local hosts are no-ops — the image is already on the same daemon.
 ///
 /// <para>Concurrency-bounded across hosts: at most
 /// <see cref="MaxConcurrentTransfers"/> transfers run at once.</para>
@@ -60,7 +61,7 @@ public sealed class ImageDistributor : IDisposable
 
     /// <summary>
     /// Transfers images to all remote hosts in <paramref name="hosts"/>; skips
-    /// any whose image IDs all match the coordinator's. Local hosts are no-ops.
+    /// any whose layer digests all match the coordinator's. Local hosts are no-ops.
     ///
     /// <para>When <paramref name="renderer"/> is non-null, per-host progress
     /// surfaces in the WebUI / CLI tree as setup-step events under the
@@ -90,6 +91,8 @@ public sealed class ImageDistributor : IDisposable
             localLayers[fullName] = ExtractLayers(inspect);
         }
 
+        var baseline = ReadBaseline();
+
         // Bucket hosts: skip those whose every image's layer list matches
         // the coordinator's; otherwise queue for transfer.
         var transferNeeded = new List<DockerHost>();
@@ -115,19 +118,26 @@ public sealed class ImageDistributor : IDisposable
             if (allMatch)
             {
                 InfrastructureEventLog.Emit("image_skip_match", new { host_id = h.Id });
+                var savedSuffix = baseline.TryGetValue(h.Id, out var saved)
+                    ? $" (~{FormatMb(saved)} skipped)" : "";
                 renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, h.Id,
-                    SetupStepStatus.Completed, "already up-to-date"));
+                    SetupStepStatus.Completed, $"already up-to-date{savedSuffix}"));
                 continue;
             }
             transferNeeded.Add(h);
         }
+
+        if (transferNeeded.Count > 0)
+            Console.Error.WriteLine(
+                $"[ImageTransfer] distributing {_imageNames.Length} image(s) to {transferNeeded.Count} host(s)");
 
         // Bounded-concurrency parallel transfer.
         using var gate = new SemaphoreSlim(MaxConcurrentTransfers, MaxConcurrentTransfers);
         var tasks = transferNeeded.Select(async h =>
         {
             await gate.WaitAsync(ct);
-            try { return await TransferWithRetryAsync(h, renderer, ct); }
+            var expectedBytes = baseline.TryGetValue(h.Id, out var b) ? b : 0L;
+            try { return await TransferWithRetryAsync(h, expectedBytes, renderer, ct); }
             finally { gate.Release(); }
         }).ToArray();
         var results = await Task.WhenAll(tasks);
@@ -161,7 +171,7 @@ public sealed class ImageDistributor : IDisposable
     }
 
     private async Task<TransferResult> TransferWithRetryAsync(
-        DockerHost host, ITestRenderer? renderer, CancellationToken ct)
+        DockerHost host, long expectedBytes, ITestRenderer? renderer, CancellationToken ct)
     {
         var delays = new[] { TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(60) };
         Exception? last = null;
@@ -174,7 +184,7 @@ public sealed class ImageDistributor : IDisposable
                     SetupStepStatus.Started,
                     attempt == 0 ? "transferring images" : $"retry {attempt}: transferring images"));
                 var sw = Stopwatch.StartNew();
-                var bytesSent = await TransferAsync(host, attempt, renderer, ct);
+                var bytesSent = await TransferAsync(host, attempt, expectedBytes, renderer, ct);
                 sw.Stop();
 
                 // Post-load: verify every image is present on the remote.
@@ -199,6 +209,8 @@ public sealed class ImageDistributor : IDisposable
                     }
                 }
 
+                WriteBaseline(host.Id, bytesSent);
+
                 InfrastructureEventLog.Emit("image_transfer_completed", new
                 {
                     host_id = host.Id,
@@ -206,10 +218,13 @@ public sealed class ImageDistributor : IDisposable
                     bytesSent,
                     elapsedMs = sw.ElapsedMilliseconds
                 });
-                Console.Error.WriteLine($"[ImageTransfer] {host.Id}: {FormatMb(bytesSent)} sent in {sw.Elapsed.TotalSeconds:F1}s");
+                var avgRate = sw.Elapsed.TotalSeconds > 0
+                    ? bytesSent / 1024.0 / 1024.0 / sw.Elapsed.TotalSeconds : 0;
+                Console.Error.WriteLine(FormattableString.Invariant(
+                    $"[ImageTransfer] {host.Id}: {FormatMb(bytesSent)} sent in {sw.Elapsed.TotalSeconds:F1}s ({avgRate:F1} MB/s)"));
                 renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, host.Id,
                     SetupStepStatus.Completed,
-                    $"{FormatMb(bytesSent)} in {sw.Elapsed.TotalSeconds:F1}s"));
+                    FormattableString.Invariant($"{FormatMb(bytesSent)} in {sw.Elapsed.TotalSeconds:F1}s")));
                 return new TransferResult(host.Id, true, null);
             }
             catch (OperationCanceledException) { throw; }
@@ -222,7 +237,7 @@ public sealed class ImageDistributor : IDisposable
                     var delay = delays[Math.Min(attempt, delays.Length - 1)];
                     renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, host.Id,
                         SetupStepStatus.InProgress,
-                        $"attempt {attempt} failed ({ex.Message}); retrying in {delay.TotalSeconds:F0}s"));
+                        FormattableString.Invariant($"attempt {attempt} failed ({ex.Message}); retrying in {delay.TotalSeconds:F0}s")));
                     try { await Task.Delay(delay, ct); }
                     catch (OperationCanceledException) { throw; }
                 }
@@ -236,7 +251,7 @@ public sealed class ImageDistributor : IDisposable
         return new TransferResult(host.Id, false, last?.Message ?? "unknown");
     }
 
-    private async Task<long> TransferAsync(DockerHost host, int attempt, ITestRenderer? renderer, CancellationToken ct)
+    private async Task<long> TransferAsync(DockerHost host, int attempt, long expectedBytes, ITestRenderer? renderer, CancellationToken ct)
     {
         var imageList = _imageNames.Select(n => $"{n}:{_imageTag}").ToArray();
         var startedAt = Stopwatch.StartNew();
@@ -246,7 +261,7 @@ public sealed class ImageDistributor : IDisposable
         // remote daemon as chunked HTTP — no temp file, no in-memory buffer.
         await using var tar = await _localClient.Images.SaveImagesAsync(imageList, ct);
         var counted = new ByteCountingStream(tar);
-        var progress = new TransferProgress(host.Id, attempt, startedAt, counted, renderer);
+        var progress = new TransferProgress(host.Id, attempt, expectedBytes, startedAt, counted, renderer);
 
         // Docker.DotNet's IProgress<JSONMessage> only fires on the daemon's
         // *response* body — silent during the chunked HTTP upload. Run a
@@ -290,7 +305,72 @@ public sealed class ImageDistributor : IDisposable
         }
     }
 
-    private static string FormatMb(long bytes) => $"{bytes / 1024.0 / 1024.0:F1} MB";
+    // Invariant culture — these strings land in CI logs and the WebUI; a locale's
+    // "," decimal would mangle them per-runner.
+    private static string FormatMb(long bytes) =>
+        FormattableString.Invariant($"{bytes / 1024.0 / 1024.0:F1} MB");
+
+    /// <summary>Compact duration for ETA display: "45s", "2m18s", "1h03m".</summary>
+    private static string FormatEta(double seconds)
+    {
+        if (seconds < 0 || double.IsInfinity(seconds) || double.IsNaN(seconds)) return "?";
+        var t = TimeSpan.FromSeconds(seconds);
+        if (t.TotalHours >= 1) return FormattableString.Invariant($"{(int)t.TotalHours}h{t.Minutes:D2}m");
+        if (t.TotalMinutes >= 1) return FormattableString.Invariant($"{t.Minutes}m{t.Seconds:D2}s");
+        return FormattableString.Invariant($"{t.Seconds}s");
+    }
+
+    // {hostId → last transfer bytes}, persisted across runs. Image metadata can't
+    // predict the deduped+compressed save-tar size, so we estimate from the prior
+    // run. Display only; never gates correctness.
+    private static readonly object BaselineLock = new();
+
+    private static string BaselinePath =>
+        Path.Combine(TestArtifacts.OutputDir, RunArtifactNames.ImageTransferBaseline);
+
+    private static Dictionary<string, long> ReadBaseline()
+    {
+        lock (BaselineLock)
+        {
+            try
+            {
+                if (!File.Exists(BaselinePath)) return new Dictionary<string, long>();
+                return JsonSerializer.Deserialize<Dictionary<string, long>>(File.ReadAllText(BaselinePath))
+                       ?? new Dictionary<string, long>();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ImageTransfer] baseline read failed: {ex.Message}");
+                return new Dictionary<string, long>();
+            }
+        }
+    }
+
+    private static void WriteBaseline(string hostId, long bytes)
+    {
+        lock (BaselineLock)
+        {
+            try
+            {
+                var map = ReadBaselineUnlocked();
+                map[hostId] = bytes;
+                Directory.CreateDirectory(TestArtifacts.OutputDir);
+                File.WriteAllText(BaselinePath, JsonSerializer.Serialize(map));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ImageTransfer] baseline write failed: {ex.Message}");
+            }
+        }
+    }
+
+    // Caller must already hold BaselineLock (it is non-recursive).
+    private static Dictionary<string, long> ReadBaselineUnlocked()
+    {
+        if (!File.Exists(BaselinePath)) return new Dictionary<string, long>();
+        return JsonSerializer.Deserialize<Dictionary<string, long>>(File.ReadAllText(BaselinePath))
+               ?? new Dictionary<string, long>();
+    }
 
     /// <summary>
     /// Read-only <see cref="Stream"/> decorator that increments a counter on
@@ -353,6 +433,7 @@ public sealed class ImageDistributor : IDisposable
 
         private readonly string _hostId;
         private readonly int _attempt;
+        private readonly long _expectedBytes; // 0 = no baseline yet (first run)
         private readonly Stopwatch _startedAt;
         private readonly ByteCountingStream _counted;
         private readonly ITestRenderer? _renderer;
@@ -363,11 +444,12 @@ public sealed class ImageDistributor : IDisposable
         private string? _lastEmittedStatus;
         private string? _firstError;
 
-        public TransferProgress(string hostId, int attempt, Stopwatch startedAt,
-            ByteCountingStream counted, ITestRenderer? renderer)
+        public TransferProgress(string hostId, int attempt, long expectedBytes,
+            Stopwatch startedAt, ByteCountingStream counted, ITestRenderer? renderer)
         {
             _hostId = hostId;
             _attempt = attempt;
+            _expectedBytes = expectedBytes;
             _startedAt = startedAt;
             _counted = counted;
             _renderer = renderer;
@@ -407,19 +489,36 @@ public sealed class ImageDistributor : IDisposable
                                     && _lastEmit.Elapsed >= StatusEmitThreshold;
                 if (!bytesAdvanced && !statusChanged) return;
 
-                var rateMbPerSec = _startedAt.Elapsed.TotalSeconds > 0
-                    ? bytesSent / 1024.0 / 1024.0 / _startedAt.Elapsed.TotalSeconds
-                    : 0;
+                var elapsedSec = _startedAt.Elapsed.TotalSeconds;
+                var rateMbPerSec = elapsedSec > 0 ? bytesSent / 1024.0 / 1024.0 / elapsedSec : 0;
+
+                // Clamp so an overrun of the estimate caps at the bar's 100%.
+                int? pct = _expectedBytes > 0
+                    ? (int)Math.Min(100, bytesSent * 100.0 / _expectedBytes) : null;
+
                 InfrastructureEventLog.Emit("image_transfer_progress", new
                 {
                     host_id = _hostId,
                     attempt = _attempt,
                     bytesSent,
+                    expectedBytes = _expectedBytes,
+                    pct,
                     elapsedMs = _startedAt.ElapsedMilliseconds,
                 });
+
                 var phase = bytesAdvanced ? "uploading" : "remote";
+                var sizePart = _expectedBytes > 0
+                    ? $"{FormatMb(bytesSent)} / ~{FormatMb(_expectedBytes)}"
+                    : FormatMb(bytesSent);
+                var pctPart = pct is int p
+                    ? (bytesSent >= _expectedBytes ? ">99%, " : $"{p}%, ")
+                    : "";
+                var etaPart = _expectedBytes > bytesSent && rateMbPerSec > 0
+                    ? $", ETA {FormatEta((_expectedBytes - bytesSent) / 1024.0 / 1024.0 / rateMbPerSec)}"
+                    : "";
                 var statusSuffix = _lastStatus != null ? $" — {_lastStatus}" : "";
-                var detail = $"{phase} {FormatMb(bytesSent)} ({rateMbPerSec:F1} MB/s, {_startedAt.Elapsed.TotalSeconds:F0}s){statusSuffix}";
+                var detail = FormattableString.Invariant(
+                    $"{phase} {sizePart} ({pctPart}{rateMbPerSec:F1} MB/s, {elapsedSec:F0}s{etaPart}){statusSuffix}");
                 Console.Error.WriteLine($"[ImageTransfer] {_hostId}: {detail}");
                 _renderer?.OnSetupStep(new SetupStepEvent(SetupCategory, _hostId,
                     SetupStepStatus.InProgress, detail));

--- a/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
+++ b/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
@@ -24,6 +24,12 @@ public static class RunArtifactNames
     public const string FlakinessJsonl = "flakiness.jsonl";
 
     /// <summary>
+    /// Cross-run sidecar (<c>{hostId → bytes}</c>) at <see cref="TestArtifacts.OutputDir"/>
+    /// estimating the next image transfer's size for progress display.
+    /// </summary>
+    public const string ImageTransferBaseline = "image-transfer-baseline.json";
+
+    /// <summary>
     /// Filename used by parent processes (TestRunner / DistributedRunner) for their
     /// own structured-event log. Distinct from <see cref="InfrastructureJsonl"/>
     /// because the test-child opens the canonical log with <c>append: false</c>


### PR DESCRIPTION
## Why

The E2E `[ImageTransfer]` line reports **~1890 MB in CI but ~713 MB locally** for the same three images. Root cause: `docker save` from the coordinator daemon emits a different tar format depending on its image store — local dev (Docker 29, containerd snapshotter) writes compressed OCI blobs (~713 MB); the CI runner (overlay2, no containerd store) writes uncompressed `layer.tar` (~1890 MB). The SSH link is the bottleneck (~4.3 MB/s), so fewer bytes ≈ proportionally faster.

## Changes

- **Enable the containerd image store on the CI runner** via `docker/setup-docker-action@v5.2.0` (first step of the `e2e` job), so its `docker save` matches local's compressed output: **~1890 MB → ~713 MB**, ~270 s faster per run, at zero per-transfer CPU (compression happens once at build time). Also aligns CI with local dev + the Docker 29 default.
- **Richer transfer progress**: `uploading X / ~Y MB (pct, rate, ETA)` instead of just `X MB`. The total `Y` is a self-calibrating per-host baseline persisted across runs (image metadata can't predict the deduped/compressed save-tar size, so it's estimated from the previous transfer — exact after one run; display-only, never gates correctness).
- Add `expectedBytes`/`pct` to the `image_transfer_progress` diagnostic event.
- Pin all transfer log/UI numeric formatting to `InvariantCulture` in both distributors (a runner's locale was rendering `,` decimals into CI logs / the WebUI).

## Verification

- Full `make test-web FILTER=PasswordProtection` against the VPS: suite green (9/9), no regression.
- Forced a real transfer: progress rendered `uploading 109.3 MB / ~713.4 MB (15%, 4.5 MB/s, 24s, ETA 2m15s)`; baseline self-calibrated (seed → actual `748015616`); `image_transfer_progress` carried `expectedBytes`/`pct`.
- `dotnet build` clean (0 warnings).
- The CI containerd flip (Part 1) is verified by this PR's own `/run-tests-e2e` run — expect `[ImageTransfer]` to report ~713 MB.

## Follow-up (separate)

Registry-based layer-incremental transfer (send only blobs the VPS lacks) would shrink a typical re-run further (~30–80 MB vs 713 MB) — tracked separately, gated on it beating the registry's setup cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image transfer progress reporting with ETA estimates and percentage completion tracking.
  * Improved baseline persistence for cross-run image transfer data.

* **Bug Fixes**
  * Fixed decimal formatting consistency in logs across different locales.

* **Chores**
  * Optimized Docker configuration for improved E2E test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->