### PR TITLE
perf(cabin): cache designated cabin-position scan per farm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ RUNNER_PROJECT := ./tests/JunimoServer.TestRunner
 #   make test FILTER="Login_WithCorrectPassword"
 #   make test FILTER="CabinStrategyNoneTests|CabinPositionPersistenceTests"
 #   make test (runs all tests)
+# Note: '|' works only for direct `make test`. The /run-tests-e2e PR-comment trigger
+# rejects '|' (it would break the sticky-comment markdown table); use one pattern there.
 FILTER ?=
 
 # Verbose output. Use VERBOSE=1 for detailed setup steps and diagnostic logs:

--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,11 @@ clean:
 TEST_PROJECT := ./tests/JunimoServer.Tests
 RUNNER_PROJECT := ./tests/JunimoServer.TestRunner
 
-# Test filtering. Use FILTER to run specific tests:
+# Test filtering. Use FILTER to run specific tests (case-insensitive substring of the
+# class FullName or {Class}.{Method} display name). Separate alternatives with '|':
 #   make test FILTER=PasswordProtection
 #   make test FILTER="Login_WithCorrectPassword"
+#   make test FILTER="CabinStrategyNoneTests|CabinPositionPersistenceTests"
 #   make test (runs all tests)
 FILTER ?=
 

--- a/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
+++ b/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
@@ -13,17 +13,28 @@ namespace JunimoServer.Services.CabinManager;
 /// </summary>
 public static class FarmCabinPositions
 {
+    // Cache the static Paths-layer scan, keyed on Farm identity. A reload/newgame realizes a
+    // fresh Farm, so reference inequality rescans and prior-session positions can't leak.
+    private static Farm _cachedFarm;
+    private static List<Vector2> _cachedPositions;
+
     /// <summary>
     /// Returns all map-designated cabin positions for the given farm, sorted by Order.
     /// Reads both tile index 29 (grouped) and 30 (separate) since we just need valid locations.
     /// </summary>
     public static List<Vector2> GetDesignatedPositions(Farm farm)
     {
+        if (ReferenceEquals(farm, _cachedFarm))
+        {
+            return _cachedPositions;
+        }
+
         var positions = new List<(int order, Vector2 position)>();
         var layer = farm.map?.GetLayer("Paths");
 
         if (layer == null)
         {
+            // Not realized yet; don't cache, so a later call on this Farm rescans.
             return new List<Vector2>();
         }
 
@@ -52,7 +63,10 @@ public static class FarmCabinPositions
             }
         }
 
-        return positions.OrderBy(p => p.order).Select(p => p.position).ToList();
+        var result = positions.OrderBy(p => p.order).Select(p => p.position).ToList();
+        _cachedFarm = farm;
+        _cachedPositions = result;
+        return result;
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
+++ b/mod/JunimoServer/Services/CabinManager/FarmCabinPositions.cs
@@ -22,7 +22,11 @@ public static class FarmCabinPositions
     /// Returns all map-designated cabin positions for the given farm, sorted by Order.
     /// Reads both tile index 29 (grouped) and 30 (separate) since we just need valid locations.
     /// </summary>
-    public static List<Vector2> GetDesignatedPositions(Farm farm)
+    /// <remarks>
+    /// Returns the cached list directly (no defensive copy) on a hit, so the type is
+    /// <see cref="IReadOnlyList{T}"/> to keep callers from mutating the cache.
+    /// </remarks>
+    public static IReadOnlyList<Vector2> GetDesignatedPositions(Farm farm)
     {
         if (ReferenceEquals(farm, _cachedFarm))
         {

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -814,11 +814,12 @@ try
         OnTestFinished = callbacks.OnTestFinished,
     };
 
-    // Apply filter if specified
-    if (!string.IsNullOrEmpty(filter))
+    // Apply filter if specified. A '|' splits into independent patterns; xUnit's
+    // included-method filters are OR'd, so one AddIncludedMethodFilter per pattern
+    // matches any of them — mirroring TestFilter's substring-OR semantics.
+    foreach (var pattern in TestFilter.ParsePatterns(filter))
     {
-        // Use method filter which matches against the fully-qualified test name
-        options.Filters.AddIncludedMethodFilter($"*{filter}*");
+        options.Filters.AddIncludedMethodFilter($"*{pattern}*");
     }
 
     // Notify run started
@@ -1100,10 +1101,6 @@ static List<(
         var className = type.Name;
         var classFullName = type.FullName ?? type.Name;
 
-        var classMatchesFilter =
-            string.IsNullOrEmpty(filter)
-            || classFullName.Contains(filter, StringComparison.OrdinalIgnoreCase);
-
         foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
         {
             var hasFact = factType != null && method.GetCustomAttribute(factType) != null;
@@ -1120,13 +1117,7 @@ static List<(
                     {
                         foreach (var theoryDisplayName in expanded)
                         {
-                            if (
-                                !classMatchesFilter
-                                && !theoryDisplayName.Contains(
-                                    filter!,
-                                    StringComparison.OrdinalIgnoreCase
-                                )
-                            )
+                            if (!TestFilter.Matches(filter, classFullName, theoryDisplayName))
                             {
                                 continue;
                             }
@@ -1138,10 +1129,7 @@ static List<(
                 }
 
                 var displayName = $"{classFullName}.{methodName}";
-                if (
-                    !classMatchesFilter
-                    && !displayName.Contains(filter!, StringComparison.OrdinalIgnoreCase)
-                )
+                if (!TestFilter.Matches(filter, classFullName, displayName))
                 {
                     continue;
                 }

--- a/tests/JunimoServer.Tests/Infrastructure/ServerConfigDiscovery.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ServerConfigDiscovery.cs
@@ -38,11 +38,11 @@ public static class ServerConfigDiscovery
     /// </para>
     /// <para>
     /// <paramref name="methodFilter"/>: when non-null and non-empty, mirrors the
-    /// runner's `--filter` substring predicate applied per-method (class FullName
-    /// contains the substring OR `{ClassFullName}.{MethodName}` contains it,
-    /// case-insensitive). Non-matching methods don't contribute to any demand's
-    /// counts, so multiple classes sharing a config key don't inflate
-    /// <c>TestCount</c>/<c>NonExclusiveTestCount</c> beyond what xUnit will
+    /// runner's `--filter` predicate via <see cref="TestFilter.Matches"/> (one or more
+    /// '|'-separated substring patterns, matched per-method against class FullName or
+    /// `{ClassFullName}.{MethodName}`, case-insensitive). Non-matching methods don't
+    /// contribute to any demand's counts, so multiple classes sharing a config key don't
+    /// inflate <c>TestCount</c>/<c>NonExclusiveTestCount</c> beyond what xUnit will
     /// actually dispatch. Used by the local-runner prestart path; distributed
     /// workers leave it null and rely on <paramref name="keyFilter"/> for
     /// scoping.
@@ -257,10 +257,10 @@ public static class ServerConfigDiscovery
     /// groups test case counts by the resulting server key. This mirrors the merge
     /// that <see cref="TestBase.InitializeAsync"/> performs at runtime.
     ///
-    /// <paramref name="methodFilter"/> mirrors the runner's `--filter` substring
-    /// predicate: methods are kept only when the class FullName contains the
-    /// substring OR the `{ClassFullName}.{MethodName}` display name does
-    /// (case-insensitive). Null/empty means "no filter".
+    /// <paramref name="methodFilter"/> mirrors the runner's `--filter` predicate via
+    /// <see cref="TestFilter.Matches"/>: '|'-separated patterns, kept when any is a
+    /// case-insensitive substring of the class FullName or `{ClassFullName}.{MethodName}`
+    /// display name. Null/empty means "no filter".
     /// </summary>
     private static List<MethodDemand> DiscoverMethodDemands(
         Type type,
@@ -273,9 +273,6 @@ public static class ServerConfigDiscovery
             new Dictionary<string, (ResourceRequirements reqs, int total, int exclusive)>();
 
         var classFull = type.FullName ?? type.Name;
-        var classMatches =
-            string.IsNullOrEmpty(methodFilter)
-            || classFull.Contains(methodFilter, StringComparison.OrdinalIgnoreCase);
 
         foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -301,13 +298,9 @@ public static class ServerConfigDiscovery
                 continue;
             }
 
-            if (!classMatches)
+            if (!TestFilter.Matches(methodFilter, classFull, $"{classFull}.{method.Name}"))
             {
-                var displayName = $"{classFull}.{method.Name}";
-                if (!displayName.Contains(methodFilter!, StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
+                continue;
             }
 
             var cases = (isFact && !isTheory) ? 1 : CountTheoryDataRows(type, method, attrs);

--- a/tests/JunimoServer.Tests/Infrastructure/TestFilter.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestFilter.cs
@@ -1,0 +1,54 @@
+namespace JunimoServer.Tests.Infrastructure;
+
+/// <summary>
+/// Parses the <c>--filter</c> / <c>FILTER=</c> value shared by the runner's discovery,
+/// the xUnit execution gate, the broker prestart, and the child expected-count seed.
+/// A '|' splits the value into independent substring patterns; a test matches when ANY
+/// pattern is a (case-insensitive) substring of its class FullName or display name —
+/// the same OR semantics xUnit's own <c>AddIncludedMethodFilter</c> collection applies.
+/// </summary>
+public static class TestFilter
+{
+    /// <summary>
+    /// Splits a raw filter into its '|'-separated patterns, trimming whitespace and
+    /// dropping empties. Returns an empty array for null/empty (meaning "no filter").
+    /// </summary>
+    public static string[] ParsePatterns(string? filter)
+    {
+        if (string.IsNullOrEmpty(filter))
+        {
+            return Array.Empty<string>();
+        }
+
+        return filter.Split(
+            '|',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries
+        );
+    }
+
+    /// <summary>
+    /// True when no filter is active, or when any pattern matches the class FullName or
+    /// the <c>{ClassFullName}.{MethodName}</c> display name (case-insensitive substring).
+    /// </summary>
+    public static bool Matches(string? filter, string classFullName, string displayName)
+    {
+        var patterns = ParsePatterns(filter);
+        if (patterns.Length == 0)
+        {
+            return true;
+        }
+
+        foreach (var pattern in patterns)
+        {
+            if (
+                classFullName.Contains(pattern, StringComparison.OrdinalIgnoreCase)
+                || displayName.Contains(pattern, StringComparison.OrdinalIgnoreCase)
+            )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Cabin position cache

- `FarmCabinPositions.GetDesignatedPositions` rescanned the whole `Paths` layer (O(W×H) tiles) on every cabin allocation/placement query. The designated cabin tiles are static once a farm map is realized, so the scan returned the same result every time within a session.
- Cache the sorted scan, keyed on the `Farm` instance (`ReferenceEquals`). A reload/newgame realizes a fresh `Farm` object, so reference inequality rescans the new map and prior-session positions can't leak — verified against decompiled SDV that every reload path here (`loadForNewGame` and `/reload`-via-title) constructs a new `Farm`, making a separate save-load clear redundant.
- Occupancy filtering stays live: `GetAvailablePositions` / `GetNextAvailablePosition` still check `farm.buildings` each call. Only the static tile scan is cached. The pre-realization (`layer == null`) path deliberately doesn't cache.

## Multi-pattern test FILTER (incidental)

- `FILTER` was a single case-insensitive substring; splitting on `|` lets a run target several classes/methods at once, e.g. `FILTER="CabinStrategyNoneTests|CabinPositionPersistenceTests"`.
- New `TestFilter` helper centralizes parse + match (substring-OR across patterns) so all consumers agree: the xUnit execution gate (one `AddIncludedMethodFilter` per pattern — xUnit OR's same-kind included filters), the runner's discovery count, and the broker prestart / child expected-count seed via `ServerConfigDiscovery`.

## Verification

- `make test FILTER="CabinStrategyNoneTests|CabinPositionPersistenceTests"` — all 6 tests pass (4 + 2 across both classes; `expectedTestCount` matched, confirming the pipe-filter parses in discovery/count seeds too). The 6-cabin `None` backfill burst exercises the cached reuse path; the reload/strategy-switch tests exercise cache invalidation across a fresh farm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced test filtering to accept multiple case-insensitive `|`-separated patterns, matching against either the test class name or the `{Class}.{Method}` display name (including theory display names).

* **Documentation**
  * Updated `make test` and test infrastructure documentation to describe `|`-syntax, including limitations for the e2e PR-comment trigger.

* **Refactor**
  * Improved farm cabin position lookup performance by caching computed designated positions per farm and returning a read-only result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->