### PR TITLE
build(deps): cap Websocket.Client below 5.0 in the mod

### DIFF
--- a/mod/JunimoServer/JunimoServer.csproj
+++ b/mod/JunimoServer/JunimoServer.csproj
@@ -38,8 +38,10 @@
         (the bundled 6.0.0.0 copy is shadowed by the game's already-loaded 5.0.0.0). DI is
         therefore pinned to 5.0.2 (Abstractions 5.0.0 transitively), matching the game. NSwag.Core
         is held at 14.2.0 — 14.3.0+ pulls a transitive System.Text.Json above the net6 6.0.0 line,
-        dragging in System.IO.Pipelines. Renovate enforces these boundaries (see renovate.json
-        PIN/CAP rules).
+        dragging in System.IO.Pipelines. Websocket.Client is capped below 5.0 — 5.x pulls
+        Microsoft.Extensions.Logging.Abstractions 8.x → DependencyInjection.Abstractions 8.0.0.0,
+        which collides with the pinned DI 5.0.2 (CS0433 on ServiceCollection). Renovate enforces
+        these boundaries (see renovate.json PIN/CAP rules).
     -->
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2"/>

--- a/renovate.json
+++ b/renovate.json
@@ -156,6 +156,14 @@
             "allowedVersions": "=5.0.2"
         },
         {
+            "description": "CAP — Websocket.Client below 5.0 in the SMAPI mod (net6.0). 4.x depends only on System.Reactive + System.Threading.Channels; 5.x adds Microsoft.Extensions.Logging.Abstractions 8.x, which transitively pulls DependencyInjection.Abstractions 8.0.0.0. That collides with the pinned DI 5.0.2 (CS0433 on ServiceCollection) and sits above the game's loaded 5.0.0.0 Abstractions line — same boundary as the DI/Grpc pins. The cap still allows safe 4.x patch bumps (4.x stays on the no-Microsoft.Extensions graph). Lift only as part of moving the whole mod off the Abstractions-5.0.0.0 floor. versioning:semver — the default nuget scheme can silently no-op allowedVersions for packages with interleaved prereleases.",
+            "matchManagers": ["nuget"],
+            "matchFileNames": ["mod/JunimoServer/JunimoServer.csproj"],
+            "matchPackageNames": ["Websocket.Client"],
+            "versioning": "semver",
+            "allowedVersions": "<5.0.0"
+        },
+        {
             "description": "CAP — Microsoft.OpenApi below 2.0 in the test-client. The 2.0/3.x rewrite changes Type (string→JsonSchemaType enum), makes SerializeAsJson/Yaml async, and redesigns OpenApiReference/OperationType, so OpenApiGenerator.cs would not compile. Lift once OpenApiGenerator.cs is ported to the 2.x model. versioning:semver — the default nuget scheme can silently no-op allowedVersions for packages with interleaved prereleases.",
             "matchManagers": ["nuget"],
             "matchFileNames": ["tests/test-client/JunimoTestClient.csproj"],


### PR DESCRIPTION
Replaces #422 (the v5 bump can't merge — see below).

## Why
Websocket.Client 5.x adds `Microsoft.Extensions.Logging.Abstractions` 8.x, which transitively pulls `Microsoft.Extensions.DependencyInjection.Abstractions` 8.0.0.0. That collides with the mod's pinned DI 5.0.2 (`CS0433` ambiguity on `ServiceCollection` in `ModEntry.cs`) and sits above the game's loaded 5.0.0.0 Abstractions line — the same net6 runtime floor the existing DI/Grpc/NSwag pins protect.

The mod (net6.0) must stay on the 5.0.0.0 Abstractions line because the game ships `Microsoft.Extensions.DependencyInjection.Abstractions.dll` at AssemblyVersion 5.0.0.0 and SMAPI loads that copy first; a mod hard-referencing a newer Abstractions is skipped with `FileLoadException` at mod-load.

## Changes
- Add a Renovate CAP rule (`<5.0.0`, `versioning: semver`) scoped to `mod/JunimoServer/JunimoServer.csproj`, mirroring the existing DI/Grpc/NSwag/OpenApi pins.
- Document the boundary in the net6-floor comment next to the other pins.

The cap still allows safe 4.x patch bumps (4.x stays on the no-`Microsoft.Extensions` dependency graph). Lift only as part of moving the whole mod off the Abstractions-5.0.0.0 floor.

Supersedes #422 (close that PR — its v5 bump can't merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management rules to enforce specific version boundaries for runtime compatibility.
  * Added configuration to cap `Websocket.Client` updates to versions below `5.0.0`, preventing automatic upgrades to 5.x and later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->