### PR TITLE
fix: classify stopOnFail cascade victims as canceled, not failed

### DIFF
--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/TestLifecycle.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/TestLifecycle.cs
@@ -381,6 +381,15 @@ internal sealed class TestLifecycle
                         }
                         else
                         {
+                            // A non-OCE body exception (e.g. DockerContainerNotFound
+                            // when abort cleanup removed this test's container, or a
+                            // Socket/Http fault) stays a failure by design. We do NOT
+                            // convert it to canceled on run-abort: a genuine crash that
+                            // coincides with an abort must remain visible, and a real
+                            // host outage already carries the infrastructure stamp
+                            // (TestBase.RecordTestFailure host-poison branch). Only OCE
+                            // cancellations — unambiguous run-abort/timeout signals —
+                            // route to canceled (here and in ThrowIfServerError).
                             var errorMessage =
                                 testState.ExceptionMessages?.FirstOrDefault()
                                 ?? "Test failed (no message)";

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -715,6 +715,22 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
             throw new ExceptionMonitorException(message, Array.Empty<CapturedException>());
         }
         EmitCancellationDiagnostic(context ?? "server-error-check");
+
+        // Distinguish a run-level abort (stopOnFail / Ctrl-C cancelled the shared
+        // run token) from a genuine per-test failure. A stopOnFail cascade cancels
+        // the in-flight HTTP call (e.g. join world) of every sibling still running;
+        // those are victims, not failures, and must record as canceled so the run
+        // ends with 1 failed + N canceled. The signal: the run/xUnit token is
+        // cancelled but the per-test budget did NOT expire (a real wall-clock
+        // timeout stays a failure) and there was no server error (handled above).
+        var budgetExpired = _budgetCts?.IsCancellationRequested == true;
+        var runAborted = TestContext.Current?.CancellationToken.IsCancellationRequested == true;
+        if (runAborted && !budgetExpired)
+        {
+            RecordTestCancellation();
+            throw ex;
+        }
+
         RecordTestFailure(ex.Message, context, exceptionType: ex.GetType().FullName);
         throw ex;
     }

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -41,6 +41,41 @@ public sealed class TestResourceBroker : IAsyncDisposable
     /// </summary>
     private static string BrokerKeyFor(string key, DockerHost host) => $"{key}@{host.Id}";
 
+    /// <summary>
+    /// Picks the exception a faulted server-acquisition hands to its waiters,
+    /// so the runner's exception-type classifier
+    /// (<c>TestRunState.ApplyTestFailed</c>) buckets stopOnFail cascade victims
+    /// as "canceled" while genuine outages stay "failed"/infrastructure.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="_stopOnFailNotified"/> is the precise signal (set only by
+    /// <see cref="NotifyStopOnFail"/>); gating on a bare <c>_runCts</c> would
+    /// also catch <c>DisposeAsync</c> and the pre-start abort fan-out, which
+    /// must remain real failures.
+    /// </para>
+    /// <para>
+    /// The OCE must be returned BARE (no inner exception, no wrapping):
+    /// <c>RunnerCallbacks.UnwrapException</c> walks to the deepest inner, so a
+    /// nested OCE whose deepest inner is something else silently reverts to
+    /// "failed".
+    /// </para>
+    /// </remarks>
+    private Exception BuildAcquisitionFault(string displayLabel, DockerHost host, Exception? cause)
+    {
+        if (_stopOnFailNotified && !host.IsPoisoned)
+        {
+            return new OperationCanceledException(
+                $"Server acquisition for {displayLabel} aborted by stopOnFail"
+            );
+        }
+
+        return cause
+            ?? new ServerUnavailableException(
+                $"All server creation attempts failed for {displayLabel} on {host.Id}"
+            );
+    }
+
     // Server.DisposeAsync tasks kicked off in the background by
     // TryEvictIdleServerForAsync so the waiting test can proceed without
     // blocking on Docker stop-grace + recording extraction. Also receives
@@ -1173,6 +1208,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
         var displayLabel = requirements.GetDisplayLabel();
         var brokerKey = BrokerKeyFor(key, host);
         var succeeded = false;
+        Exception? capturedCreateException = null;
         try
         {
             var managed = await CreateServerAsync(key, requirements, host, ct);
@@ -1227,6 +1263,9 @@ public sealed class TestResourceBroker : IAsyncDisposable
         }
         catch (Exception ex)
         {
+            // Stash the real cause so the finally's BuildAcquisitionFault can
+            // propagate it when this isn't a stopOnFail abort.
+            capturedCreateException = ex;
             TestLog.Server(
                 $"{displayLabel} creation FAILED on {host.Id}: {ex.GetType().Name}: {ex.Message}"
             );
@@ -1269,9 +1308,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 if (!succeeded && inFlightRemaining == 0 && !queue.IsReady)
                 {
                     queue.ServerFailed(
-                        new ServerUnavailableException(
-                            $"All server creation attempts failed for {displayLabel} on {host.Id}"
-                        )
+                        BuildAcquisitionFault(displayLabel, host, capturedCreateException)
                     );
                 }
             }
@@ -1681,12 +1718,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 );
                 if (!replacementSucceeded && inFlightRemaining == 0 && !queue.IsReady)
                 {
-                    queue.ServerFailed(
-                        replacementError
-                            ?? new ServerUnavailableException(
-                                $"Server replacement failed for {displayLabel} on {host.Id}"
-                            )
-                    );
+                    queue.ServerFailed(BuildAcquisitionFault(displayLabel, host, replacementError));
                 }
             }
         }


### PR DESCRIPTION
## Problem

With `stopOnFail: true`, an E2E run should end with **exactly 1 failed + N canceled**: the first test to fail is the real one, every still-in-flight test killed by the abort should count as canceled. Instead, runs showed 2–11 "failed" — cascade victims miscounted as real failures, making a single root failure look like a suite-wide collapse.

The only canceled-vs-failed classifier is exception-type based (OCE/TCE → canceled, everything else → failed). Two seams handed cascade victims a non-OCE exception:

- **Acquisition phase** — the broker's `ServerFailed` substitution sites faulted waiters with a fresh `ServerUnavailableException` even when the run was aborting, so a waiter still queued for a server classified as **failed/infrastructure**.
- **Body phase** — `ThrowIfServerError` unconditionally recorded a failure for any non-server-error OCE, so a sibling whose in-flight join/connect was cancelled by the run abort classified as **failed/timeout**.

## Changes

- **`TestResourceBroker.BuildAcquisitionFault`** — new helper picks the waiter-fault exception by cause: a bare `OperationCanceledException` when stopOnFail aborted on a healthy host, otherwise the real captured cause / `ServerUnavailableException`. Wired into both substitution sites (on-demand create + background replacement). Genuine outages (poisoned host) stay infrastructure failures via the `!host.IsPoisoned` guard. The OCE is returned bare so `RunnerCallbacks.UnwrapException` (deepest-inner walk) keeps the type as `OperationCanceledException`.
- **`TestBase.ThrowIfServerError`** — routes a run-abort OCE (run/xUnit token cancelled, per-test budget NOT expired, no server error) to `RecordTestCancellation` → canceled. A real budget timeout or server error still records a failure.
- **`TestLifecycle`** — documents the deliberate boundary: non-OCE body crashes (`DockerContainerNotFound`/Socket/Http) stay failures, so a genuine crash coinciding with an abort remains visible and a true host outage keeps its infrastructure stamp.

Both seams apply the same rule: a run-level abort → canceled; outage / timeout / server-error / crash → failed. No runner-side heuristic, no new field, no fixture edit — the runner's existing classifier does the right thing on the first write.

## Verification

- **Acquisition path** (full suite run): a network-not-found creation failure during the abort — waiter never reached its body — classified **canceled** (0 host-poison events confirmed the healthy-host branch).
- **Body path** (forced repro): siblings caught inside `ConnectViaLanAsync` emitted `cancellation_detected` with `xunitCtCancelled:true, budgetCtsCancelled:false` — exactly the fix's gate — and classified **canceled**, yielding **1 failed + N canceled**. Throwaway repro removed after verifying.
- **No regression**: a clean run shows 126 passed, 0 failed, 0 canceled.

### Not live-triggered (guarded in code, not exercised by a run)
- Genuine host outage staying infrastructure-failed — no host died in any run; guarded by `!host.IsPoisoned` + the host-poison `failureCategory` stamp.
- `SDVD_STOP_ON_FAIL=false` regression — by inspection `NotifyStopOnFail` never runs, so both seams take the unchanged failure branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure classification to accurately distinguish between run-level cancellations and actual test failures.
  * Enhanced exception handling for server resource acquisition to ensure consistent error reporting across creation and replacement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->