### PR TITLE
fix(mod): place None-strategy starting cabins via the mod's own path

### DIFF
--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -544,7 +544,11 @@ namespace JunimoServer.Services.CabinManager
                 else
                 {
                     failed++;
-                    Monitor.Log($"Cabin check: failed building cabin {i + 1}/{cabinsMissingCount}", LogLevel.Error);
+                    // Warn, not Error: a failed build is recoverable (server continues; the
+                    // failure is also surfaced via cabin_build_failed and the cabinsFailed
+                    // field below). LogLevel.Error trips ServerContainer's ERROR/FATAL test
+                    // poison. For None this is the expected "ran out of map positions" cap.
+                    Monitor.Log($"Cabin check: failed building cabin {i + 1}/{cabinsMissingCount}", LogLevel.Warn);
                 }
             }
 

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -164,7 +164,14 @@ namespace JunimoServer.Services.GameCreator
 
             _gameLoader.SetCurrentGameAsSaveToLoad(config.FarmName);
 
-            _cabinManagerService.EnsureAtLeastXCabins();
+            // Place the starting cabins through the mod's own path. Vanilla BuildStartingCabins
+            // (run during loadForNewGame) does not leave its cabins on the realized farm on the
+            // headless path, so for None we place config.StartingCabins visible cabins here via
+            // EnsureAtLeastXCabins → BuildNewCabinVisible (which runs after the farm is fully
+            // realized and verifies each interior). Stacked strategies don't use map positions,
+            // so they keep the default minimum of 1 hidden cabin.
+            var minCabins = _options.IsNone ? Math.Max(1, config.StartingCabins) : 1;
+            _cabinManagerService.EnsureAtLeastXCabins(minCabins);
 
             GameIsCreating = false;
         }

--- a/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
@@ -44,8 +44,9 @@ public class CabinStrategyNoneTests : TestBase
 
         Assert.NotNull(cabinsResponse);
         Assert.Equal("None", cabinsResponse.Strategy);
-        Assert.True(cabinsResponse.TotalCount >= 1,
-            $"Expected at least 1 cabin with default settings, got {cabinsResponse.TotalCount}");
+        // Exact count, not a lower bound: a lower bound passed even when vanilla placed 0 and
+        // the mod backfilled 1 (the bug this guards). startingCabins:1 must yield exactly 1.
+        Assert.Equal(1, cabinsResponse.TotalCount);
 
         Log($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
     }
@@ -65,10 +66,10 @@ public class CabinStrategyNoneTests : TestBase
         Assert.NotNull(cabinsResponse);
         Assert.Equal("None", cabinsResponse.Strategy);
 
-        Assert.True(cabinsResponse.TotalCount >= 1,
-            $"Expected at least 1 cabin, got {cabinsResponse.TotalCount}");
-        Assert.True(cabinsResponse.TotalCount <= 6,
-            $"Expected at most 6 cabins, got {cabinsResponse.TotalCount}");
+        // Exact count: startingCabins:6 must place 6 visible cabins (the Standard farm's Paths
+        // layer has 7 designated positions, so 6 fit). A <= 6 upper bound previously passed even
+        // when only 1 cabin existed — the silent regression this test now catches.
+        Assert.Equal(6, cabinsResponse.TotalCount);
 
         Log($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
 


### PR DESCRIPTION
## Problem

Under the `None` cabin strategy, `startingCabins > 1` produced only **1** cabin regardless of the configured value.

Vanilla `BuildStartingCabins` runs during `loadForNewGame` and does select the correct map-designated positions, but its cabins do not survive onto the realized farm on the headless new-game path. The mod's `EnsureAtLeastXCabins` then backfilled only its minimum of 1. (Confirmed via instrumented runs: all inputs correct, positions selected, `buildStructure` called — yet 0 cabins present the instant the method returns.)

This was masked because the `None` count tests asserted tolerant bounds (`>= 1`, `<= 6`) that 1 satisfies.

## Changes

- `CreateNewGame` now places the starting cabins through the mod's own robust path: `EnsureAtLeastXCabins(config.StartingCabins)` for `None`, which runs **after** the farm is fully realized and verifies each cabin interior (`BuildNewCabinVisible` → `FarmCabinPositions` + `CreateCabinBuilding`). Stacked strategies are unchanged — they don't use map positions and keep the default minimum of 1 hidden cabin.
- Downgrade `EnsureAtLeastXCabins`'s build-failure log `Error`→`Warn`. A failed build is recoverable (already surfaced via the `cabin_build_failed` event and the `cabinsFailed` field), and for `None` this is the expected "ran out of map positions" cap. `Error` trips the test harness's ERROR/FATAL detector.
- Tighten `CabinStrategyNoneTests` to assert the **exact** cabin count (1 and 6) instead of tolerant bounds — the bounds are what hid this regression.

## Verification

E2E run of both `CabinStrategyNoneTests`: `startingCabins:6` now yields exactly 6 cabins (`cabin_ensure_checked`: `minRequired:6 availableCount:0 cabinsBuilt:6 cabinsFailed:0` — vanilla left 0, the mod built all 6), `:1` yields exactly 1. The cabins stick through the following `SaveLoaded` (its re-check sees `availableCount:6` and builds nothing — no double-build). All `None` map positions (7 on the Standard farm) cap the achievable count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cabin strategy configuration to ensure the correct number of starting cabins are created when using the "None" strategy.

* **Tests**
  * Updated test assertions to verify exact cabin counts are properly maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->