### PR TITLE
test: relativize repo-root paths in human-facing harness log output

### DIFF
--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -119,7 +119,7 @@ public sealed class CIRenderer : RendererBase
 
                 // Screenshot path
                 if (!string.IsNullOrEmpty(f.ScreenshotPath))
-                    _out.WriteLine($"   Screenshot: {f.ScreenshotPath}");
+                    _out.WriteLine($"   Screenshot: {PathDisplay.ScrubMessage(f.ScreenshotPath)}");
 
                 // Test output (ConnectionHelper logs, etc.), only for failures
                 if (!string.IsNullOrWhiteSpace(fOutput))

--- a/tests/JunimoServer.TestRunner/Rendering/LLMRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/LLMRenderer.cs
@@ -165,7 +165,7 @@ public sealed class LLMRenderer : RendererBase
             DurationMs = (long)e.Duration.TotalMilliseconds,
             Error = e.Message,
             e.ExceptionType,
-            e.StackTrace,
+            StackTrace = e.StackTrace != null ? SanitizeStackTrace(e.StackTrace) : null,
             e.ScreenshotPath,
             e.ArtifactId
         });
@@ -206,7 +206,7 @@ public sealed class LLMRenderer : RendererBase
             Event = "error",
             e.Timestamp,
             e.Message,
-            e.StackTrace
+            StackTrace = e.StackTrace != null ? SanitizeStackTrace(e.StackTrace) : null
         });
     }
 

--- a/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/ReportGenerator.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using JunimoServer.Tests.Helpers;
 
 namespace JunimoServer.TestRunner.Rendering.Web;
 
@@ -160,7 +161,7 @@ public sealed class ReportGenerator
         var reportPath = Path.Combine(reportDir, "index.html");
         File.WriteAllText(reportPath, html);
 
-        Console.Error.WriteLine($"[WebUI] Static report generated: {reportPath}");
+        Console.Error.WriteLine($"[WebUI] Static report generated: {PathDisplay.ScrubMessage(reportPath)}");
     }
 
     private void CopyRootStatic(string reportDir, string fileName)
@@ -288,7 +289,7 @@ public sealed class ReportGenerator
                 var resolvedPath = ResolveArtifactPath(originalPath, testResultsPath);
                 if (resolvedPath == null || !File.Exists(resolvedPath))
                 {
-                    Console.Error.WriteLine($"[WebUI] Warning: Artifact not found: {originalPath}");
+                    Console.Error.WriteLine($"[WebUI] Warning: Artifact not found: {PathDisplay.ScrubMessage(originalPath)}");
                     continue;
                 }
 
@@ -316,7 +317,7 @@ public sealed class ReportGenerator
                 snapshotJson = snapshotJson.Replace(escapedOld, escapedNew);
             }
 
-            Console.Error.WriteLine($"[WebUI] Exported {replacements.Count} artifacts to {targetDir}");
+            Console.Error.WriteLine($"[WebUI] Exported {replacements.Count} artifacts to {PathDisplay.ScrubMessage(targetDir)}");
         }
         catch (Exception ex)
         {

--- a/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading.Channels;
+using JunimoServer.Tests.Helpers;
 using JunimoServer.Tests.Schema.Events;
 using JunimoServer.TestRunner.Rendering.Web;
 using Microsoft.AspNetCore.Builder;
@@ -492,7 +493,7 @@ public sealed class WebRenderer : RendererBase
             var snapshot = _state.ToSnapshotJson();
             snapshot = ReportGenerator.ExportMockArtifacts(snapshot, mockArtifactsDir, testResultsPath);
             File.WriteAllText(mockPath, snapshot);
-            Console.Error.WriteLine($"[WebUI] Mock data written to {mockPath}");
+            Console.Error.WriteLine($"[WebUI] Mock data written to {PathDisplay.ScrubMessage(mockPath)}");
         }
         catch (Exception ex)
         {

--- a/tests/JunimoServer.Tests/Helpers/PathDisplay.cs
+++ b/tests/JunimoServer.Tests/Helpers/PathDisplay.cs
@@ -1,0 +1,49 @@
+namespace JunimoServer.Tests.Helpers;
+
+/// <summary>
+/// Rewrites absolute repo-root paths in human-facing log lines to a relative
+/// form (<c>.\TestResults\…</c> / <c>./TestResults/…</c>). No-op for paths
+/// outside the repo root, and idempotent on already-relativized strings.
+///
+/// Free text only — structured output (the <c>--llm</c> JSONL stream, event
+/// path fields the web UI turns into <c>/artifacts/</c> URLs) must stay
+/// absolute and is never routed through here.
+/// </summary>
+public static class PathDisplay
+{
+    // OrdinalIgnoreCase on Windows so drive-letter / path-segment case drift
+    // still matches; Ordinal on POSIX where the filesystem is case-sensitive.
+    private static readonly StringComparison Comparison =
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static readonly string Replacement = "." + Path.DirectorySeparatorChar;
+
+    // Null if the repo root can't be located: ProjectRoot.Path throws on a missing
+    // marker, and a logging path must not throw — null degrades to no-op.
+    private static readonly string? _prefix = ResolvePrefix();
+
+    private static string? ResolvePrefix()
+    {
+        try
+        {
+            return ProjectRoot.Path + Path.DirectorySeparatorChar;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Single native-separator prefix-replace: repo-root paths in these messages
+    /// come from <c>Path.Combine</c> (via <see cref="TestArtifacts"/>), so they
+    /// only ever use the native separator — no forward-slash form to also catch.
+    /// </summary>
+    public static string ScrubMessage(string message)
+    {
+        if (string.IsNullOrEmpty(message) || _prefix is null)
+            return message;
+
+        return message.Replace(_prefix, Replacement, Comparison);
+    }
+}

--- a/tests/JunimoServer.Tests/Infrastructure/TestLog.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestLog.cs
@@ -1,3 +1,5 @@
+using JunimoServer.Tests.Helpers;
+
 namespace JunimoServer.Tests.Infrastructure;
 
 /// <summary>
@@ -7,13 +9,13 @@ namespace JunimoServer.Tests.Infrastructure;
 internal static class TestLog
 {
     internal static void Server(string message) =>
-        Console.Error.WriteLine($"[Server] {DateTime.UtcNow:HH:mm:ss.fff} {message}");
+        Console.Error.WriteLine($"[Server] {DateTime.UtcNow:HH:mm:ss.fff} {PathDisplay.ScrubMessage(message)}");
 
     internal static void Client(string message) =>
-        Console.Error.WriteLine($"[Client] {DateTime.UtcNow:HH:mm:ss.fff} {message}");
+        Console.Error.WriteLine($"[Client] {DateTime.UtcNow:HH:mm:ss.fff} {PathDisplay.ScrubMessage(message)}");
 
     internal static void Test(string message) =>
-        Console.Error.WriteLine($"[Test]   {DateTime.UtcNow:HH:mm:ss.fff} {message}");
+        Console.Error.WriteLine($"[Test]   {DateTime.UtcNow:HH:mm:ss.fff} {PathDisplay.ScrubMessage(message)}");
 
     /// <summary>
     /// Extracts the method name from a fully-qualified test name.


### PR DESCRIPTION
## What

Test-harness log lines printed absolute machine-specific paths, e.g. `… retrieving to D:\Development\…\server\TestResults\runs\…\full_recording.mp4`. This rewrites any path **under the repo root** to a relative form (`.\TestResults\…` / `./TestResults/…`) in **human-facing free-text log lines only**, across every output mode (`--llm`, `--ci`, `--web`, plain console). Paths outside the repo root (`C:\Windows\…`, in-container `/home/steam/…`) pass through unchanged.

## Changes

- **New `PathDisplay.ScrubMessage`** (`tests/JunimoServer.Tests/Helpers/PathDisplay.cs`): single native-separator prefix-replace against `ProjectRoot.Path`; no-op for non-repo paths and idempotent on already-relativized strings; resolved once and never throws on the logging path.
- **A1 — `TestLog`**: scrub `[Server]/[Client]/[Test]` lines at the choke point — covers the `[Recording] … retrieving to` line and every free-text path leak there.
- **A2 — 5 parent-process sites**: `ReportGenerator` (`Static report generated`, `Artifact not found`, `Exported N artifacts`), `WebRenderer` (`Mock data written`), `CIRenderer` (`Screenshot:`).
- **`LLMRenderer` stack traces**: `test_failed` + `error` JSONL now run through the shared `RendererBase.SanitizeStackTrace` (cleans repo paths, drops framework frames), matching `CIRenderer`/`TestRunState`.

## Deliberately left absolute (structured / machine-consumable)

- `--llm` JSONL path fields, the event path fields the web UI turns into `/artifacts/` URLs (relativizing double-paths → 404), the CI-scraper JSON echo, and `infrastructure.jsonl`.

## Verification

- Build clean (0 warnings / 0 errors).
- Ran a recording test in `--llm`: `[Recording] … retrieving to .\TestResults\…` on stderr; stdout JSONL `recordingPath`/`screenshotPath`/`runDir` confirmed still absolute; all 1281 JSONL lines well-formed.
- Ran `--web --report`: all `[WebUI]` path lines scrubbed; report bundle videos/screenshots still resolve; `full_recording.mp4` on disk.
- Forced a real test failure: `test_failed` JSONL stack trace shows `… in tests/JunimoServer.Tests/…cs:line N` (repo-relative, framework frames dropped, no absolute prefix).
