### PR TITLE
refactor(tests): serve web-ui artifacts via static-files middleware

### DIFF
--- a/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
@@ -107,20 +107,36 @@ public sealed class WebRenderer : RendererBase
         }
 
         // Serve test artifacts (screenshots, recordings, logs). PhysicalFileProvider owns
-        // path containment; its root must exist before Kestrel starts.
+        // path containment; its root must exist before Kestrel starts. MapWhen isolates
+        // /artifacts from the rest of the pipeline so a miss can't reach the SPA
+        // MapFallback below ([".mkv"]/[".log"] are absent from the provider defaults).
         var testResultsDir = Path.GetFullPath("TestResults");
         Directory.CreateDirectory(testResultsDir);
         var artifactContentTypes = new FileExtensionContentTypeProvider();
         artifactContentTypes.Mappings[".mkv"] = "video/x-matroska";
         artifactContentTypes.Mappings[".log"] = "text/plain";
-        _app.UseStaticFiles(
-            new StaticFileOptions
+        _app.MapWhen(
+            ctx => ctx.Request.Path.StartsWithSegments("/artifacts"),
+            branch =>
             {
-                RequestPath = "/artifacts",
-                FileProvider = new PhysicalFileProvider(testResultsDir),
-                ContentTypeProvider = artifactContentTypes,
-                ServeUnknownFileTypes = true,
-                DefaultContentType = "application/octet-stream",
+                branch.UseStaticFiles(
+                    new StaticFileOptions
+                    {
+                        RequestPath = "/artifacts",
+                        FileProvider = new PhysicalFileProvider(testResultsDir),
+                        ContentTypeProvider = artifactContentTypes,
+                        ServeUnknownFileTypes = true,
+                        DefaultContentType = "application/octet-stream",
+                    }
+                );
+                // Explicit terminal 404: the branch's default terminal throws on requests
+                // the routing middleware already matched to an endpoint (extensionless
+                // paths match the fallback route's :nonfile pattern).
+                branch.Run(ctx =>
+                {
+                    ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                    return Task.CompletedTask;
+                });
             }
         );
 

--- a/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -105,6 +106,24 @@ public sealed class WebRenderer : RendererBase
             _app.UseStaticFiles(new StaticFileOptions { FileProvider = fileProvider });
         }
 
+        // Serve test artifacts (screenshots, recordings, logs). PhysicalFileProvider owns
+        // path containment; its root must exist before Kestrel starts.
+        var testResultsDir = Path.GetFullPath("TestResults");
+        Directory.CreateDirectory(testResultsDir);
+        var artifactContentTypes = new FileExtensionContentTypeProvider();
+        artifactContentTypes.Mappings[".mkv"] = "video/x-matroska";
+        artifactContentTypes.Mappings[".log"] = "text/plain";
+        _app.UseStaticFiles(
+            new StaticFileOptions
+            {
+                RequestPath = "/artifacts",
+                FileProvider = new PhysicalFileProvider(testResultsDir),
+                ContentTypeProvider = artifactContentTypes,
+                ServeUnknownFileTypes = true,
+                DefaultContentType = "application/octet-stream",
+            }
+        );
+
         // API endpoints
         _app.MapGet(
             "/api/state",
@@ -121,44 +140,6 @@ public sealed class WebRenderer : RendererBase
                 var body = await reader.ReadToEndAsync();
                 TryHandleCommand(body);
                 return Results.Ok();
-            }
-        );
-
-        // Artifact serving with directory traversal protection
-        _app.MapGet(
-            "/artifacts/{**path}",
-            (string path) =>
-            {
-                var testResultsDir = Path.GetFullPath("TestResults");
-                var resolvedPath = Path.GetFullPath(Path.Combine(testResultsDir, path));
-
-                if (
-                    !resolvedPath.StartsWith(testResultsDir + Path.DirectorySeparatorChar)
-                    && resolvedPath != testResultsDir
-                )
-                {
-                    return Results.NotFound();
-                }
-
-                if (!File.Exists(resolvedPath))
-                {
-                    return Results.NotFound();
-                }
-
-                var contentType = Path.GetExtension(resolvedPath).ToLowerInvariant() switch
-                {
-                    ".png" => "image/png",
-                    ".jpg" or ".jpeg" => "image/jpeg",
-                    ".gif" => "image/gif",
-                    ".mp4" => "video/mp4",
-                    ".mkv" => "video/x-matroska",
-                    ".webm" => "video/webm",
-                    ".json" => "application/json",
-                    ".txt" or ".log" => "text/plain",
-                    _ => "application/octet-stream",
-                };
-
-                return Results.File(resolvedPath, contentType);
             }
         );
 


### PR DESCRIPTION
## Changes

- Replace the hand-rolled `/artifacts/{**path}` endpoint in the TestRunner web UI with `UseStaticFiles` + `PhysicalFileProvider` rooted at `TestResults` — the same pattern the SPA assets already use
- Path containment now lives in framework code, resolving CodeQL alert #25 (`cs/path-injection`); the previous manual guard was effective, but hand-rolled
- Content types via `FileExtensionContentTypeProvider` with `.mkv` and `.log` added; unknown extensions still serve as `application/octet-stream`
- `TestResults` is created before Kestrel starts (`PhysicalFileProvider` requires an existing root)

## Verification

- TestRunner builds clean (0 warnings under `TreatWarningsAsErrors`)
- Runtime-probed via a scratch harness mirroring the exact options block: content types preserved (`.log` → `text/plain`, `.png`, unknown → octet-stream), and traversal attempts (raw `..` via `--path-as-is`, encoded `..%2F`, rooted `c:\`, double-encoded `%252e%252e`) all return 404 without serving a file planted outside the root


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched test artifact serving to the platform static file middleware for more reliable and performant delivery.
  * Added explicit support for .mkv and .log artifacts.
  * Improved handling of unknown file types with a sensible default content type and explicit 404 responses for missing artifacts to prevent them from reaching the SPA fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->