### PR TITLE
feat: support mod-added farm types via FarmType 8+

### DIFF
--- a/docs/admins/configuration/server-settings.md
+++ b/docs/admins/configuration/server-settings.md
@@ -92,6 +92,7 @@ These settings only take effect when creating a **new** game. They are ignored w
 | `5` | Four Corners |
 | `6` | Beach |
 | `7` | Meadowlands |
+| `8+` | Mod-added farms in mod load order, excluding Meadowlands (8 = first mod farm, 9 = second, etc.) |
 
 ### Profit Margin
 

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -105,12 +105,13 @@ namespace JunimoServer.Services.GameCreator
             }
             else
             {
-                Game1.whichFarm = config.WhichFarm;
+                // Farm.mod_layout (7) is the game's signal to use whichModFarm; map any mod farm
+                // type (8+) to 7 upfront so the lookup branches below only need to set whichModFarm.
+                Game1.whichFarm = config.WhichFarm > 7 ? 7 : config.WhichFarm;
 
-                // Farm type 7 (Meadowlands) uses the AdditionalFarms system.
-                // whichModFarm MUST be set BEFORE loadForNewGame() because the Farm map
-                // is created during loadForNewGame() using Farm.getMapNameFromTypeInt()
-                // which checks whichModFarm when whichFarm is 7.
+                // Farm types >= 7 use the AdditionalFarms system. whichModFarm MUST be set BEFORE
+                // loadForNewGame() because the Farm map is created during loadForNewGame() using
+                // Farm.getMapNameFromTypeInt() which checks whichModFarm when whichFarm is 7.
                 if (config.WhichFarm == 7)
                 {
                     var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
@@ -119,6 +120,23 @@ namespace JunimoServer.Services.GameCreator
                     if (Game1.whichModFarm == null)
                     {
                         _monitor.Log("Could not find MeadowlandsFarm data, falling back to Standard farm", LogLevel.Warn);
+                        Game1.whichFarm = 0;
+                    }
+                }
+                else if (config.WhichFarm > 7)
+                {
+                    // 8+ = mod-added farms in load order (excluding Meadowlands), so index 0 = FarmType 8.
+                    var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
+                    var modFarms = additionalFarms?.Where(f => f.Id != "MeadowlandsFarm").ToList();
+                    var modFarmIndex = config.WhichFarm - 8;
+
+                    Game1.whichModFarm = modFarms != null && modFarmIndex < modFarms.Count
+                        ? modFarms[modFarmIndex]
+                        : null;
+
+                    if (Game1.whichModFarm == null)
+                    {
+                        _monitor.Log($"Could not find mod farm at index {modFarmIndex} (FarmType {config.WhichFarm}), falling back to Standard farm", LogLevel.Warn);
                         Game1.whichFarm = 0;
                     }
                 }


### PR DESCRIPTION
### 🔗 Linked issue

Closes #378
Partially addresses #341 (extends coverage to mod-added farm types noted as untested)

### 📚 Description

`FarmType` values >= 8 now select mod-added farms from the game's `Data/AdditionalFarms` 
system in mod load order (excluding Meadowlands), where 8 = first mod farm, 9 = second, etc.

The game uses `whichFarm = 7` (`Farm.mod_layout`) as the signal to consult `whichModFarm` 
for the actual map — so config values > 7 are mapped to 7 upfront, then `whichModFarm` is 
resolved by indexing into `AdditionalFarms` with Meadowlands excluded (since type 7 already 
handles it by ID). Falls back to Standard farm with a warning if the index is out of range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mod-added farm types when creating new games, with proper fallback handling for invalid selections.

* **Documentation**
  * Updated server settings documentation to describe mod-introduced farm types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->