### PR TITLE
ci(e2e): move concurrency singleton to the e2e job to stop bot-edit cancellations

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -49,18 +49,11 @@ on:
 permissions:
   contents: read
 
-# ONE concurrency key for the single physical VPS runner — dispatch, comment, and
-# checkbox runs all share it, so they QUEUE rather than run in parallel (active + at most
-# one pending; a newer trigger replaces the waiting one).
-#
-# cancel-in-progress is ALWAYS false: it is evaluated at the run-scheduling layer, BEFORE
-# the gate authorizes, so making it an expression on comment.body would let any commenter
-# (a non-maintainer) cancel a running job — griefing with no secret/code access, but still
-# a nuisance. Preempting an in-flight run is a maintainer action via the Actions tab, not a
-# comment-triggered one. Do NOT make this an expression on comment.body.
-concurrency:
-  group: e2e-tests-singleton
-  cancel-in-progress: false
+# Concurrency singleton is on the `e2e` JOB, not here. Workflow-level acquires the group
+# before any job `if:`, so a no-op comment run (bot edit; gate skips it) would enter the
+# group and cancel a maintainer's waiting run. Job-level acquires only when the job starts;
+# a skipped `e2e` never starts. Do NOT re-add a workflow-level `e2e-tests-singleton` group —
+# a same-name workflow+job group deadlocks.
 
 jobs:
   # ── Authorize + parse + resolve the PR HEAD. NO secrets here; this job decides
@@ -242,6 +235,13 @@ jobs:
     needs: [gate, authorize]
     if: needs.gate.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    # Singleton against the one physical VPS runner. cancel-in-progress: false — a maintainer
+    # preempts via the Actions tab, never a comment. queue: max FIFO-queues runs instead of
+    # the default `single`, which cancels the waiting run when a newer one queues.
+    concurrency:
+      group: e2e-tests-singleton
+      cancel-in-progress: false
+      queue: max
     # Holds the Steam + SSH secrets. Mirrors deploy-server.yml's per-environment
     # secret scoping.
     environment: test-vps


### PR DESCRIPTION
## Problem

`e2e-tests.yml` triggers on `issue_comment: [created, edited]`, and `issue_comment` can't be filtered at the `on:` level (only `types:` exists). So GitHub creates a run for **every** comment edit on a PR — including CodeRabbit editing its own summary comment.

The concurrency singleton was at the **workflow level**, which acquires the group at run-scheduling time, **before** any job `if:`. A no-op run (one the `gate` job will skip) therefore entered `e2e-tests-singleton` and took its single pending slot; in a `single` group a newcomer cancels the pending run. Net effect: a bot comment edit could cancel a maintainer's genuinely-waiting run.

Observed live on #364:
- #33 (`/run-tests-e2e`, real) → in_progress
- #34 (CodeRabbit edit, no-op) → took the pending slot, then cancelled
- #35 (CodeRabbit edit, no-op) → cancelled #34, took the pending slot

The gate's checks (`sender.type != 'Bot'` + marker) still stopped the no-op from *executing* the secret-bearing E2E job — nothing unsafe ran — but the no-op stole the singleton's pending slot.

## Changes

- Remove the workflow-level `concurrency` block; move it to the **`e2e` job** (`jobs.e2e.concurrency`). A job-level group is acquired only when the job *starts*, and a gate-skipped `e2e` job never starts, so no-op runs no longer enter the group. The gate `if:` stays the single source of truth — no predicate duplicated into a concurrency expression.
- Add `queue: max` so genuine runs FIFO-queue behind an in-flight one instead of the default `single` queue cancelling a waiter (requires `cancel-in-progress: false`, which the singleton already uses).
- The workflow-level block is fully removed: a same-name workflow + job concurrency group is a GitHub deadlock error.

## Verification

- YAML parses cleanly; workflow-level `concurrency` absent; `e2e.concurrency = { group: e2e-tests-singleton, cancel-in-progress: false, queue: max }`.
- `queue: max` confirmed against GitHub's 2026-05-07 changelog (≤100 FIFO; requires `cancel-in-progress: false`).
- One behavior GitHub doesn't document explicitly — that a *skipped* job stays out of its concurrency group — should be confirmed live after merge: with a real `e2e` run in-progress, trigger a bot comment edit and confirm the real run is not cancelled and the no-op run's `e2e` shows `skipped` without going `pending`; then post a second `/run-tests-e2e` and confirm it queues behind (validates `queue: max`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI test workflow concurrency to control queuing at the job level.
  * Enables FIFO queuing for test runs and prevents in-progress runs from being auto-cancelled, improving test run accumulation and execution predictability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->