### PR TITLE
ci: add Validate PR Title producer to merge-queue workflow

### DIFF
--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -3,9 +3,9 @@
 # here — hence no `authorize` gate and no environment, unlike validate-pr.yml. This is a separate
 # file rather than a trigger added to validate-pr.yml on purpose: the merge_group payload has no
 # `github.event.pull_request.*` fields, and one workflow per event keeps one required check per
-# name. All three required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`)
-# are reproduced here under the same names: a required check with no merge_group producer leaves
-# every queued PR stuck in AWAITING_CHECKS until timeout. See
+# name. All four required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`,
+# `Validate PR Title`) are reproduced here under the same names: a required check with no
+# merge_group producer leaves every queued PR stuck in AWAITING_CHECKS until timeout. See
 # docs/developers/contributing/ci-cd.md#validate-pr-pipeline.
 name: Validate Merge Group
 
@@ -52,6 +52,18 @@ jobs:
               - 'tools/netdebug/**'
               - 'tools/openapi-generator/**'
               - 'Directory.Build.props'
+
+  validate-pr-title:
+    name: Validate PR Title
+    # The PR title is linted at PR time (validate-pr.yml) and is immutable once the PR is in the
+    # queue, so there is nothing to re-lint here — but the required check still needs a merge_group
+    # producer to report, or the queue waits on it forever. This job exists solely to satisfy that
+    # contract. (The merge_group payload carries no pull_request.title to lint even if we wanted to,
+    # and the queue branch holds the PR's original commits, not the squash subject, so Validate
+    # Commits doesn't cover the title either.)
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "PR title was validated at PR time and is immutable in the queue."
 
   validate-commits:
     name: Validate Commits

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -175,10 +175,12 @@ A PR sitting in the queue shows **`AWAITING_CHECKS`** while its merge-group buil
 
 ### Why Validate Merge Group is a separate workflow
 
-The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-pipeline) does not respond to (it triggers on `pull_request_target`). The merge queue requires the same `Validate Build`, `Validate Commits`, and `Validate Line Endings` checks to report **on the merge-group ref**, so `validate-merge-group.yml` reproduces all three under the same names. It runs the same commitlint, Docker build, and line-ending scan, but without the `authorize` gate — merge-group code is already approved and runs from the base repository, so there is no fork-secret exposure to gate.
+The merge queue fires the `merge_group` event, which [Validate PR](#validate-pr-pipeline) does not respond to (it triggers on `pull_request_target`). The merge queue requires the same `Validate Build`, `Validate Commits`, `Validate Line Endings`, and `Validate PR Title` checks to report **on the merge-group ref**, so `validate-merge-group.yml` reproduces all four under the same names. The first three run the same commitlint, Docker build, and line-ending scan, but without the `authorize` gate — merge-group code is already approved and runs from the base repository, so there is no fork-secret exposure to gate.
+
+`Validate PR Title` is the exception: there is nothing to re-lint in the queue. The `merge_group` payload carries no `pull_request.title`, the title is immutable once a PR is queued (it was already linted at PR time), and the queue branch holds the PR's original commits — not the squash subject — so `Validate Commits` doesn't cover it either. Its merge-group job is therefore a no-op that exists only to report the required status; without it the queue would wait on the title check forever.
 
 ::: warning
-All three required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too.
+All four required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`, `Validate PR Title`) must have a `merge_group` producer. A required check with no merge-group workflow leaves every queued PR stuck in `AWAITING_CHECKS` until the queue's timeout. If you add a required check, make sure it reports on `merge_group` too — even if, like the title check, the merge-group job is only a stub that satisfies the contract.
 :::
 
 ## CodeQL Pipeline


### PR DESCRIPTION
## Problem

`Validate PR Title` is a required status check in the `master` ruleset (`grouping_strategy: ALLGREEN`, 60-minute `check_response_timeout`). It was added in #373 only to `validate-pr.yml`, which triggers on `pull_request_target` — so it has no `merge_group` producer. When a PR enters the merge queue, the `merge_group` event fires, nothing produces a `Validate PR Title` status, and the queue sits in "Expected — Waiting for status to be reported" until the 60-minute timeout.

This is the exact failure mode already documented in the merge-group workflow header and `ci-cd.md`: a required check with no `merge_group` producer blocks every queued PR. The other three required checks (`Validate Build`, `Validate Commits`, `Validate Line Endings`) already have producers; #373 didn't add one for the title.

## Fix

- Add a `validate-pr-title` stub job to `validate-merge-group.yml`. There is genuinely nothing to re-lint in the queue:
  - the `merge_group` payload carries no `pull_request.title`,
  - the title is immutable once a PR is queued (already linted at PR time), and
  - the queue branch holds the PR's original commits, not the squash subject, so `Validate Commits` doesn't cover it either.

  The job exists only to report the required status and unblock the queue.
- Update the workflow header comment ("three" → "four" checks) and the `ci-cd.md` Merge Queue section to document the title producer and why it's a no-op.

Validated with actionlint — the new job parses clean (the only findings are pre-existing shellcheck style notes on the untouched `Build summary` steps).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced merge-queue validation workflow to ensure all required status checks are properly recognized and emitted during merge processing, preventing queued pull requests from becoming stuck awaiting checks.

* **Documentation**
  * Clarified merge-group validation workflow and explained why certain validation checks require special handling in the merge-queue context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->