### PR TITLE
ci: validate PR title as a conventional commit at PR time

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -54,6 +54,42 @@ jobs:
               - 'tools/openapi-generator/**'
               - 'Directory.Build.props'
 
+  validate-pr-title:
+    name: Validate PR Title
+    # Squash-merge makes the PR title the commit subject, which the merge queue lints — but
+    # validate-commits lints only the fork's commits, not the title. Lint it here through the same
+    # commitlint.config.js so a bad title fails on the PR, not cryptically in the queue. Title-only,
+    # no fork code or secrets, so no `authorize` gate.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base repo code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: |
+            package.json
+            package-lock.json
+            commitlint.config.js
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate PR title
+        # Via env, never interpolated into the script — a title with shell metacharacters is data, not code.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if ! printf '%s\n' "$PR_TITLE" | npx commitlint --verbose; then
+            echo "::error title=Invalid PR title::\"$PR_TITLE\" is not a Conventional Commit. The title becomes the squash commit subject — use e.g. 'feat: add missing game options'. See CONTRIBUTING.md."
+            exit 1
+          fi
+
   validate-commits:
     name: Validate Commits
     needs: authorize

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -130,11 +130,12 @@ The validation pipeline runs on every pull request targeting `master`. It ensure
 
 ### What It Validates
 
+- **PR title** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format. The repo squash-merges, so the title becomes the commit subject the merge queue lints — checking it here fails a bad title on the PR rather than cryptically in the queue.
 - **Commit messages** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - **Docker build** - Ensures the image builds successfully (without pushing)
 - **Line endings** - Fails if a file with CRLF line endings reached the index, bypassing the LF normalization `.gitattributes` enforces
 
-These surface as three required status checks — `Validate Build`, `Validate Commits`, and `Validate Line Endings` — that must pass before a PR can merge.
+These surface as required status checks — `Validate PR Title`, `Validate Build`, `Validate Commits`, and `Validate Line Endings` — that must pass before a PR can merge.
 
 ### Trigger & Security Model
 


### PR DESCRIPTION
- Squash-merge makes the PR title the commit subject, which the merge queue lints — but `validate-commits` only lints the fork's individual commits, never the title. A non-conventional title (e.g. "Feat/extra settings" on #301) passed every PR check and failed cryptically deep in the merge queue.
- Adds a `validate-pr-title` job that lints the title through the same `commitlint.config.js` — single source of truth, so the allowed-type list can't drift from the commit/merge-queue lint.
- On failure it emits a clear `::error::` annotation with a valid example and a pointer to CONTRIBUTING.md, instead of raw commitlint output.
- No `authorize` gate: the job reads only the PR title (via env, never executed) and base-repo files — no fork code, no secrets — mirroring the `changes` job.
- Documents the new `Validate PR Title` check in `ci-cd.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation for pull request titles to enforce Conventional Commits format standards in the CI/CD pipeline. This validation runs for all pull requests, including contributions from external repository forks, ensuring consistent commit messaging across the project.

* **Documentation**
  * Updated CI/CD pipeline documentation to reflect the new PR title validation requirement as a mandatory status check that must pass before merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->