### PR TITLE
ci: enable containerd image store in-place on the runner's existing daemon

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -312,13 +312,29 @@ jobs:
       SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
 
     steps:
-      # containerd image store makes `docker save` emit compressed OCI blobs
-      # (~60% smaller), shrinking the E2E image transfer. Must be the first step.
-      - name: Set up Docker with containerd image store
-        uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 # v5.2.0
-        with:
-          daemon-config: |
-            { "features": { "containerd-snapshotter": true } }
+      # Enable the containerd image store so `docker save` emits compressed OCI
+      # blobs (~60% smaller), shrinking the E2E transfer. Must be first (pre-build).
+      # Reconfigure the runner's existing daemon in place rather than
+      # docker/setup-docker-action — that action's second daemon splits the build
+      # socket from the distributor's _localClient socket (rules/docker-save-format-
+      # source-daemon.md). One daemon = build, compose, and _localClient agree.
+      - name: Enable containerd image store on the daemon
+        run: |
+          # Merge into a temp var, not `cat f | tee f` (that pipeline truncates f);
+          # `|| echo` covers a runner with no daemon.json.
+          merged=$(sudo jq '. + {"features": {"containerd-snapshotter": true}}' \
+            /etc/docker/daemon.json 2>/dev/null \
+            || echo '{"features": {"containerd-snapshotter": true}}')
+          printf '%s\n' "$merged" | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break || sleep 1; done
+          # The containerd store reports Driver=overlayfs (classic=overlay2); fail
+          # fast if the restart didn't flip it, else save silently uses the ~2.5×
+          # legacy format.
+          driver=$(docker info --format '{{.Driver}}')
+          echo "Storage Driver: $driver"
+          [ "$driver" = "overlayfs" ] \
+            || { echo "::error::containerd snapshotter not active (Driver=$driver)"; exit 1; }
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -321,13 +321,18 @@ jobs:
       - name: Enable containerd image store on the daemon
         run: |
           # Merge into a temp var, not `cat f | tee f` (that pipeline truncates f);
-          # `|| echo` covers a runner with no daemon.json.
-          merged=$(sudo jq '. + {"features": {"containerd-snapshotter": true}}' \
+          # `(.features // {})` deep-merges so preinstalled feature keys (buildkit)
+          # survive; `|| echo` covers a runner with no daemon.json.
+          merged=$(sudo jq '.features = (.features // {}) + {"containerd-snapshotter": true}' \
             /etc/docker/daemon.json 2>/dev/null \
             || echo '{"features": {"containerd-snapshotter": true}}')
           printf '%s\n' "$merged" | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
           for i in $(seq 1 30); do docker info >/dev/null 2>&1 && break || sleep 1; done
+          # Distinguish "daemon never came back" from "store didn't flip" — else the
+          # driver check below reports a misleading Driver= empty.
+          docker info >/dev/null 2>&1 \
+            || { echo "::error::Docker daemon did not respond 30s after restart"; exit 1; }
           # The containerd store reports Driver=overlayfs (classic=overlay2); fail
           # fast if the restart didn't flip it, else save silently uses the ~2.5×
           # legacy format.


### PR DESCRIPTION
## Problem

The `E2E (VPS)` job aborts in **Image distribution** with `[ImageTransfer] aborted: ... No such image: sdvd/server:local`, despite the build reporting `✓ Built server image`. It fails before any test runs.

**Root cause:** `docker/setup-docker-action` (added in #367 to enable the containerd snapshotter for compressed `docker save`) starts a **second** dockerd on its own socket and `docker context use`s it, leaving the runner's pre-installed daemon alive on `/var/run/docker.sock`.

- `make build`'s `docker buildx build --load` follows the active docker context → image lands in the **new** daemon.
- The distributor's Docker.DotNet `_localClient` (resolved by Testcontainers, whose provider chain has no docker-context provider) falls through to the `/var/run/docker.sock` Unix default → the **old** daemon.

So the freshly-built `sdvd/server:local` lands in one daemon while the distributor inspects the other → 404. (#367's compressed-save fix never reached the save path either, for the same reason.)

## Fix

- Drop `docker/setup-docker-action`; enable the containerd store on the **one** pre-installed daemon by merging `{"features":{"containerd-snapshotter":true}}` into `/etc/docker/daemon.json` and restarting it.
- Merge via jq into a temp var (not `cat f | tee f`, which truncates) with an `|| echo` fallback for a runner without `daemon.json`.
- Wait for the socket, then fail fast unless `docker info` reports `Driver=overlayfs` (the containerd store; classic store reports `overlay2`) — so a non-flipped store can't silently fall back to the ~2.5× larger legacy save format.
- One daemon on `/var/run/docker.sock` means build, `docker compose`, and `_localClient` all agree — eliminating the split rather than bridging it with `DOCKER_HOST`.

## Notes

- Separate from #376 (SSH-tunnel test infra); this is the build→distribution handoff.
- Not yet confirmed on CI — needs a `workflow_dispatch` run on the VPS runner. The added `Driver=overlayfs` assertion is the in-job guard if the restart doesn't take.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to enforce and verify the Docker storage driver is overlayfs during end-to-end test runs. The job will stop if verification fails to prevent incompatible image transfers. This ensures more reliable, consistent test artifacts and environments (including restarting Docker as needed) with no impact on end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->