### PR TITLE
fix(mod): decouple VNC input suppression from the F9/F10 escape hatch

### DIFF
--- a/.claude/plans/bugs/vnc-input-suppression-rendering-coupling.md
+++ b/.claude/plans/bugs/vnc-input-suppression-rendering-coupling.md
@@ -1,0 +1,143 @@
+# Bug: VNC input dead whenever automation is on — input gate conflates perf-suppression with the F9/F10 escape hatch
+
+## Symptom (user report)
+
+VNC shows the game but accepts no input, no matter what. Operator set `SERVER_FPS` (rendering visibly on), tried the (now-removed) `DISABLE_RENDERING`, tried multiple browsers — input never registers. Goal was to drive the UI over VNC (e.g. start a new farm to pick a modded `FarmType`).
+
+## Root cause
+
+The input gate `SuppressInput_Prefix` (`mod/JunimoServer/Services/ServerOptim/ServerOptimizerOverrides.cs:66-67`) is:
+
+```csharp
+public static bool SuppressInput_Prefix()
+    => _rendering.CurrentFps != 0 && !_automationSuppressesInput;
+```
+
+and it is patched **unconditionally onto all three** input methods (`ServerOptimizer.cs:99-112`):
+
+- `StardewValley.Game1:UpdateControlInput` — game-side input processing (reads `Game1.input`, the `InputState` layer).
+- `Microsoft.Xna.Framework.Input.Keyboard:PlatformGetState` — raw device.
+- `Microsoft.Xna.Framework.Input.Mouse:PlatformGetState` — raw device.
+
+`InputState.UpdateStates()` (`decompiled/.../StardewValley/InputState.cs:25-37`) feeds **both** the game and SMAPI from `Keyboard.GetState()` / `Mouse.GetState()` → `PlatformGetState`. So suppressing at the device layer blinds **SMAPI's `Input.ButtonPressed` pipeline too** — including F9/F10. Since `EnableAutoMode()` sets `_automationSuppressesInput = true` on every save load (`AlwaysOn.cs:150, 388-395`), the device layer is dead whenever automation is on. **The F9 "toggle automation off to restore input" recovery path is self-defeating: F9's own delivery channel is suppressed.** Only the off-VNC `host-auto` console command can toggle it.
+
+## Regression origin
+
+Commit `c7dbf85` ("feat(mod): extract JunimoServer.Shared and add diagnostics tracing") merged the previously-separate input prefixes into one and changed the device-layer patches from *conditional* to *unconditional + automation-driven*. Pre-refactor (`c7dbf85^:ServerOptimizer.cs:89-107`):
+
+- `UpdateControlInput` was **always** patched with `UpdateControlInput_Prefix` (live-gated on rendering + automation) — game-side only.
+- `Keyboard`/`Mouse` `PlatformGetState` were patched with `Disable_Prefix` (hardcoded `return false`) **only if `_disableRendering` was true at boot** (`if (_disableRendering)`), read once from the now-removed `Env.DisableRendering`.
+
+So in the old "boot rendering-enabled, drive via VNC" path, the device layer was **never patched**, SMAPI kept seeing keys, and F9 worked. The escape hatch existed because device-layer suppression and the live automation gate were decoupled. The refactor coupled them.
+
+## Design intent (from the user)
+
+- Rendering on/off via `.env` `SERVER_FPS` (0 = off / perf mode, N>0 = on), independently changeable at runtime via the existing `rendering <fps>` console command and `POST /rendering?fps=N` — no regression to that surface.
+- **Rendering OFF**: input has no logical meaning (operator can't see anything to drive) → suppress fully. This is the performance optimization AND the accidental-interference guard, together.
+- **Rendering ON**: operator can see → the F9 (auto-mode) and F10 (visibility) toggles must work seamlessly over VNC; general input works once the operator drops automation via F9. **Pressing F9/F10 IS the explicit intent** — no new command/endpoint.
+- Retain the existing server optimizations (NullDisplayDevice swap, `Disable_Prefix` on music/butterflies/etc.). Only the input gate changes.
+
+## The model
+
+The device layer (`Keyboard/Mouse:PlatformGetState`) is the **single source** feeding every input consumer. Verified against decompiled source: `Game1._update` captures `GetKeyboardState()`/`input.GetMouseState()` once (`Game1.cs:4004-4006`) and routes that *same* state to free-roam control (`UpdateControlInput`, only when no menu is open — `Game1.cs:4287`), menus (`updateActiveMenu`), text entry (`updateTextEntry`), minigames, and chat. SMAPI's `Input.ButtonPressed` reads the same source independently: `SCore` update loop → `SInputState.TrueUpdate()` → `base.GetKeyboardState()` → `InputState._currentKeyboardState`, set by `UpdateStates()` → `Keyboard.GetState()` → `PlatformGetState`.
+
+So there is exactly one chokepoint, and the fix lives there: **suppress all input at the device layer, carving out only F9/F10 so SMAPI's `ButtonPressed` still fires for them.** No game-side `UpdateControlInput` patch is needed — when the device returns empty state, every game consumer (control AND menus AND chat) sees nothing; only SMAPI's handler sees the carve-out keys.
+
+Suppression is active whenever `fps==0` **or** automation is on:
+
+| Render state | Keyboard device returns | Mouse device returns | UI interaction (control + menus + chat) | F9/F10 |
+|---|---|---|---|---|
+| `fps==0` (perf, default) | `default` (nothing) | `default` | blocked | inert (operator can't see anyway) |
+| `fps>0`, automation **on** (default after save load) | only F9/F10 if physically down | `default` | **blocked** | **fire** (SMAPI sees them) |
+| `fps>0`, automation **off** (operator pressed F9) | full real state | full real state | works | fire |
+
+Why this satisfies every requirement:
+
+- **fps==0 (perf mode):** device returns empty → zero input cost, full guard, F9/F10 inert (nothing to see). Matches "input off makes no logical sense when rendering off." Identical to today's suppression behavior at fps 0.
+- **fps>0, automation ON:** device returns *only* F9/F10 → all keyboard/mouse UI interaction is blocked (you cannot click menus, type in chat, or move the character over VNC), but SMAPI sees F9/F10 → the toggles fire. This is the accidental-interference guard, complete: view-only except the two hotkeys we explicitly set up.
+- **fps>0, automation OFF (operator pressed F9):** device passes full real state → seamless control over VNC.
+
+SMAPI's `ButtonPressed` reading the device layer independently of `UpdateControlInput` is confirmed at source (`SInputState.TrueUpdate` → `base.GetKeyboardState` → `_currentKeyboardState` ← `PlatformGetState`), and corroborated by the pre-refactor behavior: that code skipped `UpdateControlInput` entirely in the rendering-enabled path yet F9 worked over VNC — the only unsuppressed thing there was `PlatformGetState`.
+
+## Changes
+
+### 1. Replace the prefix with device-layer postfixes (`ServerOptimizerOverrides.cs`)
+
+The keyboard and mouse `PlatformGetState` methods return different types (`KeyboardState` / `MouseState`), so each needs its own postfix — there is no shared body to factor out. Suppression is `fps==0 || _automationSuppressesInput`. Keep `SetAutomationInputSuppression` / `_automationSuppressesInput` as-is (toggled by `EnableAutoMode`/`ToggleAutoMode`/`OnReturnedToTitle`).
+
+The carve-out keys are the configured host-automation hotkeys, not hardcoded. `AlwaysOnConfig.HotKeyToggleAutoMode`/`HotKeyToggleVisibility` are `SButton`; convert to `Keys` once at `Initialize` via `SButtonExtensions.TryGetKeyboard`. Inject `AlwaysOnConfig` into `ServerOptimizer` (a DI singleton, `ModEntry.cs:180-181`) and pass the keys through to `Initialize`.
+
+```csharp
+private static Keys[] _carveOutKeys = Array.Empty<Keys>();
+
+public static void Initialize(IMonitor monitor, AlwaysOnConfig config)
+{
+    _monitor = monitor;
+    _rendering = new RenderingController(monitor, "Server");
+    _carveOutKeys = new[] { config.HotKeyToggleAutoMode, config.HotKeyToggleVisibility }
+        .Where(b => b.TryGetKeyboard(out _))
+        .Select(b => { b.TryGetKeyboard(out var k); return k; })
+        .ToArray();
+}
+
+private static bool InputSuppressed
+    => _rendering.CurrentFps == 0 || _automationSuppressesInput;
+
+// Keyboard/Mouse PlatformGetState is the single source for the game (control, menus,
+// chat, minigames) AND SMAPI's ButtonPressed pipeline. While suppressed, strip keyboard
+// state to the host-automation hotkeys so all other input is blocked but those toggles
+// still reach SMAPI — the operator's only way to drop automation from the VNC display.
+public static void KeyboardState_Postfix(ref KeyboardState __result)
+{
+    if (!InputSuppressed) return;
+    var down = Array.FindAll(_carveOutKeys, __result.IsKeyDown);
+    __result = down.Length == 0 ? default : new KeyboardState(down);
+}
+
+public static void MouseState_Postfix(ref MouseState __result)
+{
+    if (InputSuppressed) __result = default;
+}
+```
+
+The `UpdateControlInput` patch is removed — with the device returning empty state, every consumer sees no input, so a separate game-side gate is redundant.
+
+### 2. Re-point the patches (`ServerOptimizer.cs:99-112`)
+
+```csharp
+harmony.Patch(
+    original: AccessTools.Method("Microsoft.Xna.Framework.Input.Keyboard:PlatformGetState"),
+    postfix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.KeyboardState_Postfix)));
+
+harmony.Patch(
+    original: AccessTools.Method("Microsoft.Xna.Framework.Input.Mouse:PlatformGetState"),
+    postfix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.MouseState_Postfix)));
+```
+
+Drop the `Game1:UpdateControlInput` patch. Inject `AlwaysOnConfig` into the `ServerOptimizer` constructor and pass it to `ServerOptimizerOverrides.Initialize`. Rewrite the block comment above (`ServerOptimizer.cs:94-98`) for the single device-layer carve-out. Add `using Microsoft.Xna.Framework.Input;` and `using StardewModdingAPI;` (for `SButtonExtensions.TryGetKeyboard`) to `ServerOptimizerOverrides.cs`.
+
+### 3. Docs
+
+- `docs/admins/configuration/environment.md` (~97-101): while rendering is on, the VNC view is input-blocked except **F9** (toggle host automation) and **F10** (toggle visibility); press F9 to drop automation and gain full keyboard/mouse control, press it again to re-arm the guard. Input is fully suppressed while rendering is off.
+- `docs/admins/operations/commands.md` (host-auto section ~104-110): note F9 is the in-VNC equivalent of `host-auto` and works over VNC whenever rendering is on, even while automation is suppressing all other input.
+
+## Out of scope (named, not silently dropped)
+
+- **Modded `FarmType` / new-farm creation** (the user's end goal). That is a separate concern: the headless new-game path resolving a mod-added farm type by index (`"FarmType": 8`). Not touched here — file/triage separately. This plan only restores the *ability to drive the UI over VNC*, which is the prerequisite the user was blocked on.
+- **Test-client**: uses `RenderingController` for draw control only; does not patch input or use `ServerOptimizerOverrides` (`tests/test-client/ModEntry.cs:53,136`). Untouched.
+
+## Compatibility verification
+
+- **Save-load flow:** `EnableAutoMode` still sets `_automationSuppressesInput=true`. With rendering on, the keyboard postfix strips state to F9/F10 → all UI interaction blocked (movement guard preserved — matches the intentional move-freeze in `misc-triage-bugs.md`), SMAPI still sees the toggles. With rendering off, fully suppressed.
+- **Perf mode (fps==0, the production default):** `InputSuppressed` is true (the `fps==0` term), keyboard returns `default` (carve-out keys can't be physically pressed on a headless host with no VNC viewer anyway), mouse `default` → identical to today's full suppression. **No perf regression.** Postfix cost is one `Array.FindAll` over a 2-element array per device read — negligible, and only when suppressed.
+- **Runtime toggle:** `InputSuppressed` reads `_rendering.CurrentFps` and `_automationSuppressesInput` live every call, so `rendering <fps>` / `POST /rendering?fps=N` and `host-auto`/F9 flip input behavior with no restart.
+- **LAN vs Steam / lobby / unauthenticated players:** input gating is host-local (VNC operator only); does not touch netReady, lobby exclusion, or transport. No interaction.
+- **F9/F10 delivery:** confirmed at source — SMAPI's `SInputState.TrueUpdate` reads `base.GetKeyboardState()` ← `_currentKeyboardState` ← `PlatformGetState` (our postfix runs there), independent of `UpdateControlInput`. The carve-out keys survive into the state SMAPI derives `ButtonStates` from.
+- **F10 vanilla binding:** `multiplayer.StartServer()` at `Game1.cs:13289` is inside `UpdateControlInput` and gated `server == null`; inert on a running server. Letting F10 through the device layer triggers no vanilla side effect.
+
+## Post-conditions (runtime gates — must be observed, not just compiled)
+
+1. Boot with `SERVER_FPS=10`, save auto-loads (automation on): over VNC, **F9 toggles automation off** (visible HUD "Host automation: Disabled"), then keyboard/mouse drive the host. **F10 toggles visibility.**
+2. With automation on + rendering on: keyboard/mouse do **nothing** over VNC — cannot move the character, click menus, or type in chat — but F9/F10 still fire.
+3. `rendering 0` at runtime: input goes dead. `rendering 10`: F9/F10 live again — no restart. Toggling `host-auto` off then on flips between full-input and F9/F10-only without restart.
+4. Boot with `SERVER_FPS=0` (default): no input processed (perf mode), unchanged from current production behavior.

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -100,6 +100,10 @@ You don't have to restart to enable rendering for debugging. Both of these take 
 - Console: `docker compose exec server attach-cli`, then `rendering 10` (or `rendering 0`, `rendering status`).
 :::
 
+::: tip Driving the game over VNC
+While rendering is off (`SERVER_FPS=0`), VNC input is fully suppressed — there is nothing to see, so input has no meaning. While rendering is on, the VNC view is input-blocked except **F9** (toggle host automation) and **F10** (toggle visibility). Press **F9** to drop automation and gain full keyboard/mouse control; press it again to re-arm the guard.
+:::
+
 ### STEAM_REFRESH_TOKEN
 
 Alternative to username/password for automated environments. Export after initial setup:

--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -109,6 +109,8 @@ Toggle automatic host behavior (auto-sleep, event skipping, etc.):
 host-auto
 ```
 
+Pressing **F9** on the VNC display is the in-view equivalent of this command. It works over VNC whenever rendering is on (`SERVER_FPS` > 0), even while automation is suppressing all other input — F9 is deliberately kept live so you can drop automation and take manual control without a restart.
+
 ### host-visibility
 
 Toggle whether the host player is visible to other players:

--- a/mod/JunimoServer/Services/ServerOptim/ServerOptimizer.cs
+++ b/mod/JunimoServer/Services/ServerOptim/ServerOptimizer.cs
@@ -1,4 +1,5 @@
 using HarmonyLib;
+using JunimoServer.Services.AlwaysOn;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -18,13 +19,14 @@ namespace JunimoServer.Services.ServerOptim
         public ServerOptimizer(
             Harmony harmony,
             IMonitor monitor,
-            IModHelper helper
+            IModHelper helper,
+            AlwaysOnConfig alwaysOnConfig
         )
         {
             _monitor = monitor;
             _helper = helper;
 
-            ServerOptimizerOverrides.Initialize(monitor);
+            ServerOptimizerOverrides.Initialize(monitor, alwaysOnConfig);
 
             harmony.Patch(
                 original: AccessTools.Method(typeof(Game), "BeginDraw"),
@@ -91,24 +93,21 @@ namespace JunimoServer.Services.ServerOptim
                 prefix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.OnGalaxyLobbyCreated_Prefix))
             );
 
-            // Blocks input when rendering is disabled or host automation is active (e.g.
-            // toggled via F9 on VNC). The same prefix gates UpdateControlInput (where the
-            // game processes input) and the raw Keyboard/Mouse reads below (the device
-            // source); both check the live state every call, so a runtime fps switch
-            // restores input without a restart.
-            harmony.Patch(
-                original: AccessTools.Method("StardewValley.Game1:UpdateControlInput"),
-                prefix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.SuppressInput_Prefix))
-            );
-
+            // Keyboard/Mouse PlatformGetState is the single source feeding every input
+            // consumer — the game (control, menus, chat) and SMAPI's ButtonPressed pipeline.
+            // The postfixes suppress input there when rendering is off or host automation is
+            // active, carving out only the F9/F10 hotkeys so the operator can still drop
+            // automation from the VNC display. Read live, so a runtime fps switch or host-auto
+            // toggle restores input without a restart. No game-side UpdateControlInput patch
+            // is needed — when the device returns empty state, every consumer sees nothing.
             harmony.Patch(
                 original: AccessTools.Method("Microsoft.Xna.Framework.Input.Keyboard:PlatformGetState"),
-                prefix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.SuppressInput_Prefix))
+                postfix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.KeyboardState_Postfix))
             );
 
             harmony.Patch(
                 original: AccessTools.Method("Microsoft.Xna.Framework.Input.Mouse:PlatformGetState"),
-                prefix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.SuppressInput_Prefix))
+                postfix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.MouseState_Postfix))
             );
 
             // musl/.NET 6 fix: SMAPI's SModHooks.StartTask uses RunSynchronously() which

--- a/mod/JunimoServer/Services/ServerOptim/ServerOptimizerOverrides.cs
+++ b/mod/JunimoServer/Services/ServerOptim/ServerOptimizerOverrides.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using JunimoServer.Services.AlwaysOn;
 using JunimoServer.Shared;
 using Galaxy.Api;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 using StardewModdingAPI;
 using StardewValley;
 using xTile.Display;
@@ -19,10 +23,20 @@ namespace JunimoServer.Services.ServerOptim
 
         private static bool _automationSuppressesInput;
 
-        public static void Initialize(IMonitor monitor)
+        // The host-automation hotkeys (F9/F10 by default), kept live even while input is
+        // suppressed so the operator can drop automation from the VNC display. Resolved
+        // from AlwaysOnConfig at Initialize; entries that have no keyboard equivalent
+        // (e.g. a controller-only binding) are dropped.
+        private static Keys[] _carveOutKeys = Array.Empty<Keys>();
+
+        public static void Initialize(IMonitor monitor, AlwaysOnConfig config)
         {
             _monitor = monitor;
             _rendering = new RenderingController(monitor, "Server");
+            _carveOutKeys = new[] { config.HotKeyToggleAutoMode, config.HotKeyToggleVisibility }
+                .Where(b => b.TryGetKeyboard(out _))
+                .Select(b => { b.TryGetKeyboard(out var k); return k; })
+                .ToArray();
         }
 
         /// <summary>
@@ -54,17 +68,35 @@ namespace JunimoServer.Services.ServerOptim
             _automationSuppressesInput = suppress;
         }
 
+        // Input is suppressed while rendering is off (no operator can see anything to
+        // drive) or host automation is driving the host. Both inputs are read live, so a
+        // runtime fps switch (the VNC button, `rendering <fps>`, POST /rendering?fps=N) or
+        // a host-auto/F9 toggle flips input behavior without a restart.
+        private static bool InputSuppressed
+            => _rendering.CurrentFps == 0 || _automationSuppressesInput;
+
         /// <summary>
-        /// Shared Harmony prefix for Game1.UpdateControlInput and the raw Keyboard/Mouse
-        /// PlatformGetState reads. Returning false skips the original, blocking input both
-        /// where the game processes it and at the device source. Suppresses input while
-        /// rendering is off (the server isn't drawing, so a watching operator can't
-        /// meaningfully drive the game) or host automation is driving the host. Both inputs
-        /// are live, so a runtime fps switch (the VNC button, `rendering &lt;fps&gt;`,
-        /// POST /rendering?fps=N) restores input without a restart.
+        /// Harmony postfix on Keyboard.PlatformGetState — the single source feeding the game
+        /// (control, menus, chat, minigames) AND SMAPI's ButtonPressed pipeline. While
+        /// suppressed, strip the state down to the host-automation hotkeys so all other input
+        /// is blocked but those toggles still reach SMAPI — the operator's only way to drop
+        /// automation from the VNC display.
         /// </summary>
-        public static bool SuppressInput_Prefix()
-            => _rendering.CurrentFps != 0 && !_automationSuppressesInput;
+        public static void KeyboardState_Postfix(ref KeyboardState __result)
+        {
+            if (!InputSuppressed) return;
+            var down = Array.FindAll(_carveOutKeys, __result.IsKeyDown);
+            __result = down.Length == 0 ? default : new KeyboardState(down);
+        }
+
+        /// <summary>
+        /// Harmony postfix on Mouse.PlatformGetState. While suppressed the mouse is fully
+        /// blanked — there is no mouse equivalent of the keyboard carve-out.
+        /// </summary>
+        public static void MouseState_Postfix(ref MouseState __result)
+        {
+            if (InputSuppressed) __result = default;
+        }
 
         private static int _galaxyLobbyFailureCount;
         private const int MaxGalaxyLobbyRetries = 3;

--- a/mod/JunimoServer/Services/ServerOptim/ServerOptimizerOverrides.cs
+++ b/mod/JunimoServer/Services/ServerOptim/ServerOptimizerOverrides.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using JunimoServer.Services.AlwaysOn;
 using JunimoServer.Shared;
@@ -23,20 +23,22 @@ namespace JunimoServer.Services.ServerOptim
 
         private static bool _automationSuppressesInput;
 
-        // The host-automation hotkeys (F9/F10 by default), kept live even while input is
-        // suppressed so the operator can drop automation from the VNC display. Resolved
-        // from AlwaysOnConfig at Initialize; entries that have no keyboard equivalent
-        // (e.g. a controller-only binding) are dropped.
-        private static Keys[] _carveOutKeys = Array.Empty<Keys>();
+        // The host-automation hotkeys (F9/F10 by default) that stay live while automation
+        // suppresses input, so the operator can drop automation from the VNC display.
+        // Resolved from AlwaysOnConfig at Initialize; a binding with no keyboard equivalent
+        // (e.g. controller-only) is dropped.
+        private static Keys[] _allowedHotkeys = Array.Empty<Keys>();
 
         public static void Initialize(IMonitor monitor, AlwaysOnConfig config)
         {
             _monitor = monitor;
             _rendering = new RenderingController(monitor, "Server");
-            _carveOutKeys = new[] { config.HotKeyToggleAutoMode, config.HotKeyToggleVisibility }
-                .Where(b => b.TryGetKeyboard(out _))
-                .Select(b => { b.TryGetKeyboard(out var k); return k; })
-                .ToArray();
+
+            var hotkeys = new List<Keys>();
+            foreach (var button in new[] { config.HotKeyToggleAutoMode, config.HotKeyToggleVisibility })
+                if (button.TryGetKeyboard(out var key))
+                    hotkeys.Add(key);
+            _allowedHotkeys = hotkeys.ToArray();
         }
 
         /// <summary>
@@ -75,23 +77,35 @@ namespace JunimoServer.Services.ServerOptim
         private static bool InputSuppressed
             => _rendering.CurrentFps == 0 || _automationSuppressesInput;
 
+        // The hotkeys stay live only while rendering is on: they exist so an operator
+        // watching VNC can drop automation. With rendering off there's nothing to see, so
+        // input is suppressed fully.
+        private static bool HotkeysStayLive
+            => _rendering.CurrentFps > 0 && _automationSuppressesInput;
+
         /// <summary>
         /// Harmony postfix on Keyboard.PlatformGetState — the single source feeding the game
-        /// (control, menus, chat, minigames) AND SMAPI's ButtonPressed pipeline. While
-        /// suppressed, strip the state down to the host-automation hotkeys so all other input
-        /// is blocked but those toggles still reach SMAPI — the operator's only way to drop
-        /// automation from the VNC display.
+        /// (control, menus, chat, minigames) AND SMAPI's ButtonPressed pipeline. Three cases:
+        /// not suppressed → pass through; suppressed with rendering on → strip to the
+        /// host-automation hotkeys so all other input is blocked but those toggles still reach
+        /// SMAPI (the operator's only way to drop automation from VNC); suppressed with
+        /// rendering off → blank fully.
         /// </summary>
         public static void KeyboardState_Postfix(ref KeyboardState __result)
         {
             if (!InputSuppressed) return;
-            var down = Array.FindAll(_carveOutKeys, __result.IsKeyDown);
-            __result = down.Length == 0 ? default : new KeyboardState(down);
+            if (HotkeysStayLive)
+            {
+                var down = Array.FindAll(_allowedHotkeys, __result.IsKeyDown);
+                __result = down.Length == 0 ? default : new KeyboardState(down);
+                return;
+            }
+            __result = default;
         }
 
         /// <summary>
         /// Harmony postfix on Mouse.PlatformGetState. While suppressed the mouse is fully
-        /// blanked — there is no mouse equivalent of the keyboard carve-out.
+        /// blanked — there is no mouse equivalent of the keyboard hotkeys.
         /// </summary>
         public static void MouseState_Postfix(ref MouseState __result)
         {


### PR DESCRIPTION
## Problem

VNC showed the game but accepted no input whenever host automation was on (the default after every save load) — operators couldn't drive the UI over VNC, and the F9 "toggle automation off to restore input" recovery was self-defeating because F9's own delivery channel was suppressed.

The input gate (`SuppressInput_Prefix`) was patched as a `return false` prefix onto the raw `Keyboard/Mouse:PlatformGetState` device layer. That device layer is the **single source** feeding both the game *and* SMAPI's `ButtonPressed` pipeline (`InputState.UpdateStates` → `Keyboard.GetState()` → `PlatformGetState`), so suppressing it blinded SMAPI too — including F9/F10. Only the off-VNC `host-auto` console command could toggle it.

Regression introduced in `c7dbf85`, which merged the previously-separate input prefixes into one and changed the device-layer patches from conditional to unconditional + automation-driven.

## Fix

Suppress at the single device-layer chokepoint, carving out only the F9/F10 hotkeys so SMAPI's `ButtonPressed` still fires for them.

- Replace `SuppressInput_Prefix` with two device-layer postfixes:
  - `KeyboardState_Postfix` — while suppressed, strips state down to the host-automation hotkeys so all other input is blocked but F9/F10 still reach SMAPI.
  - `MouseState_Postfix` — while suppressed, fully blanks the mouse.
- Suppression condition is `fps==0 || automation` (was `fps!=0 && !automation`).
- Carve-out keys resolved from `AlwaysOnConfig.HotKeyToggleAutoMode/Visibility` via `SButtonExtensions.TryGetKeyboard` at `Initialize` — not hardcoded.
- Drop the redundant `Game1:UpdateControlInput` patch: when the device returns empty state, every consumer (control, menus, chat) already sees nothing.
- Inject `AlwaysOnConfig` into `ServerOptimizer` and pass it to `Initialize`.
- Document F9/F10-over-VNC behavior in `environment.md` and `commands.md`.

## Behavior

| Render state | Keyboard | Mouse | UI interaction | F9/F10 |
|---|---|---|---|---|
| `fps==0` (perf, default) | empty | empty | blocked | inert (nothing to see) |
| `fps>0`, automation on (default after load) | only F9/F10 | empty | blocked | fire |
| `fps>0`, automation off (operator pressed F9) | full | full | works | fire |

Retains all existing optimizations (NullDisplayDevice swap, music/butterflies `Disable_Prefix`, etc.) and the runtime `rendering <fps>` / `POST /rendering?fps=N` surface. No perf regression: at `fps==0` the postfix returns `default` identically to today's full suppression.

## Verification

- Mod builds clean (0 warnings, 0 errors).
- Confirmed at source: `KeyboardState(Keys[])` ctor (`InputState.cs:69`, `Game1.cs:12527`); `SButtonExtensions.TryGetKeyboard` (SMAPI XML); single device chokepoint (`InputState.UpdateStates`); F10's vanilla `StartServer` binding gated `server == null` — inert on a running server (`Game1.cs:13289`); committed config (`AlwaysOnConfig.FromSettings` leaves F9/F10 defaults intact).
- **Not exercised** (runtime gates requiring a live VNC session against a container): boot with `SERVER_FPS=10` and observe F9 toggling automation off, F10 toggling visibility, keyboard/mouse blocked while automation on, and `rendering 0`/`rendering 10` flipping input live without restart.

## Out of scope

- Modded `FarmType` / new-farm creation (the operator's end goal) — a separate concern tracked in `.claude/plans/features/modded-farm-type-selection.md`. This PR only restores the prerequisite ability to drive the UI over VNC.
- Test-client — uses `RenderingController` for draw control only; does not patch input. Untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VNC input suppression refined: input is fully blocked when rendering is off (SERVER_FPS=0). When rendering is on, automation-driven suppression blocks all VNC keyboard/mouse input except F9 (host-auto toggle) and F10 (visibility), ensuring those hotkeys still work.

* **Documentation**
  * Added guidance on VNC input behavior vs SERVER_FPS and note that pressing F9 on VNC equals the host-auto command when rendering is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->