### PR TITLE
fix(cropsaver): stop withering crops in season-immune locations

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -32,6 +32,10 @@ public class TestCrop
 
     /// <summary>True if CropSaver has a tracking entry for this (locationName, tile).</summary>
     public bool IsManaged { get; set; }
+
+    /// <summary>True if this location is season-immune (greenhouse, Ginger Island, indoors)
+    /// — vanilla never withers crops here, so CropSaver must not either.</summary>
+    public bool IsSeasonImmune { get; set; }
 }
 
 /// <summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -134,6 +134,7 @@ public partial class ApiService
                                 IsInPot = false,
                                 SeedItemId = crop.netSeedIndex.Value,
                                 IsManaged = CropSaverOverrides.IsManaged(locName, dirt.Tile),
+                                IsSeasonImmune = location.IsCropSeasonImmune(),
                             }
                         );
                     }
@@ -162,6 +163,7 @@ public partial class ApiService
                                 IsInPot = true,
                                 SeedItemId = crop.netSeedIndex.Value,
                                 IsManaged = CropSaverOverrides.IsManaged(locName, pot.TileLocation),
+                                IsSeasonImmune = location.IsCropSeasonImmune(),
                             }
                         );
                     }

--- a/mod/JunimoServer/Services/CropSaver/CropSaver.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaver.cs
@@ -57,16 +57,24 @@ public class CropSaver : ModService
             .ForEach(saverCrop =>
             {
                 var dirt = saverCrop.TryGetCoorespondingDirt();
-                if (dirt != null)
+                if (dirt == null)
                 {
-                    if (
-                        saverCrop.ownerId != 0
-                        && !onlineIds.Contains(saverCrop.ownerId)
-                        && dirt.state.Value != HoeDirt.watered
-                    )
-                    {
-                        saverCrop.IncrementExtraDays();
-                    }
+                    return;
+                }
+
+                // Immune crops are never killed below, so there is nothing to prolong.
+                if (dirt.Location?.IsCropSeasonImmune() == true)
+                {
+                    return;
+                }
+
+                if (
+                    saverCrop.ownerId != 0
+                    && !onlineIds.Contains(saverCrop.ownerId)
+                    && dirt.state.Value != HoeDirt.watered
+                )
+                {
+                    saverCrop.IncrementExtraDays();
                 }
             });
 
@@ -74,7 +82,8 @@ public class CropSaver : ModService
         for (var i = _cropSaverDataLoader.GetSaverCrops().Count - 1; i >= 0; i--)
         {
             var saverCrop = _cropSaverDataLoader.GetSaverCrops()[i];
-            var crop = saverCrop.TryGetCoorespondingCrop();
+            var dirt = saverCrop.TryGetCoorespondingDirt();
+            var crop = dirt?.crop;
             if (crop == null)
             {
                 _monitor.Log(
@@ -105,6 +114,16 @@ public class CropSaver : ModService
                     saverCrop.cropLocationName,
                     saverCrop.cropLocationTile
                 );
+                continue;
+            }
+
+            // CropSaver is the sole death authority for tracked crops, so it must skip
+            // season-immune locations or it withers crops vanilla never would — the
+            // greenhouse bug. A null location (resolved crop, no location) is anomalous,
+            // not immune, so fall through to the normal kill logic.
+            var location = dirt.Location;
+            if (location != null && location.IsCropSeasonImmune())
+            {
                 continue;
             }
 
@@ -194,9 +213,13 @@ public class CropSaver : ModService
 
     private static SDate CalculateDateOfDeath(Crop crop, SaverCrop saverCrop)
     {
-        var numSeasons =
-            crop.GetData().Seasons.Count
-            - (crop.GetData().Seasons.IndexOf(saverCrop.datePlanted.Season));
+        var seasons = crop.GetData().Seasons;
+        var seasonIndex = seasons.IndexOf(saverCrop.datePlanted.Season);
+        if (seasonIndex < 0)
+        {
+            seasonIndex = 0; // planted-season not in list: treat as first season
+        }
+        var numSeasons = seasons.Count - seasonIndex;
         var numDaysToLive = saverCrop.extraDays + (28 * numSeasons) - saverCrop.datePlanted.Day;
         var dateOfDeath = saverCrop.datePlanted.AddDays(numDaysToLive);
 

--- a/mod/JunimoServer/Util/GameLocationExtensions.cs
+++ b/mod/JunimoServer/Util/GameLocationExtensions.cs
@@ -48,4 +48,14 @@ public static class GameLocationExtensions
         building = location.GetCabinHidden(peerId);
         return building != null;
     }
+
+    /// <summary>
+    /// True if crops here are season-immune — vanilla never withers them.
+    /// Mirrors the Crop.newDay kill gate, which only withers when the location
+    /// is outdoors and the crop is out of season (decompiled Crop.cs:837,
+    /// IsInSeason Crop.cs:357). Greenhouse + Ginger Island return
+    /// SeedsIgnoreSeasonsHere()==true; every indoor location is !IsOutdoors.
+    /// </summary>
+    public static bool IsCropSeasonImmune(this GameLocation location) =>
+        !location.IsOutdoors || location.SeedsIgnoreSeasonsHere();
 }

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -427,6 +427,11 @@ public class TestCrop
     /// <summary>True if CropSaver has a tracking entry for this (locationName, tile).</summary>
     [JsonPropertyName("isManaged")]
     public bool IsManaged { get; set; }
+
+    /// <summary>True if this location is season-immune (greenhouse, Ginger Island, indoors)
+    /// — vanilla never withers crops here, so CropSaver must not either.</summary>
+    [JsonPropertyName("isSeasonImmune")]
+    public bool IsSeasonImmune { get; set; }
 }
 
 /// <summary>
@@ -1399,9 +1404,22 @@ public class ServerApiClient : IDisposable
         int tileY,
         int? extraDays = null,
         long? ownerId = null,
+        (string Season, int Day, int Year)? datePlanted = null,
         CancellationToken ct = default
     )
     {
+        // Cast to object? so the null and the populated-object branches share a
+        // compile-time type; System.Text.Json serializes a null property fine,
+        // and the endpoint skips DatePlanted when it's null.
+        object? datePlantedBody = datePlanted is { } dp
+            ? new
+            {
+                season = dp.Season,
+                day = dp.Day,
+                year = dp.Year,
+            }
+            : null;
+
         var response = await SendWithRetryAsync(
             HttpMethod.Post,
             "/test/saver_crop",
@@ -1415,6 +1433,7 @@ public class ServerApiClient : IDisposable
                         tileY,
                         extraDays,
                         ownerId,
+                        datePlanted = datePlantedBody,
                     }
                 )
         );

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -7,7 +7,7 @@ namespace JunimoServer.Tests;
 /// <summary>
 /// E2E coverage for CropSaver across Garden Pots.
 ///
-/// Two complementary tests, both load-bearing:
+/// Three complementary tests, all load-bearing:
 /// <list type="bullet">
 /// <item><description>
 /// <see cref="GardenPotCrop_IsRegisteredWithCropSaverWatcher"/> exercises the
@@ -23,9 +23,17 @@ namespace JunimoServer.Tests;
 /// out-of-season kill. Also exercises <c>SaverCrop.TryGetCoorespondingDirt</c>'s
 /// <c>StardewValley.Objects.IndoorPot</c> branch.
 /// </description></item>
+/// <item><description>
+/// <see cref="PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline"/>
+/// drives a pot crop in a season-immune location (the farmhand's cabin interior)
+/// past its computed date of death through a real <c>OnDayEnd</c>, asserting the
+/// <c>IsCropSeasonImmune()</c> guard spares it — the greenhouse bug class.
+/// </description></item>
 /// </list>
 /// </summary>
-[TestServer(Isolation = IsolationMode.SharedClass)]
+// Exclusive serializes the methods (SharedClass alone runs them concurrently): all
+// three mutate the global calendar and would clobber each other mid-transition.
+[TestServer(Isolation = IsolationMode.SharedClass, Exclusive = true)]
 public class CropSaverTests : TestBase
 {
     /// <summary>
@@ -34,6 +42,13 @@ public class CropSaverTests : TestBase
     /// DaysInPhase=[1,2,4,4,1] = 12 days total to maturity.
     /// </summary>
     private const string CauliflowerSeedId = "474";
+
+    /// <summary>
+    /// Pumpkin seed id (unqualified). Fall-only, so planted Fall 1 its CropSaver date
+    /// of death is Fall 28 — the immune-location test drives one SetDate to that
+    /// season-end rollover, where a seasonal crop would be killed.
+    /// </summary>
+    private const string PumpkinSeedId = "490";
 
     /// <summary>
     /// Tile coordinates on open Farm soil south of the FarmHouse front door
@@ -54,12 +69,21 @@ public class CropSaverTests : TestBase
     private const int TileB_X = 64;
     private const int TileB_Y = 22;
 
+    /// <summary>
+    /// Tile inside the farmhand's cabin interior for the immune-location test.
+    /// The cabin interior is a separate location from the Farm, so this needs no
+    /// coordination with the Farm tiles above. (3, 5) is open floor in the
+    /// starter cabin map, clear of the bed/chest/TV furniture near the walls.
+    /// </summary>
+    private const int CabinTileX = 3;
+    private const int CabinTileY = 5;
+
     [Fact]
     public async Task GardenPotCrop_IsRegisteredWithCropSaverWatcher()
     {
         var ct = TestContext.Current.CancellationToken;
         await PlacePotAndPlantCauliflowerAsync(TileA_X, TileA_Y, ct);
-        await AssertWatcherRegistersPotAsync(TileA_X, TileA_Y, ct);
+        await AssertWatcherRegistersPotAsync("Farm", TileA_X, TileA_Y, ct);
     }
 
     [Fact]
@@ -68,7 +92,7 @@ public class CropSaverTests : TestBase
         var ct = TestContext.Current.CancellationToken;
 
         var farmhand = await PlacePotAndPlantCauliflowerAsync(TileB_X, TileB_Y, ct);
-        await AssertWatcherRegistersPotAsync(TileB_X, TileB_Y, ct);
+        await AssertWatcherRegistersPotAsync("Farm", TileB_X, TileB_Y, ct);
 
         // Pre-arm extraDays past CropSaver.OnDayEnd's branch-1 / branch-2
         // floors so the prolong logic doesn't kill the crop *inside* OnDayEnd
@@ -154,6 +178,119 @@ public class CropSaverTests : TestBase
         );
     }
 
+    [Fact]
+    public async Task PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Plant a Pumpkin in a Garden Pot inside the farmhand's own cabin
+        // interior — an indoor (season-immune) location, exercising the same fix
+        // branch as the greenhouse (the Greenhouse itself is CC-pantry-gated
+        // rubble on a fresh test save and isn't warpable/plantable).
+        var farmhand = await Farmers.ConnectNewAsync(namePrefix: "CropImmune", ct: ct);
+
+        // The farmhand auto-warps into its cabin on join; the client reports the
+        // interior as "FarmHouse" + GUID (NameOrUniqueName), so confirm arrival on that.
+        // Placement and the crop snapshot below key on GameLocation.Name, which is
+        // "Cabin" — not the unique name above.
+        var arrived = await GameClient.WaitForLocationAsync(
+            "^FarmHouse",
+            TimeSpan.FromSeconds(15),
+            ct
+        );
+        Assert.NotNull(arrived);
+
+        var place = await GameClient.Actions.PlacePot(
+            "Cabin",
+            CabinTileX,
+            CabinTileY,
+            clearObstacles: true
+        );
+        Assert.True(place?.Success, $"PlacePot failed: {place?.Error}");
+
+        var plant = await GameClient.Actions.PlantCrop(
+            PumpkinSeedId,
+            "Cabin",
+            CabinTileX,
+            CabinTileY
+        );
+        Assert.True(plant?.Success, $"PlantCrop failed: {plant?.Error}");
+
+        await AssertWatcherRegistersPotAsync("Cabin", CabinTileX, CabinTileY, ct);
+
+        // The fix must classify the cabin as season-immune. Assert it on the
+        // snapshot row so a regression in IsCropSeasonImmune() fails here loudly
+        // rather than only via the survival check below.
+        var snapshot = await ServerApi.GetAllCrops(ct);
+        Assert.NotNull(snapshot);
+        var potRow = snapshot.Crops.SingleOrDefault(c =>
+            c.IsInPot && c.LocationName == "Cabin" && c.TileX == CabinTileX && c.TileY == CabinTileY
+        );
+        Assert.NotNull(potRow);
+        Assert.True(
+            potRow.IsSeasonImmune,
+            "Cabin interior must be season-immune (indoor → !IsOutdoors)"
+        );
+
+        // Stamp datePlanted = Fall 1 (death Fall 28) with extraDays left at 0, so the
+        // upcoming Fall 28 → Winter 1 rollover would kill a seasonal crop. Only the
+        // immunity guard spares this one.
+        var planted = await ServerApi.SetSaverCrop(
+            "Cabin",
+            CabinTileX,
+            CabinTileY,
+            datePlanted: ("fall", 1, 1),
+            ct: ct
+        );
+        Assert.NotNull(planted);
+        Assert.True(planted.Success, $"SetSaverCrop failed: {planted.Error}");
+        Assert.True(planted.Found, "SaverCrop entry must exist before setting datePlanted");
+
+        await ServerApi.SetDate("fall", 28, year: 1, ct);
+
+        // Disconnect the owner so branch-2's kill exception (online owner) does
+        // not apply — the kill would definitely fire here without the fix.
+        await Farmers.DisconnectAndWaitForSlotAsync(
+            farmhand.JoinResult.UniqueMultiplayerId,
+            farmhand.FarmerName,
+            ct
+        );
+
+        var statusBefore = await ServerApi.GetStatus(ct);
+        Assert.NotNull(statusBefore);
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var dayChanged = await DayChange.WaitAsync(
+                statusBefore.Day,
+                statusBefore.Season,
+                statusBefore.Year,
+                ct
+            );
+            Assert.True(dayChanged, "Day did not advance from Fall 28 → Winter 1");
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+
+        // OnDayEnd ran during the transition. The immunity guard's `continue`
+        // must have skipped the date-of-death kill for this indoor pot.
+        var cropsAfter = await ServerApi.GetAllCrops(ct);
+        Assert.NotNull(cropsAfter);
+        var stillThere = cropsAfter.Crops.SingleOrDefault(c =>
+            c.IsInPot && c.LocationName == "Cabin" && c.TileX == CabinTileX && c.TileY == CabinTileY
+        );
+        Assert.NotNull(stillThere);
+        Assert.True(
+            stillThere.IsAlive,
+            "Pumpkin in a Garden Pot inside a season-immune cabin interior must survive "
+                + "Fall 28 → Winter 1 past its computed date of death. Pre-fix: CropSaver.OnDayEnd "
+                + "had no immunity awareness and date-of-death-killed it — the greenhouse bug class."
+        );
+    }
+
     /// <summary>
     /// Connects a farmhand, warps to the Farm pot tile, places an IndoorPot,
     /// and plants Cauliflower. Returns the connected farmhand. Note: the
@@ -206,7 +343,12 @@ public class CropSaverTests : TestBase
     /// the host-side /test/crops endpoint, which sets <c>IsManaged=true</c>
     /// when <c>CropSaverData</c> has a matching entry.
     /// </summary>
-    private async Task AssertWatcherRegistersPotAsync(int tileX, int tileY, CancellationToken ct)
+    private async Task AssertWatcherRegistersPotAsync(
+        string locationName,
+        int tileX,
+        int tileY,
+        CancellationToken ct
+    )
     {
         var watcherRegisteredPot = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_CropSaver_AwaitWatcher,
@@ -216,7 +358,7 @@ public class CropSaverTests : TestBase
                 return snapshot?.Crops.Any(c =>
                         c.IsInPot
                         && c.IsManaged
-                        && c.LocationName == "Farm"
+                        && c.LocationName == locationName
                         && c.TileX == tileX
                         && c.TileY == tileY
                     ) == true;


### PR DESCRIPTION
## Problem

`CropSaver` suppresses vanilla `Crop.Kill()` for tracked crops and becomes the **sole** authority that kills them in `OnDayEnd`, using a computed date of death. That math had no concept of season-immune locations, so it withered greenhouse, Ginger Island, and indoor crops that vanilla never touches.

Reported symptom: greenhouse pumpkins and ancient fruit dying on the Fall 28 → Winter 1 rollover.

## Fix

- **One shared immunity predicate** — `GameLocation.IsCropSeasonImmune()` (`!IsOutdoors || SeedsIgnoreSeasonsHere()`), mirroring vanilla `Crop.newDay`'s kill gate. Single source of truth, consumed by both the kill logic and the test endpoint.
- **Guard at the kill site** (`OnDayEnd`), so existing affected saves are auto-fixed on load with no migration code — stale immune-crop entries are simply skipped instead of re-killed.
- Short-circuit immune crops in the prolong loop too (behavior-neutral; keeps both loops' domain to seasonal outdoor crops).
- **Harden `CalculateDateOfDeath`** against a latent `IndexOf == -1` bug (clamp the planted-season index).
- The `KillCrop_Prefix`, `CropWatcher`, and data/persistence layers are untouched.

## Why kill-site, not skip-at-watcher

Skip-at-watcher would re-kill already-affected saves on first upgrade (the stale entries are loaded by `OnSaveLoaded`, and with no kill-site guard `OnDayEnd` runs the date-of-death math on them again). The kill-site guard fixes existing saves with zero migration code.

## Test

New E2E test `PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline`: plants a Pumpkin in a Garden Pot inside the farmhand's cabin interior (indoor → immune), drives it past its computed date of death (Fall 28 → Winter 1) through a real `OnDayEnd` with the owner offline, and asserts it survives — the same fix branch and bug class as the greenhouse (which is CC-gated rubble on a fresh test save and not plantable). The class is marked `Exclusive` since all three methods mutate the global calendar.

`/test/crops` gains an `IsSeasonImmune` field (test-only) so the test can assert the location is classified correctly.

## Verification

- `dotnet build` (mod + tests): green, 0 warnings.
- `make test FILTER=CropSaverTests`: **3 passed (3 total)**, including the new immune-location survival test.
- CSharpier + `dotnet format style`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying season-immune crop locations, including greenhouses, Ginger Island, and indoor areas

* **Bug Fixes**
  * Fixed crops withering incorrectly in season-immune locations
  * Improved crop death date calculations for more accurate lifespan tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->