### PR TITLE
ci: skip release-please and server deploys in forks

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,9 @@ permissions: {}
 jobs:
   release-please:
     name: Create Release PR
+    # Skip in forks — release-please would otherwise open release PRs and tag releases there.
+    # Every other job chains off this one via `needs`, so the guard cascades.
+    if: github.repository == 'stardew-valley-dedicated-server/server'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -34,6 +34,8 @@ permissions: {}
 jobs:
   prepare:
     name: Prepare deployment
+    # Skip in forks — deploys need our VPS secrets, so a fork run can only fail red.
+    if: github.repository == 'stardew-valley-dedicated-server/server'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
- Guard the `release-please` job in `build-release.yml` with `github.repository == 'stardew-valley-dedicated-server/server'` — forks with Actions enabled were getting release PRs/tags created in their fork on every master sync. All other jobs chain off it via `needs`, so the whole workflow skips in forks.
- Same guard on `prepare` in `deploy-server.yml` — it fires via `workflow_run`/`release` and can only fail red in forks (needs our VPS secrets).

Other workflows audited and already fork-safe: `build-preview` (gated on a repo variable forks don't have), scheduled workflows (disabled in forks by default), `pull_request_target` workflows (only fire on PRs against the fork itself), `workflow_call`-only workflows (inherit the caller's guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository validation to CI/CD workflows to ensure release tagging and server deployment operations only run in the primary repository, preventing unintended behavior in forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->