### PR TITLE
ci(docs): fall back to placeholder when image lacks OpenAPI spec

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,12 +31,20 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # The spec is baked into the image at build time. Older images (e.g. a stale :latest
+      # from before the API feature) lack it — fall back to the placeholder so the docs still
+      # build (the API section renders empty until a release republishes the spec).
       - name: Extract OpenAPI spec from Docker image
         run: |
+          mkdir -p docs/assets
           docker pull sdvd/server:${{ inputs.image_tag }}
           CONTAINER_ID=$(docker create sdvd/server:${{ inputs.image_tag }})
-          mkdir -p docs/assets
-          docker cp "$CONTAINER_ID:/data/openapi.json" docs/assets/openapi.json
+          if docker cp "$CONTAINER_ID:/data/openapi.json" docs/assets/openapi.json; then
+            echo "Extracted OpenAPI spec from sdvd/server:${{ inputs.image_tag }}"
+          else
+            echo "::warning::sdvd/server:${{ inputs.image_tag }} has no /data/openapi.json — using placeholder (API section will be empty)."
+            cp docs/assets/openapi.placeholder.json docs/assets/openapi.json
+          fi
           docker rm "$CONTAINER_ID"
 
       - name: Setup Bun

--- a/docs/assets/openapi.placeholder.json
+++ b/docs/assets/openapi.placeholder.json
@@ -1,0 +1,9 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Stardew Dedicated Server API",
+    "description": "The API specification is generated from the server image at build time and was not available for this build. It will appear once a release republishes the spec.",
+    "version": "unavailable"
+  },
+  "paths": {}
+}

--- a/docs/scripts/fetch-openapi.sh
+++ b/docs/scripts/fetch-openapi.sh
@@ -16,9 +16,13 @@ OUTPUT="$SCRIPT_DIR/../assets/openapi.json"
 
 echo "Extracting OpenAPI spec from $IMAGE..."
 
-# Create a temporary container, copy the file, then remove container
+# Create a temporary container, copy the file, then remove container. Older images may lack
+# the spec — fall back to the placeholder so the docs still build (API section renders empty).
 CONTAINER_ID=$(docker create "$IMAGE")
-docker cp "$CONTAINER_ID:/data/openapi.json" "$OUTPUT"
+if docker cp "$CONTAINER_ID:/data/openapi.json" "$OUTPUT"; then
+    echo "OpenAPI spec saved to $OUTPUT"
+else
+    echo "WARNING: $IMAGE has no /data/openapi.json — using placeholder (API section will be empty)."
+    cp "$SCRIPT_DIR/../assets/openapi.placeholder.json" "$OUTPUT"
+fi
 docker rm "$CONTAINER_ID" > /dev/null
-
-echo "OpenAPI spec saved to $OUTPUT"


### PR DESCRIPTION
## Problem

The docs statically import `assets/openapi.json` (in `config.ts`, `theme/index.ts`, and the `[operationId]` route generator), and the file is extracted at build time via `docker cp` from the server image. When the target image lacks `/data/openapi.json` — e.g. the published `sdvd/server:latest`, which predates the API feature — the extract fails, the static import can't resolve, and the **entire docs build (and deploy) fails**.

## Change

Make the spec **optional**: if extraction finds no spec, fall back to a committed empty-spec placeholder so the build always succeeds.

- Add `docs/assets/openapi.placeholder.json` — a minimal valid OpenAPI 3.0 doc with empty `paths` and an `info.description` explaining the spec was unavailable.
- `build-docs.yml` extract step and the local `fetch-openapi.sh` helper now `cp` the placeholder when `docker cp` finds no spec (emitting a warning), instead of failing.

## Behavior

- **Image has the spec** (e.g. `preview`) → full API docs, unchanged.
- **Image lacks it** (stale `latest`) → builds with the placeholder; the API section renders empty until a release republishes the spec. **Self-healing** — no revert needed once `latest` is rebuilt.

## Verification

Built the docs locally with the placeholder swapped in for the real spec: exit 0, all pages + sitemap generated. The three `vitepress-openapi` consumers (`useSidebar`/`usePaths`/`useOpenapi`) all tolerate empty `paths`, so **no `.ts` changes were needed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved documentation build resilience by adding fallback handling when API specifications are unavailable, ensuring docs continue to generate with placeholder content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->