### PR TITLE
chore: repin ffmpeg (previous version got pruned)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,7 +185,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install ffmpeg 8.1.1. Debian 11 ships 4.3.x with x11grab timing bugs that break the
 # test-recording pipeline; pinning to a date-stamped BtbN release avoids the "latest" tag drift.
-RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-29-14-08/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1.tar.xz && \
+RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
     install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
     install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -187,8 +187,8 @@ RUN apt-get update && apt-get install -y \
 # test-recording pipeline; pinning to a date-stamped BtbN release avoids the "latest" tag drift.
 RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
+    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
+    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
     rm -rf /tmp/ffmpeg*
 
 # Install tmux (binary download, separate layer for cacheability)

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -140,8 +140,8 @@ RUN apt-get update && apt-get install -y \
 # Must match the server image's ffmpeg pin so both ends of the recording pipeline behave identically.
 RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
+    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
+    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
     rm -rf /tmp/ffmpeg*
 
 # System cleanup

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -138,7 +138,7 @@ RUN apt-get update && apt-get install -y \
 # Install ffmpeg 8.1.1. Debian 11 ships 4.3.x with x11grab timing bugs that break the
 # test-recording pipeline; pinning to a date-stamped BtbN release avoids the "latest" tag drift.
 # Must match the server image's ffmpeg pin so both ends of the recording pipeline behave identically.
-RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-29-14-08/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1.tar.xz && \
+RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
     install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
     install -m 0755 /tmp/ffmpeg-n8.1.1-9-g58d4114d36-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated FFmpeg autobuild versions used in the runtime image to a newer release.
  * Aligned the test-client image to the same newer FFmpeg autobuild so installed binaries match the runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->