### PR TITLE
feat(commands): defer !changewallet to the vanilla overnight flip

### DIFF
--- a/docs/admins/configuration/server-settings.md
+++ b/docs/admins/configuration/server-settings.md
@@ -171,7 +171,7 @@ Controls what happens to visible cabins already on the farm when using a stacked
 | `false` | Shared wallet: all players share one money pool |
 | `true` | Separate wallets: each player has their own money |
 
-You can toggle this in-game using the `!changewallet` admin command.
+You can switch this in-game with the `!changewallet shared` / `!changewallet separate` admin command. The change applies overnight (the game's own safe point); running the opposite command before then cancels it.
 
 ### Direct IP Connections
 

--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -151,7 +151,7 @@ These require admin role:
 | `!unban <player>` | Remove a ban |
 | `!listadmins` | List all admins |
 | `!listbans` | List all bans |
-| `!changewallet` | Toggle shared/separate wallets |
+| `!changewallet <shared\|separate>` | Switch wallet mode at the end of the day |
 | `!event` | Start current festival event (if stuck) |
 
 ### Lobby Management (Admin)

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -34,7 +34,7 @@ Yes. Stand where you want your cabin, then type `!cabin` in chat.
 
 ### Is money shared or separate?
 
-Configurable by the server admin. Default is shared wallet (all players share one money pool). Admins can toggle this with `!changewallet`.
+Configurable by the server admin. Default is shared wallet (all players share one money pool). Admins can switch it with `!changewallet shared` / `!changewallet separate`; the change applies overnight.
 
 ## Technical
 

--- a/mod/JunimoServer/Services/Commands/ChangeWalletCommand.cs
+++ b/mod/JunimoServer/Services/Commands/ChangeWalletCommand.cs
@@ -3,7 +3,7 @@ using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
-using StardewValley.Locations;
+using System;
 
 namespace JunimoServer.Services.Commands
 {
@@ -11,27 +11,78 @@ namespace JunimoServer.Services.Commands
     {
         public static void Register(IModHelper helper, ChatCommandsService chatCommandsService, RoleService roleService)
         {
-            chatCommandsService.RegisterCommand("changewallet", "Immediate toggle between shared or split money.", (args, msg) =>
-            {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
+            chatCommandsService.RegisterCommand("changewallet",
+                "Type \"!changewallet shared\" or \"!changewallet separate\" to switch wallet mode at the end of the day.",
+                (args, msg) =>
                 {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
+                    if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
+                        return;
+                    }
 
-                var isSeparateWallets = Game1.player.team.useSeparateWallets.Value;
-                if (isSeparateWallets)
-                {
-                    ManorHouse.MergeWallets();
-                    helper.SendPublicMessage("Now using shared money.");
-                }
-                else
-                {
-                    ManorHouse.SeparateWallets();
-                    helper.SendPublicMessage("Now using separate money.");
-                }
-            });
+                    bool wantSeparate;
+                    if (args.Length == 1 && args[0].Equals("separate", StringComparison.OrdinalIgnoreCase))
+                    {
+                        wantSeparate = true;
+                    }
+                    else if (args.Length == 1 && args[0].Equals("shared", StringComparison.OrdinalIgnoreCase))
+                    {
+                        wantSeparate = false;
+                    }
+                    else
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer,
+                            "Usage: !changewallet shared or !changewallet separate");
+                        return;
+                    }
+
+                    // Mid-transition, tonight's flip may already have run and the wallet mode
+                    // may be about to change under us.
+                    var dayTransitionActive =
+                        Game1.newDaySync != null && Game1.newDaySync.hasInstance() && !Game1.newDaySync.hasFinished();
+                    if (dayTransitionActive)
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer,
+                            "Cannot change wallet mode during a day transition. Try again shortly.");
+                        return;
+                    }
+
+                    // Schedule via vanilla's overnight flip (Game1.cs:8203), which runs between
+                    // newDaySync barriers where no client has menus or transactions open.
+                    var isSeparate = Game1.player.team.useSeparateWallets.Value;
+                    var flipScheduled = Game1.player.changeWalletTypeTonight.Value;
+                    var actorName = helper.GetFarmerNameById(msg.SourceFarmer) ?? Game1.player.Name;
+
+                    if (wantSeparate == isSeparate)
+                    {
+                        if (flipScheduled)
+                        {
+                            Game1.player.changeWalletTypeTonight.Value = false;
+                            helper.GetMultiplayer().globalChatInfoMessage(
+                                isSeparate ? "MergeWalletsCancel" : "SeparateWalletsCancel", actorName);
+                        }
+                        else
+                        {
+                            helper.SendPrivateMessage(msg.SourceFarmer,
+                                wantSeparate ? "Wallets are already separate." : "Wallets are already shared.");
+                        }
+                        return;
+                    }
+
+                    if (flipScheduled)
+                    {
+                        helper.SendPrivateMessage(msg.SourceFarmer,
+                            wantSeparate
+                                ? "Wallets are already scheduled to be separated tonight."
+                                : "Wallets are already scheduled to be merged tonight.");
+                        return;
+                    }
+
+                    Game1.player.changeWalletTypeTonight.Value = true;
+                    helper.GetMultiplayer().globalChatInfoMessage(
+                        wantSeparate ? "SeparateWallets" : "MergeWallets", actorName);
+                });
         }
-
     }
 }


### PR DESCRIPTION
- `!changewallet` now requires an explicit direction: `!changewallet shared` / `!changewallet separate` (case-insensitive); bare or invalid invocations get a private usage reply instead of toggling.
- The switch is scheduled via vanilla's `changeWalletTypeTonight` flag and applied by the game's own overnight handler between `newDaySync` barriers — no more mid-day `ManorHouse.MergeWallets()`/`SeparateWallets()` calls racing open shop menus, in-flight transactions, or overnight shipping-bin money routing. A pending change survives server restarts (the flag is save-persisted).
- Running the opposite direction before nightfall cancels the pending change. Schedule and cancel both emit vanilla's localized chat broadcasts (`SeparateWallets`/`MergeWallets`/`*Cancel`) with the requesting admin's name; the mod's duplicate English broadcast is gone.
- No-op requests reply truthfully in private ("already shared/separate", "already scheduled tonight") instead of announcing a change that vanilla silently skipped.
- Scheduling is blocked during an active day transition, where "tonight" is ambiguous and the current mode may be mid-flip.
- Docs updated: admin commands table, server settings, FAQ.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated `!changewallet` command to require explicit mode arguments (`shared` or `separate`)
  * Wallet mode changes now apply at end-of-day instead of immediately

* **Documentation**
  * Updated admin commands reference and FAQ to reflect wallet configuration behavior and timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->