### PR TITLE
chore(make): split lint into lint-check and lint-fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -254,17 +254,19 @@ test-diagnose:
 	@if [ ! -f "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" ]; then echo "No infrastructure log in $(LATEST_RUN)."; exit 1; fi
 	@grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5 | python3 -m json.tool --no-ensure-ascii 2>/dev/null || grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5
 
-# Auto-format all C# files using CSharpier (rewrites in place)
+# Auto-format all C# files using CSharpier (rewrites in place; fast, no build)
 format:
 	@dotnet csharpier format .
 
-# Verify all C# files are formatted (CI). Exits non-zero on diff.
-format-check:
+# Verify formatting and analyzer style rules without writing. dotnet format builds
+# the solution to run the analyzers, so this needs GAME_PATH; CI runs only the
+# csharpier half (see validate-pr.yml) since runners have no game files.
+lint-check:
 	@dotnet csharpier check .
+	@dotnet format style JunimoServer.slnx --severity error --verify-no-changes
 
 # Auto-fix analyzer style violations (braces, namespaces, usings), then re-format.
-# Slower than `make format` — dotnet format builds the solution to run the analyzers.
-lint:
+lint-fix:
 	@dotnet format style JunimoServer.slnx --severity error
 	@dotnet csharpier format .
 
@@ -297,9 +299,9 @@ help:
 	@echo "  make build-test-client - Build test client container image (for E2E tests)"
 	@echo ""
 	@echo Formatting:
-	@echo "  make format       - Format all C# files (CSharpier)"
-	@echo "  make format-check - Check formatting without writing (CI)"
-	@echo "  make lint         - Auto-fix analyzer style violations + format (slow, builds)"
+	@echo "  make format     - Format all C# files (CSharpier, fast)"
+	@echo "  make lint-check - Verify formatting + analyzer style rules (slow, builds)"
+	@echo "  make lint-fix   - Auto-fix analyzer style violations + format (slow, builds)"
 	@echo ""
 	@echo Test Observability:
 	@echo "  make test-summary  - Show test run summary (failures, timing)"

--- a/Makefile
+++ b/Makefile
@@ -254,16 +254,10 @@ test-diagnose:
 	@if [ ! -f "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" ]; then echo "No infrastructure log in $(LATEST_RUN)."; exit 1; fi
 	@grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5 | python3 -m json.tool --no-ensure-ascii 2>/dev/null || grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5
 
-# Auto-format all C# files using CSharpier (rewrites in place; fast, no build)
-format:
-	@dotnet csharpier format .
-
-# Verify formatting and analyzer style rules without writing. dotnet format builds
-# the solution to run the analyzers, so this needs GAME_PATH; CI runs only the
-# csharpier half (see validate-pr.yml) since runners have no game files.
+# Verify analyzer style rules and formatting without writing (builds the solution).
 lint-check:
-	@dotnet csharpier check .
 	@dotnet format style JunimoServer.slnx --severity error --verify-no-changes
+	@dotnet csharpier check .
 
 # Auto-fix analyzer style violations (braces, namespaces, usings), then re-format.
 lint-fix:
@@ -299,9 +293,8 @@ help:
 	@echo "  make build-test-client - Build test client container image (for E2E tests)"
 	@echo ""
 	@echo Formatting:
-	@echo "  make format     - Format all C# files (CSharpier, fast)"
-	@echo "  make lint-check - Verify formatting + analyzer style rules (slow, builds)"
-	@echo "  make lint-fix   - Auto-fix analyzer style violations + format (slow, builds)"
+	@echo "  make lint-check - Verify style rules + formatting (slow, builds)"
+	@echo "  make lint-fix   - Auto-fix style violations + re-format (slow, builds)"
 	@echo ""
 	@echo Test Observability:
 	@echo "  make test-summary  - Show test run summary (failures, timing)"

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -137,7 +137,7 @@ The validation pipeline runs on every pull request targeting `master`. It ensure
 - **PR title** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format. The repo squash-merges, so the title becomes the commit subject the merge queue lints — checking it here fails a bad title on the PR rather than cryptically in the queue.
 - **Commit messages** - Must follow [Conventional Commits](https://www.conventionalcommits.org/) format
 - **Docker build** - Ensures the image builds successfully (without pushing)
-- **Formatting** - Runs `dotnet csharpier check .` over the whole tree; fails on any C# formatting drift (fix locally with `make format`)
+- **Formatting** - Runs `dotnet csharpier check .` over the whole tree; fails on any C# formatting drift (fix locally with `make lint-fix`)
 - **Line endings** - Fails if a file with CRLF line endings reached the index, bypassing the LF normalization `.gitattributes` enforces
 
 These surface as required status checks — `Validate PR Title`, `Validate Build`, `Validate Commits`, `Validate Formatting`, and `Validate Line Endings` — that must pass before a PR can merge.

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -54,9 +54,8 @@ C# code is formatted by [CSharpier](https://csharpier.com/), and style rules (br
 Manual targets:
 
 ```bash
-make format     # format all C# files (fast, CSharpier only)
-make lint-check # verify formatting + analyzer style rules without writing (builds the solution)
-make lint-fix   # auto-fix analyzer style violations, then format (builds the solution)
+make lint-check # verify analyzer style rules + formatting without writing (builds the solution)
+make lint-fix   # auto-fix analyzer style violations, then re-format (builds the solution)
 ```
 
 CI's `Validate Formatting` runs the CSharpier half of `lint-check`; the analyzer rules are enforced as build errors wherever the code compiles.

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -54,10 +54,12 @@ C# code is formatted by [CSharpier](https://csharpier.com/), and style rules (br
 Manual targets:
 
 ```bash
-make format       # format all C# files
-make format-check # check without writing (what CI runs)
-make lint         # auto-fix analyzer style violations, then format (builds the solution, slower)
+make format     # format all C# files (fast, CSharpier only)
+make lint-check # verify formatting + analyzer style rules without writing (builds the solution)
+make lint-fix   # auto-fix analyzer style violations, then format (builds the solution)
 ```
+
+CI's `Validate Formatting` runs the CSharpier half of `lint-check`; the analyzer rules are enforced as build errors wherever the code compiles.
 
 #### Development Workflow
 


### PR DESCRIPTION
## Changes

- `format-check` → `lint-check`, which now also runs `dotnet format style --verify-no-changes` — the check target verifies everything its fixing sibling rewrites (previously it only covered the CSharpier half)
- `lint` → `lint-fix` — bare "lint" reads as check-only in most ecosystems, but the target rewrites files
- `format` removed — superseded by `lint-fix`
- Both targets run the same command order: `dotnet format style` first, CSharpier second (in `lint-fix` CSharpier must run last to normalize `dotnet format`'s rewrites)
- CI is unaffected — `Validate Formatting` invokes `dotnet csharpier check .` directly; the analyzer half of `lint-check` can't run on CI runners (building the solution needs the game assemblies)
- Contributing guide and CI docs updated to match

## Verification

- `make help` shows the new targets; `make format` and `make format-check` fail with "No rule to make target"
- `make lint-check` runs green end-to-end (solution build + analyzer verify + csharpier check)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated formatting and linting workflow into two commands: one to verify style/format and one to auto-fix issues.
  * Removed older overlapping formatting/lint targets from the workflow.
  * Updated developer documentation and CI guidance to reference the new verify-and-fix workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->