### PR TITLE
docs: add "Last built" stamp and consistent date format

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from "node:url";
 import { defineConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import { useSidebar } from "vitepress-openapi";
@@ -13,6 +14,21 @@ const openApiSidebar = useSidebar({ spec, linkPrefix: "/developers/api/" });
 
 export default withMermaid(defineConfig({
     vite: {
+        // Bake the build time into the bundle so the sidebar can show "Last built: …"
+        define: {
+            __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+        },
+        resolve: {
+            alias: [
+                {
+                    // Swap VitePress's locale-dependent "Last updated" for our fixed DD.MM.YY HH:MM format.
+                    find: /^.*\/VPDocFooterLastUpdated\.vue$/,
+                    replacement: fileURLToPath(
+                        new URL("./theme/LastUpdated.vue", import.meta.url),
+                    ),
+                },
+            ],
+        },
         plugins: [
             groupIconVitePlugin({
                 // Add custom icons which are not available otherwise

--- a/docs/.vitepress/theme/AnnouncementBar.vue
+++ b/docs/.vitepress/theme/AnnouncementBar.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
-import { withBase } from "vitepress";
+import { ref, computed, onMounted } from "vue";
+import { withBase, useData } from "vitepress";
 import DefaultTheme from "vitepress/theme";
 import ThemeSelector from "./ThemeSelector.vue";
 import VersionSwitcher from "./VersionSwitcher.vue";
+import BuildStamp from "./BuildStamp.vue";
 
 const { Layout } = DefaultTheme;
+
+// The home page has no sidebar, so its build stamp rides under the footer instead.
+const { frontmatter } = useData();
+const isHome = computed(() => frontmatter.value.layout === "home");
 
 const announcementLink = withBase("/admins/operations/upgrading#preview-builds");
 
@@ -62,12 +67,39 @@ function closeAnnouncement() {
             <ThemeSelector :inline="true" />
             <VersionSwitcher :inline="true" />
         </template>
+        <template #sidebar-nav-after>
+            <BuildStamp class="build-stamp-sidebar" />
+        </template>
+        <template #layout-bottom>
+            <BuildStamp v-if="isHome" class="build-stamp-footer" />
+        </template>
     </Layout>
 </template>
 
 <style>
 :root {
     --announcement-height: 42px;
+}
+
+/* Build stamp pinned to the bottom of the sidebar nav.
+   Make the nav a full-height flex column so margin-top:auto pushes the stamp down;
+   the divider + padding align it with the sidebar's own 32px gutter. */
+#VPSidebarNav {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+}
+
+#VPSidebarNav .build-stamp-sidebar {
+    margin-top: auto;
+    padding-top: 16px;
+    border-top: 1px solid var(--vp-c-divider);
+}
+
+/* Home page has no sidebar — center the stamp under the footer. */
+.build-stamp-footer {
+    text-align: center;
+    padding: 0 24px 32px;
 }
 
 /* Hide version switcher and theme selector in navbar on mobile - they appear in nav-screen instead */

--- a/docs/.vitepress/theme/BuildStamp.vue
+++ b/docs/.vitepress/theme/BuildStamp.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { formatDateTime } from "./formatDate";
+
+// Baked in at build time via vite `define` in config.ts.
+declare const __BUILD_TIME__: string;
+
+// Defer formatting to mount: it's rendered in the visitor's local timezone, which
+// differs from the build machine's, so formatting at SSR would mismatch on hydration.
+const builtAt = ref("");
+onMounted(() => {
+    builtAt.value = formatDateTime(__BUILD_TIME__);
+});
+</script>
+
+<template>
+    <div class="build-stamp">Last built: {{ builtAt }}</div>
+</template>
+
+<style scoped>
+.build-stamp {
+    font-size: 12px;
+    color: var(--vp-c-text-3);
+}
+</style>

--- a/docs/.vitepress/theme/LastUpdated.vue
+++ b/docs/.vitepress/theme/LastUpdated.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ref, onMounted } from "vue";
+import { useData } from "vitepress";
+import { formatDateTime } from "./formatDate";
+
+const { theme, page } = useData();
+
+const iso = new Date(page.value.lastUpdated!).toISOString();
+const datetime = ref("");
+
+// Defer formatting to mount: the visitor's local timezone differs from SSR, so
+// rendering it server-side would cause a hydration mismatch.
+onMounted(() => {
+    datetime.value = formatDateTime(page.value.lastUpdated!);
+});
+</script>
+
+<template>
+    <p class="VPLastUpdated">
+        {{ theme.lastUpdated?.text || theme.lastUpdatedText || "Last updated" }}:
+        <time :datetime="iso">{{ datetime }}</time>
+    </p>
+</template>
+
+<style scoped>
+.VPLastUpdated {
+    line-height: 24px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--vp-c-text-2);
+}
+
+@media (min-width: 640px) {
+    .VPLastUpdated {
+        line-height: 32px;
+    }
+}
+</style>

--- a/docs/.vitepress/theme/formatDate.ts
+++ b/docs/.vitepress/theme/formatDate.ts
@@ -1,0 +1,7 @@
+/** Format a date as "DD.MM.YY HH:MM" (24h) — same format for every locale, in the visitor's local timezone. */
+export function formatDateTime(value: Date | string | number): string {
+    const d = new Date(value);
+    const p = (n: number) => String(n).padStart(2, "0");
+    const date = `${p(d.getDate())}.${p(d.getMonth() + 1)}.${p(d.getFullYear() % 100)}`;
+    return `${date} ${p(d.getHours())}:${p(d.getMinutes())}`;
+}


### PR DESCRIPTION
Adds a build timestamp to the docs and makes all user-facing dates use one consistent, locale-independent format.

## Changes

- **"Last built: DD.MM.YY HH:MM"** shown at the bottom of the left sidebar (sticky-bottom with a divider) and, on the home page (which has no sidebar), centered under the footer.
- Build time is baked into the bundle at compile time via a vite `define` (`__BUILD_TIME__`) — no runtime fetch.
- **"Last updated"** now renders as a fixed `DD.MM.YY HH:MM` format for every visitor, replacing VitePress's locale-dependent default (e.g. `5/30/26, 7:17 PM`). Done by aliasing the internal `VPDocFooterLastUpdated` component via `resolve.alias`.
- Both stamps share one `formatDate.ts` helper. Formatting is deferred to `onMounted` so the visitor's local timezone can't cause an SSR hydration mismatch.

## Notes

- Dates render in the visitor's local timezone but with a fixed layout/24h format — consistent format, local clock.
- In `vitepress dev`, `__BUILD_TIME__` reflects dev-server start time; a real `build` reflects build time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Last built" timestamp display in the sidebar and on the home page footer.
  * Improved "Last updated" timestamp display for documentation pages with consistent date formatting (DD.MM.YY HH:MM).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->