### PR TITLE
fix(auth): recreate Steam lobby on GameServer reconnect

### DIFF
--- a/mod/JunimoServer/Services/AuthService/AuthService.cs
+++ b/mod/JunimoServer/Services/AuthService/AuthService.cs
@@ -36,6 +36,13 @@ namespace JunimoServer.Services.Auth
         private static SteamHelper _pendingSteamHelper;
         private static bool _galaxyInitComplete;
 
+        // Diagnostic-only: count GameServer-mode Galaxy auth-lost / state-change callbacks so a
+        // full-NIC-outage repro can tell whether the closed-source Galaxy SDK re-fires them after
+        // reconnect. That single observation decides the Galaxy-reinit fix (callback-driven if it
+        // re-fires, poll-based if it doesn't). Game thread only; remove once the design is chosen.
+        private static int _galaxyAuthLostCount;
+        private static int _galaxyStateChangeCount;
+
         // Use constants from SteamConstants for consistency
         private static string ServerName => SteamConstants.DefaultServerName;
         private static long FallbackSteamId => SteamConstants.FallbackSteamId;
@@ -66,6 +73,13 @@ namespace JunimoServer.Services.Auth
         /// Whether lobby creation has been attempted
         /// </summary>
         private static bool _lobbyCreationAttempted;
+
+        /// <summary>
+        /// Bumped on every Steam-session invalidation. A Task.Run captures it at its
+        /// game-thread spawn site and commits its lobby result only if the value still
+        /// matches — so a task from a torn-down session can't overwrite fresh state.
+        /// </summary>
+        private static volatile int _steamSessionGeneration;
 
         /// <summary>
         /// When true, UpdateGalaxyLobbyWithSteamLobbyId will be called from the main thread
@@ -163,6 +177,22 @@ namespace JunimoServer.Services.Auth
             }
         }
 
+        /// <summary>
+        /// Clears cached Steam-lobby state on session loss so reconnect re-creates the lobby
+        /// instead of early-returning on the stale _lobbyCreationAttempted latch. Bump must come
+        /// first so an in-flight Task.Run sees the new generation. _galaxyInitComplete is left set:
+        /// the Galaxy dispatch loop is gated on it and nothing re-inits Galaxy to flip it back.
+        /// </summary>
+        private static void OnSteamServersLost()
+        {
+            _monitor.Log("Steam session lost — invalidating cached Steam lobby state", LogLevel.Warn);
+            _steamSessionGeneration++;
+            _steamLobbyId = 0;
+            _lobbyCreationAttempted = false;
+            _lastSteamLobbyPrivacy = null;
+            _pendingGalaxyLobbyUpdate = false;
+        }
+
         public GalaxyAuthService(
             IMonitor monitor,
             IModHelper helper,
@@ -181,6 +211,9 @@ namespace JunimoServer.Services.Auth
 
             // Subscribe to Steam ID assignment event to create lobby at the right time
             SteamGameServerService.OnServerSteamIdReceived += OnServerSteamIdReceived;
+
+            // Invalidate cached Steam lobby state on session loss so reconnect rebuilds it
+            SteamGameServerService.OnSteamServersLost += OnSteamServersLost;
 
             // Handle race condition: If Steam ID was already received before we subscribed,
             // manually trigger the handler. This ensures Galaxy init happens even if the
@@ -374,6 +407,7 @@ namespace JunimoServer.Services.Auth
             }
 
             _lobbyCreationAttempted = true;
+            var generation = _steamSessionGeneration;
             _monitor.Log($"Creating Steam lobby via steam-auth service, GameServer ID: {gameServerSteamId}", LogLevel.Info);
 
             // Run async to avoid blocking
@@ -402,6 +436,11 @@ namespace JunimoServer.Services.Auth
                     {
                         if (ulong.TryParse(result.lobby_id, out var lobbyId))
                         {
+                            if (generation != _steamSessionGeneration)
+                            {
+                                _monitor.Log($"Discarding Steam lobby {lobbyId} from invalidated session (gen {generation}, current {_steamSessionGeneration})", LogLevel.Warn);
+                                return;
+                            }
                             _steamLobbyId = lobbyId;
                             _monitor.Log($"Steam lobby created via HTTP: {_steamLobbyId}", LogLevel.Info);
                             Diagnostics.ModEventLog.Emit("auth_steam_lobby_created", new
@@ -495,8 +534,10 @@ namespace JunimoServer.Services.Auth
         /// Recreates the Steam lobby after it was lost (e.g., NoMatch from Steam).
         /// Uses the same parameters as the original CreateSteamLobbyViaHttpAsync.
         /// Returns true if the lobby was successfully recreated.
+        /// <paramref name="capturedGeneration"/> is captured by the caller — both already run
+        /// inside a Task.Run, so capturing here would itself race OnSteamServersLost.
         /// </summary>
-        private static bool RecreateSteamLobby()
+        private static bool RecreateSteamLobby(int capturedGeneration)
         {
             try
             {
@@ -529,6 +570,11 @@ namespace JunimoServer.Services.Auth
 
                 if (result != null && !string.IsNullOrEmpty(result.lobby_id) && ulong.TryParse(result.lobby_id, out var newLobbyId))
                 {
+                    if (capturedGeneration != _steamSessionGeneration)
+                    {
+                        _monitor.Log($"Discarding recreated Steam lobby {newLobbyId} from invalidated session", LogLevel.Warn);
+                        return false;
+                    }
                     _steamLobbyId = newLobbyId;
                     _lastSteamLobbyPrivacy = null; // Reset cached privacy; new lobby needs fresh setup
                     _monitor.Log($"Steam lobby recreated: {_steamLobbyId}", LogLevel.Info);
@@ -576,6 +622,8 @@ namespace JunimoServer.Services.Auth
             // Optimistically cache so repeated calls from the game loop don't queue redundant work
             _lastSteamLobbyPrivacy = privacy;
 
+            var generation = _steamSessionGeneration; // captured on the game thread; see field doc
+
             // Run off the game thread. HTTP calls with retries would block for 7+ seconds.
             Task.Run(() =>
             {
@@ -597,7 +645,7 @@ namespace JunimoServer.Services.Auth
                     _lastSteamLobbyPrivacy = null; // Reset cache: lobby lost, need to retry on next call
                     _monitor.Log($"Steam lobby lost (NoMatch), attempting to recreate...", LogLevel.Warn);
 
-                    if (RecreateSteamLobby())
+                    if (RecreateSteamLobby(generation))
                     {
                         // Retry with the new lobby ID
                         try
@@ -636,6 +684,8 @@ namespace JunimoServer.Services.Auth
                 return;
             }
 
+            var generation = _steamSessionGeneration; // captured on the game thread; see field doc
+
             // Run off the game thread. HTTP calls with retries would block for 7+ seconds.
             Task.Run(() =>
             {
@@ -655,7 +705,7 @@ namespace JunimoServer.Services.Auth
                 {
                     _monitor.Log($"Steam lobby lost (NoMatch) while setting '{key}', attempting to recreate...", LogLevel.Warn);
 
-                    if (RecreateSteamLobby())
+                    if (RecreateSteamLobby(generation))
                     {
                         try
                         {
@@ -871,8 +921,15 @@ namespace JunimoServer.Services.Auth
 
             Action onLost = () =>
             {
-                _monitor.Log("Galaxy auth lost", LogLevel.Error);
-                Diagnostics.ModEventLog.Emit("auth_galaxy_lost", new { mode = "gameServer" });
+                var count = ++_galaxyAuthLostCount;
+                // Warn (not Error): a re-fire here is the signal we want, and Error trips test cancellation.
+                _monitor.Log($"Galaxy auth lost (GameServer mode), invocation #{count}", LogLevel.Warn);
+                Diagnostics.ModEventLog.Emit("auth_galaxy_lost", new
+                {
+                    mode = "gameServer",
+                    invocation = count,
+                    networkingSet = steamHelper.Networking != null
+                });
                 if (steamHelper.Networking == null)
                 {
                     SetSteamNetworking(steamHelper, CreateSteamNetHelper());
@@ -893,6 +950,22 @@ namespace JunimoServer.Services.Auth
 
             var onStateChange = new Action<uint>((operationalState) =>
             {
+                // Diagnostic: log BEFORE the early-return so a recovery state-change (which arrives
+                // with Networking already set, and would otherwise be dropped silently) is still
+                // observable. networkingSet distinguishes first-login from a post-reconnect re-fire.
+                var count = ++_galaxyStateChangeCount;
+                var networkingSet = steamHelper.Networking != null;
+                _monitor.Log($"Galaxy state change (GameServer mode) #{count}: state=0x{operationalState:X}, networkingSet={networkingSet}", LogLevel.Debug);
+                Diagnostics.ModEventLog.Emit("auth_galaxy_state_change", new
+                {
+                    mode = "gameServer",
+                    invocation = count,
+                    operationalState,
+                    signedIn = (operationalState & 1) != 0,
+                    loggedOn = (operationalState & 2) != 0,
+                    networkingSet
+                });
+
                 if (steamHelper.Networking != null)
                     return;
 

--- a/mod/JunimoServer/Services/SteamGameServer/SteamGameServerService.cs
+++ b/mod/JunimoServer/Services/SteamGameServer/SteamGameServerService.cs
@@ -25,6 +25,10 @@ namespace JunimoServer.Services.SteamGameServer
         private static bool _initialized = false;
         private static CSteamID _serverSteamId;
 
+        // Counts SteamServersConnected_t callbacks. >1 means an auto-reconnect happened, which is
+        // the lobby-recreation repro's success signal (emitted as steam_session_connected.isReconnect).
+        private static int _connectCount;
+
         // Callbacks
         private static Callback<SteamServersConnected_t> _steamServersConnectedCallback;
         private static Callback<SteamServerConnectFailure_t> _steamServersConnectFailureCallback;
@@ -164,6 +168,12 @@ namespace JunimoServer.Services.SteamGameServer
         /// </summary>
         public static event Action<ulong> OnServerSteamIdReceived;
 
+        /// <summary>
+        /// Fired when the GameServer loses its Steam server session.
+        /// Subscribers should treat any cached Steam lobby/session state as invalid.
+        /// </summary>
+        public static event Action OnSteamServersLost;
+
         private static void OnSteamServersConnected(SteamServersConnected_t callback)
         {
             _serverSteamId = Steamworks.SteamGameServer.GetSteamID();
@@ -180,6 +190,15 @@ namespace JunimoServer.Services.SteamGameServer
             // Check relay network status
             var relayStatus = SteamGameServerNetworkingUtils.GetRelayNetworkStatus(out var details);
             _monitor.Log($"SDR relay status: {relayStatus}", LogLevel.Info);
+
+            // Note: fires on the first connect too, not just reconnects — isReconnect disambiguates.
+            var connectNumber = ++_connectCount;
+            Diagnostics.ModEventLog.Emit("steam_session_connected", new
+            {
+                steamId = _serverSteamId.m_SteamID.ToString(),
+                connectNumber,
+                isReconnect = connectNumber > 1
+            });
 
             // Notify subscribers that the Steam ID is now available
             OnServerSteamIdReceived?.Invoke(_serverSteamId.m_SteamID);
@@ -198,6 +217,11 @@ namespace JunimoServer.Services.SteamGameServer
         {
             _monitor.Log($"Disconnected from Steam servers: {callback.m_eResult}", LogLevel.Warn);
             _monitor.Log("SDR connections may be affected until reconnected", LogLevel.Warn);
+
+            // Structured emit so the reconnect repro can grep infrastructure.jsonl, not just the text log.
+            Diagnostics.ModEventLog.Emit("steam_session_lost", new { result = callback.m_eResult.ToString() });
+
+            OnSteamServersLost?.Invoke();
         }
 
         /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
+++ b/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
@@ -116,6 +116,9 @@ namespace JunimoServer.Tests.Helpers;
 /// <c>auth_steam_sidecar_ready</c> · <c>auth_steam_sidecar_unreachable</c>
 /// (<c>exceptionType, message</c>) · <c>auth_galaxy_success</c> /
 /// <c>auth_galaxy_failed</c> (<c>reason</c>) / <c>auth_galaxy_lost</c>
+/// (<c>invocation, networkingSet</c>) · <c>auth_galaxy_state_change</c>
+/// (<c>invocation, operationalState, signedIn, loggedOn, networkingSet</c>;
+/// diagnostic — observes whether the Galaxy SDK re-fires after reconnect)
 /// (each optionally carries <c>mode:"gameServer"</c>).</item>
 ///
 /// <item><b>Mod role changes (RoleService)</b>:
@@ -138,7 +141,10 @@ namespace JunimoServer.Tests.Helpers;
 /// <c>steam_p2p_connect_failed</c> (mod, SteamGameServerNetServer:
 /// <c>clientSteamId, reason?, relayedVia?, endReason?, debug?</c>) ·
 /// <c>steam_callback_error</c> (mod, throttled: <c>callback, exceptionType,
-/// message</c>) · <c>steam_account_allocated</c> / <c>steam_account_released</c> /
+/// message</c>) · <c>steam_session_lost</c> (mod, GameServer disconnect:
+/// <c>result</c>) / <c>steam_session_connected</c> (first connect + every
+/// auto-reconnect: <c>steamId, connectNumber, isReconnect</c>) ·
+/// <c>steam_account_allocated</c> / <c>steam_account_released</c> /
 /// <c>steam_account_pool_insufficient</c> (<c>kind:"server"|"client", index?,
 /// remaining?, available?, totalSize?, inUse?</c>) ·
 /// <c>steam_account_release_error</c> (ClientPool release path).</item>


### PR DESCRIPTION
## Problem

After the dedicated server loses Steam GameServer connectivity (CM flap / brief upstream outage) and auto-reconnects, vanilla Steam clients fail to join via the invite code. The Galaxy lobby survives, so the invite still resolves — but the `SteamLobbyId` stamped into Galaxy metadata points at a Steam lobby Valve destroyed on the drop. Clients decode invite → read stale `SteamLobbyId` → connect to a dead Steam lobby → fail.

Root cause: `_lobbyCreationAttempted` tracks "ever attempted" rather than "current attempt valid", so the reconnect chain's `CreateSteamLobbyViaHttpAsync()` early-exits and no new lobby is created.

## Changes

- Add `OnSteamServersLost` event, fired from `SteamGameServerService.OnSteamServersDisconnected`.
- Subscribe in `GalaxyAuthService`; on loss, clear cached Steam-lobby state (`_steamLobbyId`, `_lobbyCreationAttempted`, `_lastSteamLobbyPrivacy`, `_pendingGalaxyLobbyUpdate`) so reconnect rebuilds the lobby. `_galaxyInitComplete` is left set — the Galaxy dispatch loop is gated on it and nothing re-inits Galaxy.
- Add a `_steamSessionGeneration` counter captured on the game thread at each `Task.Run` spawn site; lobby results (create + recreate) commit only if the captured generation still matches, closing the race where a task from a torn-down session overwrites fresh state with a stale lobby ID.
- Add diagnostic instrumentation — counted `auth_galaxy_lost` / `auth_galaxy_state_change` (logged before the `onStateChange` early-return) and `steam_session_lost` / `steam_session_connected` (`isReconnect`) — to observe whether the closed-source Galaxy SDK re-fires its callbacks after a full-NIC outage. This resolves the open question gating a separate Galaxy-reinit follow-up (a full-NIC outage also drops Galaxy, which this PR does not yet recover).
- Catalog the new events in `InfrastructureEventLog`.

## Verification

- `dotnet build mod/JunimoServer/JunimoServer.csproj` — clean, 0 warnings.
- Grep invariants: each invalidated field gains exactly one new writer (the loss handler); every pre-existing writer intact; generation captured + checked at all spawn/commit sites.
- No automated test — by design. Tests never lose a Steam session, so the recovery path isn't exercised; `make test` is a regression check on the first-connect flow only. The disconnect/reconnect recovery is gated by a manual Docker + Steam-client outage repro (no toxiproxy/netem layer exists, and Valve reconnect timing is non-deterministic). The generation counter moves the only race a test could plausibly catch from runtime to compile-time.

## Scope

Steam-CM-flap recovery only. A full-NIC outage also drops Galaxy (no reinit path today) — tracked as a separate follow-up; the diagnostic events here exist to pick its design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential state corruption from stale async operations during network disconnects

* **New Features**
  * Enhanced diagnostic logging for authentication and server connection lifecycle events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->