### PR TITLE
fix(ci): build steam-service image from repo root context

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -255,7 +255,9 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/steam-service
-      context: ./tools/steam-service
+      # Repo root, not ./tools/steam-service — the Dockerfile COPYs the repo-level
+      # Directory.Build.props and .editorconfig (code-style enforcement).
+      context: .
       dockerfile: ./tools/steam-service/Dockerfile
       version: ${{ needs.calculate-version.outputs.preview_version }}
       additional_tag: preview

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -139,7 +139,9 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     with:
       image_name: sdvd/steam-service
-      context: ./tools/steam-service
+      # Repo root, not ./tools/steam-service — the Dockerfile COPYs the repo-level
+      # Directory.Build.props and .editorconfig (code-style enforcement).
+      context: .
       dockerfile: ./tools/steam-service/Dockerfile
       version: ${{ needs.release-please.outputs.version }}
       additional_tag: latest


### PR DESCRIPTION
## Problem

The **Build Steam Service Preview** job fails at the Docker build step:

```
#15 COPY tools/steam-service/ .                              → /tools/steam-service: not found
#16 COPY Directory.Build.props CodeStyle.props .editorconfig → /.editorconfig: not found
```

(Failing run: https://github.com/stardew-valley-dedicated-server/server/actions/runs/27513768926/job/81318595407)

## Root cause

#407 rewrote `tools/steam-service/Dockerfile` to `COPY` the repo-level `Directory.Build.props`, `CodeStyle.props`, and `.editorconfig` (for C# code-style enforcement), making the **repo root** the required build context. `docker-compose.yml` was updated to match (`context: .`), but the two CI workflows still passed `context: ./tools/steam-service` — so the repo-root files and the `tools/steam-service/` subpath don't exist inside the context.

## Fix

Set `context: .` (keeping `dockerfile: ./tools/steam-service/Dockerfile`) in both workflows, mirroring `docker-compose.yml`:

- `.github/workflows/build-preview.yml` — the workflow that actually failed
- `.github/workflows/build-release.yml` — same latent bug; would have failed on the next release

`build-image.yml` forwards `context`/`dockerfile` straight to `docker/build-push-action` and does a full (non-sparse) checkout, so the repo-root files are present. The discord-bot build uses paths local to its own dir, so its `context: ./tools/discord-bot` is correct and left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for deployment processes to ensure proper access to shared repository resources.
  * Enhanced consistency and reliability of preview and production deployment pipelines.
  * Optimized build procedures to better utilize repository-level configuration files across all deployment stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->