### PR TITLE
ci: hide full CTRF test list in e2e job summary

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -516,7 +516,9 @@ jobs:
 
       # Render the runner's ctrf-report.json (TestRunArtifactWriter.WriteCtrfReport,
       # one per CI invocation) into the job Summary tab. summary-report = pass/fail
-      # table, failed-report = failing tests + errors, test-list-report = full list;
+      # table, failed-report = failing tests + errors. The full test-list-report is
+      # off — it dwarfs the summary with one row per passing test, and failures are
+      # already covered by failed-report.
       # `summary: true` (action default) targets $GITHUB_STEP_SUMMARY. No PR comment —
       # dispatch-only workflow has no PR context. The action defaults exit-on-no-files
       # and exit-on-fail to false, so a missing report (early abort) or failing tests
@@ -530,7 +532,6 @@ jobs:
           report-path: 'TestResults/runs/**/ctrf-report.json'
           summary-report: true
           failed-report: true
-          test-list-report: true
 
       # After the build (which seeds the BuildKit mount), write the updated NuGet
       # mount back for actions/cache to save. Gated on cache-miss only — matches


### PR DESCRIPTION
- Drop `test-list-report` from the CTRF reporter step in `e2e-tests.yml` so the E2E job summary no longer renders one row per test.
- Keeps `summary-report` (pass/fail summary table) and `failed-report` (failing tests + their errors).
- On a green run only the summary table shows; on failures the failed-tests report still appears.
- Updated the step comment to reflect the removed report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test reporting in continuous integration workflows. Test summaries now focus exclusively on failing tests and errors, removing verbose logs of passing test results to streamline feedback and accelerate issue identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->