### PR TITLE
feat(farm-type): select modded farms by AdditionalFarms Id (string-or-int)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -108,6 +108,18 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
     /output/JunimoServer/JunimoServer.dll \
     /output/openapi.json
 
+# Build the E2E test-fixture farm mod (needs game DLLs, hence built here). It is NOT a
+# loaded mod in normal operation — it's copied into /data/Mods only on servers that opt in
+# via SDVD_TEST_FIXTURE_FARM_MOD (see docker/rootfs/startapp.sh). manifest.json is copied
+# alongside the dll because EnableModDeploy=false leaves it in the project dir, not /output.
+COPY ./tests/fixtures/TestFarmMod /src/tests/fixtures/TestFarmMod
+RUN --mount=type=cache,target=/root/.nuget/packages \
+    dotnet build /src/tests/fixtures/TestFarmMod/TestFarmMod.csproj \
+    --configuration ${BUILD_CONFIGURATION} \
+    /p:GamePath=/game \
+    -o /output/TestFarmMod && \
+    cp /src/tests/fixtures/TestFarmMod/manifest.json /output/TestFarmMod/manifest.json
+
 # ============================================================================
 # Stage 4: Final runtime image (no game files, downloads on first run)
 # ============================================================================
@@ -236,6 +248,11 @@ RUN cp -a /tmp/services/. /etc/services.d/ && \
 
 # Copy mod from build stage (no game files included in image)
 COPY --from=mod-builder /output/JunimoServer /data/Mods/JunimoServer
+
+# Stage the E2E test-fixture farm mod OUTSIDE the loaded Mods path. startapp.sh copies it
+# into /data/Mods/TestFarmMod only when SDVD_TEST_FIXTURE_FARM_MOD=true, so it never loads
+# on normal servers (keeping Data/AdditionalFarms vanilla for everyone else).
+COPY --from=mod-builder /output/TestFarmMod /opt/test-fixtures/TestFarmMod
 
 # Copy OpenAPI spec (for extraction via: docker cp or docker run --rm sdvd/server cat /data/openapi.json)
 COPY --from=mod-builder /output/openapi.json /data/openapi.json

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -191,7 +191,7 @@ init_mods() {
     # used by the by-Id modded-farm disambiguation test. Staged at /opt/test-fixtures by
     # the image build; copied in here (a sibling of smapi/, so the rm -rf above leaves it
     # untouched) only when the test broker sets the flag.
-    if [ "${SDVD_TEST_FIXTURE_FARM_MOD}" = "true" ] && [ -d /opt/test-fixtures/TestFarmMod ]; then
+    if [ "${SDVD_TEST_FIXTURE_FARM_MOD:-false}" = "true" ] && [ -d /opt/test-fixtures/TestFarmMod ]; then
         echo "Installing E2E test fixture mod: TestFarmMod"
         rm -rf "${MODS_DEST_DIR}/TestFarmMod"
         cp -r /opt/test-fixtures/TestFarmMod "${MODS_DEST_DIR}/TestFarmMod"

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -186,6 +186,16 @@ init_mods() {
     rm -rf ${MODS_DEST_DIR}/smapi/
     mkdir -p ${MODS_DEST_DIR}/smapi/
     cp -r ${GAME_DEST_DIR}/Mods/* ${MODS_DEST_DIR}/smapi/
+
+    # E2E test fixture: opt-in extra mod that adds a second Data/AdditionalFarms entry,
+    # used by the by-Id modded-farm disambiguation test. Staged at /opt/test-fixtures by
+    # the image build; copied in here (a sibling of smapi/, so the rm -rf above leaves it
+    # untouched) only when the test broker sets the flag.
+    if [ "${SDVD_TEST_FIXTURE_FARM_MOD}" = "true" ] && [ -d /opt/test-fixtures/TestFarmMod ]; then
+        echo "Installing E2E test fixture mod: TestFarmMod"
+        rm -rf "${MODS_DEST_DIR}/TestFarmMod"
+        cp -r /opt/test-fixtures/TestFarmMod "${MODS_DEST_DIR}/TestFarmMod"
+    fi
 }
 
 init_permissions() {

--- a/docs/admins/configuration/server-settings.md
+++ b/docs/admins/configuration/server-settings.md
@@ -65,7 +65,7 @@ These settings only take effect when creating a **new** game. They are ignored w
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `FarmName` | Farm name displayed in-game | `"Junimo"` |
-| `FarmType` | Farm map type (see table below) | `0` |
+| `FarmType` | Farm map type: a number `0`-`7` or a name for a built-in farm, or a farm Id string for a mod-added farm (see table below) | `0` |
 | `ProfitMargin` | Sell price multiplier | `1.0` |
 | `StartingCabins` | Number of cabins created with new game | `1` |
 | `SpawnMonstersAtNight` | Monster spawning: `"true"`, `"false"`, or `"auto"` | `"auto"` |
@@ -82,16 +82,38 @@ These settings only take effect when creating a **new** game. They are ignored w
 
 ### Farm Types
 
-| Value | Farm Type |
-|-------|-----------|
-| `0` | Standard |
-| `1` | Riverland |
-| `2` | Forest |
-| `3` | Hilltop |
-| `4` | Wilderness |
-| `5` | Four Corners |
-| `6` | Beach |
-| `7` | Meadowlands |
+The eight built-in farms can be selected by **number or by name** (names are case- and space-insensitive, so `"FourCorners"` and `"four corners"` both work):
+
+| Value | Name | Farm Type |
+|-------|------|-----------|
+| `0` | `"Standard"` | Standard |
+| `1` | `"Riverland"` | Riverland |
+| `2` | `"Forest"` | Forest |
+| `3` | `"Hilltop"` | Hilltop |
+| `4` | `"Wilderness"` | Wilderness |
+| `5` | `"FourCorners"` | Four Corners |
+| `6` | `"Beach"` | Beach |
+| `7` | `"MeadowlandsFarm"` | Meadowlands |
+
+Either column works and the two are equivalent — e.g. `"FarmType": 7` and `"FarmType": "MeadowlandsFarm"` select the same farm.
+
+#### Mod-added farms
+
+A farm added by a mod is selected by its **Id string** (mod farms have no number):
+
+```json
+"FarmType": "FrontierFarm"
+```
+
+The Id is the `Id` field of the farm's entry in the mod's `Data/AdditionalFarms` content (check the mod for the exact value). The mod must be installed on the server for the Id to resolve. An unknown Id — or a number above `7` — falls back to the Standard farm with a warning in the log.
+
+If you have a **single** farm mod installed and don't want to look up its Id, use the keyword `"modded"`, which selects the first installed mod farm:
+
+```json
+"FarmType": "modded"
+```
+
+Because mod load order isn't guaranteed, prefer the explicit Id when more than one farm mod is installed. With no farm mod installed, `"modded"` falls back to Standard with a warning.
 
 ### Profit Margin
 

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -82,12 +82,7 @@ namespace JunimoServer.Services.Api
         /// <summary>Current time in 24-hour format (e.g., 1430 = 2:30 PM).</summary>
         public int TimeOfDay { get; set; }
 
-        /// <summary>
-        /// Farm type key as returned by Game1.GetFarmTypeKey().
-        /// Vanilla: "Standard", "Riverland", "Forest", "Hilltop", "Wilderness", "FourCorners", "Beach".
-        /// Meadowlands: "MeadowlandsFarm".
-        /// Modded farms: the mod's farm ID.
-        /// </summary>
+        /// <summary>Farm type key as returned by Game1.GetFarmTypeKey() (a vanilla name, or the farm Id for Data/AdditionalFarms farms).</summary>
         public string FarmTypeKey { get; set; } = "";
 
         /// <summary>Whether the game clock is currently paused (no players connected, or time not passing).</summary>
@@ -479,8 +474,7 @@ namespace JunimoServer.Services.Api
         /// <summary>Farm name.</summary>
         public string FarmName { get; set; } = "";
 
-        /// <summary>Farm type ID (0=Standard, 1=Riverland, 2=Forest, 3=Hilltop, 4=Wilderness, 5=Four Corners, 6=Beach, 7=Meadowlands).</summary>
-        public int FarmType { get; set; }
+        public FarmTypeSetting FarmType { get; set; } = FarmTypeSetting.Default;
 
         /// <summary>Profit margin multiplier (1.0 = normal).</summary>
         public float ProfitMargin { get; set; }
@@ -612,8 +606,8 @@ namespace JunimoServer.Services.Api
     /// </summary>
     public class NewGameRequest
     {
-        /// <summary>Farm type ID (0=Standard, 1=Riverland, 2=Forest, 3=Hilltop, 4=Wilderness, 5=FourCorners, 6=Beach, 7=Meadowlands).</summary>
-        public int? FarmType { get; set; }
+        /// <summary>Absent = use the server's configured farm type.</summary>
+        public FarmTypeSetting? FarmType { get; set; }
 
         /// <summary>Farm name.</summary>
         public string? FarmName { get; set; }

--- a/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
+++ b/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
@@ -162,6 +162,21 @@ namespace JunimoServer.Services.Api
                 return innerSchema;
             }
 
+            // Emit the union scalar explicitly: without this, the fall-through "complex type"
+            // branch would expose FarmTypeSetting's Index/Id/IsModded members as object properties.
+            if (type == typeof(GameCreator.FarmTypeSetting))
+            {
+                return new JsonSchemaProperty
+                {
+                    Description = "A built-in farm index (0-7) or name, or a Data/AdditionalFarms farm Id.",
+                    OneOf =
+                    {
+                        new JsonSchema { Type = JsonObjectType.Integer },
+                        new JsonSchema { Type = JsonObjectType.String }
+                    }
+                };
+            }
+
             // Handle common types
             if (type == typeof(string))
                 return new JsonSchemaProperty { Type = JsonObjectType.String };

--- a/mod/JunimoServer/Services/Commands/SavesCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SavesCommand.cs
@@ -1,3 +1,4 @@
+using JunimoServer.Services.GameCreator;
 using JunimoServer.Services.GameLoader;
 using JunimoServer.Services.Settings;
 using StardewModdingAPI;
@@ -108,7 +109,7 @@ namespace JunimoServer.Services.Commands
             }
 
             _monitor.Log($"Save: {saveName}", LogLevel.Info);
-            _monitor.Log($"  Farm Type:  {info.FarmTypeName} ({info.FarmType})", LogLevel.Info);
+            _monitor.Log($"  Farm Type:  {info.FarmTypeDisplay}", LogLevel.Info);
             _monitor.Log($"  Farm Name:  {info.FarmName}", LogLevel.Info);
             _monitor.Log($"  Cabins:     {info.CabinCount}", LogLevel.Info);
 
@@ -135,7 +136,7 @@ namespace JunimoServer.Services.Commands
 
                 if (info != null)
                 {
-                    _monitor.Log($"  Farm Type:               {info.FarmTypeName} ({info.FarmType})", LogLevel.Info);
+                    _monitor.Log($"  Farm Type:               {info.FarmTypeDisplay}", LogLevel.Info);
                     _monitor.Log($"  Existing Cabins:         {info.CabinCount}", LogLevel.Info);
                 }
 
@@ -157,10 +158,15 @@ namespace JunimoServer.Services.Commands
         private class SaveInfo
         {
             public string FarmName = "Unknown";
-            public int FarmType = -1;
+            /// <summary>Raw &lt;whichFarm&gt; token: a vanilla index "0"-"6" or a modded farm Id.</summary>
+            public string FarmTypeRaw = "Unknown";
             public string FarmTypeName = "Unknown";
             public int CabinCount = 0;
             public List<string> PlayerNames = new List<string>();
+
+            /// <summary>Detail label: "Name (raw)" for vanilla, just the Id for a modded farm.</summary>
+            public string FarmTypeDisplay =>
+                FarmTypeName == FarmTypeRaw ? FarmTypeName : $"{FarmTypeName} ({FarmTypeRaw})";
         }
 
         private static SaveInfo ReadSaveGameInfo(string saveDirectory)
@@ -170,12 +176,6 @@ namespace JunimoServer.Services.Commands
             {
                 return null;
             }
-
-            var farmTypeNames = new Dictionary<int, string>
-            {
-                { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
-                { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "Four Corners" }, { 6, "Beach" }
-            };
 
             try
             {
@@ -196,11 +196,18 @@ namespace JunimoServer.Services.Commands
                     var mainDoc = new XmlDocument();
                     mainDoc.Load(mainSavePath);
 
+                    // whichFarm is serialized as a string (GetFarmTypeID): "0"-"6" for vanilla
+                    // farms, or the Data/AdditionalFarms Id for a modded farm. An int.TryParse
+                    // here would return false on a modded Id and silently drop the farm type.
                     var whichFarmNode = mainDoc.SelectSingleNode("//whichFarm");
-                    if (whichFarmNode != null && int.TryParse(whichFarmNode.InnerText, out var farmType))
+                    if (whichFarmNode != null && !string.IsNullOrWhiteSpace(whichFarmNode.InnerText))
                     {
-                        info.FarmType = farmType;
-                        info.FarmTypeName = farmTypeNames.TryGetValue(farmType, out var n) ? n : $"Custom ({farmType})";
+                        info.FarmTypeRaw = whichFarmNode.InnerText;
+                        // The token is a vanilla index ("0"-"6") or a Data/AdditionalFarms Id;
+                        // DisplayName() turns either into the same friendly label as elsewhere.
+                        info.FarmTypeName = (int.TryParse(info.FarmTypeRaw, out var index)
+                            ? FarmTypeSetting.FromIndex(index)
+                            : FarmTypeSetting.FromId(info.FarmTypeRaw)).DisplayName();
                     }
 
                     var buildingNodes = mainDoc.SelectNodes("//Building[buildingType='Cabin']");

--- a/mod/JunimoServer/Services/Commands/SettingsCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SettingsCommand.cs
@@ -8,7 +8,6 @@ using StardewModdingAPI;
 using SmapiLogConfig = JunimoServer.Util.SmapiLogConfig;
 using StardewValley;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace JunimoServer.Services.Commands
@@ -76,23 +75,23 @@ namespace JunimoServer.Services.Commands
 
         #region Show Config
 
+        /// <summary>
+        /// Label for the config display: "N - Name" when selected by a built-in index, else the
+        /// name/Id. (e.g. "0 - Standard", "7 - Meadowlands", "FrontierFarm").
+        /// </summary>
+        private static string FarmTypeLabel(FarmTypeSetting farmType) =>
+            farmType.Index is { } index
+                ? $"{index} - {farmType.DisplayName()}"
+                : farmType.DisplayName();
+
         private static void ShowConfig()
         {
-            var farmTypeNames = new Dictionary<int, string>
-            {
-                { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
-                { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "Four Corners" }, { 6, "Beach" }
-            };
-
             _monitor.Log("Current Configuration (server-settings.json)", LogLevel.Info);
 
             _monitor.Log("  -- Game creation settings (immutable after game created) --", LogLevel.Info);
             _monitor.Log($"  FarmName             = {_settings.FarmName}", LogLevel.Info);
 
-            var farmTypeLabel = farmTypeNames.TryGetValue(_settings.FarmType, out var ftName)
-                ? $"{_settings.FarmType} - {ftName}"
-                : _settings.FarmType.ToString();
-            _monitor.Log($"  FarmType             = {farmTypeLabel}", LogLevel.Info);
+            _monitor.Log($"  FarmType             = {FarmTypeLabel(_settings.FarmType)}", LogLevel.Info);
             _monitor.Log($"  ProfitMargin         = {_settings.ProfitMargin}", LogLevel.Info);
             _monitor.Log($"  StartingCabins       = {_settings.StartingCabins}", LogLevel.Info);
 
@@ -134,18 +133,10 @@ namespace JunimoServer.Services.Commands
             if (!confirm)
             {
                 var config = NewGameConfig.FromSettings(_settings);
-                var farmTypeNames = new Dictionary<int, string>
-                {
-                    { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
-                    { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "Four Corners" }, { 6, "Beach" }
-                };
-                var farmLabel = farmTypeNames.TryGetValue(config.WhichFarm, out var n)
-                    ? $"{config.WhichFarm} - {n}"
-                    : config.WhichFarm.ToString();
 
                 _monitor.Log("New Game Preview (from server-settings.json):", LogLevel.Info);
                 _monitor.Log($"  Farm Name:        {config.FarmName}", LogLevel.Info);
-                _monitor.Log($"  Farm Type:        {farmLabel}", LogLevel.Info);
+                _monitor.Log($"  Farm Type:        {FarmTypeLabel(config.WhichFarm)}", LogLevel.Info);
                 _monitor.Log($"  Max Players:      {config.MaxPlayers}", LogLevel.Info);
                 _monitor.Log($"  Cabin Strategy:   {config.CabinStrategy}", LogLevel.Info);
                 _monitor.Log($"  Separate Wallets: {config.UseSeparateWallets}", LogLevel.Info);
@@ -172,22 +163,21 @@ namespace JunimoServer.Services.Commands
             int passed = 0;
             int total = 0;
 
-            // FarmType valid
             total++;
-            var validFarmTypes = new[] { 0, 1, 2, 3, 4, 5, 6 };
-            if (validFarmTypes.Contains(_settings.FarmType))
+            var farmType = _settings.FarmType;
+            // A numeric index outside the built-in 0-7 range can't name a farm (mod farms use a
+            // string Id); it resolves to Standard at creation. Everything else — a built-in
+            // index/name or a mod Id — is accepted (a mod Id is verified against
+            // Data/AdditionalFarms at game creation, with a Standard fallback if missing).
+            if (farmType.Index is { } idx && (idx < 0 || idx > FarmTypeSetting.MeadowlandsIndex))
             {
-                var farmTypeNames = new Dictionary<int, string>
-                {
-                    { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
-                    { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "Four Corners" }, { 6, "Beach" }
-                };
-                _monitor.Log($"  [PASS] FarmType={_settings.FarmType} is valid ({farmTypeNames[_settings.FarmType]})", LogLevel.Info);
+                _monitor.Log($"  [WARN] FarmType={idx} is not a built-in farm (0-{FarmTypeSetting.MeadowlandsIndex}); will use Standard. Use a mod farm's Id string instead.", LogLevel.Warn);
                 passed++;
             }
             else
             {
-                _monitor.Log($"  [FAIL] FarmType={_settings.FarmType} is not a known farm type", LogLevel.Error);
+                _monitor.Log($"  [PASS] FarmType={FarmTypeLabel(farmType)}", LogLevel.Info);
+                passed++;
             }
 
             // MaxPlayers range

--- a/mod/JunimoServer/Services/GameCreator/FarmTypeSetting.cs
+++ b/mod/JunimoServer/Services/GameCreator/FarmTypeSetting.cs
@@ -1,0 +1,161 @@
+using Newtonsoft.Json;
+using System;
+
+namespace JunimoServer.Services.GameCreator
+{
+    /// <summary>
+    /// A farm-type selector that is either a vanilla index (0-6) or a modded farm
+    /// <c>Id</c> string (the <c>Data/AdditionalFarms</c> <c>Id</c> field). Mirrors how
+    /// the game itself identifies farms: <c>whichFarm</c> is a bucket (0-6 vanilla,
+    /// 7 = "consult <c>whichModFarm</c>") and modded farms are resolved by Id, never by
+    /// position (see <see cref="GameCreatorService.ResolveFarmType"/>).
+    ///
+    /// Serializes back to the original scalar (a JSON number for an index, a JSON string
+    /// for an Id) so existing <c>"FarmType": 3</c> configs round-trip unchanged.
+    /// </summary>
+    [JsonConverter(typeof(FarmTypeSettingConverter))]
+    public readonly struct FarmTypeSetting
+    {
+        /// <summary>
+        /// The <c>whichFarm</c> bucket value the game uses for any Data/AdditionalFarms farm
+        /// (vanilla maps are 0-6; 7 means "look at whichModFarm"). Also the count of vanilla maps.
+        /// </summary>
+        public const int FirstModdedIndex = 7;
+
+        /// <summary>
+        /// Data/AdditionalFarms Id of the base-game Meadowlands farm. It ships with vanilla, so
+        /// it's treated as a built-in: the index <c>7</c> is a permanent alias for this Id (see
+        /// <see cref="GameCreatorService.ResolveFarmType"/>), independent of any installed mods.
+        /// </summary>
+        public const string MeadowlandsFarmId = "MeadowlandsFarm";
+
+        /// <summary>
+        /// The numeric index that aliases <see cref="MeadowlandsFarmId"/>. It's the modded
+        /// bucket itself (7) — Meadowlands is the one AdditionalFarms farm with a number.
+        /// </summary>
+        public const int MeadowlandsIndex = FirstModdedIndex;
+
+        /// <summary>
+        /// Convenience keyword (case-insensitive) selecting the first installed mod farm — i.e.
+        /// the first <c>Data/AdditionalFarms</c> entry that isn't the base-game Meadowlands. Lets
+        /// an operator with a single farm mod avoid looking up its Id. Order isn't guaranteed
+        /// across mod changes, so it's a best-effort convenience, not a stable selector.
+        /// </summary>
+        public const string FirstModFarmKeyword = "modded";
+
+        /// <summary>Vanilla farm index (0-6) when this is an index selector, else null.</summary>
+        public int? Index { get; }
+
+        /// <summary>Modded farm Id when this is an Id selector, else null.</summary>
+        public string? Id { get; }
+
+        /// <summary>True when this selects a modded farm by Id.</summary>
+        public bool IsModded => Id != null;
+
+        /// <summary>True when this is the <see cref="FirstModFarmKeyword"/> selector (case-insensitive).</summary>
+        public bool IsFirstModFarmKeyword =>
+            Id != null && string.Equals(Id, FirstModFarmKeyword, StringComparison.OrdinalIgnoreCase);
+
+        private FarmTypeSetting(int? index, string? id)
+        {
+            Index = index;
+            Id = id;
+        }
+
+        public static FarmTypeSetting FromIndex(int index) => new(index, null);
+        public static FarmTypeSetting FromId(string id) => new(null, id);
+
+        /// <summary>Default selector: vanilla Standard farm (index 0).</summary>
+        public static FarmTypeSetting Default => FromIndex(0);
+
+        /// <summary>
+        /// Admin-facing display names for the vanilla indices 0-6. "Four Corners" matches the
+        /// game's farm-type key only after whitespace is stripped (<c>Game1.GetFarmTypeKey()</c>
+        /// returns "FourCorners"); <see cref="TryGetVanillaIndex"/> accepts either spelling.
+        /// </summary>
+        private static readonly string[] VanillaNames =
+            { "Standard", "Riverland", "Forest", "Hilltop", "Wilderness", "Four Corners", "Beach" };
+
+        /// <summary>Friendly display name for a vanilla farm index (0-6), or null if out of range.</summary>
+        public static string? VanillaName(int index) =>
+            index >= 0 && index < VanillaNames.Length ? VanillaNames[index] : null;
+
+        /// <summary>
+        /// Maps a vanilla farm name to its index (0-6), case- and whitespace-insensitive, so
+        /// "Standard", "fourcorners", and "Four Corners" all resolve. Returns false for any
+        /// non-vanilla name (e.g. a mod farm Id).
+        /// </summary>
+        public static bool TryGetVanillaIndex(string name, out int index)
+        {
+            for (var i = 0; i < VanillaNames.Length; i++)
+            {
+                if (NameKey(VanillaNames[i]) == NameKey(name))
+                {
+                    index = i;
+                    return true;
+                }
+            }
+            index = -1;
+            return false;
+        }
+
+        /// <summary>
+        /// Human-readable label for this selector: the built-in name for a known farm (index
+        /// 0-6, index 7 / the Meadowlands Id → "Meadowlands"), or the raw Id for a mod farm.
+        /// Display only — does not validate that a mod Id exists in Data/AdditionalFarms.
+        /// </summary>
+        public string DisplayName()
+        {
+            if (Id != null)
+                return NameKey(Id) == NameKey(MeadowlandsFarmId) ? "Meadowlands" : Id;
+            var index = Index ?? 0;
+            return VanillaName(index)
+                ?? (index == MeadowlandsIndex ? "Meadowlands" : index.ToString());
+        }
+
+        private static string NameKey(string s) => s.Replace(" ", "").ToLowerInvariant();
+
+        /// <summary>The original scalar form (index as a number string, or the Id).</summary>
+        public override string ToString() => Id ?? Index?.ToString() ?? "0";
+    }
+
+    /// <summary>
+    /// Reads <see cref="FarmTypeSetting"/> from a JSON number or string and writes it back to
+    /// the same scalar form. Parsing is total — an out-of-range index or unknown Id is NOT
+    /// rejected here; that's a domain decision handled (with a graceful Standard fallback and a
+    /// warning) by <see cref="GameCreatorService.ResolveFarmType"/>. Throwing here would abort
+    /// the whole settings load and discard every other setting, which is the wrong failure mode
+    /// for one bad field — every sibling setting in ServerSettingsLoader degrades gracefully too.
+    /// A quoted integer (<c>"3"</c>) is treated as an index, not an Id.
+    /// </summary>
+    public class FarmTypeSettingConverter : JsonConverter<FarmTypeSetting>
+    {
+        public override FarmTypeSetting ReadJson(JsonReader reader, Type objectType,
+            FarmTypeSetting existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            switch (reader.TokenType)
+            {
+                case JsonToken.Integer:
+                    return FarmTypeSetting.FromIndex(Convert.ToInt32(reader.Value));
+
+                case JsonToken.String:
+                    var raw = (string)reader.Value!;
+                    return int.TryParse(raw, out var parsedIndex)
+                        ? FarmTypeSetting.FromIndex(parsedIndex)
+                        : FarmTypeSetting.FromId(raw);
+
+                default:
+                    throw new JsonSerializationException(
+                        $"FarmType must be a JSON number or string, but got {reader.TokenType}.");
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, FarmTypeSetting value, JsonSerializer serializer)
+        {
+            if (value.Id != null)
+                writer.WriteValue(value.Id);
+            else
+                writer.WriteValue(value.Index ?? 0);
+        }
+    }
+}

--- a/mod/JunimoServer/Services/GameCreator/FarmTypeSetting.cs
+++ b/mod/JunimoServer/Services/GameCreator/FarmTypeSetting.cs
@@ -136,7 +136,11 @@ namespace JunimoServer.Services.GameCreator
             switch (reader.TokenType)
             {
                 case JsonToken.Integer:
-                    return FarmTypeSetting.FromIndex(Convert.ToInt32(reader.Value));
+                    // Out-of-int values fall through to an out-of-range index, which the resolver maps
+                    // to Standard with a warning — parsing stays total (see class summary).
+                    return int.TryParse(reader.Value?.ToString(), out var jsonIndex)
+                        ? FarmTypeSetting.FromIndex(jsonIndex)
+                        : FarmTypeSetting.FromIndex(int.MaxValue);
 
                 case JsonToken.String:
                     var raw = (string)reader.Value!;

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -5,6 +5,7 @@ using JunimoServer.Services.Settings;
 using Microsoft.Xna.Framework;
 using StardewModdingAPI;
 using StardewValley;
+using StardewValley.GameData;
 using System;
 using System.Linq;
 
@@ -94,42 +95,33 @@ namespace JunimoServer.Services.GameCreator
             // map-designated positions by the unpatched BuildStartingCabins.
             Game1.startingCabins = config.StartingCabins;
 
-            // Ultimate Farm CP compat: the mod expects whichFarm to be set to Riverland (1)
-            // to correctly apply its custom farm map. Override the user's farm type setting.
             var isUltimateFarmModLoaded = _helper.ModRegistry.GetAll()
                 .Any(mod => mod.Manifest.Name == "Ultimate Farm CP");
+
+            // Resolve the user's requested farm to (whichFarm bucket, modFarm data). The
+            // monster-spawn default keys off this requested farm, matching the prior behavior
+            // even when Ultimate Farm CP overrides the map below.
+            var (whichFarm, modFarm) = ResolveFarmType(config.WhichFarm);
+
+            // Monster spawning: explicit override, else the requested farm's default — vanilla
+            // Wilderness (4) or the modded farm's SpawnMonstersByDefault (matches the new-game
+            // UI at CharacterCustomization.optionButtonClick).
+            Game1.spawnMonstersAtNight = config.SpawnMonstersAtNight
+                ?? (modFarm?.SpawnMonstersByDefault ?? whichFarm == 4);
+
+            // Ultimate Farm CP compat: the mod expects whichFarm = Riverland (1) to apply its
+            // custom farm map, overriding the requested map (but not the monster default above).
             if (isUltimateFarmModLoaded)
             {
-                Game1.whichFarm = 1;
-                Game1.whichModFarm = null;
-            }
-            else
-            {
-                Game1.whichFarm = config.WhichFarm;
-
-                // Farm type 7 (Meadowlands) uses the AdditionalFarms system.
-                // whichModFarm MUST be set BEFORE loadForNewGame() because the Farm map
-                // is created during loadForNewGame() using Farm.getMapNameFromTypeInt()
-                // which checks whichModFarm when whichFarm is 7.
-                if (config.WhichFarm == 7)
-                {
-                    var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
-                    Game1.whichModFarm = additionalFarms?.FirstOrDefault(f => f.Id == "MeadowlandsFarm");
-
-                    if (Game1.whichModFarm == null)
-                    {
-                        _monitor.Log("Could not find MeadowlandsFarm data, falling back to Standard farm", LogLevel.Warn);
-                        Game1.whichFarm = 0;
-                    }
-                }
-                else
-                {
-                    Game1.whichModFarm = null;
-                }
+                whichFarm = 1;
+                modFarm = null;
             }
 
-            // Monster spawning: explicit override or auto-detect from farm type
-            Game1.spawnMonstersAtNight = config.SpawnMonstersAtNight ?? (config.WhichFarm == 4);
+            // whichModFarm MUST be set BEFORE loadForNewGame(): the Farm map is created
+            // during loadForNewGame() via Farm.getMapNameFromTypeInt(), which consults
+            // whichModFarm when whichFarm is 7.
+            Game1.whichFarm = whichFarm;
+            Game1.whichModFarm = modFarm;
 
             Game1.player.Name = "Server";
             Game1.player.displayName = Game1.player.Name;
@@ -174,6 +166,91 @@ namespace JunimoServer.Services.GameCreator
             _cabinManagerService.EnsureAtLeastXCabins(minCabins);
 
             GameIsCreating = false;
+        }
+
+        /// <summary>
+        /// Resolves a <see cref="FarmTypeSetting"/> into the game's two-part farm identity:
+        /// the <c>whichFarm</c> bucket and the <c>whichModFarm</c> data (null for vanilla).
+        /// Accepts, interchangeably: a vanilla index 0-6 or its name ("Standard", "FourCorners",
+        /// case/space-insensitive); the index 7 or the Id "MeadowlandsFarm" (both always select
+        /// the base-game Meadowlands farm); the keyword "modded" (the first installed mod farm);
+        /// or any other Data/AdditionalFarms Id for a specific mod farm. Anything invalid — an
+        /// out-of-range index, an unknown Id, or "modded" with no mod farm installed — falls back
+        /// to Standard with a warning (a config mistake shouldn't abort game creation).
+        /// </summary>
+        private (int whichFarm, ModFarmType? modFarm) ResolveFarmType(FarmTypeSetting setting)
+        {
+            // Normalize the selector to either a vanilla index (0-6) or an AdditionalFarms Id
+            // to look up. Index 7 is a permanent alias for Meadowlands' Id (it ships with the
+            // game, so it's a built-in 0-7 farm regardless of which mods are installed).
+            string? lookupId = null;
+            if (setting.IsModded)
+            {
+                if (setting.IsFirstModFarmKeyword)
+                {
+                    return ResolveFirstModFarm();
+                }
+                if (FarmTypeSetting.TryGetVanillaIndex(setting.Id!, out var namedIndex))
+                {
+                    return (namedIndex, null);
+                }
+                lookupId = setting.Id;
+            }
+            else
+            {
+                var index = setting.Index ?? 0;
+                if (index >= 0 && index < FarmTypeSetting.FirstModdedIndex)
+                {
+                    return (index, null);
+                }
+                if (index == FarmTypeSetting.MeadowlandsIndex)
+                {
+                    lookupId = FarmTypeSetting.MeadowlandsFarmId;
+                }
+                else
+                {
+                    _monitor.Log(
+                        $"Farm type index {index} is not a vanilla farm (0-{FarmTypeSetting.MeadowlandsIndex}); " +
+                        "falling back to Standard. Use a Data/AdditionalFarms Id string to select a mod farm.",
+                        LogLevel.Warn);
+                    return (0, null);
+                }
+            }
+
+            // Resolve the Id against Data/AdditionalFarms (matched exactly, as the game does).
+            var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
+            var match = additionalFarms?.FirstOrDefault(f => f.Id == lookupId);
+            if (match != null)
+            {
+                return (FarmTypeSetting.FirstModdedIndex, match);
+            }
+
+            _monitor.Log(
+                $"Farm type '{lookupId}' not found in Data/AdditionalFarms; falling back to Standard farm. " +
+                "Check the Id matches the mod's AdditionalFarms entry.", LogLevel.Warn);
+            return (0, null);
+        }
+
+        /// <summary>
+        /// Resolves the "modded" keyword to the first installed mod farm — the first
+        /// Data/AdditionalFarms entry that isn't base-game Meadowlands. Falls back to Standard
+        /// with a warning when no mod farm is present.
+        /// </summary>
+        private (int whichFarm, ModFarmType? modFarm) ResolveFirstModFarm()
+        {
+            var additionalFarms = DataLoader.AdditionalFarms(Game1.content);
+            var modFarm = additionalFarms?.FirstOrDefault(f => f.Id != FarmTypeSetting.MeadowlandsFarmId);
+            if (modFarm != null)
+            {
+                _monitor.Log($"Farm type '{FarmTypeSetting.FirstModFarmKeyword}' resolved to mod farm '{modFarm.Id}'.", LogLevel.Info);
+                return (FarmTypeSetting.FirstModdedIndex, modFarm);
+            }
+
+            _monitor.Log(
+                $"Farm type '{FarmTypeSetting.FirstModFarmKeyword}' was requested but no mod farm is installed " +
+                "(Data/AdditionalFarms has only the base-game Meadowlands); falling back to Standard farm.",
+                LogLevel.Warn);
+            return (0, null);
         }
     }
 }

--- a/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
+++ b/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
@@ -6,7 +6,7 @@ namespace JunimoServer.Services.GameCreator
 {
     public class NewGameConfig
     {
-        public int WhichFarm { get; set; } = 0;
+        public FarmTypeSetting WhichFarm { get; set; } = FarmTypeSetting.Default;
         public bool UseSeparateWallets { get; set; } = false;
         public int StartingCabins { get; set; } = 1;
         public string FarmName { get; set; } = "Junimo";
@@ -59,7 +59,7 @@ namespace JunimoServer.Services.GameCreator
         /// Creates a NewGameConfig from API request parameters with sensible defaults.
         /// </summary>
         public static NewGameConfig FromRequest(
-            int farmType = 0, string farmName = "Junimo", int startingCabins = 1,
+            FarmTypeSetting farmType, string farmName = "Junimo", int startingCabins = 1,
             string cabinStrategy = "CabinStack", int maxPlayers = 10,
             float profitMargin = 1.0f, bool? spawnMonstersAtNight = null,
             bool separateWallets = false)

--- a/mod/JunimoServer/Services/Settings/ServerSettings.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettings.cs
@@ -1,3 +1,4 @@
+using JunimoServer.Services.GameCreator;
 using System;
 
 namespace JunimoServer.Services.Settings
@@ -22,7 +23,7 @@ namespace JunimoServer.Services.Settings
     public class GameSettings
     {
         public string FarmName { get; set; } = "Junimo";
-        public int FarmType { get; set; } = 0;
+        public FarmTypeSetting FarmType { get; set; } = FarmTypeSetting.Default;
         public float ProfitMargin { get; set; } = 1.0f;
         public int StartingCabins { get; set; } = 1;
         public string SpawnMonstersAtNight { get; set; } = "auto";

--- a/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettingsLoader.cs
@@ -1,4 +1,5 @@
 using JunimoServer.Services.CabinManager;
+using JunimoServer.Services.GameCreator;
 using Newtonsoft.Json;
 using StardewModdingAPI;
 using System;
@@ -28,7 +29,7 @@ namespace JunimoServer.Services.Settings
         #region Typed accessors: game creation settings (immutable after game created)
 
         public string FarmName => _settings.Game.FarmName;
-        public int FarmType => _settings.Game.FarmType;
+        public FarmTypeSetting FarmType => _settings.Game.FarmType;
         public float ProfitMargin => _settings.Game.ProfitMargin;
         public int StartingCabins => _settings.Game.StartingCabins;
 

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
 using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
 
 namespace JunimoServer.Tests.Clients;
 
@@ -56,12 +57,7 @@ public class ServerStatus
     [JsonPropertyName("timeOfDay")]
     public int TimeOfDay { get; set; }
 
-    /// <summary>
-    /// Farm type key as returned by Game1.GetFarmTypeKey().
-    /// Vanilla: "Standard", "Riverland", "Forest", "Hilltop", "Wilderness", "FourCorners", "Beach".
-    /// Meadowlands: "MeadowlandsFarm".
-    /// Modded farms: the mod's farm ID.
-    /// </summary>
+    /// <summary>Farm type key from Game1.GetFarmTypeKey() (a vanilla name, or the farm Id for Data/AdditionalFarms farms).</summary>
     [JsonPropertyName("farmTypeKey")]
     public string FarmTypeKey { get; set; } = string.Empty;
 
@@ -573,7 +569,7 @@ public class GameSettingsInfo
     public string FarmName { get; set; } = string.Empty;
 
     [JsonPropertyName("farmType")]
-    public int FarmType { get; set; }
+    public FarmTypeSetting FarmType { get; set; }
 
     [JsonPropertyName("profitMargin")]
     public float ProfitMargin { get; set; }
@@ -1392,7 +1388,7 @@ public class ServerApiClient : IDisposable
     /// Only explicitly provided fields are sent; omitted fields use server-settings.json defaults.
     /// </summary>
     public async Task<NewGameResponse?> CreateNewGameAsync(
-        int? farmType = null,
+        FarmTypeSetting? farmType = null,
         string? farmName = null,
         int? startingCabins = null,
         string? cabinStrategy = null,
@@ -1401,7 +1397,7 @@ public class ServerApiClient : IDisposable
         CancellationToken ct = default)
     {
         var body = new Dictionary<string, object>();
-        if (farmType.HasValue) body["farmType"] = farmType.Value;
+        if (farmType.HasValue) body["farmType"] = farmType.Value.ToJsonValue();
         if (farmName != null) body["farmName"] = farmName;
         if (startingCabins.HasValue) body["startingCabins"] = startingCabins.Value;
         if (cabinStrategy != null) body["cabinStrategy"] = cabinStrategy;

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -217,7 +217,7 @@ public class ServerContainer : IAsyncDisposable
         var savesVolume = $"sdvd-test-saves-{runId}";
         var containerName = $"sdvd-server-{runId}";
 
-        logCallback?.Invoke($"Creating Server {serverIndex} ({options.FarmTypeName} farm)...");
+        logCallback?.Invoke($"Creating Server {serverIndex} (farm {options.FarmType})...");
 
         // Build the server-settings.json bytes injected into the container at start
         // via WithResourceMapping (Testcontainers tar API). No host temp file involved.
@@ -270,6 +270,9 @@ public class ServerContainer : IAsyncDisposable
             .WithEnvironment("DISPLAY_HEIGHT", RecordingPolicy.Height.ToString())
             .WithEnvironment("TEST_FAIL_FAST", options.FailFast.ToString().ToLowerInvariant())
             .WithEnvironment("SDVD_ENV", "test")
+            // Opt-in: copy the image-staged TestFarmMod fixture into /data/Mods at startup
+            // (adds a second Data/AdditionalFarms entry for the by-Id disambiguation test).
+            .WithEnvironment("SDVD_TEST_FIXTURE_FARM_MOD", options.FixtureFarmMod.ToString().ToLowerInvariant())
             // GPU passthrough — per-host, no-op on hosts without GPU
             .WithGpuIfEnabled(host)
             // SYS_TIME capability for GOG Galaxy auth + Docker labels for ownership
@@ -351,7 +354,7 @@ public class ServerContainer : IAsyncDisposable
             game = new
             {
                 farmName = options.FarmName,
-                farmType = options.FarmType,
+                farmType = options.FarmType.ToJsonValue(),
                 profitMargin = options.ProfitMargin,
                 startingCabins = options.StartingCabins,
                 spawnMonstersAtNight = options.SpawnMonstersAtNight
@@ -369,7 +372,7 @@ public class ServerContainer : IAsyncDisposable
 
         var json = JsonConvert.SerializeObject(settings, Formatting.Indented);
 
-        logCallback?.Invoke($"Settings: FarmType={options.FarmType} ({options.FarmTypeName}), Cabins={options.StartingCabins}");
+        logCallback?.Invoke($"Settings: FarmType={options.FarmType}, Cabins={options.StartingCabins}");
 
         return Encoding.UTF8.GetBytes(json);
     }

--- a/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
@@ -1,3 +1,5 @@
+using JunimoServer.Tests.Infrastructure;
+
 namespace JunimoServer.Tests.Containers;
 
 /// <summary>
@@ -28,13 +30,8 @@ public class ServerContainerOptions
     /// </summary>
     public string FarmName { get; set; } = "Junimo";
 
-    /// <summary>
-    /// Farm type ID (0-7):
-    /// 0=Standard, 1=Riverland, 2=Forest, 3=Hilltop,
-    /// 4=Wilderness, 5=Four Corners, 6=Beach, 7=Meadowlands
-    /// Note: Type 7 (Meadowlands) uses the AdditionalFarms system internally.
-    /// </summary>
-    public int FarmType { get; set; } = 0;
+    /// <summary>Boot farm type written to server-settings.json.</summary>
+    public FarmTypeSetting FarmType { get; set; } = FarmTypeSetting.FromIndex(0);
 
     /// <summary>
     /// Profit margin multiplier (1.0 = normal).
@@ -89,6 +86,12 @@ public class ServerContainerOptions
     /// </summary>
     public bool WithSteam { get; set; } = false;
 
+    /// <summary>
+    /// Whether to inject the TestFarmMod fixture (adds a second Data/AdditionalFarms entry)
+    /// into /data/Mods at container start. See <see cref="ServerContainer"/>.
+    /// </summary>
+    public bool FixtureFarmMod { get; set; } = false;
+
     #region Container Settings
 
     /// <summary>
@@ -107,39 +110,4 @@ public class ServerContainerOptions
     public bool FailFast { get; set; } = true;
 
     #endregion
-
-    /// <summary>
-    /// Creates options for a specific farm type with sensible defaults.
-    /// </summary>
-    public static ServerContainerOptions ForFarmType(int farmType, string? farmName = null)
-    {
-        var farmTypeNames = new Dictionary<int, string>
-        {
-            { 0, "Standard" }, { 1, "Riverland" }, { 2, "Forest" },
-            { 3, "Hilltop" }, { 4, "Wilderness" }, { 5, "FourCorners" },
-            { 6, "Beach" }, { 7, "Meadowlands" }
-        };
-
-        return new ServerContainerOptions
-        {
-            FarmType = farmType,
-            FarmName = farmName ?? farmTypeNames.GetValueOrDefault(farmType, $"Farm{farmType}")
-        };
-    }
-
-    /// <summary>
-    /// Gets the farm type name for display purposes.
-    /// </summary>
-    public string FarmTypeName => FarmType switch
-    {
-        0 => "Standard",
-        1 => "Riverland",
-        2 => "Forest",
-        3 => "Hilltop",
-        4 => "Wilderness",
-        5 => "Four Corners",
-        6 => "Beach",
-        7 => "Meadowlands",
-        _ => $"Custom ({FarmType})"
-    };
 }

--- a/tests/JunimoServer.Tests/FarmMapTypeTests.cs
+++ b/tests/JunimoServer.Tests/FarmMapTypeTests.cs
@@ -7,7 +7,10 @@ using Xunit;
 namespace JunimoServer.Tests;
 
 /// <summary>
-/// Tests that verify game creation and player joining works for all 8 farm map types.
+/// Tests that game creation and player joining work for the vanilla farm types (0-6) plus
+/// modded-farm selection by Data/AdditionalFarms Id (base-game MeadowlandsFarm) and the
+/// unknown-Id → Standard fallback. By-Id disambiguation between two AdditionalFarms entries
+/// needs a fixture mod and lives in <see cref="ModFarmDisambiguationTests"/>.
 /// Uses a single shared server and POST /newgame to reset between tests instead of
 /// spinning up separate containers.
 ///
@@ -24,6 +27,7 @@ public class FarmMapTypeTests : TestBase
     public FarmMapTypeTests() { }
 
     [Theory]
+    // Built-in farms by index.
     [InlineData(0, "Standard")]
     [InlineData(1, "Riverland")]
     [InlineData(2, "Forest")]
@@ -31,13 +35,25 @@ public class FarmMapTypeTests : TestBase
     [InlineData(4, "Wilderness")]
     [InlineData(5, "FourCorners")]
     [InlineData(6, "Beach")]
+    // Meadowlands is a built-in farm too — selectable by index 7 or its Id, interchangeably.
     [InlineData(7, "MeadowlandsFarm")]
-    public async Task NewGame_WithFarmType_CabinsBuiltAndPlayerCanJoin(int farmType, string expectedFarmTypeKey)
+    [InlineData("MeadowlandsFarm", "MeadowlandsFarm")]
+    // Vanilla farms are also selectable by name (case/space-insensitive).
+    [InlineData("Standard", "Standard")]
+    [InlineData("four corners", "FourCorners")]
+    // Unknown Id, out-of-range index, and the "modded" keyword with no mod farm installed all
+    // fall back to Standard with a Warn, not a crash. ("modded" resolving to an actual mod farm
+    // is covered by ModFarmDisambiguationTests, which loads the fixture mod.)
+    [InlineData("Nonexistent.Farm", "Standard")]
+    [InlineData(9, "Standard")]
+    [InlineData("modded", "Standard")]
+    public async Task NewGame_WithFarmType_CabinsBuiltAndPlayerCanJoin(object farmType, string expectedFarmTypeKey)
     {
-        LogSection($"Testing {expectedFarmTypeKey} farm (type {farmType})");
+        var farmTypeSetting = FarmTypeSetting.FromObject(farmType);
+        LogSection($"Testing {expectedFarmTypeKey} farm (type {farmTypeSetting})");
 
         // Create a new game with the specified farm type on the shared server
-        await CreateNewGameOnServerAsync(farmType);
+        await CreateNewGameOnServerAsync(farmTypeSetting);
 
         Log($"Server ready: {Server.BaseUrl}");
 

--- a/tests/JunimoServer.Tests/Infrastructure/FarmTypeSetting.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/FarmTypeSetting.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JunimoServer.Tests.Infrastructure;
+
+/// <summary>
+/// Test-harness mirror of the mod's farm-type selector: either a vanilla index (0-6)
+/// or a modded farm <c>Id</c> string (the <c>Data/AdditionalFarms</c> <c>Id</c>). The
+/// test project does not reference the mod assembly, so this is a parallel type that
+/// carries the same union over the wire (server-settings.json, the <c>/newgame</c> body,
+/// and the <c>/settings</c> response).
+///
+/// Implicit conversions from <see cref="int"/> and <see cref="string"/> let call sites pass
+/// a bare index (<c>farmType: 0</c>) or Id (<c>farmType: "MeadowlandsFarm"</c>) directly.
+/// </summary>
+[JsonConverter(typeof(FarmTypeSettingJsonConverter))]
+public readonly struct FarmTypeSetting
+{
+    public int? Index { get; }
+    public string? Id { get; }
+    public bool IsModded => Id != null;
+
+    private FarmTypeSetting(int? index, string? id)
+    {
+        Index = index;
+        Id = id;
+    }
+
+    public static FarmTypeSetting FromIndex(int index) => new(index, null);
+    public static FarmTypeSetting FromId(string id) => new(null, id);
+
+    /// <summary>
+    /// Builds a selector from a boxed <c>[InlineData]</c> argument (an <see cref="int"/> index
+    /// or a <see cref="string"/> Id), since theory arguments can't be a custom struct.
+    /// </summary>
+    public static FarmTypeSetting FromObject(object value) => value switch
+    {
+        int index => FromIndex(index),
+        string id => FromId(id),
+        _ => throw new ArgumentException($"Farm type must be an int index or string Id, got {value?.GetType().Name ?? "null"}.")
+    };
+
+    public static implicit operator FarmTypeSetting(int index) => FromIndex(index);
+    public static implicit operator FarmTypeSetting(string id) => FromId(id);
+
+    /// <summary>
+    /// The scalar value as it goes onto the wire: a boxed <see cref="int"/> for an index
+    /// or a <see cref="string"/> for an Id. Both Newtonsoft and System.Text.Json serialize
+    /// a boxed int/string to the correct JSON scalar.
+    /// </summary>
+    public object ToJsonValue() => Id ?? (object)(Index ?? 0);
+
+    /// <summary>Stable scalar string for cache keys and display labels.</summary>
+    public override string ToString() => Id ?? (Index ?? 0).ToString();
+}
+
+/// <summary>
+/// Reads/writes <see cref="FarmTypeSetting"/> as a JSON number (index) or string (Id),
+/// matching the mod's scalar wire form. Used when deserializing the <c>/settings</c> response.
+/// </summary>
+public class FarmTypeSettingJsonConverter : JsonConverter<FarmTypeSetting>
+{
+    public override FarmTypeSetting Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        => reader.TokenType switch
+        {
+            JsonTokenType.Number => FarmTypeSetting.FromIndex(reader.GetInt32()),
+            JsonTokenType.String => FarmTypeSetting.FromId(reader.GetString()!),
+            _ => throw new JsonException($"FarmType must be a number or string, got {reader.TokenType}.")
+        };
+
+    public override void Write(Utf8JsonWriter writer, FarmTypeSetting value, JsonSerializerOptions options)
+    {
+        if (value.Id != null)
+            writer.WriteStringValue(value.Id);
+        else
+            writer.WriteNumberValue(value.Index ?? 0);
+    }
+}

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -950,7 +950,7 @@ internal sealed class ManagedServer : IAsyncDisposable
     /// <summary>
     /// Requests a new game creation via the API, suspending health checks during the transition.
     /// </summary>
-    public async Task CreateNewGameAsync(int farmType, string farmName = "Junimo",
+    public async Task CreateNewGameAsync(FarmTypeSetting farmType, string farmName = "Junimo",
         int startingCabins = 1, string cabinStrategy = "CabinStack",
         CancellationToken ct = default)
     {

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
@@ -86,7 +86,7 @@ public sealed class ResourceLease : IAsyncDisposable
     /// <summary>
     /// Creates a new game on the server, suspending health checks during the transition.
     /// </summary>
-    public async Task CreateNewGameAsync(int farmType, string farmName = "Junimo",
+    public async Task CreateNewGameAsync(FarmTypeSetting farmType, string farmName = "Junimo",
         int startingCabins = 1, string cabinStrategy = "CabinStack",
         CancellationToken ct = default)
     {

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
@@ -9,11 +9,12 @@ namespace JunimoServer.Tests.Infrastructure;
 /// The server key includes isolation context, not just config.
 /// </summary>
 public sealed record ResourceRequirements(
-    string? Password, int FarmType, bool WithSteam, string? SharedGroup,
+    string? Password, FarmTypeSetting FarmType, bool WithSteam, string? SharedGroup,
     int StartingCabins, int MaxPlayers, int Clients,
     string CabinStrategy, bool AllowIpConnections,
     IsolationMode Isolation, string? TestClassName, string? TestMethodName,
-    bool Exclusive = false, string ExistingCabinBehavior = "KeepExisting")
+    bool Exclusive = false, string ExistingCabinBehavior = "KeepExisting",
+    bool FixtureFarmMod = false)
 {
     private static int _perTestCounter;
 
@@ -41,16 +42,19 @@ public sealed record ResourceRequirements(
     {
         var connection = WithSteam ? "steam" : "lan";
         var pw = Password != null ? "+pw" : "";
-        return $"{connection}{pw}-farm{FarmType}-{CabinStrategy}-c{StartingCabins}";
+        var fixture = FixtureFarmMod ? "+fixturemod" : "";
+        return $"{connection}{pw}{fixture}-farm{FarmType}-{CabinStrategy}-c{StartingCabins}";
     }
 
     /// <summary>
     /// Hash of server-affecting config fields (not Clients, which doesn't affect server identity).
+    /// FixtureFarmMod changes which mods load, which is server identity — so it enters the key.
     /// </summary>
     private string ComputeConfigHash()
     {
         var configString = $"{Password}|{FarmType}|{WithSteam}|{StartingCabins}" +
-                          $"|{MaxPlayers}|{CabinStrategy}|{AllowIpConnections}|{ExistingCabinBehavior}";
+                          $"|{MaxPlayers}|{CabinStrategy}|{AllowIpConnections}|{ExistingCabinBehavior}" +
+                          $"|{FixtureFarmMod}";
         var bytes = Encoding.UTF8.GetBytes(configString);
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
@@ -72,18 +76,8 @@ public sealed record ResourceRequirements(
         AllowIpConnections: attr.WithSteam ? attr.AllowIpConnections : true,
         Isolation: attr.Isolation, TestClassName: testClassName,
         TestMethodName: testMethodName,
-        Exclusive: attr.Exclusive, ExistingCabinBehavior: attr.ExistingCabinBehavior);
-
-    /// <summary>
-    /// Convenience factory for FarmMapTypeTests Theory parameters.
-    /// </summary>
-    public static ResourceRequirements ForFarmType(int farmType, string testClassName,
-        string? cabinStrategy = null, int startingCabins = 1) => new(
-        Password: null, FarmType: farmType, WithSteam: false, SharedGroup: null,
-        StartingCabins: startingCabins, MaxPlayers: 10, Clients: 1,
-        CabinStrategy: cabinStrategy ?? "CabinStack", AllowIpConnections: true,
-        Isolation: IsolationMode.PerTest, TestClassName: testClassName,
-        TestMethodName: $"FarmType_{farmType}");
+        Exclusive: attr.Exclusive, ExistingCabinBehavior: attr.ExistingCabinBehavior,
+        FixtureFarmMod: attr.FixtureFarmMod);
 
     /// <summary>
     /// Maps requirements to ServerContainerOptions for container creation.
@@ -98,7 +92,8 @@ public sealed record ResourceRequirements(
             CabinStrategy = CabinStrategy,
             ExistingCabinBehavior = ExistingCabinBehavior,
             AllowIpConnections = AllowIpConnections,
-            WithSteam = WithSteam
+            WithSteam = WithSteam,
+            FixtureFarmMod = FixtureFarmMod
         };
         return options;
     }

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -521,7 +521,7 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
     /// Suspends health checks during the transition and waits for the server to come back online.
     /// Only valid when the test has an active server lease.
     /// </summary>
-    protected async Task CreateNewGameOnServerAsync(int farmType, string farmName = "Junimo",
+    protected async Task CreateNewGameOnServerAsync(FarmTypeSetting farmType, string farmName = "Junimo",
         int startingCabins = 1, string cabinStrategy = "CabinStack")
     {
         if (Lease == null)

--- a/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
@@ -24,6 +24,7 @@ public class TestServerAttribute : Attribute
     private bool? _keepConnected;
     internal bool? _exclusive;
     private bool? _artifacts;
+    private bool? _fixtureFarmMod;
 
     // "Was this property explicitly set?" tracking for Password
     // because null is a meaningful value (no password)
@@ -35,7 +36,21 @@ public class TestServerAttribute : Attribute
         set { _password = value; _passwordSet = true; }
     }
 
+    /// <summary>
+    /// Vanilla boot farm index (0-6). Attribute arguments can't hold a custom struct, so
+    /// only vanilla indices are expressible here; a modded farm is selected at runtime via
+    /// <c>CreateNewGameOnServerAsync("&lt;Id&gt;")</c> (POST /newgame), not at boot.
+    /// </summary>
     public int FarmType { get => _farmType ?? 0; set => _farmType = value; }
+
+    /// <summary>
+    /// When true, the test's server loads the TestFarmMod fixture (adds a second
+    /// Data/AdditionalFarms entry) so by-Id farm disambiguation can be exercised. This
+    /// changes which mods load, so it is part of the server reuse key — at most one extra
+    /// pooled server for the test class that sets it.
+    /// </summary>
+    public bool FixtureFarmMod { get => _fixtureFarmMod ?? false; set => _fixtureFarmMod = value; }
+
     public bool WithSteam { get => _withSteam ?? false; set => _withSteam = value; }
     public int StartingCabins { get => _startingCabins ?? Math.Max(4, HostPool.Instance.Hosts.Max(h => h.ClientCapacity.Capacity) * 3); set => _startingCabins = value; }
     public int MaxPlayers { get => _maxPlayers ?? Math.Max(10, StartingCabins + 1); set => _maxPlayers = value; }
@@ -106,6 +121,7 @@ public class TestServerAttribute : Attribute
         merged._priority = method._priority ?? _priority;
         merged._keepConnected = method._keepConnected ?? _keepConnected;
         merged._exclusive = method._exclusive ?? _exclusive;
+        merged._fixtureFarmMod = method._fixtureFarmMod ?? _fixtureFarmMod;
         merged.SharedGroup = method.SharedGroup ?? SharedGroup;
 
         // DeferAcquisition uses OR: if either says defer, we defer

--- a/tests/JunimoServer.Tests/ModFarmDisambiguationTests.cs
+++ b/tests/JunimoServer.Tests/ModFarmDisambiguationTests.cs
@@ -1,0 +1,68 @@
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Proves the server resolves a mod-added farm by its <c>Data/AdditionalFarms</c> <c>Id</c>
+/// rather than by position. The base game ships exactly one AdditionalFarms entry
+/// (MeadowlandsFarm), so resolving it can't distinguish "by Id" from "by index 0". The
+/// TestFarmMod fixture (loaded via <see cref="TestServerAttribute.FixtureFarmMod"/>) adds a
+/// second entry, <c>JunimoTest.SecondFarm</c>; selecting it by Id and getting that exact key
+/// back proves resolution is keyed on Id — the regression PR #379's positional approach hit.
+///
+/// Its own class (not folded into FarmMapTypeTests): the fixture mod loads at container start
+/// and changes Data/AdditionalFarms, so it must run on a separate, fixture-loaded server. The
+/// FixtureFarmMod flag is part of the server reuse key, so this costs at most one extra pooled
+/// server for this class.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedClass, Priority = 91, Exclusive = true, FixtureFarmMod = true)]
+public class ModFarmDisambiguationTests : TestBase
+{
+    /// <summary>Must match the Id TestFarmMod adds to Data/AdditionalFarms (separate net6.0 assembly, not referenced here).</summary>
+    private const string FixtureFarmId = "JunimoTest.SecondFarm";
+
+    [Fact]
+    public async Task NewGame_WithModdedFarmId_ResolvesSecondAdditionalFarmsEntryById()
+    {
+        LogSection($"Testing modded farm selection by Id: {FixtureFarmId}");
+
+        await CreateNewGameOnServerAsync(FixtureFarmId);
+
+        Log($"Server ready: {Server.BaseUrl}");
+
+        // The fixture's entry is the SECOND AdditionalFarms entry (after base MeadowlandsFarm);
+        // getting its Id back proves resolution matched on Id, not array position.
+        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Equal(FixtureFarmId, status.FarmTypeKey);
+        Log($"Farm type key verified: {status.FarmTypeKey}");
+
+        // Verify the modded farm map built cabins (server-side proof the farm loaded).
+        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        Assert.NotNull(cabins);
+        Assert.True(cabins.TotalCount >= 1, $"Expected at least 1 cabin, got {cabins.TotalCount}");
+
+        // NOTE: deliberately no client join here. A joining client re-resolves whichModFarm.Id
+        // against ITS OWN Data/AdditionalFarms and throws "<Id> is not a valid farm type" if
+        // absent (NetWorldState.SetFarmType, decompiled :899-902). The fixture mod is only on
+        // the server, so the test client lacks the entry. The by-Id resolution under test is
+        // fully proven server-side via FarmTypeKey; the join-a-modded-farm path is already
+        // covered by FarmMapTypeTests' MeadowlandsFarm case (base content every client has).
+    }
+
+    [Fact]
+    public async Task NewGame_WithModdedKeyword_ResolvesToTheInstalledModFarm()
+    {
+        LogSection("Testing the \"modded\" keyword resolves to the installed mod farm");
+
+        await CreateNewGameOnServerAsync("modded");
+
+        // "modded" picks the first non-Meadowlands AdditionalFarms entry; the fixture mod adds
+        // exactly one (JunimoTest.SecondFarm), so the keyword must land on it.
+        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        Assert.NotNull(status);
+        Assert.Equal(FixtureFarmId, status.FarmTypeKey);
+        Log($"\"modded\" resolved to: {status.FarmTypeKey}");
+    }
+}

--- a/tests/JunimoServer.Tests/ServerSettingsTests.cs
+++ b/tests/JunimoServer.Tests/ServerSettingsTests.cs
@@ -35,15 +35,17 @@ public class ServerSettingsTests : TestBase
     }
 
     /// <summary>
-    /// Test data for default settings verification.
-    /// Each entry: (settingName, expectedValue, valueExtractor)
+    /// Test data for default settings verification: (settingPath, expectedValue), matched
+    /// against <see cref="GetSettingValue"/>. Expected values must be xUnit-serializable for
+    /// theory discovery, so a non-serializable value type (FarmTypeSetting) is given as its
+    /// scalar string and compared via ToString().
     /// </summary>
     public static IEnumerable<object[]> DefaultSettingsData =>
         new List<object[]>
         {
             // Game settings
             new object[] { "Game.FarmName", "Junimo" },
-            new object[] { "Game.FarmType", 0 },
+            new object[] { "Game.FarmType", "0" },
             new object[] { "Game.ProfitMargin", 1.0f },
             new object[] { "Game.StartingCabins", Math.Max(4, HostPool.Instance.Hosts.Max(h => h.ClientCapacity.Capacity) * 3) },
             new object[] { "Game.SpawnMonstersAtNight", "auto" },
@@ -75,7 +77,7 @@ public class ServerSettingsTests : TestBase
         return path switch
         {
             "Game.FarmName" => settings.Game.FarmName,
-            "Game.FarmType" => settings.Game.FarmType,
+            "Game.FarmType" => settings.Game.FarmType.ToString(),
             "Game.ProfitMargin" => settings.Game.ProfitMargin,
             "Game.StartingCabins" => settings.Game.StartingCabins,
             "Game.SpawnMonstersAtNight" => settings.Game.SpawnMonstersAtNight,

--- a/tests/fixtures/TestFarmMod/ModEntry.cs
+++ b/tests/fixtures/TestFarmMod/ModEntry.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley.GameData;
+
+namespace TestFarmMod
+{
+    /// <summary>
+    /// E2E test fixture mod. Appends a single entry to <c>Data/AdditionalFarms</c> so the
+    /// registry holds two entries (base-game MeadowlandsFarm + this one), letting the E2E suite
+    /// prove the server resolves a mod farm by its <c>Id</c> rather than by position. The farm
+    /// reuses the vanilla Standard map (<c>MapName: "Farm"</c>), so no custom .tmx/.xnb asset is
+    /// needed — only the registry entry matters for the by-Id test.
+    /// </summary>
+    public class ModEntry : Mod
+    {
+        public override void Entry(IModHelper helper)
+        {
+            helper.Events.Content.AssetRequested += OnAssetRequested;
+        }
+
+        private void OnAssetRequested(object? sender, AssetRequestedEventArgs e)
+        {
+            if (!e.Name.IsEquivalentTo("Data/AdditionalFarms"))
+                return;
+
+            e.Edit(asset =>
+            {
+                var farms = asset.GetData<List<ModFarmType>>();
+                farms.Add(new ModFarmType
+                {
+                    // Kept in sync by hand with ModFarmDisambiguationTests.FixtureFarmId — the
+                    // test selects this Id over /newgame (separate assembly, can't share a const).
+                    Id = "JunimoTest.SecondFarm",
+                    // Reuse the vanilla Standard map; the by-Id test only needs the entry to be
+                    // selectable, not to render a distinct map.
+                    MapName = "Farm",
+                    TooltipStringPath = "Strings/1_6_Strings:Farm_Standard_Description",
+                    SpawnMonstersByDefault = false,
+                });
+            });
+        }
+    }
+}

--- a/tests/fixtures/TestFarmMod/TestFarmMod.csproj
+++ b/tests/fixtures/TestFarmMod/TestFarmMod.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>TestFarmMod</AssemblyName>
+    <RootNamespace>TestFarmMod</RootNamespace>
+    <Version>0.1.0</Version>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Test fixture: never auto-deploy to the dev machine's Mods folder, never zip.
+         The compiled output is injected into the container at create time. -->
+    <EnableModDeploy>false</EnableModDeploy>
+    <EnableModZip>false</EnableModZip>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Pulls in Stardew Valley.dll (ModFarmType) and StardewModdingAPI.dll (Mod, content events)
+         via $(GamePath). The game DLLs are only available inside a Docker build stage that has
+         the game files, so this project is compiled there (docker/Dockerfile TestFarmMod stage),
+         not on the host. -->
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/fixtures/TestFarmMod/manifest.json
+++ b/tests/fixtures/TestFarmMod/manifest.json
@@ -1,0 +1,9 @@
+{
+  "Name": "JunimoTest Farm Mod",
+  "Author": "JunimoHost",
+  "Version": "0.1.0",
+  "Description": "E2E test fixture: adds a second Data/AdditionalFarms entry so by-Id modded-farm disambiguation can be tested.",
+  "UniqueID": "JunimoHost.TestFarmMod",
+  "EntryDll": "TestFarmMod.dll",
+  "MinimumApiVersion": "3.0.0"
+}


### PR DESCRIPTION
Closes #378. Supersedes #379.

`FarmType` in `server-settings.json` (and the `/newgame` API) now accepts a string Id in addition to the existing numeric index, so mod-added farms (Frontier Farm, etc.) can be selected. Resolution mirrors the game — modded farms are keyed by their `Data/AdditionalFarms` `Id`, never by position (the non-portability #379 was rejected for).

## Accepted values

- **`0`–`6`** or their **name** (`"Standard"`, `"FourCorners"`, case/space-insensitive) — the built-in maps
- **`7`** or **`"MeadowlandsFarm"`** — both always select base-game Meadowlands
- **`"modded"`** — the first installed mod farm (convenience for a single-farm-mod setup)
- **any `Data/AdditionalFarms` Id** — a specific mod farm
- Existing `"FarmType": 3` int configs round-trip unchanged (no migration)
- Anything invalid (out-of-range index, unknown Id, `"modded"` with no mod farm) falls back to Standard with a warning — never aborts game creation

## Changes

- **`FarmTypeSetting`** union value type + Newtonsoft converter. Parsing is total; validity is a domain decision in `ResolveFarmType` (graceful Standard fallback), so one bad field never discards the rest of the settings file.
- **`GameCreatorService.ResolveFarmType`** — single resolution path; deletes the hardcoded `MeadowlandsFarm` special case. Monster-spawn default keys off the modded farm's `SpawnMonstersByDefault` (matches the vanilla new-game UI).
- **API/settings/command surface** carries the union. OpenAPI emits a `oneOf[integer,string]` schema. `SettingsCommand`/`SavesCommand` display friendly names; `SavesCommand` also reads `<whichFarm>` as the string it is — fixing a pre-existing silent drop of modded saves' farm type.
- **Tests**: harness threads the union end-to-end. New `TestFarmMod` fixture (built inside the server image, injected into `/data/Mods` only when the hashed `FixtureFarmMod` flag is set) adds a second `AdditionalFarms` entry so `ModFarmDisambiguationTests` proves by-Id (not positional) resolution. `FarmMapTypeTests` covers indices, names, `7`/Id Meadowlands, `"modded"`, and fallbacks.
- **Docs**: `server-settings.md` documents numbers, names, `"modded"`, and mod Ids.

## Verification

Mod, tests, fixture, and the OpenAPI generator build clean; resolution and both serializer paths verified. The runtime E2E cases (`FarmMapTypeTests`, `ModFarmDisambiguationTests`, `ServerSettingsTests`) require `make build-server` + a filtered run to confirm against a live server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Farm type accepts built-in names, numeric indices, or modded farm identifiers; supports the "modded" keyword with fallback behavior.
* **Documentation**
  * Expanded farm type docs with full built-in name mapping and guidance for modded farm selection.
* **Tests**
  * Added end-to-end tests verifying modded-farm resolution by Id and "modded" keyword.
* **Chores**
  * Test fixture mod can be staged and opt‑in at container startup via an environment flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->