### PR TITLE
chore: disable lefthook colors so hook output is readable in fork

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,7 @@
+# Truecolor SGR escapes in lefthook's banner render as literal garbage in some
+# clients (e.g. fork); plain output keeps it readable.
+colors: false
+
 commit-msg:
   commands:
     commitlint:


### PR DESCRIPTION
- Set `colors: false` in `lefthook.yml`.

Lefthook draws its banner with truecolor SGR escapes (`[38;2;R;G;Bm`) that some clients (e.g. fork) print literally as escape-code garbage rather than interpreting. `colors: false` keeps the output plain text.

The `meta`/version banner is preserved — this only affects coloring, not which output blocks lefthook prints. The `block-master` guard itself was working correctly; only its surrounding decorative output was unreadable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbled text display in command output for certain clients by disabling colored output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->