### PR TITLE
feat(cabin): validate footprint before !cabin placement

### DIFF
--- a/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
@@ -1,0 +1,135 @@
+using System;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.Buildings;
+
+namespace JunimoServer.Services.CabinManager
+{
+    /// <summary>
+    /// Read-only mirror of vanilla <c>buildStructure</c>'s safety checks (no state mutation).
+    /// Source of truth: decompiled buildStructure:16637-16717, isBuildable:17096-17132.
+    ///
+    /// Two deliberate divergences:
+    /// - Map-property reads go through <c>farm</c>, not <c>Game1.currentLocation</c> as
+    ///   <c>isBuildable</c> does — the AlwaysOn host warps off-farm (e.g. FarmHouse), where
+    ///   the vanilla path would read the wrong location's tiles and reject every valid slot.
+    /// - Farmer-collision uses absolute tile coords, not <c>buildStructure</c>'s loop-index
+    ///   offsets (:16668) — a vanilla bug we don't reproduce — and skips the host farmer
+    ///   (see the loop below).
+    /// </summary>
+    public static class CabinPlacementValidator
+    {
+        public static bool TryValidate(Farm farm, Building cabin, Point topLeft, out string failureReason)
+        {
+            var buildableRect = farm.GetBuildableRectangle();
+
+            for (int dy = 0; dy < cabin.tilesHigh.Value; dy++)
+            {
+                for (int dx = 0; dx < cabin.tilesWide.Value; dx++)
+                {
+                    var tile = new Vector2(topLeft.X + dx, topLeft.Y + dy);
+
+                    // The cabin being moved may overlap its own current footprint.
+                    if (farm.buildings.Contains(cabin) && cabin.occupiesTile(tile))
+                    {
+                        continue;
+                    }
+
+                    if (!IsTileBuildable(farm, cabin, tile, buildableRect, out failureReason))
+                    {
+                        return false;
+                    }
+
+                    foreach (var farmer in farm.farmers)
+                    {
+                        // Skip the AlwaysOn host: it stands parked on the Farm but is
+                        // invisible and has ignoreCollisions set (AlwaysOn.cs), so a cabin
+                        // placed over it never traps it — blocking on it would be a false
+                        // positive players can't diagnose. Honor real (visible) farmhands.
+                        if (farmer.IsMainPlayer)
+                        {
+                            continue;
+                        }
+
+                        if (farmer.GetBoundingBox().Intersects(new Rectangle((int)tile.X * 64, (int)tile.Y * 64, 64, 64)))
+                        {
+                            failureReason = "another player is standing there";
+                            return false;
+                        }
+                    }
+                }
+            }
+
+            // Door-front tile (one south of the human door) must be buildable or a path.
+            if (cabin.humanDoor.Value != new Point(-1, -1))
+            {
+                var doorFront = new Vector2(topLeft.X + cabin.humanDoor.X, topLeft.Y + cabin.humanDoor.Y + 1);
+                bool selfOverlap = farm.buildings.Contains(cabin) && cabin.occupiesTile(doorFront);
+                if (!selfOverlap && !farm.isPath(doorFront)
+                    && !IsTileBuildable(farm, cabin, doorFront, buildableRect, out failureReason))
+                {
+                    return false;
+                }
+            }
+
+            var prevention = cabin.isThereAnythingtoPreventConstruction(farm, topLeft.ToVector2());
+            if (prevention != null)
+            {
+                failureReason = prevention;
+                return false;
+            }
+
+            failureReason = "";
+            return true;
+        }
+
+        /// <summary>One tile of <c>isBuildable</c>'s non-passable branch (:17111-17131).</summary>
+        private static bool IsTileBuildable(Farm farm, Building cabin, Vector2 tile, Rectangle buildableRect, out string failureReason)
+        {
+            if (buildableRect != Rectangle.Empty && !buildableRect.Contains((int)tile.X, (int)tile.Y))
+            {
+                failureReason = "out of bounds";
+                return false;
+            }
+
+            var other = farm.getBuildingAt(tile);
+            if (other != null && other != cabin && !other.isMoving)
+            {
+                failureReason = "another building is in the way";
+                return false;
+            }
+
+            // (O)590 is the artifact spot, which buildStructure permits building over
+            // (isBuildable:17116) — there is no isArtifactSpot helper.
+            bool placeable = farm.CanItemBePlacedHere(tile, itemIsPassable: false, CollisionMask.All, ~CollisionMask.Objects, useFarmerTile: true)
+                || farm.getObjectAtTile((int)tile.X, (int)tile.Y)?.QualifiedItemId == "(O)590";
+            if (!placeable)
+            {
+                failureReason = "blocked by terrain or object";
+                return false;
+            }
+
+            // Map "Buildable"/"Diggable" gate (isBuildable:17122-17129). The
+            // LooserBuildRestrictions branch (:17118) is omitted: it's an opt-in map
+            // property, and omitting it only makes us stricter (reject a buildable tile),
+            // never laxer — a safe direction for a placement guard.
+            var buildableProp = farm.doesTileHavePropertyNoNull((int)tile.X, (int)tile.Y, "Buildable", "Back");
+            if (buildableProp.Equals("f", StringComparison.OrdinalIgnoreCase))
+            {
+                failureReason = "blocked by terrain or object";
+                return false;
+            }
+            bool buildableYes = buildableProp.Equals("t", StringComparison.OrdinalIgnoreCase)
+                || buildableProp.Equals("true", StringComparison.OrdinalIgnoreCase);
+            bool diggable = farm.doesTileHaveProperty((int)tile.X, (int)tile.Y, "Diggable", "Back") != null;
+            if (!buildableYes && !diggable)
+            {
+                failureReason = "blocked by terrain or object";
+                return false;
+            }
+
+            failureReason = "";
+            return true;
+        }
+    }
+}

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -40,24 +40,30 @@ namespace JunimoServer.Services.Commands
 
 
                     // TODO:
-                    // a) Add checks to prevent placing cabin out-of-bounds, over trees, buildings etc.
-                    // b) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
+                    // a) Potentially add preview mode consisting of a few commands? (first, check if we can trigger native building-move mode on clients)
                     //  - 'cabin move [direction=top|right|bottom|left]': Start "ghost" mode, manipulate LocationIntroduction package to show building as ghost without updating warp targets etc?
                     //  - 'cabin cancel': Cancel the move, reset to position from before the ghost mode
                     //  - 'cabin confirm': Confirm the move, update warp targets etc
 
                     // Place cabin on the right-hand side of the farmer
-                    var newPosition = new Vector2(farmer.Tile.X + 1, farmer.Tile.Y);
+                    var topLeft = new Point((int)farmer.Tile.X + 1, (int)farmer.Tile.Y);
+
+                    if (!CabinPlacementValidator.TryValidate(Game1.getFarm(), cabin, topLeft, out var reason))
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer, $"Can't move cabin: {reason}.");
+                        return;
+                    }
 
                     // Record the player's intent BEFORE relocating. The building's
                     // tileX/tileY is what persists the position to the save; this map
                     // only records that the move was intentional, so the MoveToStack /
                     // strategy-switch bulk movers don't sweep it back into the hidden
-                    // stack on the next load.
-                    cabinService.Data.PlayerCabinPositions[msg.SourceFarmer] = newPosition;
+                    // stack on the next load. Guard above precedes this write so a
+                    // rejected move records no false intent.
+                    cabinService.Data.PlayerCabinPositions[msg.SourceFarmer] = topLeft.ToVector2();
                     cabinService.Data.Write();
 
-                    cabin.Relocate(newPosition.ToPoint());
+                    cabin.Relocate(topLeft);
                 }
             );
         }

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -138,7 +138,10 @@ public class CabinPlacementValidationTests : TestBase
 
         // Second farmer over its own lease + ConnectionHelper (LAN; Steam not needed).
         var nameB = Farmers.GenerateName("FarmerB");
-        var leaseB = await LeaseClientAsync(ct);
+        // Scope leaseB so its client disconnects before this class's DisposeAsync runs
+        // /newgame — that reset returns 409 while any client is still connected, and
+        // ResourceLease.DisposeAsync would otherwise dispose leaseB too late.
+        await using var leaseB = await LeaseClientAsync(ct);
         var connB = new ConnectionHelper(leaseB.Client, serverApi: ServerApi);
         var joinB = await connB.JoinWorldViaLanAsync(
             Lease!.ServerLanAddress, Lease.ServerLanPort, nameB, cancellationToken: ct);

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -1,0 +1,178 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E coverage for CabinPlacementValidator, which gates the !cabin command: it
+/// validates the target footprint (bounds, building/terrain/object overlap, farmer
+/// collision, door-front) before relocating and replies "Can't move cabin: ..." on
+/// rejection. The validator is a pure helper with no E2E coverage otherwise.
+///
+/// Placement is deterministic: warpFarmer lands on the exact tile, and !cabin
+/// relocates to farmer.Tile + (1,0) with no adjustment, so a warp to (x,y) means a
+/// footprint of (x+1..x+5, y). Rejection is asserted on the positive chat reply plus
+/// an unchanged /cabins snapshot — a "didn't move" poll has no positive edge.
+///
+/// Exclusive + a fresh game per test so the farm starts clean and assertions scope to
+/// the single connected farmer.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedAssembly, Exclusive = true)]
+public class CabinPlacementValidationTests : TestBase
+{
+    public CabinPlacementValidationTests() { }
+
+    public override async ValueTask DisposeAsync()
+    {
+        // Reset to a clean default game so a moved cabin doesn't leak to a sibling class
+        // reusing this server. Disconnect first: /newgame returns 409 while a client is
+        // connected, and our tests stay connected through the body.
+        if (Lease != null)
+        {
+            try
+            {
+                await DisconnectAsync();
+                await CreateNewGameOnServerAsync(farmType: 0);
+            }
+            catch (Exception ex) { LogWarning($"Server reset failed during cleanup: {ex.Message}"); }
+        }
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// A clear in-bounds target passes validation: the cabin moves out of the hidden
+    /// stack to farmer.Tile + (1,0).
+    /// </summary>
+    [Fact]
+    public async Task ValidPlacement_MovesCabinToFarmerTilePlusOne()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
+
+        CabinInfoResponse? moved = null;
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Moved,
+            async () =>
+            {
+                // Resend each poll: the !cabin handler reads the server's view of the
+                // farmer location, which can lag the client warp by a tick.
+                await GameClient.SendChat("!cabin");
+                moved = await GetOurCabinAsync(ownerId, ct);
+                return !moved.IsHidden;
+            }, TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+
+        Assert.True(ok, "Cabin did not move out of the hidden stack after !cabin");
+        Assert.Equal(CabinPlacementHelper.ExpectedCabinTile, (moved!.TileX, moved.TileY));
+
+        await Exceptions.AssertNoExceptionsAsync("after valid !cabin");
+    }
+
+    /// <summary>
+    /// An object inside the footprint fails validation: !cabin replies "Can't move
+    /// cabin" and the cabin stays put. This exercises the same IsTileBuildable reject
+    /// path as out-of-bounds/door-front, without depending on the farm's map geometry.
+    /// </summary>
+    [Fact]
+    public async Task ObstacleInFootprint_RejectsAndDoesNotMove()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
+        var baseline = await GetOurCabinAsync(ownerId, ct);
+
+        // Place a Garden Pot inside the just-cleared footprint so the validator's
+        // terrain/object check rejects on a single, deterministic obstacle.
+        var pot = await GameClient.Actions.PlacePot(
+            "Farm", CabinPlacementHelper.ExpectedCabinTile.X + 1, CabinPlacementHelper.ExpectedCabinTile.Y,
+            clearObstacles: true);
+        Assert.True(pot?.Success == true, $"PlacePot failed: {pot?.Error}");
+
+        var rejected = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Rejected,
+            // "Can't move cabin" (validator reply), not "Must be on Farm" (off-Farm
+            // bail); resends absorb server-location lag.
+            () => Chat.AssertResponseAsync("!cabin", "Can't move cabin"),
+            TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+
+        Assert.True(rejected, "Expected a 'Can't move cabin' rejection reply");
+
+        // Reply alone only proves a message; confirm the move was actually blocked.
+        var after = await GetOurCabinAsync(ownerId, ct);
+        Assert.True(after.IsHidden, "Cabin should still be hidden after a rejected move");
+        Assert.Equal((baseline.TileX, baseline.TileY), (after.TileX, after.TileY));
+
+        await Exceptions.AssertNoExceptionsAsync("after rejected !cabin");
+    }
+
+    /// <summary>
+    /// Another connected, visible farmer standing in the footprint must reject with
+    /// "another player is standing there" — and the host (skipped via IsMainPlayer)
+    /// must NOT trigger that rejection on its own.
+    ///
+    /// Skipped: needs a second concurrently-connected farmer, which the shared
+    /// connection helpers don't support (they bind to the single primary client). The
+    /// body documents the contained mechanism — a second ConnectionHelper over a
+    /// second lease — so enabling it later is mechanical.
+    /// </summary>
+    [Fact(Skip = "Needs a 2nd concurrently-connected farmer (first in suite); deferred — see body for approach")]
+    public async Task AnotherPlayerInFootprint_RejectsAndDoesNotMove()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var clientA = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerIdA = clientA.JoinResult.UniqueMultiplayerId;
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
+        var baseline = await GetOurCabinAsync(ownerIdA, ct);
+
+        // Second farmer over its own lease + ConnectionHelper (LAN; Steam not needed).
+        var nameB = Farmers.GenerateName("FarmerB");
+        var leaseB = await LeaseClientAsync(ct);
+        var connB = new ConnectionHelper(leaseB.Client, serverApi: ServerApi);
+        var joinB = await connB.JoinWorldViaLanAsync(
+            Lease!.ServerLanAddress, Lease.ServerLanPort, nameB, cancellationToken: ct);
+        Farmers.TrackFarmer(nameB, joinB.UniqueMultiplayerId);
+
+        // Stand B inside A's prospective footprint.
+        var warpB = await leaseB.Client.Actions.Warp(
+            "Farm", CabinPlacementHelper.ExpectedCabinTile.X + 1, CabinPlacementHelper.ExpectedCabinTile.Y);
+        Assert.True(warpB?.Success == true, $"B warp failed: {warpB?.Error}");
+        await leaseB.Client.WaitForLocationAsync("^Farm$", ct: ct);
+
+        var rejected = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Rejected,
+            () => Chat.AssertResponseAsync("!cabin", "another player is standing there"),
+            TestTimings.CabinAssignmentTimeout, cancellationToken: ct);
+        Assert.True(rejected, "Expected an 'another player is standing there' rejection");
+
+        var after = await GetOurCabinAsync(ownerIdA, ct);
+        Assert.True(after.IsHidden, "A's cabin should still be hidden after rejection");
+        Assert.Equal((baseline.TileX, baseline.TileY), (after.TileX, after.TileY));
+
+        await Exceptions.AssertNoExceptionsAsync("after farmer-collision !cabin");
+    }
+
+    #region Helpers
+
+    private async Task<CabinInfoResponse> GetOurCabinAsync(long ownerId, CancellationToken ct)
+    {
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        var ours = cabins.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+        Assert.NotNull(ours);
+        return ours;
+    }
+
+    #endregion
+}

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -180,11 +180,10 @@ public class CabinPositionPersistenceTests : TestBase
     /// </summary>
     private async Task<(int X, int Y)> MoveCabinViaCommandAsync(long ownerId, CancellationToken ct)
     {
-        // !cabin requires the farmer to be on the Farm. The exact tile doesn't matter —
-        // we read the resulting cabin position back from /cabins.
-        var warp = await GameClient.Actions.Warp("Farm", 64, 15);
-        Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
-        await GameClient.WaitForLocationAsync("Farm", ct: ct);
+        // !cabin requires the farmer on the Farm AND a clear footprint (CabinPlacementValidator
+        // rejects the farmhouse/debris). The helper warps to a known-clear spot and clears the
+        // footprint; we read the resulting position back rather than predicting it.
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
 
         var before = await GetOurCabinAsync(ownerId, ct);
 

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -238,6 +238,15 @@ public class PlacePotResult
     public int? TileY { get; set; }
 }
 
+public class ClearAreaResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 public class PlantCropResult
 {
     [JsonPropertyName("success")]
@@ -561,6 +570,15 @@ public class ActionsClient
     public Task<PlacePotResult?> PlacePot(string locationName, int tileX, int tileY, bool clearObstacles = false)
         => _client.PostAsync<PlacePotResult>("/actions/place_pot",
             new { locationName, tileX, tileY, clearObstacles });
+
+    /// <summary>
+    /// Clear debris (objects, terrain features, bushes, resource clumps) from a tile
+    /// area on the player's current location. Use to prep a building footprint.
+    /// POST /actions/clear_area
+    /// </summary>
+    public Task<ClearAreaResult?> ClearArea(string locationName, int tileX, int tileY, int width, int height)
+        => _client.PostAsync<ClearAreaResult>("/actions/clear_area",
+            new { locationName, tileX, tileY, width, height });
 
     /// <summary>
     /// Plant a seed in a HoeDirt or IndoorPot at the given tile.

--- a/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
@@ -1,0 +1,35 @@
+using JunimoServer.Tests.Clients;
+using Xunit;
+
+namespace JunimoServer.Tests.Helpers;
+
+/// <summary>
+/// Shared setup for !cabin placement tests: positions the farmer at a known-clear
+/// standard-farm tile and clears the prospective cabin footprint, so
+/// CabinPlacementValidator isn't tripped by the farmhouse or spawn-time debris.
+/// </summary>
+public static class CabinPlacementHelper
+{
+    // Open western field on the standard farm, clear of the farmhouse (door at 64,15),
+    // greenhouse (25,10), and shipping bin. !cabin places the cabin at farmer.Tile + (1,0).
+    public const int FarmerTileX = 40;
+    public const int FarmerTileY = 18;
+
+    /// <summary>Where !cabin places the cabin's top-left when the farmer stands at the tile above.</summary>
+    public static readonly (int X, int Y) ExpectedCabinTile = (FarmerTileX + 1, FarmerTileY);
+
+    /// <summary>
+    /// Warps the farmer to <see cref="FarmerTileX"/>,<see cref="FarmerTileY"/> and clears the
+    /// 5x3 cabin footprint plus the door-front row at farmer.Tile + (1,0). Debris spawn on a
+    /// new farm is random per seed, so the clear is load-bearing for a deterministic placement.
+    /// </summary>
+    public static async Task WarpAndClearFootprintAsync(GameTestClient client, CancellationToken ct)
+    {
+        var warp = await client.Actions.Warp("Farm", FarmerTileX, FarmerTileY);
+        Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
+        await client.WaitForLocationAsync("^Farm$", ct: ct);
+
+        var cleared = await client.Actions.ClearArea("Farm", FarmerTileX + 1, FarmerTileY, width: 5, height: 4);
+        Assert.True(cleared?.Success == true, $"ClearArea failed: {cleared?.Error}");
+    }
+}

--- a/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
@@ -27,7 +27,8 @@ public static class CabinPlacementHelper
     {
         var warp = await client.Actions.Warp("Farm", FarmerTileX, FarmerTileY);
         Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
-        await client.WaitForLocationAsync("^Farm$", ct: ct);
+        var arrived = await client.WaitForLocationAsync("^Farm$", ct: ct);
+        Assert.True(arrived is not null, "Warp to Farm did not complete before clearing footprint");
 
         var cleared = await client.Actions.ClearArea("Farm", FarmerTileX + 1, FarmerTileY, width: 5, height: 4);
         Assert.True(cleared?.Success == true, $"ClearArea failed: {cleared?.Error}");

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -139,4 +139,8 @@ public enum WaitName
 
     // CropSaverTests.cs (1)
     Polling_CropSaver_AwaitWatcher,
+
+    // CabinPlacementValidationTests.cs (2)
+    Polling_CabinPlacement_Moved,
+    Polling_CabinPlacement_Rejected,
 }

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -156,6 +156,37 @@ public class ActionsController
     }
 
     /// <summary>
+    /// Clear objects, terrain features, bushes, and resource clumps from a tile area
+    /// on the player's current location, via the same <c>removeObjectsAndSpawned</c>
+    /// the game uses to clear under a placed building. Lets placement tests prepare a
+    /// debris-free footprint so cabin/building validation isn't tripped by spawn-time
+    /// rocks/weeds/grass.
+    /// </summary>
+    public ClearAreaResult ClearArea(string locationName, int tileX, int tileY, int width, int height)
+    {
+        if (!Context.IsWorldReady)
+            return new ClearAreaResult { Success = false, Error = "Not in a game world" };
+
+        if (Game1.player.currentLocation?.Name != locationName)
+            return new ClearAreaResult
+            {
+                Success = false,
+                Error = $"Player is on '{Game1.player.currentLocation?.Name}', not '{locationName}'"
+            };
+
+        Game1.player.currentLocation.removeObjectsAndSpawned(tileX, tileY, width, height);
+        return new ClearAreaResult
+        {
+            Success = true,
+            LocationName = locationName,
+            TileX = tileX,
+            TileY = tileY,
+            Width = width,
+            Height = height
+        };
+    }
+
+    /// <summary>
     /// Plant a seed via <c>HoeDirt.plant</c>. The dirt may be a terrain HoeDirt or
     /// the inner HoeDirt of a Garden Pot at the same tile. <c>plant</c> requires
     /// <c>player.currentLocation == dirt.Location</c>.
@@ -237,6 +268,26 @@ public class PlacePotParams
     /// <summary>If true, remove any existing Object or terrainFeature at the
     /// tile before placing the pot (handles spawn-time rocks/weeds/twigs).</summary>
     public bool ClearObstacles { get; set; }
+}
+
+public class ClearAreaResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+    public string? LocationName { get; set; }
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
+}
+
+public class ClearAreaParams
+{
+    public string LocationName { get; set; } = "";
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+    public int Width { get; set; }
+    public int Height { get; set; }
 }
 
 public class PlantCropResult

--- a/tests/test-client/HttpServer/ApiDefinitions.cs
+++ b/tests/test-client/HttpServer/ApiDefinitions.cs
@@ -136,6 +136,11 @@ public class ApiDefinitions
     [ApiResponse(typeof(PlacePotResult), 200)]
     private void PlacePot() { }
 
+    [ApiEndpoint("POST", "/actions/clear_area", Summary = "Clear a tile area", Description = "Remove objects, terrain features, bushes, and resource clumps from a tile area on the player's current location.", Tag = "Actions")]
+    [ApiRequestBody(typeof(ClearAreaParams))]
+    [ApiResponse(typeof(ClearAreaResult), 200)]
+    private void ClearArea() { }
+
     [ApiEndpoint("POST", "/actions/plant_crop", Summary = "Plant a crop seed", Description = "Plant a seed in a HoeDirt or IndoorPot at the given tile.", Tag = "Actions")]
     [ApiRequestBody(typeof(PlantCropParams))]
     [ApiResponse(typeof(PlantCropResult), 200)]

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -486,6 +486,15 @@ public class ModEntry : Mod
             return ExecuteOnGameThread(() => _actionsController!.PlacePot(body.LocationName, body.TileX, body.TileY, body.ClearObstacles));
         });
 
+        // POST /actions/clear_area - Clear debris from a tile area (prep a building footprint)
+        _server.Post("actions/clear_area", req =>
+        {
+            var body = TestApiServer.ReadBody<ClearAreaParams>(req);
+            if (body == null) return new ClearAreaResult { Success = false, Error = "Missing body" };
+            return ExecuteOnGameThread(() =>
+                _actionsController!.ClearArea(body.LocationName, body.TileX, body.TileY, body.Width, body.Height));
+        });
+
         // POST /actions/plant_crop - Plant a seed in a HoeDirt or IndoorPot at the given tile
         _server.Post("actions/plant_crop", req =>
         {


### PR DESCRIPTION
Validates a cabin's target footprint before `!cabin` relocates it, so placement onto blocked tiles is rejected with a reason instead of silently moving onto an invalid spot.

- Add `CabinPlacementValidator`: rejects placement when the footprint is blocked (farmhouse, buildings, debris, water / non-placeable tiles)
- `CabinCommand` consults the validator and reports the rejection reason
- Add `/actions/clear_area` test-client endpoint (`removeObjectsAndSpawned`) so placement tests can prep a debris-free footprint
- Add `CabinPlacementValidationTests` + `CabinPlacementHelper`; update `CabinPositionPersistenceTests` to warp-and-clear via the helper


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cabin placement now validates target tiles and prevents moves when out-of-bounds, blocked by terrain/objects, doors not on a path, other buildings, or another player standing there; shows specific rejection reasons.
  * Test client gained an API to clear rectangular areas to support deterministic placement tests.

* **Tests**
  * Added end-to-end tests covering valid moves, obstacle rejections, and player-occupied rejections for cabin placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->