### PR TITLE
fix(cabin): abort & revert CabinStack→None migration when designated positions < hidden cabins

### DIFF
--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -271,7 +271,6 @@ namespace JunimoServer.Services.CabinManager
             bool toUsesHidden = (to == CabinStrategy.CabinStack || to == CabinStrategy.FarmhouseStack);
 
             int migrated = 0;
-            int migrateFailed = 0;
 
             if (fromUsesHidden && !toUsesHidden)
             {
@@ -280,20 +279,45 @@ namespace JunimoServer.Services.CabinManager
                     .Where(b => b.isCabin && b.IsInHiddenStack())
                     .ToList();
 
+                var availablePositions = FarmCabinPositions.GetAvailablePositions(farm);
+
+                if (hiddenCabins.Count > availablePositions.Count)
+                {
+                    Monitor.Log(
+                        $"CabinStrategy migration {from} → {to} aborted: {hiddenCabins.Count} hidden cabin(s) " +
+                        $"but only {availablePositions.Count} designated position(s) available on this farm map. " +
+                        $"Reverting strategy to {from}. Add cabin positions to the Paths layer or remove " +
+                        $"surplus cabins before retrying.",
+                        LogLevel.Warn);
+
+                    Diagnostics.ModEventLog.Emit("cabin_strategy_migration_aborted", new
+                    {
+                        fromStrategy = from.ToString(),
+                        toStrategy = to.ToString(),
+                        hiddenCabinCount = hiddenCabins.Count,
+                        availablePositionCount = availablePositions.Count,
+                        deficit = hiddenCabins.Count - availablePositions.Count,
+                        reason = "insufficient_designated_positions"
+                    });
+
+                    // Revert the persisted strategy so the on-disk state matches what actually
+                    // happened. RecaptureAndSync already wrote the new strategy to Data and disk
+                    // (via SyncFromSettings → Save) before OnSaveLoaded ran; without this revert,
+                    // the next load captures previous == current == new and never retries.
+                    options.Data.CabinStrategy = from;
+                    options.Save();
+                    return;
+                }
+
                 foreach (var cabin in hiddenCabins)
                 {
                     var nextPos = FarmCabinPositions.GetNextAvailablePosition(farm);
-                    if (nextPos.HasValue)
-                    {
-                        cabin.Relocate(nextPos.Value);
-                        Monitor.Log($"  Migrated cabin to ({nextPos.Value.X}, {nextPos.Value.Y})", LogLevel.Info);
-                        migrated++;
-                    }
-                    else
-                    {
-                        Monitor.Log("  No available farm position for cabin migration", LogLevel.Error);
-                        migrateFailed++;
-                    }
+                    // Pre-validation above guarantees a slot for every hidden cabin: MigrateCabins
+                    // runs synchronously on the game thread inside OnSaveLoaded, no buildStructure
+                    // call can interleave, so the count cannot shrink mid-loop. nextPos is always set.
+                    cabin.Relocate(nextPos.Value);
+                    Monitor.Log($"  Migrated cabin to ({nextPos.Value.X}, {nextPos.Value.Y})", LogLevel.Info);
+                    migrated++;
                 }
             }
             else if (!fromUsesHidden && toUsesHidden)
@@ -313,12 +337,13 @@ namespace JunimoServer.Services.CabinManager
             }
             // Stacked ↔ Stacked: no relocation needed, only warp behavior changes
 
+            // Aborts (insufficient positions) emit cabin_strategy_migration_aborted and
+            // return early, so this success event never carries a failure count.
             Diagnostics.ModEventLog.Emit("cabin_strategy_migration", new
             {
                 fromStrategy = from.ToString(),
                 toStrategy = to.ToString(),
-                migrated,
-                migrateFailed
+                migrated
             });
         }
 

--- a/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
+++ b/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
@@ -67,22 +67,26 @@ namespace JunimoServer.Services.CabinManager
         }
 
         /// <summary>
+        /// Returns all designated cabin positions that are not currently occupied by a building.
+        /// Mirrors the resolution used by GetNextAvailablePosition: if this returns N entries,
+        /// then exactly N successive calls to GetNextAvailablePosition (with no other building
+        /// changes in between) will succeed; the (N+1)th will return null.
+        /// </summary>
+        public static List<Vector2> GetAvailablePositions(Farm farm)
+        {
+            return GetDesignatedPositions(farm)
+                .Where(p => !IsPositionOccupied(farm, p))
+                .ToList();
+        }
+
+        /// <summary>
         /// Returns the next available designated position where no building currently exists.
         /// Returns null if all designated positions are occupied.
         /// </summary>
         public static Vector2? GetNextAvailablePosition(Farm farm)
         {
-            var positions = GetDesignatedPositions(farm);
-
-            foreach (var pos in positions)
-            {
-                if (!IsPositionOccupied(farm, pos))
-                {
-                    return pos;
-                }
-            }
-
-            return null;
+            var available = GetAvailablePositions(farm);
+            return available.Count > 0 ? available[0] : null;
         }
 
         private static bool IsPositionOccupied(Farm farm, Vector2 position)

--- a/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
+++ b/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
@@ -96,7 +96,11 @@ namespace JunimoServer.Tests.Helpers;
 /// <c>clearedUserId, ownerUniqueMultiplayerId</c>) ·
 /// <c>cabin_claims_swept_on_load</c> (save-load sweep summary, emitted only when it
 /// released at least one claim: <c>cleared</c>) · <c>cabin_strategy_migration</c>
-/// (<c>fromStrategy, toStrategy, migrated, migrateFailed</c>) ·
+/// (success path: <c>fromStrategy, toStrategy, migrated</c>) ·
+/// <c>cabin_strategy_migration_aborted</c> (Stacked→None migration pre-validation
+/// found fewer designated positions than hidden cabins; no cabin moved and strategy
+/// reverted: <c>fromStrategy, toStrategy, hiddenCabinCount, availablePositionCount,
+/// deficit, reason:"insufficient_designated_positions"</c>) ·
 /// <c>farmhand_references_cleaned</c> (save-load stale-ref cleanup:
 /// <c>orphansRemoved, homeCleared, lastSleepCleared, validCabins</c>).</item>
 ///


### PR DESCRIPTION
# fix(cabin): abort & revert CabinStack→None migration when designated positions < hidden cabins

## Problem

`CabinManagerService.MigrateCabins` (Stacked→None branch) walked each hidden cabin and called `FarmCabinPositions.GetNextAvailablePosition`. When there were more hidden cabins than free designated positions on the farm map, the call returned `null` mid-loop: already-relocated cabins moved to visible tiles while the rest stayed stranded at `HiddenCabinLocation` (`-20,-20`) — a silent partial migration.

The partial state was unrecoverable: by the time `MigrateCabins` ran, `PersistentOptions` had already persisted the new strategy (`None`) to disk. On the next load `previous == current == None`, so migration never retried. Under `None` the warp interceptors are unregistered, so stranded cabins' owners had no client-side rewrite and no operator command to recover them — the cabin and its owner's progress were effectively orphaned.

## Fix

Pre-validate before relocating any cabin. When `hiddenCabins.Count > availablePositions.Count`:
- Log a `Warn`-level message naming the deficit (not `Error` — per `debugging.md`, `LogLevel.Error` trips `ServerContainer` test cancellation; this is an operator config issue, not a server crash).
- Emit a distinct `cabin_strategy_migration_aborted` diagnostic event with `hiddenCabinCount` / `availablePositionCount` / `deficit`.
- Relocate **no** cabins.
- Revert the persisted `Data.CabinStrategy` to `from` and `Save()`, so disk state matches what actually happened.

The revert gives auto-retry semantics: the settings file still reads `None`, so on the next reload `SyncFromSettings` re-applies `None`, `PreviousCabinStrategy` is recaptured as the reverted `from`, `previous != current` holds again — and once the operator adds enough Paths-layer positions (or removes surplus cabins), the next reload migrates successfully with no further config change.

The original per-cabin `LogLevel.Error` null path is removed (pre-validation makes it unreachable). The post-validation loop comment records the invariant that guarantees `nextPos` is always set. With its only increment site gone, the `migrateFailed` counter (always 0) is dropped from the `cabin_strategy_migration` success event — failures now surface only via `cabin_strategy_migration_aborted`.

## Changes

- `mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs` — add `GetAvailablePositions(Farm)` public helper; refactor `GetNextAvailablePosition` to delegate to it so the pre-validation count and the loop consumption cannot drift (`mirror-target-component-resolution.md`).
- `mod/JunimoServer/Services/CabinManager/CabinManagerService.cs` — pre-validate hidden-cabin count vs available positions in the `MigrateCabins` Stacked→None branch; revert strategy on abort; remove the now-unreachable `LogLevel.Error` per-cabin failure path and the always-0 `migrateFailed` event field.
- `tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs` — document the new `cabin_strategy_migration_aborted` event in the event catalog and drop `migrateFailed` from the `cabin_strategy_migration` field list.

Scope is only the `fromUsesHidden && !toUsesHidden` branch (CabinStack→None, FarmhouseStack→None). The None→Stacked branch moves cabins to a single shared `HiddenCabinLocation` — no shortage possible — and is untouched.

## Verification

- `make build` — clean (0 warnings / 0 errors).
- `make test FILTER=CabinPositionPersistenceTests` — **4/4 passed** (happy-path migration + move-to-stack coverage; no `CabinManagerService` `Error` lines).

## Test deferral (gated)

Regression test for the abort path is gated on a save+reload + **non-destructive strategy-switch** harness primitive (also blocking `server-cabin-management` Test 08). `CreateNewGameOnServerAsync` destroys the save on a strategy change, so it cannot exercise the migration path; the abort additionally requires a previously-completed CabinStack run with more accumulated hidden cabins than the farm map's designated positions. Test plan lives in `.claude/plans/bugs/cabin-strategy-migration-rollback.md`, "## Test plan once primitive lands" — to land together with the harness extension.

**Manually verify the abort path before merge**: accumulate more hidden CabinStack cabins than the farm's designated positions, sleep through a day to persist the save, switch `CabinStrategy` to `None`, restart the container with the same save volume. Observe the `[Warn]` deficit log from `CabinManagerService`, `cabin_strategy_migration_aborted` in `infrastructure.jsonl`, and `/settings` reporting `CabinStack` (not `None`); confirm each cabin is still at `(-20,-20)` via `/cabins`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cabin strategy migrations now validate available positions before processing. If insufficient positions exist, migrations abort gracefully and restore the previous configuration.

* **New Features**
  * Added cabin migration abort event to track failed relocations and provide diagnostic information including position deficits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->