### PR TITLE
fix(test-runner): report canceled tests separately in the CI summary

### DIFF
--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -168,16 +168,23 @@ public sealed class CIRenderer : RendererBase
             _out.WriteLine();
         }
 
-        // Summary footer: include implicit skips (tests that never executed)
+        // Summary footer: include implicit skips (tests that never executed). e.Failed is xUnit's
+        // raw count (it lumps canceled in), so use it for the implicit-skip math but report the
+        // reclassified FailedCount/CanceledCount (matching summary.json) below.
         var executedTotal = e.Passed + e.Failed + e.Skipped;
         var implicitSkipped = Math.Max(0, TotalDiscovered - executedTotal);
         var totalSkipped = e.Skipped + implicitSkipped;
-        var totalTests = e.Passed + e.Failed + totalSkipped;
+        var totalTests = e.Passed + FailedCount + CanceledCount + totalSkipped;
         var parts = new List<string>();
 
-        if (e.Failed > 0)
+        if (FailedCount > 0)
         {
-            parts.Add(RedBold($"{e.Failed} failed"));
+            parts.Add(RedBold($"{FailedCount} failed"));
+        }
+
+        if (CanceledCount > 0)
+        {
+            parts.Add(Yellow($"{CanceledCount} canceled"));
         }
 
         if (totalSkipped > 0)


### PR DESCRIPTION
## Problem

The console summary footer (`CIRenderer.OnRunFinished`) rendered xUnit's raw `e.Failed`, which lumps canceled tests (`OperationCanceledException`/`TaskCanceledException`) into the failed count. On a run where the suite hit its wall-clock budget and canceled the backlog, this showed **"70 failed"** while `summary.json` correctly reported `failed: 1, canceled: 69` — misleading triage into thinking real failures occurred.

## Fix

- Report the reclassified `FailedCount` / `CanceledCount` from `RendererBase` (the same counts that feed `summary.json`) instead of xUnit's lumped `e.Failed`.
- Add a distinct **"N canceled"** part to the summary line.
- `e.Failed` is still used for the implicit-skip math, since it's xUnit's full executed-non-pass count.

## Notes

- No behavior change for the common all-pass run (both counts zero → identical output); only the canceled-backlog case now renders correctly and agrees with `summary.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test result summary reporting to accurately count and display skipped tests, failed tests, and canceled tests. Test totals are now recalculated using updated counts for more precise result summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->