### PR TITLE
chore(tools): port test observability to portable bun script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,10 @@ test-flaky:
 
 # Rank tests by runtime across recent runs to find suite-shortening targets.
 # Reads the per-test timing already in flakiness.jsonl (same file as test-flaky).
-# Default sort is total slot-time (count x p50) — the best proxy for "improving
-# this shortens the whole suite", since tests run in parallel and a frequently-run
-# or theory-multiplied test consumes more wall-clock than a slow-but-rare singleton.
+# Default sort is total observed slot-time (sum of sampled durations) — the best
+# proxy for "improving this shortens the whole suite", since tests run in parallel
+# and a frequently-run or theory-multiplied test consumes more wall-clock than a
+# slow-but-rare singleton.
 # Usage: make test-slowest [N=15] [SORT=total|p50|p90|max] [FIELD=durationMs|testBodyMs] [LASTRUNS=20] [MINRUNS=3]
 N ?= 15
 SORT ?= total
@@ -241,8 +242,7 @@ MINRUNS ?= 3
 test-slowest:
 	@bun tools/test-observability.ts slowest N=$(N) SORT=$(SORT) FIELD=$(FIELD) LASTRUNS=$(LASTRUNS) MINRUNS=$(MINRUNS)
 
-# Dump the last failure_context event from the latest run for quick triage.
-# Usage: make test-diagnose [TEST=ClassName.MethodName]
+# Dump the last few failure_context events from the latest run for quick triage.
 test-diagnose:
 	@bun tools/test-observability.ts diagnose
 
@@ -297,7 +297,7 @@ help:
 	@echo "  make test-infra-log - Show infrastructure lifecycle log"
 	@echo "  make test-metadata - Show run metadata (git, env, runtime)"
 	@echo "  make test-flaky    - Show flakiness data across recent runs"
-	@echo "  make test-slowest  - Rank tests by runtime (SORT=total|p50|p90) to find suite-shortening targets"
+	@echo "  make test-slowest  - Rank tests by runtime (SORT=total|p50|p90|max) to find suite-shortening targets"
 	@echo "  make test-diagnose - Show last failure_context events for triage"
 	@echo "  make test-container-log - Show full container log (Usage: CONTAINER=server-0)"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -198,61 +198,53 @@ test-web-report: build-test-ui
 	@dotnet run --project $(RUNNER_PROJECT) -- --web --report $(if $(VERBOSE),--verbose) $(if $(FILTER),--filter "$(FILTER)")
 
 # --- Test Observability Targets ---
-# Resolve latest run: prefer latest.txt, fall back to most recent run dir with summary.json
-LATEST_RUN = $(shell cat TestResults/latest.txt 2>/dev/null)
-ifeq ($(LATEST_RUN),)
-  LATEST_RUN = $(shell ls -1d TestResults/runs/*/ 2>/dev/null | sort -r | while read d; do test -f "$$d/summary.json" && echo "$$d" && break; done)
-endif
+# All run via tools/test-observability.ts so they work from any shell (PowerShell,
+# cmd, bash) with no jq/python/awk/column dependency. Latest-run resolution and
+# all queries live in the script; these targets just pass args through.
 
 # Show test run summary (failures, timing, classification)
 test-summary:
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found. Run tests first."; exit 1; fi
-	@if [ ! -f "$(LATEST_RUN)/summary.json" ]; then echo "No summary.json in $(LATEST_RUN) (run may have been aborted)."; exit 1; fi
-	@cat "$(LATEST_RUN)/summary.json" | python3 -m json.tool 2>/dev/null || cat "$(LATEST_RUN)/summary.json"
+	@bun tools/test-observability.ts summary
 
 # Show per-test event log (Usage: make test-events TEST=ClassName.MethodName[(arg=...)])
 # Filters infrastructure.jsonl by test displayName; matches both fact and theory tests.
 test-events:
-	@test -n "$(TEST)" || { echo "Usage: make test-events TEST=ClassName.MethodName[(arg=value)]"; exit 1; }
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found."; exit 1; fi
-	@if [ ! -f "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" ]; then echo "No infrastructure.jsonl in $(LATEST_RUN)."; exit 1; fi
-	@jq -c 'select(.test.displayName // "" | contains("$(TEST)"))' \
-	    "$(LATEST_RUN)/diagnostics/infrastructure.jsonl"
+	@bun tools/test-observability.ts events TEST="$(TEST)"
 
 # Show infrastructure lifecycle log (server/client creation, capacity, sessions)
 test-infra-log:
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found."; exit 1; fi
-	@cat "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" 2>/dev/null || echo "No infrastructure log in $(LATEST_RUN)."
+	@bun tools/test-observability.ts infra-log
 
 # Show full lifecycle log for a container (Usage: make test-container-log CONTAINER=server-0)
 test-container-log:
-	@test -n "$(CONTAINER)" || { echo "Usage: make test-container-log CONTAINER=server-0|client-0|steam-auth-shared|steam-auth-per-N"; exit 1; }
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found."; exit 1; fi
-	@if [ -f "$(LATEST_RUN)/containers/$(CONTAINER)/container.log" ]; then \
-	  cat "$(LATEST_RUN)/containers/$(CONTAINER)/container.log"; \
-	elif [ -f "$(LATEST_RUN)/containers/$(CONTAINER)/container.log.gz" ]; then \
-	  gunzip -c "$(LATEST_RUN)/containers/$(CONTAINER)/container.log.gz"; \
-	else \
-	  echo "No container.log for $(CONTAINER) in $(LATEST_RUN)."; \
-	  ls "$(LATEST_RUN)/containers/" 2>/dev/null | head -20; \
-	  exit 1; \
-	fi
+	@bun tools/test-observability.ts container-log CONTAINER="$(CONTAINER)"
 
 # Show run metadata (git, env, runtime info)
 test-metadata:
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found."; exit 1; fi
-	@cat "$(LATEST_RUN)/run-metadata.json" 2>/dev/null | python3 -m json.tool 2>/dev/null || cat "$(LATEST_RUN)/run-metadata.json" 2>/dev/null || echo "No metadata in $(LATEST_RUN)."
+	@bun tools/test-observability.ts metadata
 
 # Show flakiness data across recent runs
 test-flaky:
-	@test -f TestResults/flakiness.jsonl && tail -2000 TestResults/flakiness.jsonl || echo "No flakiness data. Run tests multiple times first."
+	@bun tools/test-observability.ts flaky
+
+# Rank tests by runtime across recent runs to find suite-shortening targets.
+# Reads the per-test timing already in flakiness.jsonl (same file as test-flaky).
+# Default sort is total slot-time (count x p50) — the best proxy for "improving
+# this shortens the whole suite", since tests run in parallel and a frequently-run
+# or theory-multiplied test consumes more wall-clock than a slow-but-rare singleton.
+# Usage: make test-slowest [N=15] [SORT=total|p50|p90|max] [FIELD=durationMs|testBodyMs] [LASTRUNS=20] [MINRUNS=3]
+N ?= 15
+SORT ?= total
+FIELD ?= durationMs
+LASTRUNS ?= 20
+MINRUNS ?= 3
+test-slowest:
+	@bun tools/test-observability.ts slowest N=$(N) SORT=$(SORT) FIELD=$(FIELD) LASTRUNS=$(LASTRUNS) MINRUNS=$(MINRUNS)
 
 # Dump the last failure_context event from the latest run for quick triage.
 # Usage: make test-diagnose [TEST=ClassName.MethodName]
 test-diagnose:
-	@if [ -z "$(LATEST_RUN)" ]; then echo "No test runs found."; exit 1; fi
-	@if [ ! -f "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" ]; then echo "No infrastructure log in $(LATEST_RUN)."; exit 1; fi
-	@grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5 | python3 -m json.tool --no-ensure-ascii 2>/dev/null || grep -F '"event":"failure_context"' "$(LATEST_RUN)/diagnostics/infrastructure.jsonl" | tail -5
+	@bun tools/test-observability.ts diagnose
 
 # Verify analyzer style rules and formatting without writing (builds the solution).
 # Biome covers the JS/TS projects scoped in biome.jsonc.
@@ -305,6 +297,7 @@ help:
 	@echo "  make test-infra-log - Show infrastructure lifecycle log"
 	@echo "  make test-metadata - Show run metadata (git, env, runtime)"
 	@echo "  make test-flaky    - Show flakiness data across recent runs"
+	@echo "  make test-slowest  - Rank tests by runtime (SORT=total|p50|p90) to find suite-shortening targets"
 	@echo "  make test-diagnose - Show last failure_context events for triage"
 	@echo "  make test-container-log - Show full container log (Usage: CONTAINER=server-0)"
 	@echo ""

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -13,7 +13,9 @@
             // public/ holds Vite static assets (copied verbatim into the build) — vendor-exported
             // artwork, not source. Linting them is a category error (e.g. noSvgWithoutTitle on the logo).
             "!tests/test-ui/public",
-            "tools/discord-bot/**"
+            "tools/discord-bot/**",
+            "tools/test-observability.ts",
+            "tools/tsconfig.json"
         ]
     },
     "formatter": {

--- a/tools/test-observability.ts
+++ b/tools/test-observability.ts
@@ -19,12 +19,13 @@ const RECENT_FAILURES = 5; // failure_context events to show for triage
 const CONTAINER_LIST_LIMIT = 20; // container names to suggest when one isn't found
 
 // One per-test timing record in flakiness.jsonl (one line, one test, one run).
+// testBodyMs is absent on non-passed records (e.g. canceled), so it's optional.
 interface FlakinessRecord {
     runId: string;
     test: string;
     result: string;
     durationMs: number;
-    testBodyMs: number;
+    testBodyMs?: number;
 }
 
 const SORT_KEYS = ["n", "p50", "p90", "max", "total"] as const;
@@ -112,6 +113,15 @@ function requireOneOf<T extends string>(name: string, value: string, allowed: re
         return value as T;
     }
     return die(`Invalid ${name}=${value}. Allowed: ${allowed.join(", ")}`);
+}
+
+// Parse a CLI argument as a positive integer, or exit with a clear message.
+function requirePositiveInt(name: string, value: string): number {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        return die(`Invalid ${name}=${value}. Expected a positive integer.`);
+    }
+    return parsed;
 }
 
 // Nearest-rank percentile over an already-ascending array. `quantile` is 0.5, 0.9, etc.
@@ -222,9 +232,9 @@ const commands: Record<string, () => void> = {
 
     slowest() {
         const args = parseArgs({ N: "15", SORT: "total", FIELD: "durationMs", LASTRUNS: "20", MINRUNS: "3" });
-        const limit = Number(args.N);
-        const lastRuns = Number(args.LASTRUNS);
-        const minRuns = Number(args.MINRUNS);
+        const limit = requirePositiveInt("N", args.N);
+        const lastRuns = requirePositiveInt("LASTRUNS", args.LASTRUNS);
+        const minRuns = requirePositiveInt("MINRUNS", args.MINRUNS);
         const field: TimingField = requireOneOf("FIELD", args.FIELD, TIMING_FIELDS);
         const sort: SortKey = requireOneOf("SORT", args.SORT, SORT_KEYS);
 
@@ -251,8 +261,12 @@ const commands: Record<string, () => void> = {
             if (record.result !== "passed" || !recentRuns.has(record.runId)) {
                 continue;
             }
+            const value = record[field];
+            if (typeof value !== "number") {
+                continue;
+            }
             const durations = durationsByTest.get(record.test) ?? [];
-            durations.push(record[field]);
+            durations.push(value);
             durationsByTest.set(record.test, durations);
         }
 

--- a/tools/test-observability.ts
+++ b/tools/test-observability.ts
@@ -1,0 +1,289 @@
+#!/usr/bin/env bun
+// Portable test-observability queries over TestResults/, callable from any shell
+// (PowerShell, cmd, bash). Replaces a family of bash+jq+python Makefile recipes that
+// only ran under Git Bash. Invoked via `make test-*`; each subcommand mirrors one
+// target. The latest run is resolved once here so subcommands don't reimplement it.
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { gunzipSync } from "node:zlib";
+
+const RESULTS = "TestResults";
+
+// process.argv is [bunExecutable, scriptPath, subcommand, ...subcommandArgs].
+const SUBCOMMAND_INDEX = 2;
+const FIRST_ARG_INDEX = 3;
+
+// Output caps inherited from the original Makefile recipes.
+const FLAKY_TAIL_LINES = 2000; // recent flakiness records to print
+const RECENT_FAILURES = 5; // failure_context events to show for triage
+const CONTAINER_LIST_LIMIT = 20; // container names to suggest when one isn't found
+
+// One per-test timing record in flakiness.jsonl (one line, one test, one run).
+interface FlakinessRecord {
+    runId: string;
+    test: string;
+    result: string;
+    durationMs: number;
+    testBodyMs: number;
+}
+
+const SORT_KEYS = ["n", "p50", "p90", "max", "total"] as const;
+const TIMING_FIELDS = ["durationMs", "testBodyMs"] as const;
+type SortKey = (typeof SORT_KEYS)[number];
+type TimingField = (typeof TIMING_FIELDS)[number];
+
+interface TestStats {
+    test: string;
+    n: number;
+    p50: number;
+    p90: number;
+    max: number;
+    total: number;
+}
+
+function die(message: string): never {
+    console.error(message);
+    process.exit(1);
+}
+
+// Resolve the latest run the way the old Makefile did: latest.txt wins; otherwise
+// the newest runs/* directory that holds a summary.json (an aborted run has none).
+function latestRun(): string {
+    const pointer = join(RESULTS, "latest.txt");
+    if (existsSync(pointer)) {
+        const path = readFileSync(pointer, "utf8").trim();
+        if (path && existsSync(path)) {
+            return path;
+        }
+    }
+
+    const runsDir = join(RESULTS, "runs");
+    if (existsSync(runsDir)) {
+        const candidates = readdirSync(runsDir)
+            .map((name) => join(runsDir, name))
+            .filter((dir) => statSync(dir).isDirectory() && existsSync(join(dir, "summary.json")))
+            .sort()
+            .reverse();
+        if (candidates.length > 0) {
+            return candidates[0];
+        }
+    }
+
+    return die("No test runs found. Run tests first.");
+}
+
+// Parse the subcommand's `KEY=value` arguments over the defaults.
+function parseArgs<T extends Record<string, string>>(defaults: T): T {
+    const parsed: Record<string, string> = { ...defaults };
+    for (const argument of process.argv.slice(FIRST_ARG_INDEX)) {
+        const separator = argument.indexOf("=");
+        if (separator > 0) {
+            const key = argument.slice(0, separator);
+            const value = argument.slice(separator + 1);
+            parsed[key] = value;
+        }
+    }
+    return parsed as T;
+}
+
+function readJsonl<T>(path: string): T[] {
+    return readFileSync(path, "utf8")
+        .split("\n")
+        .filter((line) => line.trim())
+        .map((line) => JSON.parse(line) as T);
+}
+
+function printJsonFile(path: string): void {
+    console.log(JSON.stringify(JSON.parse(readFileSync(path, "utf8")), null, 2));
+}
+
+// Render a grid of rows as a left-aligned table, padding each column to its widest cell.
+function renderTable(rows: (string | number)[][]): string {
+    const header = rows[0];
+    const columnWidths = header.map((_, column) => Math.max(...rows.map((row) => String(row[column]).length)));
+    return rows
+        .map((row) => row.map((cell, column) => String(cell).padEnd(columnWidths[column])).join("  "))
+        .join("\n");
+}
+
+// Narrow a CLI argument to one of its allowed values, or exit with a clear message.
+function requireOneOf<T extends string>(name: string, value: string, allowed: readonly T[]): T {
+    if ((allowed as readonly string[]).includes(value)) {
+        return value as T;
+    }
+    return die(`Invalid ${name}=${value}. Allowed: ${allowed.join(", ")}`);
+}
+
+// Nearest-rank percentile over an already-ascending array. `quantile` is 0.5, 0.9, etc.
+// The median uses `length` rather than `length - 1` to match the original jq index math
+// the table output was validated against, so the two implementations never diverge.
+function percentile(values: number[], quantile: number): number {
+    const rank = quantile === 0.5 ? values.length * quantile : (values.length - 1) * quantile;
+    return values[Math.floor(rank)];
+}
+
+const commands: Record<string, () => void> = {
+    summary() {
+        const run = latestRun();
+        const file = join(run, "summary.json");
+        if (!existsSync(file)) {
+            die(`No summary.json in ${run} (run may have been aborted).`);
+        }
+        printJsonFile(file);
+    },
+
+    metadata() {
+        const run = latestRun();
+        const file = join(run, "run-metadata.json");
+        if (!existsSync(file)) {
+            die(`No metadata in ${run}.`);
+        }
+        printJsonFile(file);
+    },
+
+    "infra-log"() {
+        const run = latestRun();
+        const file = join(run, "diagnostics", "infrastructure.jsonl");
+        if (!existsSync(file)) {
+            die(`No infrastructure log in ${run}.`);
+        }
+        process.stdout.write(readFileSync(file, "utf8"));
+    },
+
+    events() {
+        const { TEST } = parseArgs({ TEST: "" });
+        if (!TEST) {
+            die("Usage: make test-events TEST=ClassName.MethodName[(arg=value)]");
+        }
+        const run = latestRun();
+        const file = join(run, "diagnostics", "infrastructure.jsonl");
+        if (!existsSync(file)) {
+            die(`No infrastructure.jsonl in ${run}.`);
+        }
+        for (const event of readJsonl<{ test?: { displayName?: string } }>(file)) {
+            if ((event.test?.displayName ?? "").includes(TEST)) {
+                console.log(JSON.stringify(event));
+            }
+        }
+    },
+
+    diagnose() {
+        const run = latestRun();
+        const file = join(run, "diagnostics", "infrastructure.jsonl");
+        if (!existsSync(file)) {
+            die(`No infrastructure log in ${run}.`);
+        }
+        const failures = readFileSync(file, "utf8")
+            .split("\n")
+            .filter((line) => line.includes('"event":"failure_context"'))
+            .slice(-RECENT_FAILURES);
+        for (const line of failures) {
+            console.log(JSON.stringify(JSON.parse(line), null, 2));
+        }
+    },
+
+    "container-log"() {
+        const { CONTAINER } = parseArgs({ CONTAINER: "" });
+        if (!CONTAINER) {
+            die("Usage: make test-container-log CONTAINER=server-0|client-0|steam-auth-shared|steam-auth-per-N");
+        }
+        const run = latestRun();
+        const dir = join(run, "containers", CONTAINER);
+        const plain = join(dir, "container.log");
+        const gzipped = join(dir, "container.log.gz");
+
+        if (existsSync(plain)) {
+            process.stdout.write(readFileSync(plain, "utf8"));
+            return;
+        }
+        if (existsSync(gzipped)) {
+            process.stdout.write(gunzipSync(readFileSync(gzipped)).toString("utf8"));
+            return;
+        }
+
+        console.error(`No container.log for ${CONTAINER} in ${run}.`);
+        const containers = join(run, "containers");
+        if (existsSync(containers)) {
+            console.error(readdirSync(containers).slice(0, CONTAINER_LIST_LIMIT).join("\n"));
+        }
+        process.exit(1);
+    },
+
+    flaky() {
+        const file = join(RESULTS, "flakiness.jsonl");
+        if (!existsSync(file)) {
+            die("No flakiness data. Run tests multiple times first.");
+        }
+        const lines = readFileSync(file, "utf8")
+            .split("\n")
+            .filter((line) => line.trim());
+        console.log(lines.slice(-FLAKY_TAIL_LINES).join("\n"));
+    },
+
+    slowest() {
+        const args = parseArgs({ N: "15", SORT: "total", FIELD: "durationMs", LASTRUNS: "20", MINRUNS: "3" });
+        const limit = Number(args.N);
+        const lastRuns = Number(args.LASTRUNS);
+        const minRuns = Number(args.MINRUNS);
+        const field: TimingField = requireOneOf("FIELD", args.FIELD, TIMING_FIELDS);
+        const sort: SortKey = requireOneOf("SORT", args.SORT, SORT_KEYS);
+
+        const file = join(RESULTS, "flakiness.jsonl");
+        if (!existsSync(file)) {
+            die("No flakiness data. Run tests multiple times first.");
+        }
+        const records = readJsonl<FlakinessRecord>(file);
+
+        // Keep only the most recent LASTRUNS runs (the file is append-chronological).
+        const runOrder: string[] = [];
+        const seenRuns = new Set<string>();
+        for (const record of records) {
+            if (!seenRuns.has(record.runId)) {
+                seenRuns.add(record.runId);
+                runOrder.push(record.runId);
+            }
+        }
+        const recentRuns = new Set(runOrder.slice(-lastRuns));
+
+        // Collect passing durations per test within the window.
+        const durationsByTest = new Map<string, number[]>();
+        for (const record of records) {
+            if (record.result !== "passed" || !recentRuns.has(record.runId)) {
+                continue;
+            }
+            const durations = durationsByTest.get(record.test) ?? [];
+            durations.push(record[field]);
+            durationsByTest.set(record.test, durations);
+        }
+
+        const stats: TestStats[] = [];
+        for (const [test, durations] of durationsByTest) {
+            if (durations.length < minRuns) {
+                continue;
+            }
+            const ascending = durations.slice().sort((a, b) => a - b);
+            stats.push({
+                test: test.replace(/^JunimoServer\.Tests\./, ""),
+                n: ascending.length,
+                p50: percentile(ascending, 0.5),
+                p90: percentile(ascending, 0.9),
+                max: ascending[ascending.length - 1],
+                total: ascending.reduce((sum, value) => sum + value, 0),
+            });
+        }
+        stats.sort((a, b) => b[sort] - a[sort]);
+
+        const rows: (string | number)[][] = [["TEST", "n", "p50ms", "p90ms", "maxms", "totalms"]];
+        for (const stat of stats.slice(0, limit)) {
+            rows.push([stat.test, stat.n, stat.p50, stat.p90, stat.max, stat.total]);
+        }
+        console.log(renderTable(rows));
+    },
+};
+
+const subcommand = process.argv[SUBCOMMAND_INDEX];
+const command = commands[subcommand];
+if (!command) {
+    die(`Unknown subcommand: ${subcommand ?? "(none)"}. Known: ${Object.keys(commands).join(", ")}`);
+}
+command();

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "lib": ["ESNext"],
+        "target": "ESNext",
+        "module": "Preserve",
+        "moduleResolution": "bundler",
+        "moduleDetection": "force",
+        "allowImportingTsExtensions": true,
+        "verbatimModuleSyntax": true,
+        "noEmit": true,
+
+        "strict": true,
+        "skipLibCheck": true,
+
+        "types": ["node"]
+    },
+    "include": ["*.ts"]
+}


### PR DESCRIPTION
Moves the `test-*` observability Makefile targets to a single bun script so they run from any shell (PowerShell, cmd, bash). Previously they used bash + jq + python + awk + column, so they only worked under Git Bash and failed from PowerShell.

## Changes

- **`tools/test-observability.ts`** (new) — one bun script with subcommands mirroring each target: `summary`, `metadata`, `infra-log`, `events`, `container-log`, `flaky`, `diagnose`, plus a new `slowest`. Latest-run resolution and all queries live here; no external CLI deps (gzip via `node:zlib`).
- **`make test-slowest`** (new target) — ranks tests by runtime over recent runs to find suite-shortening candidates. Default sort is total slot-time (`count × p50`), the best proxy for "improving this shortens the suite" given tests run in parallel. Knobs: `N`, `SORT=total|p50|p90|max`, `FIELD=durationMs|testBodyMs`, `LASTRUNS`, `MINRUNS`.
- **`Makefile`** — the 8 observability recipes become thin `@bun tools/test-observability.ts <cmd>` lines; drops the bash-only `LATEST_RUN` shell block.
- **`tools/tsconfig.json`** (new) — bun-idiomatic config (`module: Preserve`, `moduleDetection: force`, `verbatimModuleSyntax`, `types: ["node"]`) so the editor resolves node globals.
- **`biome.jsonc`** — extend `includes` to lint/format the new files.

## Verification

- All 8 targets produce correct output via `make` from PowerShell (the original failure case).
- `slowest` output matches the prior jq implementation byte-for-byte; `container-log` gzip branch verified round-trip.
- `tsc -p tools/tsconfig.json` → exit 0; biome 2.5.0 check → clean.

Note: the pre-commit hook surfaced a stale local biome (2.4.16 vs pinned 2.5.0); resynced via `npm ci`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked test observability tasks to use a centralized script for discovering runs and extracting summaries, events, metadata, logs, and diagnostics.
  * Added a new `test-slowest` task to rank slow tests with configurable filters and limits.
  * Updated formatting/linting configuration to include the new test observability tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->