### PR TITLE
fix: bound CropWatcher crop-tracking map to live tiles

### DIFF
--- a/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
@@ -12,7 +12,14 @@ namespace JunimoServer.Services.CropSaver;
 
 public class CropWatcher
 {
-    private readonly Dictionary<(string, Vector2), bool> _previousHasCrop = new();
+    // Whether each tile had a crop. Double-buffered: CheckTile reads the last
+    // scan's state from _previousHasCrop and writes this scan's state to
+    // _currentHasCrop, then the two are swapped at scan end. Tiles whose
+    // soil/pot is gone simply aren't written this scan, so they drop out
+    // automatically — keeping the maps sized to live tiles, not every tile ever
+    // seen, with no per-scan allocation.
+    private Dictionary<(string, Vector2), bool> _previousHasCrop = new();
+    private Dictionary<(string, Vector2), bool> _currentHasCrop = new();
 
     private readonly Action<CropLocation> _onCropAdded;
     private readonly Action<CropLocation> _onCropRemoved;
@@ -40,6 +47,8 @@ public class CropWatcher
             return;
         }
         _timer = UpdateEveryTicks;
+
+        _currentHasCrop.Clear();
 
         Utility.ForEachLocation(location =>
         {
@@ -74,6 +83,12 @@ public class CropWatcher
 
             return true;
         });
+
+        // This scan's state becomes the next scan's baseline; the old map is
+        // cleared and reused. A harvested tile keeps its soil, so it's still
+        // scanned and rewritten — only tiles whose soil is actually gone fall
+        // out, leaving a replant to read as a fresh crop, not a stale one.
+        (_previousHasCrop, _currentHasCrop) = (_currentHasCrop, _previousHasCrop);
     }
 
     private void CheckTile(CropLocation cropLoc)
@@ -93,7 +108,7 @@ public class CropWatcher
                 _onCropAdded(cropLoc);
             }
 
-            _previousHasCrop[key] = hasCrop;
+            _currentHasCrop[key] = hasCrop;
             return;
         }
 
@@ -106,7 +121,7 @@ public class CropWatcher
             _onCropRemoved(cropLoc);
         }
 
-        _previousHasCrop[key] = hasCrop;
+        _currentHasCrop[key] = hasCrop;
     }
 }
 


### PR DESCRIPTION
## Problem

`CropWatcher._previousHasCrop` recorded one `(location, tile)` entry per tile ever scanned and **never removed any**. On a long-running 24/7 server the dictionary grew without bound — proportional to total tilled tiles over uptime, not to currently-planted crops. A slow but unbounded memory leak.

## Fix

Double-buffer the map:

- Each scan writes live tiles to a fresh map (`_currentHasCrop`) and swaps it in as the next scan's baseline. Tiles whose soil/pot is gone simply aren't written, so they drop out automatically — no explicit prune, no count guard, no LINQ.
- A harvested tile **keeps its soil** (verified against `HoeDirt.destroyCrop` in the decompiled source), so it's still scanned and rewritten each pass. This preserves the first-observation dedupe contract: replanting a previously-harvested tile reads as a fresh crop, and a tile whose soil is genuinely gone re-deduped via `CropSaverData` if it ever returns.

## Performance

The swap reuses both dictionaries (`Clear()` retains capacity), so steady-state scans allocate **nothing** on the game thread — important since this runs in `UpdateTicked`. The change is also net-simpler than an explicit prune would be (removed code rather than added it).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal crop state tracking implementation to use an enhanced buffering approach for more efficient state management during scan operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->