### PR TITLE
perf(qiplane): complete overnight QiPlaneEvent via player-style skip

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -92,7 +92,7 @@ public class AlwaysOnServer : ModService
         // Force-complete the Mr. Qi mystery-box overnight cutscene on the host. Its completion gate
         // lives in draw() rather than tickUpdate(), so on a headless host (draws gated/desynced) it
         // never converges and the new day never starts. See QiPlaneEventOverrides.
-        QiPlaneEventOverrides.Initialize(monitor);
+        QiPlaneEventOverrides.Initialize();
         harmony.Patch(
             original: AccessTools.Method(
                 typeof(StardewValley.Events.QiPlaneEvent),
@@ -688,12 +688,12 @@ public class AlwaysOnServer : ModService
 
     /// <summary>
     /// Watchdog for overnight farm events that never complete on a headless host. The known
-    /// headless-hangers are handled directly — <see cref="QiPlaneEventOverrides"/> force-completes
-    /// the Mr. Qi mystery box, and <see cref="HandleOvernightNamingMenu"/> auto-names births — so
-    /// those resolve before this fires. For an unknown/modded <c>FarmEvent</c> still stuck well past
-    /// any vanilla event's natural duration, log once at Warn with its type so we can see what's
-    /// hanging. We deliberately do NOT force-complete unknown types: skipping their tickUpdate would
-    /// bypass their makeChangesToLocation side effects and could corrupt the save.
+    /// headless-hangers are handled directly — <see cref="QiPlaneEventOverrides"/> completes the Mr.
+    /// Qi mystery box, and <see cref="HandleOvernightNamingMenu"/> auto-names births — so those
+    /// resolve before this fires. For an unknown/modded <c>FarmEvent</c> still stuck well past any
+    /// vanilla event's natural duration, log once at Warn with its type so we can see what's hanging.
+    /// We deliberately do NOT force-complete unknown types: skipping their tickUpdate would bypass
+    /// their makeChangesToLocation side effects and could corrupt the save.
     /// </summary>
     private void HandleStuckFarmEvent()
     {
@@ -711,9 +711,9 @@ public class AlwaysOnServer : ModService
 
         _farmEventActiveMs += Game1.currentGameTime?.ElapsedGameTime.TotalMilliseconds ?? 0.0;
 
-        // Fire only well after the QiPlane fallback so a healthy or already-handled event never
-        // trips this — anything still stuck past here is an event we don't auto-complete.
-        const double StuckThresholdMs = QiPlaneEventOverrides.FallbackThresholdMs + 15000.0;
+        // Well past any vanilla overnight event's natural duration — anything still stuck here is an
+        // event we don't auto-complete.
+        const double StuckThresholdMs = 25000.0;
         if (_stuckFarmEventLogged || _farmEventActiveMs < StuckThresholdMs)
         {
             return;

--- a/mod/JunimoServer/Services/AlwaysOnServer/QiPlaneEventOverrides.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/QiPlaneEventOverrides.cs
@@ -1,86 +1,49 @@
-using Microsoft.Xna.Framework;
-using StardewModdingAPI;
+using HarmonyLib;
 using StardewValley;
 using StardewValley.Events;
 
 namespace JunimoServer.Services.AlwaysOn;
 
 /// <summary>
-/// Force-completes the Mr. Qi mystery-box overnight cutscene (<see cref="QiPlaneEvent"/>) on the
-/// host. Unlike every other overnight <c>FarmEvent</c>, QiPlaneEvent's completion gate
-/// (<c>finalFadeTimer &gt; 4000</c>) is advanced inside its <c>draw()</c>, not its
-/// <c>tickUpdate()</c> — so when the headless host's draw cadence is gated/throttled/desynced from
-/// the per-tick update pump, the gate never converges and <c>tickUpdate</c> returns false forever.
-/// The new day never starts and clients hang on "Waiting for the host's event to finish."
-///
-/// The postfix accumulates <see cref="GameTime.ElapsedGameTime"/> (game-time, not wall-clock and not
-/// draw-coupled) per event instance and forces <c>tickUpdate</c> to return true once the event has
-/// run longer than it ever would with healthy draws. This is framerate-independent: with draws
-/// running normally the event self-completes first and the postfix is a no-op; otherwise the
-/// fallback fires and the vanilla completion block (warp-to-bed + save) runs unchanged.
+/// Completes the Mr. Qi mystery-box overnight cutscene (<see cref="QiPlaneEvent"/>) on the host the
+/// way a player holding Escape would. QiPlaneEvent's completion gate advances only in <c>draw()</c>,
+/// so on a headless host (draws gated) it never converges and the new day never starts (issue #242;
+/// see <c>host-automation.md</c> #4). Vanilla's Escape branch advances the same gate from
+/// <c>tickUpdate</c> instead (QiPlaneEvent.cs:80-88); the host has no keyboard, so this postfix
+/// drives those private fields past their gates. The cutscene is never drawn here, so rather than
+/// ramp the timers tick-by-tick we jump straight past both thresholds in one tick — the event then
+/// completes through its own gate and runs the vanilla completion block (warp-to-bed + save)
+/// unchanged, starting the new day a few seconds sooner. With healthy draws the event self-completes
+/// first and the postfix is a no-op.
 /// </summary>
 public static class QiPlaneEventOverrides
 {
-    private static IMonitor _monitor;
+    private static AccessTools.FieldRef<QiPlaneEvent, float> _finalFadeTimerRef;
+    private static AccessTools.FieldRef<QiPlaneEvent, float> _textTimerRef;
+    private static AccessTools.FieldRef<QiPlaneEvent, string> _strRef;
 
-    private static QiPlaneEvent _trackedInstance;
-    private static double _accumulatedMs;
-    private static bool _forcedThisInstance;
-
-    /// <summary>
-    /// Game-time the event may run before we force completion. Natural draw-driven completion is
-    /// ~15-25s of game-time; 30s sits above that so a host with a healthy draw cadence always
-    /// self-completes first (postfix no-op), while a host where draws never advance the gate still
-    /// escapes after 30s of accumulated game-time. tickUpdate runs every update tick regardless of
-    /// draws, so this elapses quickly in wall-clock on a stuck host. The stuck-farm-event watchdog
-    /// (<c>AlwaysOnServer.HandleStuckFarmEvent</c>) keys its own threshold off this so the two stay
-    /// ordered (watchdog fires only well after this).
-    /// </summary>
-    public const double FallbackThresholdMs = 30000.0;
-
-    public static void Initialize(IMonitor monitor) => _monitor = monitor;
-
-    /// <summary>
-    /// Harmony postfix for <see cref="QiPlaneEvent.tickUpdate"/>. Forces the event to complete on
-    /// the host after the game-time fallback threshold if its draw-driven gate never converged.
-    /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public static void TickUpdate_Postfix(QiPlaneEvent __instance, GameTime time, ref bool __result)
+    /// <summary>Resolves the private fields up front; throws loudly if a future SDV renames them.</summary>
+    public static void Initialize()
     {
-        if (!Game1.IsMasterGame)
+        _finalFadeTimerRef = AccessTools.FieldRefAccess<QiPlaneEvent, float>("finalFadeTimer");
+        _textTimerRef = AccessTools.FieldRefAccess<QiPlaneEvent, float>("textTimer");
+        _strRef = AccessTools.FieldRefAccess<QiPlaneEvent, string>("str");
+    }
+
+    // ReSharper disable once InconsistentNaming
+    public static void TickUpdate_Postfix(QiPlaneEvent __instance, ref bool __result)
+    {
+        if (!Game1.IsMasterGame || __result)
         {
-            return; // only the host runs the completion block + newDaySync
+            return; // only the host completes the event; __result already true means draws handled it
         }
 
-        if (__result)
-        {
-            return; // event self-completed (draws were healthy) — nothing to do
-        }
-
-        // Reset the accumulator when a new event instance starts ticking.
-        if (!ReferenceEquals(__instance, _trackedInstance))
-        {
-            _trackedInstance = __instance;
-            _accumulatedMs = 0.0;
-            _forcedThisInstance = false;
-        }
-        if (_forcedThisInstance)
-        {
-            return;
-        }
-
-        _accumulatedMs += time.ElapsedGameTime.TotalMilliseconds;
-        if (_accumulatedMs < FallbackThresholdMs)
-        {
-            return;
-        }
-
-        _forcedThisInstance = true;
+        // The host doesn't draw the cutscene, so jump both private fields past the gates vanilla
+        // checks (text-scrolled: textTimer/100 > str.Length + 27, then finalFadeTimer > 4000;
+        // QiPlaneEvent.cs:57,120) in one tick. tickUpdate then returns true through the event's own
+        // gate, running the vanilla completion block unchanged.
+        _textTimerRef(__instance) = ((_strRef(__instance)?.Length ?? 0) + 28) * 100f;
+        _finalFadeTimerRef(__instance) = 4001f;
         __result = true;
-        _monitor?.Log(
-            "QiPlaneEvent (Mr. Qi mystery box) did not self-complete — forcing overnight completion "
-                + "so the new day can start.",
-            LogLevel.Info
-        );
     }
 }

--- a/tests/JunimoServer.Tests/HostAutomationTests.cs
+++ b/tests/JunimoServer.Tests/HostAutomationTests.cs
@@ -394,15 +394,16 @@ public class HostAutomationTests : TestBase
     /// Regression for issue #242: the Mr. Qi mystery-box overnight cutscene (QiPlaneEvent) hangs the
     /// host, so the new day never starts. QiPlaneEvent's completion gate is advanced in its draw(),
     /// not its tickUpdate(), so on a headless host (draws gated/desynced) it never converges.
-    /// QiPlaneEventOverrides force-completes it via a framerate-independent game-time fallback.
+    /// QiPlaneEventOverrides drives the gate forward from tickUpdate the way an Escape-holding player
+    /// would, draw-independent (the test client does the same via QiPlaneSkip).
     ///
-    /// Runs across an FPS matrix because the fix must NOT assume a particular SERVER_FPS — the bug
-    /// reporter was on unbounded FPS. The day must advance whether rendering is disabled (0) or capped.
+    /// Brackets draws-disabled (0) and draws-capped (5): 0 is the original #242 condition (the only
+    /// row that catches a reintroduced draw dependency), 5 is the CI-proven server FPS. Completion is
+    /// draw-independent, so intermediate caps add no distinct coverage.
     /// </summary>
     [Theory]
     [InlineData(0)]
     [InlineData(5)]
-    [InlineData(1)]
     [TestServer(Exclusive = true)]
     public async Task HostCompletesQiPlaneEvent_AcrossFpsMatrix(int fps)
     {
@@ -435,7 +436,8 @@ public class HostAutomationTests : TestBase
             Assert.True(sleepResult?.Success, $"Sleep action failed: {sleepResult?.Error}");
 
             // Without the fix the overnight transition hangs here (QiPlaneEvent never completes) and
-            // this times out. With the fix the game-time fallback completes the event and the day starts.
+            // this times out. With the fix the host drives the event's gate forward from tickUpdate,
+            // completing it so the day starts.
             var (dayChanged, disconnected) = await DayChange.WaitAsync(
                 dayBefore,
                 seasonBefore,

--- a/tests/test-client/GameTweaks/QiPlaneSkip.cs
+++ b/tests/test-client/GameTweaks/QiPlaneSkip.cs
@@ -1,0 +1,57 @@
+using HarmonyLib;
+using Microsoft.Xna.Framework.Input;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Events;
+
+namespace JunimoTestClient.GameTweaks;
+
+/// <summary>
+/// Skips the Mr. Qi mystery-box overnight cutscene (<see cref="QiPlaneEvent"/>) the honest way a real
+/// player does — by holding Escape, which vanilla <c>QiPlaneEvent.tickUpdate</c> reads to advance the
+/// event's own timers (QiPlaneEvent.cs:80-88), draw-independent.
+///
+/// The test client suppresses its own draws (CLIENT_FPS), so its draw-driven completion would
+/// otherwise crawl through the full cutscene — leaving the host blocked on the client at the
+/// <c>ready_for_save</c> barrier ("waiting for players"). Reporting Escape held while the event is up
+/// completes it promptly through the exact vanilla player path, with no force-skip.
+/// </summary>
+public class QiPlaneSkip
+{
+    private readonly IMonitor _monitor;
+    private readonly Harmony _harmony;
+
+    private static readonly KeyboardState EscapeHeld = new(Keys.Escape);
+
+    public QiPlaneSkip(IMonitor monitor, Harmony harmony)
+    {
+        _monitor = monitor;
+        _harmony = harmony;
+    }
+
+    public void Apply()
+    {
+        try
+        {
+            _harmony.Patch(
+                AccessTools.Method(typeof(InputState), nameof(InputState.GetKeyboardState)),
+                postfix: new HarmonyMethod(typeof(QiPlaneSkip), nameof(GetKeyboardState_Postfix))
+            );
+            _monitor.Log("QiPlaneSkip applied.", LogLevel.Info);
+        }
+        catch (System.Exception ex)
+        {
+            _monitor.Log($"Failed to apply QiPlaneSkip patch: {ex.Message}", LogLevel.Warn);
+        }
+    }
+
+    // Headless: no human at the keyboard, so reporting only Escape while the event is up is safe.
+    // ReSharper disable once InconsistentNaming
+    private static void GetKeyboardState_Postfix(ref KeyboardState __result)
+    {
+        if (Game1.farmEvent is QiPlaneEvent)
+        {
+            __result = EscapeHeld;
+        }
+    }
+}

--- a/tests/test-client/GameTweaks/QiPlaneSkip.cs
+++ b/tests/test-client/GameTweaks/QiPlaneSkip.cs
@@ -41,7 +41,7 @@ public class QiPlaneSkip
         }
         catch (System.Exception ex)
         {
-            _monitor.Log($"Failed to apply QiPlaneSkip patch: {ex.Message}", LogLevel.Warn);
+            _monitor.Log($"Failed to apply QiPlaneSkip patch: {ex.Message}", LogLevel.Error);
         }
     }
 

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -31,6 +31,7 @@ public class ModEntry : Mod
     private ConvenienceTweaks? _tweaks;
     private SkipIntro? _skipIntro;
     private GodTool? _godTool;
+    private QiPlaneSkip? _qiPlaneSkip;
 
     // Diagnostics
     private HealthWatchdog? _healthWatchdog;
@@ -78,6 +79,9 @@ public class ModEntry : Mod
 
         _godTool = new GodTool(helper, Monitor, _harmony);
         _godTool.Apply();
+
+        _qiPlaneSkip = new QiPlaneSkip(Monitor, _harmony);
+        _qiPlaneSkip.Apply();
 
         // Apply Steam/Galaxy auth patches (must be before Steam diagnostics)
         var authService = new ClientAuthService(helper, Monitor, _harmony);


### PR DESCRIPTION
The Mr. Qi mystery-box overnight cutscene (`QiPlaneEvent`) advances its completion gate (`finalFadeTimer > 4000`) only inside `draw()`, so on a headless host (draws gated/desynced) it never converges and the new day never starts (issue #242). The host previously force-completed it after an arbitrary **30s game-time fallback**, and the connected test client — which has no skip and suppresses its own draws — played the **full cutscene** before signalling `ready_for_save`, leaving the host blocked on the client ("waiting for players (1/2)"). Both sides paid ~30s, serialized across a 3-row FPS matrix.

This makes both sides complete the way a real player skipping the cutscene does — by holding **Escape**, which vanilla `QiPlaneEvent.tickUpdate` reads to advance the event's own timers draw-independently (`QiPlaneEvent.cs:80-88`).

## Changes

- **Server** (`QiPlaneEventOverrides.cs`): the `tickUpdate` postfix now drives the event's own `textTimer`/`finalFadeTimer` forward each tick — the host's equivalent of an Escape-holding player — so it completes through the real gate and runs the **vanilla completion block (warp-to-bed + save) unchanged**. Single honest path (no dual-mechanism fallback); `Initialize` fails loud if a future SDV renames the private fields. Fields touched via cached `AccessTools.FieldRef` (allocation-free).
- **Test client** (new `QiPlaneSkip.cs`): postfixes `InputState.GetKeyboardState` to report Escape held only while a `QiPlaneEvent` is active, so vanilla code completes it the player way — no force-skip, no completion-state mutation.
- **Watchdog** (`AlwaysOn.cs`): `HandleStuckFarmEvent` decoupled to its own `25000.0` threshold (was keyed off the removed fallback constant); now-inaccurate "force-completes" phrasing corrected.
- **Test** (`HostAutomationTests.cs`): FPS matrix collapsed from 3 rows to 2 (`0` + `5`) — completion is now draw-independent, so the intermediate `1` cap adds no distinct coverage. `0` keeps the original #242 draws-disabled regression; `5` is the CI-proven server FPS.

## Verification

Both rows pass (`make test-llm FILTER=HostCompletesQiPlaneEvent_AcrossFpsMatrix`). At `fps=0` (rendering fully disabled — the original stuck case) the day now advances in **~3.6s** vs ~30s+ before, and the logs confirm the real save flow ran (`before save` → mail trigger → `after save, starting spring 3`). Saves roughly ~80-90s per full suite run (one fewer overnight cycle + each remaining row's ~30s→~5s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Mr. Qi’s overnight cutscene completion, making it resolve more consistently across timing and rendering variations.

* **Tests**
  * Updated automated host automation coverage for the Mr. Qi overnight hang scenario.
  * Added a test-client tweak to skip the Mr. Qi overnight cutscene during automated runs (so normal input-driven progression can continue).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->