### PR TITLE
fix(mod): gate /reload and /newgame completion on SaveLoaded

### DIFF
--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -63,6 +63,16 @@ namespace JunimoServer.Services.GameManager
         /// </summary>
         public Task RequestNewGame(NewGameConfig config)
         {
+            // One load operation in flight at a time: reject if a /reload is already pending.
+            // Without this, both completion TCSs would be armed at once and OnUpdateTicked's
+            // first SaveLoaded would resolve both, returning a false success to whichever
+            // operation never ran. Game-thread serialized, so the check needs no lock.
+            if (_reloadCompletion != null)
+            {
+                return Task.FromException(
+                    new InvalidOperationException("A reload is already in progress; cannot start a new game."));
+            }
+
             IsNewGamePending = true;
             _pendingNewGameConfig = config;
             _newGameCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -86,6 +96,14 @@ namespace JunimoServer.Services.GameManager
         /// </summary>
         public Task RequestReloadSave()
         {
+            // One load operation in flight at a time: reject if a /newgame is already pending
+            // (see RequestNewGame for why a second concurrent op would falsely succeed).
+            if (_newGameCompletion != null)
+            {
+                return Task.FromException(
+                    new InvalidOperationException("A new game is already in progress; cannot reload."));
+            }
+
             // Coalesce overlapping requests: a second /reload while one is in flight would
             // otherwise replace _reloadCompletion and orphan the first caller until its 120s
             // timeout. Always invoked on the game thread (via RunOnGameThreadAsync), so this

--- a/mod/JunimoServer/Services/GameManager/GameManagerService.cs
+++ b/mod/JunimoServer/Services/GameManager/GameManagerService.cs
@@ -31,6 +31,10 @@ namespace JunimoServer.Services.GameManager
         private bool _pendingReload;
         private TaskCompletionSource<bool>? _reloadCompletion;
 
+        // Set by OnSaveLoaded; consumed on the next UpdateTicked to resolve a pending reload/
+        // newgame completion after all SaveLoaded handlers have run. See OnUpdateTicked.
+        private bool _saveLoadedSinceRequest;
+
         /// <summary>
         /// Whether a new game creation has been requested via the API.
         /// Checked by AlwaysOnServer to distinguish intentional returns to title.
@@ -66,6 +70,9 @@ namespace JunimoServer.Services.GameManager
             _titleLaunched = false;
             _healthCheckTimer = 0;
             _lastNullCodeTime = null;
+            // Clear any stale flag from a prior load (e.g. boot), so the completion resolves
+            // only after THIS request's SaveLoaded — not on the first tick from an old one.
+            _saveLoadedSinceRequest = false;
             Game1.ExitToTitle();
             return _newGameCompletion.Task;
         }
@@ -97,6 +104,9 @@ namespace JunimoServer.Services.GameManager
             _titleLaunched = false;
             _healthCheckTimer = 0;
             _lastNullCodeTime = null;
+            // Clear any stale flag from a prior load, so the completion resolves only after
+            // THIS reload's SaveLoaded — not on the first tick from an old one.
+            _saveLoadedSinceRequest = false;
             Game1.ExitToTitle();
             return _reloadCompletion.Task;
         }
@@ -106,10 +116,39 @@ namespace JunimoServer.Services.GameManager
             // Unsubscribe first to avoid duplicate bindings
             Helper.Events.Display.RenderedActiveMenu -= OnRenderedActiveMenu;
             Helper.Events.GameLoop.OneSecondUpdateTicked -= OnOneSecondTicked;
+            Helper.Events.GameLoop.SaveLoaded -= OnSaveLoaded;
+            Helper.Events.GameLoop.UpdateTicked -= OnUpdateTicked;
 
             // Subscribe to the events
             Helper.Events.Display.RenderedActiveMenu += OnRenderedActiveMenu;
             Helper.Events.GameLoop.OneSecondUpdateTicked += OnOneSecondTicked;
+            Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+            Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
+        }
+
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            _saveLoadedSinceRequest = true;
+        }
+
+        // Resolve a pending /reload or /newgame completion only AFTER SaveLoaded has fired —
+        // by then every SaveLoaded handler (cabin migration/sync/sweep, EnsureAtLeastXCabins)
+        // has run this tick, so a post-reload snapshot reflects the final world. LoadSave()
+        // /CreateNewGame() only arm the loader (SaveGame.Load sets Game1.currentLoader; the
+        // world loads over later ticks), so resolving when they return would race that work.
+        // Next-tick (not in OnSaveLoaded) so the resolve never depends on SaveLoaded subscriber
+        // order — all handlers run synchronously in the firing tick. The completion TCSs are
+        // non-null only while a request is pending, so a stray SaveLoaded is a no-op here.
+        private void OnUpdateTicked(object sender, UpdateTickedEventArgs e)
+        {
+            if (!_saveLoadedSinceRequest)
+                return;
+            _saveLoadedSinceRequest = false;
+
+            _reloadCompletion?.TrySetResult(true);
+            _reloadCompletion = null;
+            _newGameCompletion?.TrySetResult(true);
+            _newGameCompletion = null;
         }
 
         private void OnOneSecondTicked(object sender, OneSecondUpdateTickedEventArgs e)
@@ -171,7 +210,8 @@ namespace JunimoServer.Services.GameManager
                     {
                         throw new InvalidOperationException("LoadSave returned false (no loadable save found)");
                     }
-                    _reloadCompletion?.TrySetResult(true);
+                    // Success is signalled from OnUpdateTicked once SaveLoaded has fired and run
+                    // the migration/sync/sweep — not here, where the loader has only been armed.
                 }
                 catch (Exception ex)
                 {
@@ -179,9 +219,11 @@ namespace JunimoServer.Services.GameManager
                     // of early-returning on _gameStarted and parking the server at title.
                     _gameStarted = false;
                     Monitor.Log($"World reload failed: {ex}", LogLevel.Warn);
+                    // No SaveLoaded fires on a failed load, so fault the TCS here or the
+                    // /reload HTTP call hangs to its 120s timeout.
                     _reloadCompletion?.TrySetException(ex);
+                    _reloadCompletion = null;
                 }
-                _reloadCompletion = null;
                 return;
             }
 
@@ -195,14 +237,18 @@ namespace JunimoServer.Services.GameManager
                 {
                     Monitor.Log($"Creating new game from API request: {config}", LogLevel.Info);
                     _gameCreatorService.CreateNewGame(config);
-                    _newGameCompletion?.TrySetResult(true);
+                    // Success is signalled from OnUpdateTicked once SaveLoaded has fired — see
+                    // the reload branch. CreateNewGame's loadForNewGame also loads over later ticks.
                 }
                 catch (Exception ex)
                 {
-                    Monitor.Log($"New game creation failed: {ex}", LogLevel.Error);
+                    // Warn, not Error: LogLevel.Error trips ServerContainer's ERROR/FATAL test-
+                    // poison detector. The faulted TCS already surfaces the failure as a 500.
+                    Monitor.Log($"New game creation failed: {ex}", LogLevel.Warn);
+                    // No SaveLoaded fires on a failed create, so fault the TCS here.
                     _newGameCompletion?.TrySetException(ex);
+                    _newGameCompletion = null;
                 }
-                _newGameCompletion = null;
                 return;
             }
 


### PR DESCRIPTION
## Problem

`/reload` and `/newgame` resolved their completion `Task` the instant `LoadSave()` / `CreateNewGame()` returned. Those calls only *arm* the loader — `SaveGame.Load` sets `Game1.currentLoader` and the world loads over subsequent ticks. So the completion raced the `GameLoop.SaveLoaded` handlers that run the cabin migration/sync/sweep. A test (or operator) reading `/cabins` right after a reload could observe a **pre-migration** snapshot.

This was the root cause of the intermittent `CabinPositionPersistenceTests.MoveToStack_UnclaimedCabinSweptOnReload` failure: the post-reload `/cabins` read landed *before* `mod_phase save_loaded` ran the `None→CabinStack` migration.

## Changes

- Resolve the `/reload` and `/newgame` completion `Task` on the first `UpdateTicked` **after** `SaveLoaded` fires, when every `SaveLoaded` handler (migration/sync/sweep, `EnsureAtLeastXCabins`) has run for that tick.
- Resolve on the next tick (not inside `OnSaveLoaded`) so it never depends on `SaveLoaded` subscriber order.
- Reset `_saveLoadedSinceRequest` when arming a request, so a stale flag from a prior load (e.g. boot) can't resolve the new completion early.
- Failure path unchanged in spirit: a throwing `LoadSave()`/`CreateNewGame()` still faults the `Task` synchronously (no `SaveLoaded` fires on failure), so the HTTP call returns its error rather than hanging to the 120s cap.
- Downgrade the new-game failure log `Error`→`Warn` (the faulted `Task` already surfaces the failure as a 500; `Error` trips the test harness's ERROR/FATAL detector).

## Verification

E2E run of `MoveToStack_UnclaimedCabinSweptOnReload`: the `/reload` HTTP response now lands **after** the reload's `mod_phase save_loaded` and `cabin_strategy_migration` events (previously inverted), and the test's post-reload `/cabins` read follows. Reload still completes promptly (no 120s hang); boot path unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure reload and new-game requests only report success after the save has loaded and the game advances to the next update, improving accuracy and reliability.
  * Immediately surface and fail requests on errors; prevent conflicting concurrent reload/new-game requests.
  * Lower logging severity for new-game creation failures.

* **Chores**
  * Make event handler wiring more robust to avoid stale or duplicate callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->