### PR TITLE
ci: add CI status badges + nightly E2E run on master

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -4,11 +4,14 @@
 # reached over SSH — the harness's existing multi-host model with SDVD_DOCKER_HOSTS
 # set to a VPS-only fleet.
 #
-# THREE ways in, all manual and maintainer-gated — never an automatic merge gate:
+# FOUR ways in — three manual/maintainer-gated, plus one bounded nightly schedule:
 #   1. workflow_dispatch (Actions tab) — runs the full suite from a trusted branch.
 #   2. `/run-tests-e2e [filter]` PR comment.
 #   3. the "Re-run E2E tests" checkbox in the bot's results comment (a click in the
 #      PR view; toggling it fires issue_comment: edited).
+#   4. schedule (nightly 08:00 UTC) — a full-suite run on master so the README E2E
+#      badge has a real, recent master result to show. Trusted (default-branch
+#      workflow on master), no PR context; it never gates a merge (see below).
 #
 # Why this is safe despite touching PRs:
 #   - issue_comment ALWAYS runs THIS workflow file from the default branch (master),
@@ -25,8 +28,11 @@
 #     cancel triggers the runner's abort path (writes summary.json, sweeps VPS containers
 #     by run-id), and the sticky reports "⚪ aborted".
 #   - This workflow must NEVER become a required check (external-VPS availability can't
-#     gate the merge queue). Do NOT add pull_request_target / push / schedule /
-#     merge_group.
+#     gate the merge queue). The nightly `schedule` is the ONLY automatic trigger and is
+#     safe precisely because it doesn't gate anything — it runs on master after the fact,
+#     never blocks a merge, and is bounded to one run/day on the single VPS. Do NOT add a
+#     merge-coupled trigger (push / pull_request_target / merge_group) or mark any job a
+#     required check.
 #
 # All secrets resolve from the `test-vps` GitHub Environment (the same per-environment
 # mechanism deploy-server.yml uses), not loose repo-level secrets. R2_BUCKET /
@@ -40,6 +46,11 @@ on:
         description: 'Test filter (xUnit class/method substring). Empty = run the full suite.'
         required: false
         default: ''
+  # Nightly full-suite run on master so the README E2E badge reflects a real, recent
+  # result. 08:00 UTC is clear of the other crons (CodeQL Wed 07:17; cleanups Sun/Mon
+  # 06:00). Handled like workflow_dispatch in the gate (trusted, no PR context).
+  schedule:
+    - cron: '0 8 * * *'
   # PR comments: `created` = the typed `/run-tests-e2e` command; `edited` = the re-run
   # checkbox in the bot's results comment being ticked. The `gate` job's `if:` narrows
   # this to PR comments that are actually our command or our sticky (see that job).
@@ -73,6 +84,7 @@ jobs:
     # filter would block every re-run. sender is the human who clicked.
     if: >
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       (github.event_name == 'issue_comment'
        && github.event.issue.pull_request != null
        && github.event.sender.type != 'Bot'
@@ -110,10 +122,14 @@ jobs:
             const helper = require('./.github/scripts/e2e-pr-sticky.js');
             const { owner, repo } = context.repo;
 
-            // ---- workflow_dispatch: trusted branch, no PR context ----
-            if (context.eventName === 'workflow_dispatch') {
+            // ---- workflow_dispatch / schedule: trusted, no PR context ----
+            // Both run the default-branch workflow with no PR head; leaving head_sha
+            // unset makes the e2e checkout fall back to the default ref (master).
+            // dispatch may carry a filter input; the nightly schedule always runs the
+            // full suite.
+            if (context.eventName === 'workflow_dispatch' || context.eventName === 'schedule') {
               core.setOutput('proceed', 'true');
-              core.setOutput('filter', process.env.DISPATCH_FILTER || '');
+              core.setOutput('filter', context.eventName === 'workflow_dispatch' ? (process.env.DISPATCH_FILTER || '') : '');
               core.setOutput('is_fork', 'false');
               return;
             }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ![GitHub Tag](https://img.shields.io/github/v/tag/stardew-valley-dedicated-server/server?label=Latest%20Release&style=flat&colorA=18181B)
 ![Static Badge](https://img.shields.io/badge/Stardew%20Valley-v1.6.15-34D058?style=flat&colorA=18181B)
+[![Build Release](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/build-release.yml?branch=master&label=Build%20Release&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/build-release.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/codeql.yml?branch=master&label=CodeQL&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/codeql.yml)
+[![E2E Tests](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/e2e-tests.yml?branch=master&label=E2E%20Tests&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/e2e-tests.yml)
 [![Discord](https://img.shields.io/discord/947923329057185842?label=Discord&logo=discord&color=34D058&style=flat&colorA=18181B)](https://discord.gg/w23GVXdSF7)
 
 **JunimoServer** makes [Stardew Valley](https://www.stardewvalley.net/) multiplayer hosting simple and flexible. Host your farm anytime, anywhere — on your local machine, a VPS, or a dedicated server.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # JunimoServer
 
+<!-- Project -->
 ![GitHub Tag](https://img.shields.io/github/v/tag/stardew-valley-dedicated-server/server?label=Latest%20Release&style=flat&colorA=18181B)
 ![Static Badge](https://img.shields.io/badge/Stardew%20Valley-v1.6.15-34D058?style=flat&colorA=18181B)
-[![Build Release](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/build-release.yml?branch=master&label=Build%20Release&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/build-release.yml)
+<!-- CI status (master) -->
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/codeql.yml?branch=master&label=CodeQL&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/codeql.yml)
 [![E2E Tests](https://img.shields.io/github/actions/workflow/status/stardew-valley-dedicated-server/server/e2e-tests.yml?branch=master&label=E2E%20Tests&style=flat&colorA=18181B)](https://github.com/stardew-valley-dedicated-server/server/actions/workflows/e2e-tests.yml)
+<!-- Community -->
 [![Discord](https://img.shields.io/discord/947923329057185842?label=Discord&logo=discord&color=34D058&style=flat&colorA=18181B)](https://discord.gg/w23GVXdSF7)
 
 **JunimoServer** makes [Stardew Valley](https://www.stardewvalley.net/) multiplayer hosting simple and flexible. Host your farm anytime, anywhere — on your local machine, a VPS, or a dedicated server.


### PR DESCRIPTION
## What & why

The repo is trunk-based (feature → master via merge queue; releases are git tags; no `develop`). Master is continuously green by design, so there was no honest live signal to badge for the new E2E pipeline. This adds master-scoped CI badges to the README and gives the E2E suite a *real* recurring master run to back its badge.

## Changes

**`README.md`** — add three status badges to the existing badge row:
- **Build Release** and **CodeQL** — both already run on `push: [master]`, so they're genuine master-health signals.
- **E2E Tests** — backed by the new nightly run (below).
- Uses shields.io's `actions/workflow/status` endpoint (not GitHub's native `badge.svg`) so the badges honor the row's existing style (`flat`, `colorA=18181B`) and match visually. All scoped to `?branch=master`.

**`.github/workflows/e2e-tests.yml`** — add a nightly schedule so the E2E badge reflects a real, recent master result instead of a stale maintainer-triggered run:
- `on:` → `schedule: cron '0 8 * * *'` (08:00 UTC; clear of CodeQL Wed 07:17 and the Sun/Mon 06:00 cleanups).
- Wired through all four required points — a one-line `on:` add would be inert because the gate filters unknown events:
  1. `on:` block
  2. gate job `if:` admits `github.event_name == 'schedule'`
  3. gate github-script merges `schedule` into the trusted `workflow_dispatch` branch (full suite, no PR head → e2e checkout falls back to master)
  4. header comment updated ("FOUR ways in") and the prohibition rewritten to mark the non-gating nightly schedule as the deliberate exception
- The nightly run **never gates a merge** and is bounded to one run/day on the single VPS. `push` / `pull_request_target` / `merge_group` and required-check status remain prohibited. No PR-comment side effects (the sticky steps stay `issue_comment`-only).

## Not introduced (with reasons)

- **No `develop` branch** — nothing would feed its CI; master is the integration line and releases are tags.
- **No release-tag badge** — already present in the README.
- **No `push`/`pull_request` E2E trigger** — would create single-VPS backlog and bypass the fork-pr security gate; the bounded nightly schedule was chosen instead.

## Verification

- YAML parses; triggers `[workflow_dispatch, schedule, issue_comment]`, schedule cron and gate `if:` confirmed.
- Embedded gate JS syntax-checked.
- Schedule-safety confirmed by reading the actual steps: e2e checkout falls back to master when `head_sha` is empty; trusted-helper checkout and "Update PR sticky" are `issue_comment`-only (skipped); R2 `BRANCH_REF` falls back to `master`.
- All three badge URLs return HTTP 200.

**Not runtime-verified:** firing an actual `schedule` event end-to-end requires merging (schedule only runs from the default branch) and a multi-hour VPS run. First true confirmation will come from the Actions tab after merge (the E2E badge will track nightly runs from then on; it may show a stale "passing" until the first nightly fires).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CodeQL and E2E status badges to the README for clearer CI visibility.

* **Chores**
  * Added nightly scheduled E2E runs on master (08:00 UTC) alongside manual triggers; updated workflow documentation and adjusted trigger/gating logic so scheduled runs are allowed and handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->