### PR TITLE
fix(always-on): guard ccDoorUnlock mail add against duplicates

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -594,6 +594,10 @@ public class AlwaysOnServer : ModService
         if (!Game1.player.eventsSeen.Contains("611439"))
         {
             Game1.player.eventsSeen.Add("611439");
+        }
+
+        if (!Game1.MasterPlayer.mailReceived.Contains("ccDoorUnlock"))
+        {
             Game1.MasterPlayer.mailReceived.Add("ccDoorUnlock");
         }
     }


### PR DESCRIPTION
@
- `HandleCommunityCenterUnlock` guarded the `mailReceived.Add` on `eventsSeen.Contains("611439")` instead of on the list being written.
- `mailReceived` is a `NetStringList`; re-adding `ccDoorUnlock` (e.g. on a repeat unlock pass) appends a duplicate entry, bloating the netcode list and the save with no behavioral effect (reads are `Contains`-based).
- Guard the add on `mailReceived.Contains("ccDoorUnlock")` so the flag is recorded exactly once. The separate `eventsSeen` guard for event `611439` is unchanged.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with community center unlock logic to ensure proper execution at the correct scope level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->