### PR TITLE
fix(test-client): build mod-builder stage on .NET SDK 10.0

### DIFF
--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -60,7 +60,9 @@ RUN curl -L "https://github.com/Pathoschild/SMAPI/releases/download/${SMAPI_VERS
 # ============================================================================
 # Stage 3: Build test-client mod using game DLLs
 # ============================================================================
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS mod-builder
+# SDK 10.0 (not 6.0): ModBuildConfig 4.4.0's analyzer targets Roslyn 4.9, which
+# the 6.0 SDK's 4.3 compiler rejects (CS9057). The net6.0 TFM still builds fine.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS mod-builder
 
 ARG BUILD_CONFIGURATION=Release
 


### PR DESCRIPTION
## Problem

The E2E suite aborts before any test runs because the **test-client image build fails with exit code 2** during the mod-builder stage (server image builds fine). Seen on [run 27511917893](https://github.com/stardew-valley-dedicated-server/server/actions/runs/27511917893/job/81313455351).

## Root cause

`#309` bumped `Pathoschild.Stardew.ModBuildConfig` to `4.4.0`, whose Roslyn 4.9 analyzer is rejected by the .NET 6.0 SDK's 4.3 compiler (CS9057). The bump updated the server `Dockerfile` mod-builder stage to `sdk:10.0` but left `Dockerfile.test-client` on `sdk:6.0`, so every test-client image build has failed since.

## Fix

- Build the test-client mod-builder stage on `sdk:10.0`, matching the server Dockerfile. The `net6.0` TFM is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to use .NET SDK 10.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->