### PR TITLE
fix: festival leave-only/no-players end handling + E2E coverage

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -230,6 +230,7 @@ export default withMermaid(
                             { text: "Networking Internals", link: "/developers/architecture/networking" },
                             { text: "Game Engine Reference", link: "/developers/architecture/game-engine-notes" },
                             { text: "Mod Architecture", link: "/developers/architecture/mod-architecture" },
+                            { text: "Festival Handling", link: "/developers/architecture/festival-handling" },
                             { text: "Events Schema", link: "/developers/events-schema" },
                         ],
                     },

--- a/docs/developers/architecture/festival-handling.md
+++ b/docs/developers/architecture/festival-handling.md
@@ -10,9 +10,9 @@ A festival day runs through four phases, each driven from a per-tick or per-seco
 
 2. **Main event** — `HandleFestivalEvents` (per second), for festivals that have one. It announces a countdown in chat, and when the countdown elapses the host answers the festival host's "start the event?" dialogue. The `!event` chat command short-circuits the countdown and starts immediately.
 
-3. **Leave** — `HandleFestivalLeave` (per tick). The host triggers `TryStartEndFestivalDialogue` (ending the festival for everyone) in two cases, both matching the game's dedicated host: when the `festivalEnd` ready-check shows every remaining player is ready to leave, or immediately once the last player has left so the host isn't stranded.
+3. **Leave** — `HandleFestivalLeave` (per tick). The host ends the festival for everyone in two cases, both matching the game's dedicated host: when the `festivalEnd` ready-check shows every remaining player is ready to leave (via `TryStartEndFestivalDialogue`, the ReadyCheckDialog flow players expect when they vote to leave), or immediately once the last player has left so the host isn't stranded (via `forceEndFestival`, which ends without a dialog). Either way the game's own exit path warps every player home.
 
-4. **Reset** — `UpdateFestivalStatus` (on time change). In-game time is frozen while a festival event is active, so this runs only after the festival has ended and time resumes: once it passes the festival's window, active-festival state is cleared and the server returns to `online` mode. It is deliberately not gated on connected players, so a festival that ended with nobody present still clears its state instead of poisoning the next festival.
+4. **Reset** — `UpdateFestivalStatus` (on time change). In-game time is frozen while a festival event is active, so this runs only after the festival has ended and time resumes: once it passes the festival's window, active-festival state is cleared. It is deliberately not gated on connected players, so a festival that ended with nobody present still clears its state instead of poisoning the next festival.
 
 ### Ready-check formula
 
@@ -20,7 +20,7 @@ A festival day runs through four phases, each driven from a per-tick or per-seco
 
 ### Timeout backstop
 
-Players drive entry and exit, but an AFK festival where no one votes to leave would otherwise stay open until its time window closes. `RunOfflineTimeout` is the wall-clock backstop: after `*TimeOut` elapses it warns players (`FestivalExitWarningSeconds` before the deadline) and then switches the server to `offline` mode, which disconnects everyone. It does not end the festival directly — but with the last player gone, the Leave phase's no-players path ends it on the next tick. There is no fixed "dwell then auto-leave" timer for leave-only festivals; they end on the `festivalEnd` ready-check, the no-players path, or (via this backstop's disconnect) the time window — nothing in between.
+Players drive entry and exit, but an AFK festival where no one votes to leave would otherwise stay open until its time window closes. `RunFestivalTimeout` is the wall-clock backstop: after `*TimeOut` elapses it warns players (`FestivalExitWarningSeconds` before the deadline) and then ends the festival directly via `forceEndFestival`, which warps every player home (and the host) with their connections intact — the same exit the game uses for a player-voted end. It does **not** disconnect anyone or take the server offline; a new client can still join afterward. There is no fixed "dwell then auto-leave" timer for leave-only festivals; they end on the `festivalEnd` ready-check, the no-players path, or this backstop — nothing in between.
 
 ## Per-festival reference
 

--- a/docs/developers/architecture/festival-handling.md
+++ b/docs/developers/architecture/festival-handling.md
@@ -1,0 +1,49 @@
+# Festival Handling
+
+How the always-on server gets the host into and out of in-game festivals without a human present. The logic lives in [`AlwaysOnServerFestivals`](https://github.com/stardew-valley-dedicated-server/server/blob/master/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs) and deliberately mirrors the game's own [`DedicatedServer`](https://github.com/stardew-valley-dedicated-server/server/blob/master/decompiled/sdv-1.6.15-24356/StardewValley/Network/Dedicated/DedicatedServer.cs): monitor ready-checks, warp/answer via public entry points, no reflection-driven reinvention. The manual reproduction steps are in the [festival testing runbook](../testing/festivals-manual.md).
+
+## Lifecycle
+
+A festival day runs through four phases, each driven from a per-tick or per-second handler in [`AlwaysOn`](https://github.com/stardew-valley-dedicated-server/server/blob/master/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs):
+
+1. **Enter** — `HandleFestivalStart` (per tick). When `Game1.whereIsTodaysFest` is set and the `festivalStart` ready-check shows every player except the host is ready, the host marks itself ready (so clients' "Waiting for players…" dialog clears) and warps to the festival. Once warped, `BeginActiveFestival` records which festival is active.
+
+2. **Main event** — `HandleFestivalEvents` (per second), for festivals that have one. It announces a countdown in chat, and when the countdown elapses the host answers the festival host's "start the event?" dialogue. The `!event` chat command short-circuits the countdown and starts immediately.
+
+3. **Leave** — `HandleFestivalLeave` (per tick). The host triggers `TryStartEndFestivalDialogue` (ending the festival for everyone) in two cases, both matching the game's dedicated host: when the `festivalEnd` ready-check shows every remaining player is ready to leave, or immediately once the last player has left so the host isn't stranded.
+
+4. **Reset** — `UpdateFestivalStatus` (on time change). In-game time is frozen while a festival event is active, so this runs only after the festival has ended and time resumes: once it passes the festival's window, active-festival state is cleared and the server returns to `online` mode. It is deliberately not gated on connected players, so a festival that ended with nobody present still clears its state instead of poisoning the next festival.
+
+### Ready-check formula
+
+"Everyone except the host is ready" is `numberReady >= GetNumberRequired(check) - 1 && !IsReady(check) && numberReady > 0`, matching `DedicatedServer.CheckOthersReady`. The same formula gates both `festivalStart` (warp in) and `festivalEnd` (leave). See [`.claude/rules/host-automation.md`](https://github.com/stardew-valley-dedicated-server/server/blob/master/.claude/rules/host-automation.md) item 2 for why variants break specific transports.
+
+### Timeout backstop
+
+Players drive entry and exit, but an AFK festival where no one votes to leave would otherwise stay open until its time window closes. `RunOfflineTimeout` is the wall-clock backstop: after `*TimeOut` elapses it warns players (`FestivalExitWarningSeconds` before the deadline) and then switches the server to `offline` mode, which disconnects everyone. It does not end the festival directly — but with the last player gone, the Leave phase's no-players path ends it on the next tick. There is no fixed "dwell then auto-leave" timer for leave-only festivals; they end on the `festivalEnd` ready-check, the no-players path, or (via this backstop's disconnect) the time window — nothing in between.
+
+## Per-festival reference
+
+Two shapes:
+
+- **Main event** — the host warps in, runs a countdown, and starts a host-triggered event (egg hunt, grange judging, soup tasting, etc.).
+- **Leave-only** — no host-triggered event; the host just waits for the `festivalEnd` ready-check (or the timeout). Spirit's Eve and the Feast of Winter Star are the only two.
+
+Only the **Stardew Valley Fair** auto-ends on its own once the countdown finishes — grange judging *is* the whole festival, so there is nothing left to do. Every other festival, main-event or leave-only, ends on the `festivalEnd` ready-check or the timeout backstop.
+
+| Festival | Date | Shape | Countdown (default) | Timeout (default) |
+|----------|------|-------|--------------------|-------------------|
+| Egg Festival | Spring 13 | Main event | 5 min | ~33 min |
+| Flower Dance | Spring 24 | Main event | 5 min | ~33 min |
+| Luau | Summer 11 | Main event (adds iridium starfruit to the soup) | 5 min | ~33 min |
+| Dance of the Moonlight Jellies | Summer 28 | Main event | 5 min | ~33 min |
+| Stardew Valley Fair | Fall 16 | Main event, **auto-ends after countdown** | 5 min | ~33 min |
+| Spirit's Eve | Fall 27 | Leave-only | — | ~33 min |
+| Festival of Ice | Winter 8 | Main event | 5 min | ~33 min |
+| Feast of the Winter Star | Winter 25 | Leave-only | — | ~33 min |
+
+All durations are operator-tunable via [`AlwaysOnConfig`](https://github.com/stardew-valley-dedicated-server/server/blob/master/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnConfig.cs): the `*CountdownSeconds` knobs (seconds) and the `*TimeOut` knobs (ticks at 60 TPS, so `120000` ≈ 2000 s ≈ 33 min). Most main-event timeouts start counting once the event begins; leave-only festivals and the Fair start theirs on entry.
+
+## Why no fixed auto-end for leave-only festivals
+
+The game's dedicated host never auto-leaves a festival on a fixed dwell timer — it leaves on the `festivalEnd` ready-check, or immediately once no players remain. The server matches that exactly. A short fixed "dwell then leave" timer would be a second wall-clock timeout layered on top of the existing AFK backstop, so it is deliberately absent.

--- a/docs/developers/testing/festivals-manual.md
+++ b/docs/developers/testing/festivals-manual.md
@@ -1,6 +1,6 @@
 # Manual Testing: Festivals
 
-Runbook for manually reproducing festival behavior. The sleep-through requirement (do not use `/debug day` to skip to a festival day) is the rule at [.claude/rules/host-automation.md](https://github.com/stardew-valley-dedicated-server/server/blob/master/.claude/rules/host-automation.md), item 3.
+Runbook for manually reproducing festival behavior. For how the server handles festivals (warp-in, countdown, leave, timeout backstop) and a per-festival reference, see [Festival Handling](../architecture/festival-handling.md). The sleep-through requirement (do not use `/debug day` to skip to a festival day) is the rule at [.claude/rules/host-automation.md](https://github.com/stardew-valley-dedicated-server/server/blob/master/.claude/rules/host-automation.md), item 3.
 
 ## Quick Setup
 

--- a/docs/features/server-mechanics.md
+++ b/docs/features/server-mechanics.md
@@ -63,3 +63,5 @@ To prevent griefing, the server locks player storage:
 - Players participate normally
 - If stuck, use the `!event` command to force-start
 
+For the full handling model and a per-festival reference, see [Festival Handling](/developers/architecture/festival-handling) in the developer docs.
+

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -13,7 +13,7 @@ public class AlwaysOnServerFestivals
 {
     private const string StartNowText = "Type !event to start now";
 
-    // When does the offline-timeout clock start
+    // When the offline-timeout clock starts ticking
     private enum TimeoutStart
     {
         OnEntry,
@@ -24,43 +24,43 @@ public class AlwaysOnServerFestivals
     {
         public Func<bool> IsToday;
 
+        // Clear active-festival state once in-game time reaches this (HHMM, e.g. 1410 = 14:10)
         public int ResetCutoff;
         public bool RestoreHudOnReset;
 
+        // Main-event festivals run a host-triggered countdown then start the event;
+        // leave-only festivals (HasMainEvent = false) just wait for players to leave.
         public bool HasMainEvent;
-
         public Func<int> CountdownSeconds;
         public string AnnounceText;
-        public Action OnAnnounce; // optional action (add iridium star in Luau)
-        public bool AutoEndAfterCountdown;
+        public Action OnAnnounce; // e.g. add the iridium starfruit to the Luau soup
+        public bool AutoEndAfterCountdown; // host ends the festival once the countdown elapses (Fair)
+        public string EndLogText; // logged when AutoEndAfterCountdown fires
 
+        // Wall-clock backstop: kick everyone once this elapses (from entry or after the main event)
         public Func<double> TimeoutSeconds;
         public TimeoutStart TimeoutStart;
-        public string EndLogText;
     }
 
     private readonly List<FestivalSpec> _festivals;
 
-    // Current festival & run state
+    // Active festival and main-event countdown state
     private FestivalSpec _activeFestival;
     private DateTime? _runStartTime;
     private bool _announced;
     private bool _started;
+    private bool _eventCommandUsed;
 
-    private bool eventCommandUsed;
-
-    // Variables for timeout reset
+    // Wall-clock timeout backstop state
     private DateTime? _timeoutStartTime;
     private bool _timeoutWarned;
 
-    // Track if we're currently warping to festival to avoid repeated warps
     private bool _warpingToFestival;
-
-    // Track if we've started the festival end process
     private bool _startedFestivalEnd;
 
-    // Log throttle
-    private DateTime _lastLogTime = DateTime.MinValue;
+    // Independent per-second throttles for the two diagnostic log lines
+    private DateTime _lastStartLogTime = DateTime.MinValue;
+    private DateTime _lastLeaveLogTime = DateTime.MinValue;
 
     protected readonly IModHelper _helper;
     protected readonly IMonitor _monitor;
@@ -152,7 +152,6 @@ public class AlwaysOnServerFestivals
                 HasMainEvent = false,
                 TimeoutStart = TimeoutStart.OnEntry,
                 TimeoutSeconds = () => TicksToSeconds(Config.SpiritsEveTimeOut),
-                EndLogText = "Spirit's Eve timeout, triggering festival end",
             },
             new FestivalSpec
             {
@@ -171,7 +170,6 @@ public class AlwaysOnServerFestivals
                 HasMainEvent = false,
                 TimeoutStart = TimeoutStart.OnEntry,
                 TimeoutSeconds = () => TicksToSeconds(Config.WinterStarTimeOut),
-                EndLogText = "Winter Feast timeout, triggering festival end",
             },
         };
     }
@@ -207,7 +205,11 @@ public class AlwaysOnServerFestivals
     /// </summary>
     public void UpdateFestivalStatus()
     {
-        if (Game1.otherFarmers.Count == 0)
+        // Reset once we hold festival state and time has passed the festival window.
+        // Not gated on connected players: a festival can end with nobody present
+        // (the no-players leave path), and that stale state must still clear so it
+        // doesn't poison the next festival. The _activeFestival guard keeps it one-shot.
+        if (_activeFestival == null)
         {
             return;
         }
@@ -244,24 +246,26 @@ public class AlwaysOnServerFestivals
         _runStartTime = null;
         _announced = false;
         _started = false;
-        eventCommandUsed = false;
+        _eventCommandUsed = false;
     }
 
     /// <summary>
-    /// Called every tick. Handles warping the host to the festival when other players are ready.
-    /// Uses the same approach as the game's DedicatedServer - monitor ready state and warp directly.
+    /// Called every tick. Warps the host to the festival when other players are ready,
+    /// mirroring the game's DedicatedServer (monitor ready state, then warp directly).
     /// </summary>
     public void HandleFestivalStart()
     {
-        // Debug: log once per second on festival days
-        if (Game1.whereIsTodaysFest != null && (DateTime.UtcNow - _lastLogTime).TotalSeconds >= 1.0)
+        if (
+            Game1.whereIsTodaysFest != null
+            && (DateTime.UtcNow - _lastStartLogTime).TotalSeconds >= 1.0
+        )
         {
-            _lastLogTime = DateTime.UtcNow;
+            _lastStartLogTime = DateTime.UtcNow;
             var numberReady = Game1.netReady.GetNumberReady("festivalStart");
             var numberRequired = Game1.netReady.GetNumberRequired("festivalStart");
             _monitor.Log(
                 $"[Festival] otherFarmers={Game1.otherFarmers.Count}, isFestival={Game1.CurrentEvent?.isFestival}, warping={_warpingToFestival}, ready={numberReady}/{numberRequired}, CheckOthersReady={CheckOthersReady("festivalStart")}",
-                LogLevel.Info
+                LogLevel.Trace
             );
         }
 
@@ -270,13 +274,11 @@ public class AlwaysOnServerFestivals
             return;
         }
 
-        // Already at festival or already warping
         if (Game1.CurrentEvent?.isFestival == true || _warpingToFestival)
         {
             return;
         }
 
-        // Check if there's a festival today and others are ready
         if (Game1.whereIsTodaysFest != null && CheckOthersReady("festivalStart"))
         {
             _monitor.Log(
@@ -292,7 +294,7 @@ public class AlwaysOnServerFestivals
             locationRequest.OnWarp += delegate
             {
                 _warpingToFestival = false;
-                SetFestivalAvailableFlag();
+                BeginActiveFestival();
             };
 
             int x = -1;
@@ -303,9 +305,10 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Set the appropriate festival available flag based on today's festival.
+    /// Mark today's festival active and reset its main-event countdown state.
+    /// Called once the host finishes warping into the festival.
     /// </summary>
-    private void SetFestivalAvailableFlag()
+    private void BeginActiveFestival()
     {
         _activeFestival = _festivals.FirstOrDefault(spec => spec.IsToday());
         _runStartTime = null;
@@ -346,14 +349,13 @@ public class AlwaysOnServerFestivals
         return false;
     }
 
+    /// <summary>
+    /// Called once per second. Drives the active festival's main-event countdown
+    /// (or, for leave-only festivals, just the timeout backstop).
+    /// </summary>
     public void HandleFestivalEvents()
     {
-        if (Game1.CurrentEvent == null || !Game1.CurrentEvent.isFestival)
-        {
-            return;
-        }
-
-        if (_activeFestival == null)
+        if (Game1.CurrentEvent?.isFestival != true || _activeFestival == null)
         {
             return;
         }
@@ -369,11 +371,12 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Festivals with a host-triggered main event
+    /// Announce a countdown, start the host-triggered main event when it elapses,
+    /// then (for the Fair) auto-end. !event short-circuits the countdown.
     /// </summary>
     private void RunMainEventCountdown(FestivalSpec spec)
     {
-        if (eventCommandUsed)
+        if (_eventCommandUsed)
         {
             _runStartTime = DateTime.UtcNow.AddSeconds(-spec.CountdownSeconds());
             if (!_announced)
@@ -381,7 +384,7 @@ public class AlwaysOnServerFestivals
                 spec.OnAnnounce?.Invoke();
                 _announced = true;
             }
-            eventCommandUsed = false;
+            _eventCommandUsed = false;
         }
 
         if (!_runStartTime.HasValue)
@@ -416,6 +419,7 @@ public class AlwaysOnServerFestivals
             _started = true;
         }
 
+        // +5 ticks of slack so the main event has been kicked off before we start its timeout / auto-end
         if (elapsed >= countdownSeconds + 5.0 / 60.0)
         {
             if (spec.TimeoutStart == TimeoutStart.AfterMainEvent)
@@ -433,25 +437,20 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Festivals with no host-triggered main event
+    /// Festivals with no host-triggered main event. Like the game's DedicatedServer,
+    /// the host only leaves once other players are ready (handled in
+    /// <see cref="HandleFestivalLeave"/>); here we just run the wall-clock backstop
+    /// so an empty or AFK festival still ends.
     /// </summary>
     private void RunLeaveOnly(FestivalSpec spec)
     {
-        if (!_runStartTime.HasValue)
-        {
-            _runStartTime = DateTime.UtcNow;
-        }
-
         RunOfflineTimeout(spec);
-
-        if (ElapsedSeconds(_runStartTime) >= TicksToSeconds(10) && !_startedFestivalEnd)
-        {
-            _monitor.Log(spec.EndLogText);
-            Game1.CurrentEvent.TryStartEndFestivalDialogue(Game1.player);
-            _startedFestivalEnd = true;
-        }
     }
 
+    /// <summary>
+    /// Wall-clock backstop: warn at <see cref="AlwaysOnConfig.FestivalExitWarningSeconds"/>
+    /// before the timeout, then kick everyone (offline mode) so a stalled festival can't hang.
+    /// </summary>
     private void RunOfflineTimeout(FestivalSpec spec)
     {
         if (!_timeoutStartTime.HasValue)
@@ -462,6 +461,7 @@ public class AlwaysOnServerFestivals
         double resetElapsed = ElapsedSeconds(_timeoutStartTime);
         double timeoutSeconds = spec.TimeoutSeconds();
 
+        // FestivalExitWarningSeconds is already seconds (unlike the *TimeOut configs, which are ticks)
         if (!_timeoutWarned && resetElapsed >= timeoutSeconds - Config.FestivalExitWarningSeconds)
         {
             _helper.SendPublicMessage(
@@ -478,50 +478,52 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Called every tick. Handles leaving the festival when other players are ready.
-    /// Uses TryStartEndFestivalDialogue like the game's DedicatedServer does.
+    /// Called every tick. Ends the festival via TryStartEndFestivalDialogue, like the
+    /// game's DedicatedServer: immediately once the last player leaves, otherwise once
+    /// the remaining players are ready to leave.
     /// </summary>
     public void HandleFestivalLeave()
     {
-        if (Game1.otherFarmers.Count == 0)
-        {
-            return;
-        }
-
-        // Only handle if we're at a festival and haven't started ending yet
         if (Game1.CurrentEvent?.isFestival != true || _startedFestivalEnd)
         {
             return;
         }
 
-        // Debug: log festivalEnd ready state once per second
-        var endReady = Game1.netReady.GetNumberReady("festivalEnd");
-        var endRequired = Game1.netReady.GetNumberRequired("festivalEnd");
-        if ((DateTime.UtcNow - _lastLogTime).TotalSeconds >= 1.0)
+        // No players left at the festival: end it now so the host isn't stranded
+        // (mirrors DedicatedServer.Tick's onlineIds.Count == 0 branch).
+        if (Game1.otherFarmers.Count == 0)
         {
-            _lastLogTime = DateTime.UtcNow;
+            EndFestival("No players remaining at festival, triggering end dialogue");
+            return;
+        }
+
+        if ((DateTime.UtcNow - _lastLeaveLogTime).TotalSeconds >= 1.0)
+        {
+            _lastLeaveLogTime = DateTime.UtcNow;
+            var endReady = Game1.netReady.GetNumberReady("festivalEnd");
+            var endRequired = Game1.netReady.GetNumberRequired("festivalEnd");
             _monitor.Log(
                 $"[FestivalLeave] ready={endReady}/{endRequired}, CheckOthersReady={CheckOthersReady("festivalEnd")}",
-                LogLevel.Info
+                LogLevel.Trace
             );
         }
 
         if (CheckOthersReady("festivalEnd"))
         {
-            _monitor.Log(
-                "Other players ready to leave festival, triggering end dialogue",
-                LogLevel.Info
-            );
-            Game1.CurrentEvent.TryStartEndFestivalDialogue(Game1.player);
-            _startedFestivalEnd = true;
+            EndFestival("Other players ready to leave festival, triggering end dialogue");
         }
     }
 
+    private void EndFestival(string reason)
+    {
+        _monitor.Log(reason, LogLevel.Info);
+        Game1.CurrentEvent.TryStartEndFestivalDialogue(Game1.player);
+        _startedFestivalEnd = true;
+    }
+
     /// <summary>
-    /// Starts the current days event if there is any.
+    /// !event chat command: force-start today's main-event countdown.
     /// </summary>
-    /// <param name="args"></param>
-    /// <param name="msg"></param>
     private void StartEventCommand(string[] args, ReceivedMessage msg)
     {
         if (Game1.CurrentEvent is not { isFestival: true })
@@ -542,7 +544,7 @@ public class AlwaysOnServerFestivals
             return;
         }
 
-        eventCommandUsed = true;
+        _eventCommandUsed = true;
         _activeFestival = spec;
     }
 }

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -264,12 +264,16 @@ public class AlwaysOnServerFestivals
             var numberReady = Game1.netReady.GetNumberReady("festivalStart");
             var numberRequired = Game1.netReady.GetNumberRequired("festivalStart");
             _monitor.Log(
-                $"[Festival] otherFarmers={Game1.otherFarmers.Count}, isFestival={Game1.CurrentEvent?.isFestival}, warping={_warpingToFestival}, ready={numberReady}/{numberRequired}, CheckOthersReady={CheckOthersReady("festivalStart")}",
+                $"[Festival] online={CountOnlineOtherPlayers()}, otherFarmers={Game1.otherFarmers.Count}, isFestival={Game1.CurrentEvent?.isFestival}, warping={_warpingToFestival}, ready={numberReady}/{numberRequired}, CheckOthersReady={CheckOthersReady("festivalStart")}",
                 LogLevel.Trace
             );
         }
 
-        if (Game1.otherFarmers.Count == 0)
+        // Don't warp the host in if nobody (online, non-disconnecting) is there to attend.
+        // Consistent with the no-players end check; CurrentEvent is null here so otherFarmers
+        // would be live, but use the same online count so a player disconnecting mid-warp-in is
+        // seen immediately rather than one removeDisconnectedFarmers pass later.
+        if (CountOnlineOtherPlayers() == 0)
         {
             return;
         }
@@ -347,6 +351,30 @@ public class AlwaysOnServerFestivals
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Count online non-host players, excluding any mid-disconnect, mirroring how the game's
+    /// <c>DedicatedServer</c> builds its <c>onlineIds</c> set (DedicatedServer.cs:286-293).
+    ///
+    /// <para>
+    /// Do NOT use <c>Game1.otherFarmers.Count</c> for "is the festival empty?". A player who
+    /// disconnects mid-festival is only <i>marked</i> in <c>disconnectingFarmers</c>; the actual
+    /// <c>Game1.otherFarmers.Remove</c> runs in <c>Multiplayer.removeDisconnectedFarmers</c>, which
+    /// is gated on <c>Game1.CurrentEvent == null</c> (Multiplayer.cs:1821). So during a festival
+    /// the count never drops — and gating the no-players force-end on it would hang the festival
+    /// forever (event up → not removed → count stays 1 → never ends → event stays up).
+    /// <c>isDisconnecting</c> is the signal the engine itself uses to see through that.
+    /// </para>
+    /// </summary>
+    private static int CountOnlineOtherPlayers()
+    {
+        return Game1
+            .getOnlineFarmers()
+            .Count(f =>
+                f.UniqueMultiplayerID != Game1.player.UniqueMultiplayerID
+                && !Game1.Multiplayer.isDisconnecting(f)
+            );
     }
 
     /// <summary>
@@ -481,9 +509,10 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Called every tick. Ends the festival like the game's DedicatedServer: immediately
-    /// once the last player leaves (forceEndFestival), otherwise once the remaining players
-    /// are ready to leave (TryStartEndFestivalDialogue).
+    /// Called every tick. Ends the festival like the game's DedicatedServer: once no online
+    /// players remain, or once the remaining players are ready to leave. Both paths go through
+    /// <c>TryStartEndFestivalDialogue</c> (the host's own festivalEnd ready then satisfies the
+    /// check, since NumberRequired excludes disconnecting players) — matching DedicatedServer.cs:306.
     /// </summary>
     public void HandleFestivalLeave()
     {
@@ -492,13 +521,16 @@ public class AlwaysOnServerFestivals
             return;
         }
 
-        // No players left at the festival: end it now so the host isn't stranded
-        // (mirrors DedicatedServer.Tick's onlineIds.Count == 0 branch).
-        if (Game1.otherFarmers.Count == 0)
+        // No online players left at the festival: end it so the host isn't stranded. Mirrors
+        // DedicatedServer.Tick's onlineIds.Count == 0 branch (DedicatedServer.cs:294-308), which
+        // ends via TryStartEndFestivalDialogue (force: false) — with no one else online the host's
+        // own festivalEnd ready satisfies the check and the festival ends gracefully. Counts
+        // online non-disconnecting players, NOT otherFarmers.Count (see CountOnlineOtherPlayers).
+        if (CountOnlineOtherPlayers() == 0)
         {
             EndFestival(
                 "No players remaining at festival, ending and sending host home",
-                force: true
+                force: false
             );
             return;
         }
@@ -509,7 +541,7 @@ public class AlwaysOnServerFestivals
             var endReady = Game1.netReady.GetNumberReady("festivalEnd");
             var endRequired = Game1.netReady.GetNumberRequired("festivalEnd");
             _monitor.Log(
-                $"[FestivalLeave] ready={endReady}/{endRequired}, CheckOthersReady={CheckOthersReady("festivalEnd")}",
+                $"[FestivalLeave] online={CountOnlineOtherPlayers()}, ready={endReady}/{endRequired}, CheckOthersReady={CheckOthersReady("festivalEnd")}",
                 LogLevel.Trace
             );
         }
@@ -524,11 +556,12 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// End the active festival. <paramref name="force"/> = true calls
-    /// <c>forceEndFestival</c> (ends immediately, warps everyone home, no dialog) for the
-    /// no-players and timeout paths; false uses <c>TryStartEndFestivalDialogue</c> (the
-    /// ReadyCheckDialog flow) for the ready-check-met path, matching the game's DedicatedServer.
-    /// The <c>?.</c> guards against <c>CurrentEvent</c> clearing before this runs.
+    /// End the active festival. <paramref name="force"/> = true calls <c>forceEndFestival</c>
+    /// (ends immediately, warps everyone home, no dialog) for the wall-clock timeout backstop,
+    /// where players may still be online but stalled. false uses <c>TryStartEndFestivalDialogue</c>
+    /// (the ReadyCheckDialog flow) for the graceful paths — players ready to leave, or no online
+    /// players remaining — matching the game's DedicatedServer. The <c>?.</c> guards against
+    /// <c>CurrentEvent</c> clearing before this runs.
     /// </summary>
     private void EndFestival(string reason, bool force)
     {

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -314,10 +314,18 @@ public class AlwaysOnServerFestivals
     /// </summary>
     private void BeginActiveFestival()
     {
+        // Clear the end/timeout latches too, not just countdown state. Normally
+        // UpdateFestivalStatus's reset-cutoff path clears them when the prior festival's day
+        // ends, but a date jump (/test/set_date) lands at 06:00 — below any ResetCutoff — so a
+        // prior festival's _startedFestivalEnd can survive into the next one and make
+        // HandleFestivalLeave early-return, stranding it on the wall-clock timeout. Resetting
+        // here makes each festival start clean regardless of how the day changed.
+        ResetFestivalState();
         _activeFestival = _festivals.FirstOrDefault(spec => spec.IsToday());
         _runStartTime = null;
         _announced = false;
         _started = false;
+        _eventCommandUsed = false;
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -13,7 +13,7 @@ public class AlwaysOnServerFestivals
 {
     private const string StartNowText = "Type !event to start now";
 
-    // When the offline-timeout clock starts ticking
+    // When the timeout backstop clock starts ticking
     private enum TimeoutStart
     {
         OnEntry,
@@ -37,8 +37,11 @@ public class AlwaysOnServerFestivals
         public bool AutoEndAfterCountdown; // host ends the festival once the countdown elapses (Fair)
         public string EndLogText; // logged when AutoEndAfterCountdown fires
 
-        // Wall-clock backstop: kick everyone once this elapses (from entry or after the main event)
+        // Wall-clock backstop: end the festival and warp everyone home once this elapses
+        // (from entry or after the main event)
         public Func<double> TimeoutSeconds;
+
+        // Only read on the main-event path; leave-only festivals leave it defaulted (OnEntry).
         public TimeoutStart TimeoutStart;
     }
 
@@ -150,7 +153,6 @@ public class AlwaysOnServerFestivals
                 ResetCutoff = 2400,
                 RestoreHudOnReset = true,
                 HasMainEvent = false,
-                TimeoutStart = TimeoutStart.OnEntry,
                 TimeoutSeconds = () => TicksToSeconds(Config.SpiritsEveTimeOut),
             },
             new FestivalSpec
@@ -168,7 +170,6 @@ public class AlwaysOnServerFestivals
                 IsToday = SDateHelper.IsFeastOfWinterStarToday,
                 ResetCutoff = 1410,
                 HasMainEvent = false,
-                TimeoutStart = TimeoutStart.OnEntry,
                 TimeoutSeconds = () => TicksToSeconds(Config.WinterStarTimeOut),
             },
         };
@@ -233,7 +234,6 @@ public class AlwaysOnServerFestivals
 
     private void ResetFestivalState()
     {
-        Game1.options.setServerMode("online");
         _timeoutStartTime = null;
         _timeoutWarned = false;
         _warpingToFestival = false;
@@ -397,7 +397,7 @@ public class AlwaysOnServerFestivals
 
         if (spec.TimeoutStart == TimeoutStart.OnEntry)
         {
-            RunOfflineTimeout(spec);
+            RunFestivalTimeout(spec);
         }
 
         if (!_announced)
@@ -424,14 +424,12 @@ public class AlwaysOnServerFestivals
         {
             if (spec.TimeoutStart == TimeoutStart.AfterMainEvent)
             {
-                RunOfflineTimeout(spec);
+                RunFestivalTimeout(spec);
             }
 
             if (spec.AutoEndAfterCountdown && !_startedFestivalEnd)
             {
-                _monitor.Log(spec.EndLogText);
-                Game1.CurrentEvent.TryStartEndFestivalDialogue(Game1.player);
-                _startedFestivalEnd = true;
+                EndFestival(spec.EndLogText, force: false);
             }
         }
     }
@@ -444,14 +442,15 @@ public class AlwaysOnServerFestivals
     /// </summary>
     private void RunLeaveOnly(FestivalSpec spec)
     {
-        RunOfflineTimeout(spec);
+        RunFestivalTimeout(spec);
     }
 
     /// <summary>
     /// Wall-clock backstop: warn at <see cref="AlwaysOnConfig.FestivalExitWarningSeconds"/>
-    /// before the timeout, then kick everyone (offline mode) so a stalled festival can't hang.
+    /// before the timeout, then end the festival and warp everyone home so a stalled
+    /// festival can't hang.
     /// </summary>
-    private void RunOfflineTimeout(FestivalSpec spec)
+    private void RunFestivalTimeout(FestivalSpec spec)
     {
         if (!_timeoutStartTime.HasValue)
         {
@@ -465,22 +464,26 @@ public class AlwaysOnServerFestivals
         if (!_timeoutWarned && resetElapsed >= timeoutSeconds - Config.FestivalExitWarningSeconds)
         {
             _helper.SendPublicMessage(
-                $"{Config.FestivalExitWarningSeconds / 60f:0.#} minutes to the exit or"
+                $"{Config.FestivalExitWarningSeconds / 60f:0.#} minutes to the exit or everyone will be sent home."
             );
-            _helper.SendPublicMessage("everyone will be kicked.");
             _timeoutWarned = true;
         }
 
-        if (resetElapsed >= timeoutSeconds)
+        // !_startedFestivalEnd so this and HandleFestivalLeave's no-players path don't
+        // both fire on the same tick.
+        if (resetElapsed >= timeoutSeconds && !_startedFestivalEnd)
         {
-            Game1.options.setServerMode("offline");
+            EndFestival(
+                "Festival timeout reached, ending festival and sending players home",
+                force: true
+            );
         }
     }
 
     /// <summary>
-    /// Called every tick. Ends the festival via TryStartEndFestivalDialogue, like the
-    /// game's DedicatedServer: immediately once the last player leaves, otherwise once
-    /// the remaining players are ready to leave.
+    /// Called every tick. Ends the festival like the game's DedicatedServer: immediately
+    /// once the last player leaves (forceEndFestival), otherwise once the remaining players
+    /// are ready to leave (TryStartEndFestivalDialogue).
     /// </summary>
     public void HandleFestivalLeave()
     {
@@ -493,7 +496,10 @@ public class AlwaysOnServerFestivals
         // (mirrors DedicatedServer.Tick's onlineIds.Count == 0 branch).
         if (Game1.otherFarmers.Count == 0)
         {
-            EndFestival("No players remaining at festival, triggering end dialogue");
+            EndFestival(
+                "No players remaining at festival, ending and sending host home",
+                force: true
+            );
             return;
         }
 
@@ -510,14 +516,31 @@ public class AlwaysOnServerFestivals
 
         if (CheckOthersReady("festivalEnd"))
         {
-            EndFestival("Other players ready to leave festival, triggering end dialogue");
+            EndFestival(
+                "Other players ready to leave festival, triggering end dialogue",
+                force: false
+            );
         }
     }
 
-    private void EndFestival(string reason)
+    /// <summary>
+    /// End the active festival. <paramref name="force"/> = true calls
+    /// <c>forceEndFestival</c> (ends immediately, warps everyone home, no dialog) for the
+    /// no-players and timeout paths; false uses <c>TryStartEndFestivalDialogue</c> (the
+    /// ReadyCheckDialog flow) for the ready-check-met path, matching the game's DedicatedServer.
+    /// The <c>?.</c> guards against <c>CurrentEvent</c> clearing before this runs.
+    /// </summary>
+    private void EndFestival(string reason, bool force)
     {
         _monitor.Log(reason, LogLevel.Info);
-        Game1.CurrentEvent.TryStartEndFestivalDialogue(Game1.player);
+        if (force)
+        {
+            Game1.CurrentEvent?.forceEndFestival(Game1.player);
+        }
+        else
+        {
+            Game1.CurrentEvent?.TryStartEndFestivalDialogue(Game1.player);
+        }
         _startedFestivalEnd = true;
     }
 

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -122,6 +122,45 @@ public class TestHouseUpgradeResponse
 }
 
 /// <summary>
+/// Response from GET /test/festival_state (test-only). A direct read of the host's
+/// festival state, so E2E tests can assert "festival still active" / "festival ended"
+/// without proxying through the client's location (which reads "Temp" during a festival)
+/// or the timeOfDay jump. Mirrors the signals the AlwaysOnServerFestivals service acts on.
+/// </summary>
+public class TestFestivalStateResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>True if today is a festival day (SDateHelper.IsFestivalToday).</summary>
+    public bool IsFestivalDay { get; set; }
+
+    /// <summary>
+    /// The festival map name today, or null. Populated only by a real day-transition
+    /// (sleep-through) — empty after /test/set_date alone (see host-automation.md item 3).
+    /// </summary>
+    public string? WhereIsTodaysFest { get; set; }
+
+    /// <summary>
+    /// True once the festival event is loaded and running (Game1.CurrentEvent.isFestival).
+    /// This is the headline signal: it stays true while players are at the festival and
+    /// flips to false when the festival ends.
+    /// </summary>
+    public bool IsFestivalActive { get; set; }
+
+    /// <summary>Game1.netReady ready/required counts for the festivalStart check.</summary>
+    public int FestivalStartReady { get; set; }
+    public int FestivalStartRequired { get; set; }
+
+    /// <summary>Game1.netReady ready/required counts for the festivalEnd check.</summary>
+    public int FestivalEndReady { get; set; }
+    public int FestivalEndRequired { get; set; }
+
+    /// <summary>Current in-game time (HHMM). Jumps to the festival's reset cutoff once it ends.</summary>
+    public int TimeOfDay { get; set; }
+}
+
+/// <summary>
 /// Response from POST /test/stamp_claim (test-only). Constructs an abandoned-claim slot
 /// deterministically: stamps a synthetic userID onto an uncustomized, homed farmhandData entry,
 /// reproducing the on-disk shape (<c>userID != "" &amp;&amp; isCustomized == false</c>, homeLocation

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -56,6 +56,9 @@ public partial class ApiService
                     case "/test/crops":
                         await WriteJsonAsync(response, await HandleGetTestCropsAsync());
                         return;
+                    case "/test/festival_state":
+                        await WriteJsonAsync(response, await HandleGetTestFestivalStateAsync());
+                        return;
                 }
                 break;
             case "POST":
@@ -172,6 +175,41 @@ public partial class ApiService
     }
 
     [ApiEndpoint(
+        "GET",
+        "/test/festival_state",
+        Summary = "Read the host's current festival state (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestFestivalStateResponse), 200)]
+    private async Task<TestFestivalStateResponse> HandleGetTestFestivalStateAsync()
+    {
+        var result = new TestFestivalStateResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                result.IsFestivalDay = SDateHelper.IsFestivalToday();
+                result.WhereIsTodaysFest = Game1.whereIsTodaysFest;
+                result.IsFestivalActive = Game1.CurrentEvent?.isFestival == true;
+                result.FestivalStartReady = Game1.netReady.GetNumberReady("festivalStart");
+                result.FestivalStartRequired = Game1.netReady.GetNumberRequired("festivalStart");
+                result.FestivalEndReady = Game1.netReady.GetNumberReady("festivalEnd");
+                result.FestivalEndRequired = Game1.netReady.GetNumberRequired("festivalEnd");
+                result.TimeOfDay = Game1.timeOfDay;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
         "POST",
         "/test/set_date",
         Summary = "Set season/day/year directly (test-only)",
@@ -243,11 +281,22 @@ public partial class ApiService
             Game1.season = season;
             Game1.dayOfMonth = body.Day;
             Game1.year = body.Year;
-            // Writes to Game1.season/dayOfMonth/year mirror NetWorldState
-            // fields that replicate to peers. Without this push, the next
-            // peer's sendServerIntroduction snapshot carries the previous
-            // day's stale NetField — see decompiled Game1.cs:8264 for
-            // Stardew's own day-end usage of the same primitive.
+
+            // Reconcile the date-dependent host state, mirroring the engine's own new-day reset
+            // block (newDayAfterFade, Game1.cs:7818/7842/updateWeatherIcon): a date jump is "start
+            // of this day", so reset to morning, clear any prior festival target, and recompute the
+            // host's weather icon from the new date. weatherIcon is local (not replicated) — each
+            // instance derives it from isFestivalDay — so this only fixes the host; clients recompute
+            // theirs once the date replicates. Without it, a stale weatherIcon == 1 (festival) bleeds
+            // onto a non-festival day, making performTenMinuteClockUpdate load a non-existent
+            // Data/Festivals/<season><day> file and crash the update loop.
+            Game1.timeOfDay = 600;
+            Game1.gameTimeInterval = 0;
+            Game1.whereIsTodaysFest = null;
+            Game1.updateWeatherIcon();
+
+            // Push the reconciled date + time to NetWorldState so peers replicate them (both are
+            // replicated NetFields; see decompiled Game1.cs:8264 for Stardew's own day-end usage).
             Game1.netWorldState.Value.UpdateFromGame1();
         });
 

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -297,7 +297,8 @@ public partial class ApiService
 
             // Push the reconciled date + time to NetWorldState so peers replicate them (both are
             // replicated NetFields; see decompiled Game1.cs:8264 for Stardew's own day-end usage).
-            Game1.netWorldState.Value.UpdateFromGame1();
+            // Null-safe: netWorldState.Value is null before a save loads.
+            Game1.netWorldState?.Value?.UpdateFromGame1();
         });
 
         Monitor.Log(

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -276,6 +276,14 @@ public partial class ApiService
             };
         }
 
+        // Fail closed before mutating: with no world loaded netWorldState.Value is null, so the
+        // replication push below would silently no-op while we still reported Success — E2E setup
+        // would advance on a date jump that never reached peers. (gameMode == 3 is playingGameMode.)
+        if (Game1.gameMode != 3 || !Game1.IsServer)
+        {
+            return new TestSetDateResponse { Success = false, Error = "Server not ready" };
+        }
+
         await RunOnGameThreadAsync(() =>
         {
             Game1.season = season;
@@ -297,8 +305,7 @@ public partial class ApiService
 
             // Push the reconciled date + time to NetWorldState so peers replicate them (both are
             // replicated NetFields; see decompiled Game1.cs:8264 for Stardew's own day-end usage).
-            // Null-safe: netWorldState.Value is null before a save loads.
-            Game1.netWorldState?.Value?.UpdateFromGame1();
+            Game1.netWorldState.Value.UpdateFromGame1();
         });
 
         Monitor.Log(

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -3996,7 +3996,8 @@ public partial class ApiService : ModService
             // local write never reaches clients, which keep their stale time until the host's
             // next natural 10-minute tick broadcasts a delta. Push it so SetTime is observable
             // on peers immediately (mirrors /test/set_date's same UpdateFromGame1 call).
-            Game1.netWorldState.Value.UpdateFromGame1();
+            // Null-safe: netWorldState.Value is null before a save loads.
+            Game1.netWorldState?.Value?.UpdateFromGame1();
         });
         Monitor.Log($"Time set to {time} via API", LogLevel.Info);
 

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -3992,6 +3992,11 @@ public partial class ApiService : ModService
         {
             Game1.timeOfDay = time;
             Game1.gameTimeInterval = 0;
+            // timeOfDay is a replicated NetWorldState field; without this push the host's
+            // local write never reaches clients, which keep their stale time until the host's
+            // next natural 10-minute tick broadcasts a delta. Push it so SetTime is observable
+            // on peers immediately (mirrors /test/set_date's same UpdateFromGame1 call).
+            Game1.netWorldState.Value.UpdateFromGame1();
         });
         Monitor.Log($"Time set to {time} via API", LogLevel.Info);
 

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -3988,6 +3988,19 @@ public partial class ApiService : ModService
             };
         }
 
+        // Fail closed before mutating: with no world loaded netWorldState.Value is null, so the
+        // replication push below would silently no-op while we still reported Success — the time
+        // would never reach peers. (gameMode == 3 is playingGameMode; pattern matches /roles.)
+        if (Game1.gameMode != 3 || !Game1.IsServer)
+        {
+            return new TimeSetResponse
+            {
+                Success = false,
+                TimeOfDay = Game1.timeOfDay,
+                Error = "Server not ready",
+            };
+        }
+
         await RunOnGameThreadAsync(() =>
         {
             Game1.timeOfDay = time;
@@ -3996,8 +4009,7 @@ public partial class ApiService : ModService
             // local write never reaches clients, which keep their stale time until the host's
             // next natural 10-minute tick broadcasts a delta. Push it so SetTime is observable
             // on peers immediately (mirrors /test/set_date's same UpdateFromGame1 call).
-            // Null-safe: netWorldState.Value is null before a save loads.
-            Game1.netWorldState?.Value?.UpdateFromGame1();
+            Game1.netWorldState.Value.UpdateFromGame1();
         });
         Monitor.Log($"Time set to {time} via API", LogLevel.Info);
 

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -217,6 +217,15 @@ public class WarpResult
     public string? LocationName { get; set; }
 }
 
+public class LeaveFestivalResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 public class PlacePotResult
 {
     [JsonPropertyName("success")]
@@ -407,6 +416,24 @@ public class FarmerInfoResponse
 
     [JsonPropertyName("uniqueId")]
     public string UniqueId { get; set; } = string.Empty;
+
+    [JsonPropertyName("weatherIcon")]
+    public int WeatherIcon { get; set; }
+
+    [JsonPropertyName("whereIsTodaysFest")]
+    public string? WhereIsTodaysFest { get; set; }
+
+    [JsonPropertyName("isFestival")]
+    public bool IsFestival { get; set; }
+
+    [JsonPropertyName("festivalStartReady")]
+    public int FestivalStartReady { get; set; }
+
+    [JsonPropertyName("festivalStartRequired")]
+    public int FestivalStartRequired { get; set; }
+
+    [JsonPropertyName("timeOfDay")]
+    public int TimeOfDay { get; set; }
 }
 
 #endregion
@@ -560,6 +587,18 @@ public class ActionsClient
     public Task<SleepResult?> Sleep()
     {
         return _client.PostAsync<SleepResult>("/actions/sleep", new { });
+    }
+
+    /// <summary>
+    /// Vote to leave the current festival (the real-player exit path). Returns
+    /// Success=false if the client isn't at a festival. The festival only ends
+    /// once the host is also ready, so callers should then poll
+    /// <see cref="ServerApiClient.GetFestivalState"/> for IsFestivalActive=false.
+    /// POST /actions/leave_festival
+    /// </summary>
+    public Task<LeaveFestivalResult?> LeaveFestival()
+    {
+        return _client.PostAsync<LeaveFestivalResult>("/actions/leave_festival", new { });
     }
 
     /// <summary>
@@ -1004,6 +1043,19 @@ public class GameTestClient : IDisposable
             PlayerName = status.Farmer?.Name,
             UniqueId = status.Farmer?.UniqueId,
         };
+    }
+
+    /// <summary>
+    /// Raw client-side farmer info, including the festival diagnostic fields
+    /// (weatherIcon, whereIsTodaysFest, festivalStart ready). Used to debug
+    /// festival-entry failures — the host warps in only when this client has
+    /// whereIsTodaysFest set locally and festivalStart ready.
+    /// GET /status
+    /// </summary>
+    public async Task<FarmerInfoResponse?> GetFestivalDebug()
+    {
+        var status = await GetAsync<StatusResponse>("/status");
+        return status?.Farmer;
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -445,6 +445,43 @@ public class TestCropsResponse
 }
 
 /// <summary>
+/// Response from /test/festival_state GET endpoint (test-only). Mirrors the server-side
+/// TestFestivalStateResponse DTO — a direct read of the host's festival state.
+/// </summary>
+public class TestFestivalStateResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("isFestivalDay")]
+    public bool IsFestivalDay { get; set; }
+
+    [JsonPropertyName("whereIsTodaysFest")]
+    public string? WhereIsTodaysFest { get; set; }
+
+    [JsonPropertyName("isFestivalActive")]
+    public bool IsFestivalActive { get; set; }
+
+    [JsonPropertyName("festivalStartReady")]
+    public int FestivalStartReady { get; set; }
+
+    [JsonPropertyName("festivalStartRequired")]
+    public int FestivalStartRequired { get; set; }
+
+    [JsonPropertyName("festivalEndReady")]
+    public int FestivalEndReady { get; set; }
+
+    [JsonPropertyName("festivalEndRequired")]
+    public int FestivalEndRequired { get; set; }
+
+    [JsonPropertyName("timeOfDay")]
+    public int TimeOfDay { get; set; }
+}
+
+/// <summary>
 /// Response from /test/set_date POST endpoint.
 /// </summary>
 public class TestSetDateResponse
@@ -1223,6 +1260,20 @@ public class ServerApiClient : IDisposable
         var response = await _httpClient.GetAsync("/test/crops", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestCropsResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: read the host's current festival state directly (whether a festival
+    /// is active, today's festival map, and the festivalStart/festivalEnd ready counts).
+    /// Used by FestivalTests to assert festival-active / festival-ended without proxying
+    /// through the client location (which reads "Temp" during a festival).
+    /// GET /test/festival_state
+    /// </summary>
+    public async Task<TestFestivalStateResponse?> GetFestivalState(CancellationToken ct = default)
+    {
+        var response = await _httpClient.GetAsync("/test/festival_state", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestFestivalStateResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -1,0 +1,501 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E coverage for festival handling (<c>AlwaysOnServerFestivals</c>).
+///
+/// <para>
+/// The headline test is the regression gate for the leave-only auto-end bug: the two
+/// no-main-event festivals (Spirit's Eve, Feast of Winter Star) used to host-end ~0.17 s
+/// after loading (<c>RunLeaveOnly</c> firing <c>TicksToSeconds(10)</c>). The fix removed
+/// that auto-end so the festival only ends when players leave or the wall-clock timeout
+/// elapses. Nothing automated caught the bug before; these tests are that gate.
+/// </para>
+///
+/// <para>
+/// <b>Entry mechanic (verified against the decompiled source).</b> A festival is entered
+/// by warping a connected client to the festival map (Spirit's Eve = "Town") <i>during the
+/// festival's time window</i> (fall27 conditions "Town/2200 2350"). The day-transition
+/// lands at 06:00, so each test <see cref="ServerApiClient.SetTime"/>s into the window
+/// before warping. <c>Game1.warpFarmer</c> then sets the client's <c>festivalStart</c>
+/// ready flag and opens an auto-confirming <c>ReadyCheckDialog</c>; the host's
+/// <c>HandleFestivalStart</c> sees <c>CheckOthersReady("festivalStart")</c>, warps in and
+/// sets its own ready, the dialog auto-confirms, and the client warps into the festival.
+/// No manual menu click is needed.
+/// </para>
+///
+/// <para>
+/// <b>Observation.</b> During an active festival the client's <c>CurrentLocation</c> reads
+/// "Temp" (the festival temp location <c>new Town("Maps\\Town", "Temp")</c>), not "Town",
+/// so location is a poor proxy. Tests assert via the test-only <c>/test/festival_state</c>
+/// endpoint (<see cref="ServerApiClient.GetFestivalState"/>), whose <c>IsFestivalActive</c>
+/// mirrors <c>Game1.CurrentEvent.isFestival</c> — true while the festival runs, false once
+/// it ends.
+/// </para>
+/// </summary>
+// Exclusive (not just SharedClass): these tests mutate GLOBAL game state — the calendar
+// (SetDate/SetTime), Game1.whereIsTodaysFest, and the single AlwaysOnServerFestivals
+// instance. xUnit v3 starts a class's methods concurrently and SharedClass does NOT
+// serialize them, so without Exclusive all four would race the one game clock (Test 1's
+// Fall 27 vs Test 4's Spring 13, etc.). Exclusive serializes the methods via the
+// per-class turn lock and holds the gate between them so another class can't /newgame the
+// shared server mid-test. (Not KeepConnected, so the Exclusive+KeepConnected broker
+// prohibition doesn't apply.)
+[TestServer(Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class FestivalTests : TestBase
+{
+    // Festival time windows (Data/Festivals "conditions"). A player can only enter between
+    // Open and Close; warpFarmer bounces them before Open and ignores the festival after Close.
+    // The test enters at Open to maximise in-window runway (the clock runs at 1x during entry).
+    private static readonly (int Open, int Close) SpiritsEveWindow = (2200, 2350);
+    private static readonly (int Open, int Close) IceWindow = (900, 1400);
+    private static readonly (int Open, int Close) EggWindow = (900, 1400);
+
+    // Spirit's Eve: Fall 27, leave-only (HasMainEvent = false), in Town.
+    private const string SpiritsEveSeason = "fall";
+    private const int SpiritsEveDay = 27;
+    private const int SpiritsEveBeforeDay = 26;
+
+    // Festival of Ice: Winter 8, main-event (HasMainEvent = true), in Forest.
+    // Test 3's "next festival" — a different season so it can't collide with the Spirit's Eve
+    // calendar state on the shared-class server.
+    private const string IceSeason = "winter";
+    private const int IceDay = 8;
+    private const int IceBeforeDay = 7;
+    private const string IceLocation = "Forest";
+
+    // Egg Festival: Spring 13, main-event, in Town. Used by Test 4.
+    private const string EggSeason = "spring";
+    private const int EggDay = 13;
+    private const int EggBeforeDay = 12;
+
+    // Per-map warp-in tiles (the engine's own area-warp tiles, Game1.cs:13204/13212).
+    // warpFarmer's festival-entry guard keys on the location NAME matching whereIsTodaysFest,
+    // not the tile, so any in-bounds tile on the festival map triggers entry.
+    private static readonly (int X, int Y) TownEntryTile = (35, 35);
+    private static readonly (int X, int Y) ForestEntryTile = (34, 13);
+
+    // How long a festival must stay active to prove the 0.17s auto-end is gone. Comfortably
+    // larger than the old window, far below the ~33-min (SpiritsEveTimeOut) wall-clock backstop.
+    private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
+
+    /// <summary>
+    /// Test 1 (the regression gate): Spirit's Eve does NOT auto-end immediately.
+    ///
+    /// Pre-fix, <c>RunLeaveOnly</c> fired <c>TryStartEndFestivalDialogue</c> ~0.17 s after
+    /// the festival loaded, ending it before the player could do anything. With the fix the
+    /// festival stays active until a player leaves or the wall-clock timeout elapses, so it
+    /// must still be active several seconds after entry.
+    /// </summary>
+    [Fact]
+    public async Task SpiritsEve_DoesNotAutoEndImmediately()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await EnterFestivalAsync(
+            SpiritsEveSeason,
+            SpiritsEveBeforeDay,
+            SpiritsEveDay,
+            SpiritsEveWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestEve",
+            ct
+        );
+
+        // The fix is the only thing keeping the festival alive here: pre-fix it would have
+        // ended within ~0.17s. Poll for the whole settle window and fail the moment the
+        // festival is observed inactive.
+        var endedEarly = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_StillActiveAfterSettle,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive != true;
+            },
+            timeout: FestivalSettleWindow,
+            cancellationToken: ct
+        );
+
+        Assert.False(
+            endedEarly,
+            $"Spirit's Eve ended within {FestivalSettleWindow.TotalSeconds:0}s of entry. "
+                + "Pre-fix, RunLeaveOnly's TicksToSeconds(10) ≈ 0.17s auto-end did exactly this; "
+                + "the leave-only fix removed it so the festival must stay active until players leave."
+        );
+
+        // Sanity: confirm it is genuinely still active (not merely "not yet ended" due to a
+        // read race) and that the festival event is the one we entered.
+        var finalState = await ServerApi.GetFestivalState(ct);
+        Assert.NotNull(finalState);
+        Assert.True(finalState.Success, $"festival_state read failed: {finalState.Error}");
+        Assert.True(
+            finalState.IsFestivalActive,
+            "Festival should still be active after the settle window"
+        );
+        LogSuccess("Spirit's Eve stayed active through the settle window (no insta-end)");
+    }
+
+    /// <summary>
+    /// Test 2: the festival ends when the connected player votes to leave.
+    ///
+    /// Exercises the intended end path: the client's <c>festivalEnd</c> ready (via the new
+    /// <c>leave_festival</c> action → <c>TryStartEndFestivalDialogue</c>) satisfies the host's
+    /// <c>HandleFestivalLeave</c> <c>CheckOthersReady("festivalEnd")</c>, which ends it.
+    /// </summary>
+    [Fact]
+    public async Task SpiritsEve_EndsWhenPlayerLeaves()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await EnterFestivalAsync(
+            SpiritsEveSeason,
+            SpiritsEveBeforeDay,
+            SpiritsEveDay,
+            SpiritsEveWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestLeave",
+            ct
+        );
+
+        // Vote to leave (real-player exit path). The host votes too once it sees us ready,
+        // satisfying festivalEnd and ending the festival for everyone.
+        var leave = await GameClient.Actions.LeaveFestival();
+        Assert.NotNull(leave);
+        Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
+
+        var ended = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_EndedAfterLeave,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == false;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(
+            ended,
+            "Festival should end after the connected player votes to leave "
+                + "(host's HandleFestivalLeave -> CheckOthersReady(\"festivalEnd\"))."
+        );
+        LogSuccess("Spirit's Eve ended after the player voted to leave");
+    }
+
+    /// <summary>
+    /// Test 3: an empty festival ends on its own (no online players left), and the NEXT festival
+    /// is still leavable — guarding both the no-online-players end and the per-festival state reset.
+    ///
+    /// Disconnecting the only client leaves nobody online at the festival; the host's
+    /// <c>HandleFestivalLeave</c> no-online-players branch (<c>CountOnlineOtherPlayers() == 0</c>)
+    /// ends it gracefully via the host's own festivalEnd ready. Then a fresh client enters a later
+    /// festival (Festival of Ice) and votes to leave: that leave must be honoured, which it isn't
+    /// if a stale <c>_startedFestivalEnd</c> survives the empty festival (the engine sets
+    /// timeOfDay to 2400 on the Spirit's Eve fade, which fires <c>UpdateFestivalStatus</c>'s reset).
+    /// </summary>
+    [Fact]
+    public async Task EmptyFestivalEnds_AndNextFestivalIsLeavable()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var farmhand = await EnterFestivalAsync(
+            SpiritsEveSeason,
+            SpiritsEveBeforeDay,
+            SpiritsEveDay,
+            SpiritsEveWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestEmpty",
+            ct
+        );
+
+        // Disconnect the only player — nobody is left at the festival.
+        await Farmers.DisconnectAndWaitForSlotAsync(
+            farmhand.JoinResult.UniqueMultiplayerId,
+            farmhand.FarmerName,
+            ct
+        );
+
+        // The host ends the now-empty festival via HandleFestivalLeave's no-online-players branch.
+        var emptyEnded = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_EndedNoPlayers,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == false;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            emptyEnded,
+            "An empty festival (no online players left) should end via HandleFestivalLeave's "
+                + "CountOnlineOtherPlayers() == 0 branch — otherFarmers.Count can't reach 0 during a "
+                + "festival, so the end must key off the online (non-disconnecting) count."
+        );
+        LogSuccess("Empty Spirit's Eve ended with no online players present");
+
+        // Connect a fresh client and enter the next festival, the Festival of Ice (Winter 8).
+        // EnterFestivalAsync already asserts it becomes active.
+        var nextFarmhand = await EnterFestivalAsync(
+            IceSeason,
+            IceBeforeDay,
+            IceDay,
+            IceWindow,
+            IceLocation,
+            ForestEntryTile,
+            namePrefix: "FestNext",
+            ct
+        );
+        Assert.NotNull(nextFarmhand);
+
+        // The real gate for the per-festival reset: the next festival must be able to END VIA LEAVE.
+        // A stale _startedFestivalEnd (carried over from the empty Spirit's Eve) would make
+        // HandleFestivalLeave early-return on its _startedFestivalEnd guard, so the player's leave
+        // vote would be ignored and the festival could only end via the ~33-min wall-clock timeout.
+        // UpdateFestivalStatus clears _startedFestivalEnd once timeOfDay passes the festival's reset
+        // cutoff while _activeFestival is set — and the engine sets timeOfDay to 2400 on the Spirit's
+        // Eve end fade (Event.cs:4780), which deterministically trips that reset.
+        var leaveNext = await GameClient.Actions.LeaveFestival();
+        Assert.NotNull(leaveNext);
+        Assert.True(
+            leaveNext.Success,
+            $"leave_festival on the next festival failed: {leaveNext.Error}"
+        );
+
+        var nextEnded = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_NextFestivalEndedOnLeave,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == false;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            nextEnded,
+            "The Festival of Ice should end when the player leaves — a stale _startedFestivalEnd "
+                + "from the empty Spirit's Eve would make HandleFestivalLeave early-return and ignore "
+                + "the leave vote. This is the regression gate for the UpdateFestivalStatus reset."
+        );
+        LogSuccess("Festival of Ice ran cleanly and ended on leave after the empty-festival end");
+    }
+
+    /// <summary>
+    /// Test 4: a main-event festival (Egg Festival) skips its countdown via <c>!event</c> and
+    /// proceeds. Lower priority — main-event festivals weren't the leave-only bug — but it
+    /// covers the <c>!event</c> path so the main-event branch has a runtime gate too.
+    /// </summary>
+    [Fact]
+    public async Task EggFestival_MainEventStartsWithCountdownSkip()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        await EnterFestivalAsync(
+            EggSeason,
+            EggBeforeDay,
+            EggDay,
+            EggWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestEgg",
+            ct
+        );
+
+        // On a main-event festival the host announces the countdown within ~1s of the festival
+        // becoming active (RunMainEventCountdown's announce block). Wait for it from chat history
+        // — this confirms we entered a real main-event festival and the countdown is running.
+        var announce = await GameClient.Chat.WaitForMessageContainingAsync(
+            new[] { "Egg Hunt", "!event" },
+            timeout: TestTimings.ChatCommandTimeout
+        );
+        Assert.NotNull(announce);
+
+        // Skip the 5-minute wall-clock countdown via !event (otherwise the main event waits 5 real
+        // minutes). The success path sends no reply, so assert on the festival state, not a chat
+        // response: !event back-dates the countdown so the host immediately answers the festival
+        // host's "start the event?" dialogue — the festival stays active while the main event runs.
+        var sent = await GameClient.Chat.Send("!event");
+        Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
+
+        // Give the once-per-second HandleFestivalEvents a moment to consume the command and kick off
+        // the main event, then confirm the festival is still active (the main event runs inside it —
+        // !event must not have broken or prematurely ended it).
+        var brokeOrEnded = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_MainEventStillActive,
+            async () =>
+            {
+                var s = await ServerApi.GetFestivalState(ct);
+                return s?.IsFestivalActive != true;
+            },
+            timeout: FestivalSettleWindow,
+            cancellationToken: ct
+        );
+        Assert.False(
+            brokeOrEnded,
+            "Egg Festival should still be active while its main event runs after the !event skip — "
+                + "!event must start the main event in place, not end the festival."
+        );
+        LogSuccess("Egg Festival accepted the !event countdown skip and kept running");
+    }
+
+    /// <summary>
+    /// Connects a client, sleeps through to the given festival day, moves the clock into the
+    /// festival window, waits for the client to sync into that window, warps it into the festival
+    /// map, and waits until the host has warped in and the festival is active. Returns the client.
+    ///
+    /// <para>
+    /// Order matters: <see cref="ServerApiClient.SetTime"/> into the window happens AFTER the
+    /// day-transition (which lands at 06:00); the warp happens only AFTER the client's own clock
+    /// has caught up to the window. warpFarmer's festival-entry guard reads the warping player's
+    /// LOCAL time, so warping before the client syncs bounces it with "festival is being set up".
+    /// </para>
+    /// </summary>
+    private async Task<Infrastructure.Fixture.FarmerTestHelper.ClientConnection> EnterFestivalAsync(
+        string season,
+        int dayBefore,
+        int festivalDay,
+        (int Open, int Close) window,
+        string festivalLocation,
+        (int X, int Y) entryTile,
+        string namePrefix,
+        CancellationToken ct
+    )
+    {
+        // Land on the day before the festival, then connect a client.
+        var setDate = await ServerApi.SetDate(season, dayBefore, year: 1, ct);
+        Assert.NotNull(setDate);
+        Assert.True(setDate.Success, $"SetDate({season} {dayBefore}) failed: {setDate.Error}");
+
+        var farmhand = await Farmers.ConnectNewAsync(namePrefix: namePrefix, ct: ct);
+
+        // Sleep-through to the festival day. The client sleeps, the host auto-sleeps, and the
+        // day transitions — the only path that populates Game1.whereIsTodaysFest (a /test/set_date
+        // jump does not; see host-automation.md item 3). SetClockSpeed(20) accelerates any
+        // remaining in-game time so the transition completes in seconds.
+        var sleep = await GameClient.Actions.Sleep();
+        Assert.NotNull(sleep);
+        Assert.True(sleep.Success, $"Sleep action failed: {sleep.Error}");
+
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var (dayChanged, disconnected) = await DayChange.WaitAsync(
+                dayBefore,
+                season,
+                year: 1,
+                checkConnection: true,
+                ct
+            );
+            Assert.False(
+                disconnected,
+                "Farmhand disconnected during the sleep-through to the festival day"
+            );
+            Assert.True(dayChanged, $"Day did not advance to {season} {festivalDay}");
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+
+        // Confirm we landed on the festival day with whereIsTodaysFest populated before trying to
+        // enter — a clearer failure than a downstream warp/entry timeout. whereIsTodaysFest is set
+        // by the time-update tick, not the day flip / IsReady gate, so poll rather than read once.
+        var onFestivalDay = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_DayConfirmed,
+            async () =>
+            {
+                var s = await ServerApi.GetFestivalState(ct);
+                return s?.IsFestivalDay == true && s.WhereIsTodaysFest == festivalLocation;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            onFestivalDay,
+            $"Expected festival day {season} {festivalDay} with whereIsTodaysFest == \"{festivalLocation}\"."
+        );
+
+        // Move the server clock to the festival window's open time. The window is real game
+        // behavior: warpFarmer only arms festivalStart when the warping player's LOCAL time is
+        // inside it (fall27 = 2200-2350); before it, the engine bounces the player with
+        // "Today's festival is being set up. Come back later." (Game1.cs:9961-9967). Entering at
+        // Open maximises runway since the clock runs at 1x while we sync and warp.
+        var setTime = await ServerApi.SetTime(window.Open, ct);
+        Assert.NotNull(setTime);
+        Assert.True(setTime.Success, $"SetTime({window.Open}) failed: {setTime.Error}");
+
+        // Wait for the CLIENT to actually be festival-ready before warping it in. SetTime mutates
+        // the server clock; the client only learns the new time/festival-day state when the host's
+        // world-state broadcast reaches it. Warping before that sync lands warps the client at its
+        // stale pre-window local time (e.g. 0630) → the engine bounces it home, festivalStart never
+        // arms, and the host never warps in. Gate on the client's own /status: its local time must
+        // be in the window with whereIsTodaysFest/weatherIcon synced, mirroring a real player
+        // standing in Town as the clock ticks into the window. The window check is [Open, Close):
+        // the engine permits entry through Close inclusive (Game1.cs:9959), but we stop one tick
+        // short so the clock can't tick past Close during the async warp and bounce the client.
+        var clientReady = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_ClientWindowSynced,
+            async () =>
+            {
+                var f = await GameClient.GetFestivalDebug();
+                return f is { WeatherIcon: 1 }
+                    && f.WhereIsTodaysFest == festivalLocation
+                    && f.TimeOfDay >= window.Open
+                    && f.TimeOfDay < window.Close;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            clientReady,
+            $"Client never synced into the festival window (expected whereIsTodaysFest == "
+                + $"\"{festivalLocation}\", weatherIcon == 1, {window.Open} <= timeOfDay < {window.Close})."
+        );
+
+        // Warp the client into the festival map. Now that the client's local time is in-window, the
+        // warp arms festivalStart + opens an auto-confirming ReadyCheckDialog; the host's reactive
+        // CheckOthersReady("festivalStart") then warps it in and the festival becomes active.
+        var warp = await GameClient.Actions.Warp(festivalLocation, entryTile.X, entryTile.Y);
+        Assert.True(warp?.Success, $"Warp to {festivalLocation} failed: {warp?.Error}");
+
+        var active = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_BecameActive,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == true;
+            },
+            timeout: TestTimings.GameReadyTimeout,
+            cancellationToken: ct
+        );
+        if (!active)
+        {
+            // Dump both sides of the festivalStart handshake so the failure names which guard
+            // is unmet (client whereIsTodaysFest/weatherIcon vs the ready counts vs host state).
+            var clientDbg = await GameClient.GetFestivalDebug();
+            var serverDbg = await ServerApi.GetFestivalState(ct);
+            Assert.Fail(
+                $"Festival ({festivalLocation}) did not become active after warping the client in.\n"
+                    + $"  client: loc={clientDbg?.CurrentLocation}, weatherIcon={clientDbg?.WeatherIcon}, "
+                    + $"whereIsTodaysFest={clientDbg?.WhereIsTodaysFest ?? "null"}, "
+                    + $"isFestival={clientDbg?.IsFestival}, timeOfDay={clientDbg?.TimeOfDay}, "
+                    + $"festivalStart={clientDbg?.FestivalStartReady}/{clientDbg?.FestivalStartRequired}\n"
+                    + $"  server: whereIsTodaysFest={serverDbg?.WhereIsTodaysFest ?? "null"}, "
+                    + $"isFestivalActive={serverDbg?.IsFestivalActive}, timeOfDay={serverDbg?.TimeOfDay}, "
+                    + $"festivalStart={serverDbg?.FestivalStartReady}/{serverDbg?.FestivalStartRequired}"
+            );
+        }
+        LogSuccess($"Festival active at {festivalLocation} ({season} {festivalDay})");
+
+        return farmhand;
+    }
+}

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -146,4 +146,14 @@ public enum WaitName
     // CabinPlacementValidationTests.cs (2)
     Polling_CabinPlacement_Moved,
     Polling_CabinPlacement_Rejected,
+
+    // FestivalTests.cs (8)
+    Polling_Festival_DayConfirmed,
+    Polling_Festival_ClientWindowSynced,
+    Polling_Festival_BecameActive,
+    Polling_Festival_StillActiveAfterSettle,
+    Polling_Festival_EndedAfterLeave,
+    Polling_Festival_EndedNoPlayers,
+    Polling_Festival_NextFestivalEndedOnLeave,
+    Polling_Festival_MainEventStillActive,
 }

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -121,6 +121,40 @@ public class ActionsController
     }
 
     /// <summary>
+    /// Vote to leave the current festival, exactly as a real player walking out does.
+    /// <c>Event.TryStartEndFestivalDialogue</c> sets this client's <c>festivalEnd</c> ready
+    /// flag and opens an auto-confirming <c>ReadyCheckDialog</c>; once the host is also ready
+    /// (its <c>HandleFestivalLeave</c> sees <c>CheckOthersReady("festivalEnd")</c>), the
+    /// festival ends for everyone. No-op (returns Success=false) if not at a festival.
+    /// </summary>
+    public LeaveFestivalResult LeaveFestival()
+    {
+        if (!Context.IsWorldReady)
+        {
+            return new LeaveFestivalResult { Success = false, Error = "Not in a game world" };
+        }
+
+        var currentEvent = Game1.CurrentEvent;
+        if (currentEvent is not { isFestival: true })
+        {
+            return new LeaveFestivalResult
+            {
+                Success = false,
+                Error = "Not currently at a festival",
+            };
+        }
+
+        var started = currentEvent.TryStartEndFestivalDialogue(Game1.player);
+        return new LeaveFestivalResult
+        {
+            Success = started,
+            Error = started
+                ? null
+                : "TryStartEndFestivalDialogue declined (not local player or no longer a festival)",
+        };
+    }
+
+    /// <summary>
     /// Place a Garden Pot at the given tile on the player's current location. The
     /// IndoorPot ctor reads <c>Game1.currentLocation</c> when initializing its inner
     /// HoeDirt, so the player must already be at <paramref name="locationName"/>.
@@ -297,6 +331,12 @@ public class WarpResult
     public string? Message { get; set; }
     public string? Error { get; set; }
     public string? LocationName { get; set; }
+}
+
+public class LeaveFestivalResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
 }
 
 public class WarpParams

--- a/tests/test-client/GameControl/MenuDetector.cs
+++ b/tests/test-client/GameControl/MenuDetector.cs
@@ -161,6 +161,12 @@ public static class MenuDetector
             IsMainPlayer = Game1.player.IsMainPlayer,
             UniqueId = Game1.player.UniqueMultiplayerID.ToString(),
             CurrentLocation = Game1.player.currentLocation?.NameOrUniqueName,
+            WeatherIcon = Game1.weatherIcon,
+            WhereIsTodaysFest = Game1.whereIsTodaysFest,
+            IsFestival = Game1.CurrentEvent?.isFestival == true,
+            FestivalStartReady = Game1.netReady.GetNumberReady("festivalStart"),
+            FestivalStartRequired = Game1.netReady.GetNumberRequired("festivalStart"),
+            TimeOfDay = Game1.timeOfDay,
         };
     }
 
@@ -371,6 +377,18 @@ public class FarmerInfo
     public bool IsMainPlayer { get; set; }
     public string UniqueId { get; set; } = "";
     public string? CurrentLocation { get; set; }
+
+    // Client-side festival state. Festival entry keys on the client's LOCAL festival state
+    // (warpFarmer's guard reads weatherIcon/whereIsTodaysFest/timeOfDay on this client), so
+    // tests gate the warp-in on these and dump them when an entry fails to debug which guard
+    // is unmet. WhereIsTodaysFest/WeatherIcon/TimeOfDay are load-bearing for that gate; the
+    // ready counts and IsFestival are diagnostic-only.
+    public int WeatherIcon { get; set; }
+    public string? WhereIsTodaysFest { get; set; }
+    public bool IsFestival { get; set; }
+    public int FestivalStartReady { get; set; }
+    public int FestivalStartRequired { get; set; }
+    public int TimeOfDay { get; set; }
 }
 
 public class MenuButtonsInfo

--- a/tests/test-client/HttpServer/ApiDefinitions.cs
+++ b/tests/test-client/HttpServer/ApiDefinitions.cs
@@ -258,6 +258,16 @@ public class ApiDefinitions
 
     [ApiEndpoint(
         "POST",
+        "/actions/leave_festival",
+        Summary = "Leave the festival",
+        Description = "Vote to leave the current festival (TryStartEndFestivalDialogue). No-op if not at a festival.",
+        Tag = "Actions"
+    )]
+    [ApiResponse(typeof(LeaveFestivalResult), 200)]
+    private void LeaveFestival() { }
+
+    [ApiEndpoint(
+        "POST",
         "/actions/warp",
         Summary = "Warp the player",
         Description = "Queue an asynchronous warp to a location/tile. Caller must poll /status to confirm arrival.",

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -576,6 +576,12 @@ public class ModEntry : Mod
             _ => ExecuteOnGameThread(() => _actionsController!.GoToSleep())
         );
 
+        // POST /actions/leave_festival - Vote to leave the current festival
+        _server.Post(
+            "actions/leave_festival",
+            _ => ExecuteOnGameThread(() => _actionsController!.LeaveFestival())
+        );
+
         // POST /actions/warp - Queue a warp to the given location/tile (async; caller polls /status to confirm)
         _server.Post(
             "actions/warp",


### PR DESCRIPTION
Fixes festival auto-end / no-players handling on the dedicated host, plus E2E coverage and docs.

## Behavior fixes
- **Leave-only festivals no longer insta-end.** Spirit's Eve and Feast of Winter Star (no main event) used to host-end ~0.17s after loading (`RunLeaveOnly` fired `TicksToSeconds(10)`). Removed that auto-end so a leave-only festival stays up until players leave or the wall-clock timeout elapses.
- **No-players end keys off the online count, not `otherFarmers.Count`.** During a festival `Multiplayer.removeDisconnectedFarmers` is gated on `CurrentEvent == null`, so `otherFarmers.Count` can never reach 0 mid-festival — the old check would hang the festival forever. New `CountOnlineOtherPlayers()` mirrors `DedicatedServer.Tick`'s `onlineIds` set (online, non-disconnecting, excluding host).
- **Empty festival ends gracefully via `TryStartEndFestivalDialogue` (`force: false`)**, matching the game's `DedicatedServer`; `force: true` (`forceEndFestival`) is now reserved for the wall-clock timeout backstop where players may still be online but stalled.
- **Timeout warps players home instead of kicking them** (carried in this branch).
- **Stale festival state reset** so a prior festival's `_startedFestivalEnd` can't suppress the next festival's leave path.

## Test infrastructure
- New `/test/festival_state` read endpoint (host-side festival signals) and `/actions/leave_festival` client action (real-player exit path via `TryStartEndFestivalDialogue`).
- Client-side festival fields exposed on `/status` (`weatherIcon`, `whereIsTodaysFest`, `timeOfDay`, festivalStart ready) to debug entry-handshake failures.
- `/test/set_date` now resets `timeOfDay`/`whereIsTodaysFest` and recomputes `weatherIcon` on a date jump (mirrors `newDayAfterFade`), so a stale festival `weatherIcon` can't crash `performTenMinuteClockUpdate` on a non-festival day. `/test/set_time` pushes `UpdateFromGame1` so the change replicates to peers.

## Tests
`FestivalTests.cs` (E2E, `Exclusive`):
- Spirit's Eve does **not** auto-end immediately (regression gate for the leave-only bug).
- Festival ends when the connected player votes to leave.
- Empty festival (no online players) ends on its own, and the **next** festival is still leavable (guards the per-festival state reset).
- Egg Festival main-event path accepts the `!event` countdown skip and keeps running.

## Docs
- `docs/developers/architecture/festival-handling.md` and related references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added developer docs for always-on festival handling (full lifecycle, readiness checks, timeouts) and cross-references; updated the architecture sidebar and testing runbook.
* **New Features**
  * Added test-only endpoints to inspect festival state and to trigger leaving a festival, plus extra festival diagnostics in test/status responses.
* **Bug Fixes / Improvements**
  * Improved always-on festival timeout/ending and player-disconnect handling; unified wall-clock backstop and updated festival lifecycle/reset logic.
  * Hardened the `/time` endpoint to fail when the server isn’t ready and to propagate time changes immediately.
* **Tests**
  * Added E2E festival lifecycle coverage (auto-end behavior, leave flows, main-event `!event` path) and expanded polling instrumentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->