### PR TITLE
fix(diagnostics): gate SDVD_EVENT emission on SDVD_ENV=test

### DIFF
--- a/mod/JunimoServer/Services/Diagnostics/ModEventLog.cs
+++ b/mod/JunimoServer/Services/Diagnostics/ModEventLog.cs
@@ -10,6 +10,11 @@ namespace JunimoServer.Services.Diagnostics;
 /// Envelope schema: see docs/developers/events-schema.md
 ///
 /// <para>
+/// Only emits when <see cref="Env.IsTest"/> (<c>SDVD_ENV=test</c>): the lines
+/// are consumed solely by the E2E harness, so prod builds skip them.
+/// </para>
+///
+/// <para>
 /// Transport: each event is one <c>Console.Out.WriteLine</c> prefixed
 /// with <c>SDVD_EVENT </c>. The host-side <c>SimpleContainerLogStreamer</c>
 /// parses the prefix and forwards the payload to <c>infrastructure.jsonl</c>,
@@ -44,6 +49,14 @@ public static class ModEventLog
     /// because reading <c>Game1.ticks</c> off the game thread is unsafe.</param>
     public static void Emit(string eventType, object? data = null, int? tickMs = null)
     {
+        // SDVD_EVENT lines are consumed only by the E2E harness's
+        // SimpleContainerLogStreamer; in prod nothing reads them, so skip the
+        // serialize + stdout write entirely.
+        if (!Env.IsTest)
+        {
+            return;
+        }
+
         try
         {
             var entry = new

--- a/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
+++ b/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
@@ -131,6 +131,10 @@ public class SharedSteamAuth : IAsyncDisposable
             .WithEnvironment("PORT", ContainerPort.ToString())
             .WithEnvironment("GAME_DIR", "/data/game")
             .WithEnvironment("SESSION_DIR", "/data/steam-session")
+            // Gate for the sidecar's SDVD_EVENT emit (Logger.LogEvent). Without
+            // this its structured events stay silent even here, where the harness
+            // consumes them via SimpleContainerLogStreamer.
+            .WithEnvironment("SDVD_ENV", "test")
             .WithCreateParameterModifier(p =>
             {
                 p.HostConfig ??= new HostConfig();

--- a/tools/steam-service/Logger.cs
+++ b/tools/steam-service/Logger.cs
@@ -50,9 +50,14 @@ public static class Logger
     /// the first failure of each type and suppress the rest.</summary>
     private static readonly ConcurrentDictionary<Type, byte> _reportedEventFailures = new();
 
-    /// <summary>Mirrors the mod's <c>Env.IsTest</c>: <c>SDVD_ENV=test</c>.
+    /// <summary>Mirrors the mod's <c>Env.IsTest</c>: <c>SDVD_ENV=test</c>
+    /// (case-insensitive, matching <c>Env.SdvdEnv</c>'s <c>ToLowerInvariant</c>).
     /// Only the E2E harness consumes <c>SDVD_EVENT </c> lines, so prod skips them.</summary>
-    private static readonly bool _isTest = Environment.GetEnvironmentVariable("SDVD_ENV") == "test";
+    private static readonly bool _isTest = string.Equals(
+        Environment.GetEnvironmentVariable("SDVD_ENV"),
+        "test",
+        StringComparison.OrdinalIgnoreCase
+    );
 
     /// <summary>
     /// Emits a structured event line. Interleaves with the free-text log

--- a/tools/steam-service/Logger.cs
+++ b/tools/steam-service/Logger.cs
@@ -50,12 +50,21 @@ public static class Logger
     /// the first failure of each type and suppress the rest.</summary>
     private static readonly ConcurrentDictionary<Type, byte> _reportedEventFailures = new();
 
+    /// <summary>Mirrors the mod's <c>Env.IsTest</c>: <c>SDVD_ENV=test</c>.
+    /// Only the E2E harness consumes <c>SDVD_EVENT </c> lines, so prod skips them.</summary>
+    private static readonly bool _isTest = Environment.GetEnvironmentVariable("SDVD_ENV") == "test";
+
     /// <summary>
     /// Emits a structured event line. Interleaves with the free-text log
     /// stream on stdout; the host-side streamer filters by the
     /// <c>SDVD_EVENT </c> prefix and forwards to <c>infrastructure.jsonl</c>.
     ///
     /// Envelope schema: see docs/developers/events-schema.md
+    ///
+    /// <para>
+    /// Only emits when <c>SDVD_ENV=test</c>: the lines are consumed solely by
+    /// the E2E harness, so prod builds skip the serialize + stdout write.
+    /// </para>
     ///
     /// <para>
     /// Never throws: a dropped event is preferable to a crashed sidecar.
@@ -66,6 +75,11 @@ public static class Logger
     /// </summary>
     public static void LogEvent(string name, object? data = null)
     {
+        if (!_isTest)
+        {
+            return;
+        }
+
         try
         {
             var entry = new


### PR DESCRIPTION
`SDVD_EVENT` lines are consumed **only** by the E2E harness (`SimpleContainerLogStreamer` forwards them to `infrastructure.jsonl`). In prod nothing reads them, so the server mod and steam-auth sidecar were writing them to stdout for no consumer — spamming the operator CLI.

This gates emission on `SDVD_ENV=test` so prod builds skip them entirely (no serialize, no write).

- `ModEventLog.Emit` (server mod): early-return unless `Env.IsTest` — skips both the JSON serialize and the stdout write in prod.
- `Logger.LogEvent` (steam-service sidecar): gate on `SDVD_ENV=test`, replacing a previously commented-out emit; mirrors the mod's `Env.IsTest`.
- `SharedSteamAuth`: pass `SDVD_ENV=test` to the sidecar container so its events still reach the harness under the new gate (the sidecar previously received no `SDVD_ENV`).

Left as-is: the test-client `ClientEventLog` emit — it's a test-only artifact that never runs in prod, so gating it would be a behavioral no-op.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated diagnostic/telemetry event logging so structured `SDVD_EVENT` lines are emitted only during test runs, eliminating test-only output from production logs.
* **Tests**
  * Adjusted the shared Steam authentication test container setup to set the test environment flag, ensuring the harness can observe the gated diagnostic events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->