### PR TITLE
feat(saves): one-shot co-op save import with optional host swap

### DIFF
--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -84,17 +84,15 @@ Manage save files:
 | `saves import <name>` | Import a save as-is (its owner becomes the headless host); loaded on restart |
 | `saves import <name> --swap-host-to <id>` | Import + demote the save's owner into a cabin farmhand bound to the given platform id (Steam64 or GOG Galaxy id), installing a fresh "Server" host |
 
-> **`--swap-host-to` rewrites the target save in place — back up first.** The swap transform mutates
-> the save folder (fault-tolerantly: a failed transform leaves the loadable save byte-intact). Plain
-> as-is import makes **no** file changes — it only points the next boot at the save.
+> **As-is vs swap.** Importing **as-is** makes the save's original player the automated headless host —
+> correct for a single-player save, wrong for a co-op save whose owner is a real player. For a co-op
+> save, use `--swap-host-to <id>` so the owner stays a player: it demotes them to a cabin farmhand
+> scoped to that platform account (the player selects it from the farmhand menu on connect). The bind
+> is enforced only on Steam/GOG, not LAN.
 >
-> Importing **as-is** makes the save's original player the automated headless host (correct for a
-> single-player save; for a co-op save whose owner is a real player, use `--swap-host-to <id>` so they
-> stay a player). The bind stamps the demoted owner's farmhand with that platform id so it is **scoped
-> to — and selectable by — that account**; the player still picks it from the farmhand menu (vanilla
-> allows multiple farmhands per account, so it is not auto-selected). The `--swap-host-to` bind is only
-> enforced on Steam/GOG (LAN clients have no platform id), and the import is one-shot: run it, restart
-> once, done.
+> **Back up before `--swap-host-to`.** The swap rewrites the save folder in place (fault-tolerantly — a
+> failed transform leaves the save loadable). As-is import changes no files; it only sets the next-boot
+> target. Either way the import is one-shot: run it, restart once.
 
 ### rendering
 

--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -81,8 +81,20 @@ Manage save files:
 |---------|-------------|
 | `saves` | List available saves (marks currently active) |
 | `saves info <name>` | Show save details (farm type, cabins, players) |
-| `saves select <name>` | Preview importing a save |
-| `saves select <name> --confirm` | Set save as active (loaded on restart) |
+| `saves import <name>` | Import a save as-is (its owner becomes the headless host); loaded on restart |
+| `saves import <name> --swap-host-to <id>` | Import + demote the save's owner into a cabin farmhand bound to the given platform id (Steam64 or GOG Galaxy id), installing a fresh "Server" host |
+
+> **`--swap-host-to` rewrites the target save in place — back up first.** The swap transform mutates
+> the save folder (fault-tolerantly: a failed transform leaves the loadable save byte-intact). Plain
+> as-is import makes **no** file changes — it only points the next boot at the save.
+>
+> Importing **as-is** makes the save's original player the automated headless host (correct for a
+> single-player save; for a co-op save whose owner is a real player, use `--swap-host-to <id>` so they
+> stay a player). The bind stamps the demoted owner's farmhand with that platform id so it is **scoped
+> to — and selectable by — that account**; the player still picks it from the farmhand menu (vanilla
+> allows multiple farmhands per account, so it is not auto-selected). The `--swap-host-to` bind is only
+> enforced on Steam/GOG (LAN clients have no platform id), and the import is one-shot: run it, restart
+> once, done.
 
 ### rendering
 

--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -83,6 +83,10 @@ Manage save files:
 | `saves info <name>` | Show save details (farm type, cabins, players) |
 | `saves import <name>` | Import a save as-is (its owner becomes the headless host); loaded on restart |
 | `saves import <name> --swap-host-to <id>` | Import + demote the save's owner into a cabin farmhand bound to the given platform id (Steam64 or GOG Galaxy id), installing a fresh "Server" host |
+| `saves import <name> --reload` | Import, then load it in-process without a restart (refuses if players are connected) |
+| `saves import <name> --force-reload` | Same, but kick connected players first |
+| `saves reload` | Reload the active world in-process — apply a manual save edit without a restart (refuses if players are connected) |
+| `saves reload --force` | Same, but kick connected players first |
 
 > **As-is vs swap.** Importing **as-is** makes the save's original player the automated headless host —
 > correct for a single-player save, wrong for a co-op save whose owner is a real player. For a co-op
@@ -92,7 +96,13 @@ Manage save files:
 >
 > **Back up before `--swap-host-to`.** The swap rewrites the save folder in place (fault-tolerantly — a
 > failed transform leaves the save loadable). As-is import changes no files; it only sets the next-boot
-> target. Either way the import is one-shot: run it, restart once.
+> target.
+>
+> **Applying it.** A plain import loads on the next restart. The `--reload` variants skip the restart
+> and load it in-process; they refuse while players are connected (the log names them) unless you use
+> `--force-reload`, which kicks them first. A refused import is **not** lost — it still loads on the
+> next restart. `saves reload` does the same in-process reload for the active world, so a manual save
+> edit takes effect without a restart.
 
 ### rendering
 

--- a/docs/admins/troubleshooting.md
+++ b/docs/admins/troubleshooting.md
@@ -182,8 +182,9 @@ docker compose logs server | grep -i error
 
 1. Confirm the save folder is copied in correctly (the whole `{FarmName}_{number}` folder) and `saves` lists it
 2. Run `saves import <name>`, then restart to load it — copying the folder alone doesn't activate it (see [Importing Existing Saves](/features/backup#importing-existing-saves))
-3. Co-op save where the wrong player became the host? Re-import with `saves import <name> --swap-host-to <id>`
-4. Check folder structure and file permissions
+3. Used `--reload` and nothing happened? It refuses while players are connected (the log names them) — disconnect them or use `--force-reload`. The import is still queued, so a plain restart also loads it
+4. Co-op save where the wrong player became the host? Re-import with `saves import <name> --swap-host-to <id>`
+5. Check folder structure and file permissions
 
 ### Save corruption
 

--- a/docs/admins/troubleshooting.md
+++ b/docs/admins/troubleshooting.md
@@ -181,7 +181,7 @@ docker compose logs server | grep -i error
 ### Importing a save doesn't work
 
 1. Confirm the save folder is copied in correctly (the whole `{FarmName}_{number}` folder) and `saves` lists it
-2. Run `saves import <name>` to load it, then restart — copying the folder alone doesn't activate it (see [Importing Existing Saves](/features/backup#importing-existing-saves))
+2. Run `saves import <name>`, then restart to load it — copying the folder alone doesn't activate it (see [Importing Existing Saves](/features/backup#importing-existing-saves))
 3. Co-op save where the wrong player became the host? Re-import with `saves import <name> --swap-host-to <id>`
 4. Check folder structure and file permissions
 

--- a/docs/admins/troubleshooting.md
+++ b/docs/admins/troubleshooting.md
@@ -180,10 +180,10 @@ docker compose logs server | grep -i error
 
 ### Importing a save doesn't work
 
-1. Stop server: `docker compose down`
-2. Copy save correctly into the volume
-3. Ensure folder structure is correct
-4. Check file permissions
+1. Confirm the save folder is copied in correctly (the whole `{FarmName}_{number}` folder) and `saves` lists it
+2. Run `saves import <name>` to load it, then restart — copying the folder alone doesn't activate it (see [Importing Existing Saves](/features/backup#importing-existing-saves))
+3. Co-op save where the wrong player became the host? Re-import with `saves import <name> --swap-host-to <id>`
+4. Check folder structure and file permissions
 
 ### Save corruption
 

--- a/docs/community/faq.md
+++ b/docs/community/faq.md
@@ -6,9 +6,9 @@
 
 Yes. JunimoServer is open-source and free to use. You need to own a copy of Stardew Valley on Steam (the server downloads game files using your Steam account).
 
-### Can I use my existing single-player save?
+### Can I use my existing single-player or co-op save?
 
-Yes. See [Backup & Recovery](/features/backup#importing-existing-saves) for import instructions.
+Yes. Copy it onto the server and run `saves import` — see [Importing Existing Saves](/features/backup#importing-existing-saves). For a co-op save, use `--swap-host-to` so the original owner stays a player instead of becoming the automated host.
 
 ### How many players can join?
 

--- a/docs/features/backup.md
+++ b/docs/features/backup.md
@@ -169,7 +169,7 @@ Consider automating backups with cron (Linux) or Task Scheduler (Windows):
 ## Importing Existing Saves
 
 Bring an existing single-player or co-op save to your server. This has two parts: copy the save folder
-onto the server, then run `saves import` to load it.
+onto the server, then run `saves import` to queue it for the next restart.
 
 **1. Copy the save folder into the saves volume** (replace `junimoserver` with your directory name):
 

--- a/docs/features/backup.md
+++ b/docs/features/backup.md
@@ -197,13 +197,24 @@ original human owner into that automated host — they can no longer play as tha
 `--swap-host-to <id>` (their Steam64 or GOG Galaxy id) to keep them a player.
 :::
 
-**3. Restart to load it:**
+**3. Load it.** A plain import loads on the next restart:
 
 ```sh
 docker compose restart server
 ```
 
-The save loads on restart; a swap import finalizes the farmhand on that first load. Connect via VNC or
+Or skip the restart — add `--reload` to load it in-process immediately (use `--force-reload` to kick
+connected players first):
+
+```text
+# Applies right away if nobody is connected; otherwise refuses and names them.
+saves import YourFarm_123456789 --reload
+
+# Kicks connected players, then reloads.
+saves import YourFarm_123456789 --force-reload
+```
+
+Either way the save loads and a swap import finalizes the farmhand on that load. Connect via VNC or
 join in-game to verify.
 
 ## Recovery Scenarios

--- a/docs/features/backup.md
+++ b/docs/features/backup.md
@@ -168,29 +168,43 @@ Consider automating backups with cron (Linux) or Task Scheduler (Windows):
 
 ## Importing Existing Saves
 
-To bring an existing save to your server:
+Bring an existing single-player or co-op save to your server. This has two parts: copy the save folder
+onto the server, then run `saves import` to load it.
 
-**1. Stop the server:**
-
-```sh
-docker compose down
-```
-
-**2. Copy save folder into volume** (replace `junimoserver` with your directory name)**:**
+**1. Copy the save folder into the saves volume** (replace `junimoserver` with your directory name):
 
 ```sh
 docker run --rm -v junimoserver_saves:/saves -v $(pwd):/backup ubuntu cp -r /backup/YourFarm_123456789 /saves/
 ```
 
-**3. Start server:**
+The folder name is `{FarmName}_{number}` — copy the whole folder, not its contents.
 
-```sh
-docker compose up -d
+**2. Import it.** Run `saves` to confirm it's listed, then import it from the server console (see the
+[`saves` command](/admins/operations/commands#saves)):
+
+```text
+# Single-player save — the save's owner becomes the headless host:
+saves import YourFarm_123456789
+
+# Co-op save — keep the original owner as a player, demote them to a cabin
+# farmhand bound to their Steam/GOG id (back up first; this rewrites the save):
+saves import YourFarm_123456789 --swap-host-to 76561198XXXXXXXXX
 ```
 
-**4. Verify in game:**
+::: warning Co-op saves need `--swap-host-to`
+On this server the main farmer is the automated host. Importing a co-op save **as-is** turns the
+original human owner into that automated host — they can no longer play as that farmer. Use
+`--swap-host-to <id>` (their Steam64 or GOG Galaxy id) to keep them a player.
+:::
 
-Connect via VNC and check that your save appears.
+**3. Restart to load it:**
+
+```sh
+docker compose restart server
+```
+
+The save loads on restart; a swap import finalizes the farmhand on that first load. Connect via VNC or
+join in-game to verify.
 
 ## Recovery Scenarios
 

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -11,6 +11,7 @@ using JunimoServer.Services.Lobby;
 using JunimoServer.Services.PasswordProtection;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Roles;
+using JunimoServer.Services.SaveImport;
 using JunimoServer.Services.Settings;
 using JunimoServer.Shared;
 using JunimoServer.Util;
@@ -293,11 +294,12 @@ internal class ModEntry : Mod
         var cabinManager = _services.GetRequiredService<CabinManagerService>();
         var persistentOptions = _services.GetRequiredService<PersistentOptions>();
         var settings = _services.GetRequiredService<ServerSettingsLoader>();
+        var saveImport = _services.GetRequiredService<SaveImportService>();
 
         RenderingCommand.Register(Helper, Monitor);
         SettingsCommand.Register(Helper, Monitor, gameLoader, persistentOptions, settings);
         CabinsConsoleCommand.Register(Helper, Monitor, cabinManager, persistentOptions);
-        SavesCommand.Register(Helper, Monitor, gameLoader, settings);
+        SavesCommand.Register(Helper, Monitor, saveImport);
     }
 
     private void RegisterChatCommands()

--- a/mod/JunimoServer/ServerFarmerIdentity.cs
+++ b/mod/JunimoServer/ServerFarmerIdentity.cs
@@ -1,0 +1,27 @@
+namespace JunimoServer;
+
+/// <summary>
+/// Identity literals for the headless "Server" host farmer that are genuinely constant
+/// and shared between the two host-creation paths: <c>GameCreatorService.CreateNewGame</c>
+/// (a brand-new game's host) and <c>SaveImportXmlTransform</c> (the clone-blank host installed
+/// when importing a save with <c>--swap-host-to</c>). Keeping the literals in one place means
+/// the imported host and the new-game host are the same farmer by construction and cannot drift.
+///
+/// Deliberately excluded:
+/// - <c>DisplayName</c>: there is no serialized display-name field — <c>Character.displayName</c>
+///   and its backing field are both <c>[XmlIgnore]</c> and recomputed from <c>name</c> at runtime.
+///   The new-game path's <c>displayName = Name</c> is a runtime assignment, not an identity field.
+/// - <c>WhichPetType</c>: not a constant — the new-game path picks Cat/Dog from <c>config.PetBreed</c>.
+///   The import clone-blank host never plays, so it hardcodes its own cosmetic pet default locally.
+/// </summary>
+internal static class ServerFarmerIdentity
+{
+    /// <summary>The host farmer's name. Also the runtime display name (derived from name).</summary>
+    public const string Name = "Server";
+
+    /// <summary>The host farmer's favorite thing.</summary>
+    public const string FavoriteThing = "Junimos";
+
+    /// <summary>The host farmer is always a "customized" farmer (master, never an empty slot).</summary>
+    public const bool IsCustomized = true;
+}

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace JunimoServer.Services.Api;
@@ -311,6 +312,29 @@ public class TestImportSaveRequest
 
     /// <summary>Skip the clone step (import an existing/pre-corrupted target directly — resilience test).</summary>
     public bool SkipClone { get; set; }
+}
+
+/// <summary>
+/// Body for POST /test/console (test-only). Invokes a registered SMAPI console command by name with
+/// the given args, exactly as a server operator typing it would — used to drive the <c>saves reload</c>
+/// guard/kick path, which has no HTTP endpoint of its own (the guard + kick live in the console
+/// command). Reflects into SMAPI's internal command registry; test-only, so it cannot affect production.
+/// </summary>
+public class TestConsoleCommandRequest
+{
+    /// <summary>The registered console command name (e.g. "saves").</summary>
+    public string Name { get; set; } = "";
+
+    /// <summary>The command args (e.g. ["reload", "--force"]).</summary>
+    public string[] Args { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>Response from POST /test/console.</summary>
+public class TestConsoleCommandResponse
+{
+    /// <summary>True if the named command was found and its callback invoked without throwing.</summary>
+    public bool Success { get; set; }
+    public string? Error { get; set; }
 }
 
 /// <summary>Response from POST /test/import_save.</summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -314,19 +314,12 @@ public class TestImportSaveRequest
     public bool SkipClone { get; set; }
 }
 
-/// <summary>
-/// Body for POST /test/console (test-only). Invokes a registered SMAPI console command by name with
-/// the given args, exactly as a server operator typing it would — used to drive the <c>saves reload</c>
-/// guard/kick path, which has no HTTP endpoint of its own (the guard + kick live in the console
-/// command). Reflects into SMAPI's internal command registry; test-only, so it cannot affect production.
-/// </summary>
+/// <summary>Body for POST /test/console (test-only): a console command name + args to invoke.</summary>
 public class TestConsoleCommandRequest
 {
-    /// <summary>The registered console command name (e.g. "saves").</summary>
-    public string Name { get; set; } = "";
+    public string Name { get; set; } = ""; // e.g. "saves"
 
-    /// <summary>The command args (e.g. ["reload", "--force"]).</summary>
-    public string[] Args { get; set; } = Array.Empty<string>();
+    public string[] Args { get; set; } = Array.Empty<string>(); // e.g. ["reload", "--force"]
 }
 
 /// <summary>Response from POST /test/console.</summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -199,3 +199,145 @@ public class TestGalaxyReloginResponse
     public bool Triggered { get; set; }
     public string? Error { get; set; }
 }
+
+/// <summary>
+/// Body for POST /test/seed_import_source (test-only). All fields optional. Seeds the active game's
+/// master (Game1.player — what the swap import demotes) and FarmHouse to look like a real importable
+/// owner before SleepToSaveAsync, so the save's &lt;player&gt; reads as a played human and carries the
+/// world/relationship/house state and contents the save-import tests assert.
+/// </summary>
+public class TestSeedImportSourceRequest
+{
+    /// <summary>Override the master's name (default "ImportedOwner"). Must NOT be "Server".</summary>
+    public string? OwnerName { get; set; }
+
+    /// <summary>Set the master's house upgrade level (drives the cabin level + cellar warn).</summary>
+    public int? HouseUpgradeLevel { get; set; }
+
+    /// <summary>Set the master's caveChoice (1 = bat/fruit cave) — bucket-B carry test (7b).</summary>
+    public int? CaveChoice { get; set; }
+
+    /// <summary>Set the master's NPC spouse name — spouse-clear-on-master test (8).</summary>
+    public string? Spouse { get; set; }
+
+    /// <summary>Add a mailReceived flag (e.g. "ccDoorUnlock") — mail/event carry test (7).</summary>
+    public string? MailFlag { get; set; }
+
+    /// <summary>Add an eventsSeen id — mail/event carry test (7).</summary>
+    public string? EventSeen { get; set; }
+
+    /// <summary>Set a friendshipData[key].Points entry — shadow-pacifism gate carry test (7c).</summary>
+    public int? ShadowFriendshipPoints { get; set; }
+
+    /// <summary>The friendshipData key for ShadowFriendshipPoints (default "Krobus").</summary>
+    public string? ShadowFriendshipKey { get; set; }
+
+    /// <summary>Set stats.DaysPlayed — same-day-reconnect gate carry test (7c).</summary>
+    public int? DaysPlayed { get; set; }
+
+    /// <summary>Place a chest (with a known item) in the FarmHouse — contents-move test (2).</summary>
+    public bool PlaceChest { get; set; }
+    public int ChestTileX { get; set; } = 3;
+    public int ChestTileY { get; set; } = 3;
+
+    /// <summary>Add an item to the FarmHouse fridge — contents-move test (2).</summary>
+    public bool PlaceFridgeItem { get; set; }
+
+    /// <summary>Spawn a pet into the FarmHouse — household-relocation test (3).</summary>
+    public bool SpawnPet { get; set; }
+
+    /// <summary>Place an item in the master's "Cellar"-1 — cellar-contents-move test (11).</summary>
+    public bool PlaceCellarItem { get; set; }
+
+    /// <summary>Stamp this userID onto a spare uncustomized farmhand slot — userID-collision test (10).</summary>
+    public string? InjectFarmhandUserId { get; set; }
+}
+
+/// <summary>Response from POST /test/seed_import_source.</summary>
+public class TestSeedImportSourceResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>The seeded master's UniqueMultiplayerID (becomes the demoted owner's uid after swap).</summary>
+    public long OwnerUid { get; set; }
+    public string OwnerName { get; set; } = "";
+    public bool ChestPlaced { get; set; }
+    public bool FridgeItemPlaced { get; set; }
+    public bool PetSpawned { get; set; }
+    public bool CellarItemPlaced { get; set; }
+    public bool FarmhandUserIdInjected { get; set; }
+}
+
+/// <summary>Body for POST /test/corrupt_save (test-only).</summary>
+public class TestCorruptSaveRequest
+{
+    /// <summary>Folder to clone from (default: the active save).</summary>
+    public string? SourceSaveName { get; set; }
+
+    /// <summary>Folder to clone to + corrupt (required).</summary>
+    public string? TargetSaveName { get; set; }
+}
+
+/// <summary>Response from POST /test/corrupt_save / GET /test/save_tmp_exists.</summary>
+public class TestSaveFileOpResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>For save_tmp_exists: whether a leftover .tmp exists next to the main file.</summary>
+    public bool Exists { get; set; }
+
+    /// <summary>For corrupt_save: the actual clone folder name created (derived from a re-stamped
+    /// uniqueID); the caller imports this with SkipClone.</summary>
+    public string TargetSaveName { get; set; } = "";
+}
+
+/// <summary>
+/// Body for POST /test/import_save (test-only). Clones a source save folder under a new name, then
+/// runs saves-import on the clone (ExecuteImport rejects importing the active save, so the clone is
+/// required). Defaults: source = the active save, target = source + "-import".
+/// </summary>
+public class TestImportSaveRequest
+{
+    /// <summary>Folder to clone from (default: the currently-active save).</summary>
+    public string? SourceSaveName { get; set; }
+
+    /// <summary>Folder to clone to + import (default: SourceSaveName + "-import").</summary>
+    public string? TargetSaveName { get; set; }
+
+    /// <summary>The platform id to bind on swap (all-digit Steam64/Galaxy id). Absent = as-is import.</summary>
+    public string? SwapHostTo { get; set; }
+
+    /// <summary>Skip the clone step (import an existing/pre-corrupted target directly — resilience test).</summary>
+    public bool SkipClone { get; set; }
+}
+
+/// <summary>Response from POST /test/import_save.</summary>
+public class TestImportSaveResponse
+{
+    /// <summary>True if the endpoint's own steps (clone + dispatch) succeeded.</summary>
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>The target save folder the import ran against.</summary>
+    public string TargetSaveName { get; set; } = "";
+
+    /// <summary>Whether the import was a host swap (vs as-is).</summary>
+    public bool Swapped { get; set; }
+
+    /// <summary>Whether the import only re-pointed an existing pending bind.</summary>
+    public bool RepointedBind { get; set; }
+
+    /// <summary>The demoted owner's UniqueMultiplayerID (swap only).</summary>
+    public long FormerOwnerUid { get; set; }
+
+    /// <summary>The import's own error/warn message (when ImportError is set, the import did not succeed).</summary>
+    public string? ImportError { get; set; }
+
+    /// <summary>SHA-256 (base64) of the target main file before import — for the byte-unchanged assertion.</summary>
+    public string PreImportMainFileHash { get; set; } = "";
+
+    /// <summary>SHA-256 (base64) of the target main file after import.</summary>
+    public string PostImportMainFileHash { get; set; } = "";
+}

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using StardewModdingAPI;
 using StardewModdingAPI.Utilities;
 using StardewValley;
+using StardewValley.Characters;
 using StardewValley.Locations;
 using StardewValley.Objects;
 using StardewValley.TerrainFeatures;
@@ -60,6 +61,9 @@ public partial class ApiService
                     case "/test/festival_state":
                         await WriteJsonAsync(response, await HandleGetTestFestivalStateAsync());
                         return;
+                    case "/test/save_tmp_exists":
+                        await WriteJsonAsync(response, HandleGetTestSaveTmpExists(request));
+                        return;
                 }
                 break;
             case "POST":
@@ -85,6 +89,24 @@ public partial class ApiService
                         return;
                     case "/test/galaxy_relogin":
                         await WriteJsonAsync(response, await HandlePostTestGalaxyReloginAsync());
+                        return;
+                    case "/test/seed_import_source":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestSeedImportSourceAsync(request)
+                        );
+                        return;
+                    case "/test/import_save":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestImportSaveAsync(request)
+                        );
+                        return;
+                    case "/test/corrupt_save":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestCorruptSaveAsync(request)
+                        );
                         return;
                 }
                 break;
@@ -665,5 +687,525 @@ public partial class ApiService
         }
 
         return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/seed_import_source",
+        Summary = "Seed the active game's master + FarmHouse to look like a real importable owner (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestSeedImportSourceResponse), 200)]
+    private async Task<TestSeedImportSourceResponse> HandlePostTestSeedImportSourceAsync(
+        HttpListenerRequest request
+    )
+    {
+        // The in-process generator always creates a "Server" master, but a real imported co-op save's
+        // <player> is a human owner. So before saving, this makes the active master (Game1.player —
+        // which is what the swap import demotes) look like a real owner: a non-Server name + an
+        // inventory (so the re-import guard doesn't mistake it for a clone-blank Server master), plus
+        // optional world-gating/relationship/house state and FarmHouse contents the import tests
+        // assert move/carry. Mirrors /test/stamp_claim's "construct a precise pre-save state" role.
+        TestSeedImportSourceRequest body;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            body = string.IsNullOrWhiteSpace(json)
+                ? new TestSeedImportSourceRequest()
+                : JsonConvert.DeserializeObject<TestSeedImportSourceRequest>(json)
+                    ?? new TestSeedImportSourceRequest();
+        }
+        catch (Exception ex)
+        {
+            return new TestSeedImportSourceResponse
+            {
+                Success = false,
+                Error = $"Failed to parse body: {ex.Message}",
+            };
+        }
+
+        var result = new TestSeedImportSourceResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var master = Game1.player;
+                var farmHouse = Game1.getLocationFromName("FarmHouse") as FarmHouse;
+                if (master == null || farmHouse == null)
+                {
+                    result.Error = "Master player or FarmHouse not available";
+                    return;
+                }
+
+                // Identity: a non-Server name + a guaranteed inventory item so the save's <player>
+                // reads as a real played owner (defeats the clone-blank re-import fingerprint).
+                master.Name = string.IsNullOrEmpty(body.OwnerName)
+                    ? "ImportedOwner"
+                    : body.OwnerName;
+                master.displayName = master.Name;
+                if (!master.Items.Any(i => i != null))
+                {
+                    master.Items.Add(ItemRegistry.Create("(O)388", 10)); // wood — marks a played owner
+                }
+
+                if (body.HouseUpgradeLevel.HasValue)
+                {
+                    master.HouseUpgradeLevel = body.HouseUpgradeLevel.Value;
+                }
+                if (body.CaveChoice.HasValue)
+                {
+                    master.caveChoice.Value = body.CaveChoice.Value;
+                }
+                if (!string.IsNullOrEmpty(body.Spouse))
+                {
+                    master.spouse = body.Spouse;
+                }
+                if (!string.IsNullOrEmpty(body.MailFlag))
+                {
+                    master.mailReceived.Add(body.MailFlag);
+                }
+                if (!string.IsNullOrEmpty(body.EventSeen))
+                {
+                    master.eventsSeen.Add(body.EventSeen);
+                }
+                if (body.ShadowFriendshipPoints.HasValue)
+                {
+                    // Mirror the Dark Shrine pacifism gate (MasterPlayer.friendshipData[key].Points).
+                    var key = string.IsNullOrEmpty(body.ShadowFriendshipKey)
+                        ? "Krobus"
+                        : body.ShadowFriendshipKey;
+                    if (!master.friendshipData.TryGetValue(key, out var fr) || fr == null)
+                    {
+                        fr = new Friendship();
+                        master.friendshipData[key] = fr;
+                    }
+                    fr.Points = body.ShadowFriendshipPoints.Value;
+                }
+                if (body.DaysPlayed.HasValue)
+                {
+                    master.stats.DaysPlayed = (uint)body.DaysPlayed.Value;
+                }
+
+                // FarmHouse contents the contents-move test asserts: a chest (with a known item) and
+                // a fridge item. Place the chest at a known open floor tile.
+                if (body.PlaceChest)
+                {
+                    var tile = new Vector2(body.ChestTileX, body.ChestTileY);
+                    var chest = new Chest(playerChest: true, tile, "232");
+                    chest.Items.Clear();
+                    chest.Items.Add(ItemRegistry.Create("(O)388", 5)); // wood — a known chest item
+                    farmHouse.objects[tile] = chest;
+                    result.ChestPlaced = true;
+                }
+                if (body.PlaceFridgeItem && farmHouse.fridge.Value != null)
+                {
+                    farmHouse.fridge.Value.Items.Add(ItemRegistry.Create("(O)24", 1)); // parsnip
+                    result.FridgeItemPlaced = true;
+                }
+
+                // Pet: spawn a Pet into the FarmHouse characters for the household-relocation test.
+                if (body.SpawnPet)
+                {
+                    var existing = master.getPet();
+                    if (existing == null)
+                    {
+                        var pet = new Pet(5, 5, "0", "Cat") { Name = "TestPet" };
+                        pet.homeLocationName.Value = "Farm";
+                        farmHouse.addCharacter(pet);
+                        pet.currentLocation = farmHouse;
+                        result.PetSpawned = true;
+                    }
+                    else
+                    {
+                        result.PetSpawned = true; // already present
+                    }
+                }
+
+                // Cellar item: place a known object in the master's "Cellar"-1 (the location the owner
+                // built their casks in while master). The "Cellar" location always exists in
+                // Game1.locations regardless of house level, so this faithfully reproduces cellar
+                // contents the swap must carry into the demoted owner's reassigned cellar.
+                if (body.PlaceCellarItem)
+                {
+                    var cellar = Game1.getLocationFromName("Cellar");
+                    if (cellar != null)
+                    {
+                        var tile = new Vector2(2, 2);
+                        var cask = new Cask(tile); // an aged-goods cask — the canonical cellar object
+                        cellar.objects[tile] = cask;
+                        result.CellarItemPlaced = true;
+                    }
+                }
+
+                // Inject a userID onto a spare uncustomized farmhand slot (for the collision test).
+                // LAN never stamps a userID, so the test needs a server-side inject to set up the
+                // cross-farmhand collision the import guard must catch.
+                if (!string.IsNullOrEmpty(body.InjectFarmhandUserId))
+                {
+                    var stamped = false;
+                    foreach (var building in Game1.getFarm().buildings)
+                    {
+                        if (!building.isCabin || LobbyService.IsLobbyCabin(building))
+                        {
+                            continue;
+                        }
+                        var slot = building.GetIndoors<Cabin>()?.owner;
+                        if (
+                            slot == null
+                            || slot.isCustomized.Value
+                            || !string.IsNullOrEmpty(slot.userID.Value)
+                        )
+                        {
+                            continue;
+                        }
+                        slot.userID.Value = body.InjectFarmhandUserId;
+                        stamped = true;
+                        break;
+                    }
+                    result.FarmhandUserIdInjected = stamped;
+                }
+
+                result.OwnerUid = master.UniqueMultiplayerID;
+                result.OwnerName = master.Name;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/import_save",
+        Summary = "Clone an existing save under a new name and run saves-import on it (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestImportSaveResponse), 200)]
+    private async Task<TestImportSaveResponse> HandlePostTestImportSaveAsync(
+        HttpListenerRequest request
+    )
+    {
+        // Mirrors the operator console path (SaveImportService.ExecuteImport) but on the game thread
+        // (matching /test/stamp_claim). ExecuteImport's Layer A logic stays engine-free; the live
+        // engine here is incidental. Because ExecuteImport rejects importing the currently-active
+        // save, the test must import a DIFFERENT folder — so this endpoint first clones a source
+        // folder (default: the active save) to a fresh target folder, then imports the target.
+        TestImportSaveRequest body;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            body = string.IsNullOrWhiteSpace(json)
+                ? new TestImportSaveRequest()
+                : JsonConvert.DeserializeObject<TestImportSaveRequest>(json)
+                    ?? new TestImportSaveRequest();
+        }
+        catch (Exception ex)
+        {
+            return new TestImportSaveResponse
+            {
+                Success = false,
+                Error = $"Failed to parse body: {ex.Message}",
+            };
+        }
+
+        var result = new TestImportSaveResponse();
+
+        // Resolve source. The target FOLDER name is computed by CloneSaveFolder from the clone's
+        // re-stamped uniqueIDForThisGame so that Constants.SaveFolderName after load EQUALS the
+        // folder name (a real operator import already satisfies this — folders are named
+        // {farmName}_{uniqueID}; a naive "{name}-import" clone would not, and the finalizer's
+        // wrong-save guard — SaveFolderName == intent.SaveName — would then skip the finalize).
+        var sourceName = string.IsNullOrEmpty(body.SourceSaveName)
+            ? Constants.SaveFolderName
+            : body.SourceSaveName;
+
+        // The caller's TargetSaveName is used only as a uniqueness SEED (so distinct tests don't
+        // collide); the actual folder name is derived. SkipClone imports an existing folder verbatim.
+        string targetName;
+        if (!body.SkipClone)
+        {
+            try
+            {
+                targetName = CloneSaveFolder(sourceName, body.TargetSaveName);
+                result.TargetSaveName = targetName;
+            }
+            catch (Exception ex)
+            {
+                result.Success = false;
+                result.Error =
+                    $"Failed to clone save '{sourceName}' → '{body.TargetSaveName}': {ex.Message}";
+                return result;
+            }
+        }
+        else
+        {
+            targetName = string.IsNullOrEmpty(body.TargetSaveName)
+                ? sourceName
+                : body.TargetSaveName;
+            result.TargetSaveName = targetName;
+        }
+
+        // Capture a pre-import hash of the target's main file so the resilience test can assert
+        // byte-unchanged on a failed import.
+        result.PreImportMainFileHash = TryHashSaveMainFile(targetName);
+
+        // Run the import on the game thread.
+        SaveImport.SaveImportService.ImportResult import = null;
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                import = _saveImportService.ExecuteImport(
+                    targetName,
+                    string.IsNullOrWhiteSpace(body.SwapHostTo) ? null : body.SwapHostTo
+                );
+            });
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.Error = ex.Message;
+            return result;
+        }
+
+        result.PostImportMainFileHash = TryHashSaveMainFile(targetName);
+
+        result.Success = import?.Success ?? false;
+        result.Swapped = import?.Swapped ?? false;
+        result.RepointedBind = import?.RepointedBind ?? false;
+        result.FormerOwnerUid = import?.FormerOwnerUid ?? 0;
+        result.ImportError = import?.Error;
+        return result;
+    }
+
+    /// <summary>
+    /// Clones <paramref name="sourceName"/> into a NEW independent save whose folder name matches its
+    /// internal identity, and returns the actual folder name. Re-stamps <c>uniqueIDForThisGame</c> to
+    /// a fresh value (derived deterministically from <paramref name="seed"/> — Date.Now is unavailable
+    /// and irrelevant here) and names the folder <c>{FilterFileName(farmName)}_{newId}</c>, so that
+    /// <c>Constants.SaveFolderName</c> after the engine loads it EQUALS the folder name. Without this,
+    /// the clone (same uniqueID as the source, different folder name) loads with a SaveFolderName that
+    /// differs from its folder, and the finalizer's wrong-save guard skips the finalize.
+    /// </summary>
+    private static string CloneSaveFolder(string sourceName, string seed)
+    {
+        var savesPath = Constants.SavesPath;
+        var sourceDir = System.IO.Path.Combine(savesPath, sourceName);
+        if (!System.IO.Directory.Exists(sourceDir))
+        {
+            throw new System.IO.DirectoryNotFoundException($"Source save '{sourceName}' not found");
+        }
+
+        var sourceMain = System.IO.Path.Combine(sourceDir, sourceName);
+        if (!System.IO.File.Exists(sourceMain))
+        {
+            throw new System.IO.FileNotFoundException($"Source main file '{sourceName}' not found");
+        }
+
+        // Read farmName + a fresh unique id from the source XML.
+        var doc = new System.Xml.XmlDocument();
+        doc.Load(sourceMain);
+        var farmName =
+            doc.SelectSingleNode("//SaveGame/player/farmName")?.InnerText
+            ?? doc.SelectSingleNode("//SaveGame/farmhands/Farmer/farmName")?.InnerText
+            ?? "Imported";
+
+        // Deterministic new id from the source id + seed (no Date.Now; just needs to be distinct from
+        // the source and stable for this call). Use an unsigned cast of the hash — Math.Abs would
+        // throw on int.MinValue. The +1 keeps it strictly above the source id.
+        var sourceId = doc.SelectSingleNode("//SaveGame/uniqueIDForThisGame")?.InnerText ?? "0";
+        ulong.TryParse(sourceId, out var srcIdVal);
+        var seedOffset = (ulong)((uint)(seed ?? "import").GetHashCode() % 1000000) + 1;
+        var newId = (srcIdVal == 0 ? 1000000000UL : srcIdVal) + seedOffset;
+
+        var targetName = $"{StardewValley.SaveGame.FilterFileName(farmName)}_{newId}";
+        var targetDir = System.IO.Path.Combine(savesPath, targetName);
+        if (System.IO.Directory.Exists(targetDir))
+        {
+            System.IO.Directory.Delete(targetDir, recursive: true);
+        }
+        System.IO.Directory.CreateDirectory(targetDir);
+
+        // Re-stamp uniqueIDForThisGame in the cloned main XML and write it as the target's main file.
+        var idNode = doc.SelectSingleNode("//SaveGame/uniqueIDForThisGame");
+        if (idNode != null)
+        {
+            idNode.InnerText = newId.ToString();
+        }
+        doc.Save(System.IO.Path.Combine(targetDir, targetName));
+
+        // Copy SaveGameInfo too (re-stamp its uniqueIDForThisGame if present), plus any other files.
+        foreach (var file in System.IO.Directory.GetFiles(sourceDir))
+        {
+            var fileName = System.IO.Path.GetFileName(file);
+            if (fileName == sourceName)
+            {
+                continue; // main file already written above
+            }
+            // Skip the engine's recovery backups (named after the SOURCE folder). Copying them into a
+            // differently-named target folder would leave untransformed pre-swap copies on the volume;
+            // and were they ever renamed to {target}_*, SaveGame.TryReadSaveFileWithFallback could
+            // silently auto-recover the un-swapped original. A fresh clone needs no backups.
+            if (
+                fileName.EndsWith("_old", StringComparison.Ordinal)
+                || fileName.Contains("_STARDEWVALLEYSAVETMP")
+            )
+            {
+                continue;
+            }
+            if (fileName == "SaveGameInfo")
+            {
+                try
+                {
+                    var sgi = new System.Xml.XmlDocument();
+                    sgi.Load(file);
+                    var sgiId = sgi.SelectSingleNode("//uniqueIDForThisGame");
+                    if (sgiId != null)
+                    {
+                        sgiId.InnerText = newId.ToString();
+                    }
+                    sgi.Save(System.IO.Path.Combine(targetDir, "SaveGameInfo"));
+                    continue;
+                }
+                catch
+                {
+                    // fall through to a raw copy if SaveGameInfo isn't parseable
+                }
+            }
+            System.IO.File.Copy(file, System.IO.Path.Combine(targetDir, fileName), overwrite: true);
+        }
+
+        return targetName;
+    }
+
+    private static string TryHashSaveMainFile(string saveName)
+    {
+        try
+        {
+            var mainFile = System.IO.Path.Combine(Constants.SavesPath, saveName, saveName);
+            if (!System.IO.File.Exists(mainFile))
+            {
+                return "";
+            }
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            using var stream = System.IO.File.OpenRead(mainFile);
+            return Convert.ToBase64String(sha.ComputeHash(stream));
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/corrupt_save",
+        Summary = "Clone a save under a new name and corrupt the clone's <player> (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestSaveFileOpResponse), 200)]
+    private async Task<TestSaveFileOpResponse> HandlePostTestCorruptSaveAsync(
+        HttpListenerRequest request
+    )
+    {
+        // Used by the resilience test: clone the active (valid) save to a target folder, then mangle
+        // the clone's main file so a swap import of it fails the XmlDocument.Load — proving the
+        // transform leaves the file byte-unchanged on a malformed input. Plain file IO (off-thread).
+        TestCorruptSaveRequest body;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            body = string.IsNullOrWhiteSpace(json)
+                ? new TestCorruptSaveRequest()
+                : JsonConvert.DeserializeObject<TestCorruptSaveRequest>(json)
+                    ?? new TestCorruptSaveRequest();
+        }
+        catch (Exception ex)
+        {
+            return new TestSaveFileOpResponse
+            {
+                Success = false,
+                Error = $"Failed to parse body: {ex.Message}",
+            };
+        }
+
+        if (string.IsNullOrEmpty(body.TargetSaveName))
+        {
+            return new TestSaveFileOpResponse
+            {
+                Success = false,
+                Error = "TargetSaveName required",
+            };
+        }
+
+        try
+        {
+            var source = string.IsNullOrEmpty(body.SourceSaveName)
+                ? Constants.SaveFolderName
+                : body.SourceSaveName;
+            // CloneSaveFolder derives the real folder name (re-stamped uniqueID); return it so the
+            // caller imports the actual corrupted folder with SkipClone.
+            var actualTarget = CloneSaveFolder(source, body.TargetSaveName);
+
+            // Mangle the clone's main file into non-well-formed XML so XmlDocument.Load throws.
+            var mainFile = System.IO.Path.Combine(Constants.SavesPath, actualTarget, actualTarget);
+            System.IO.File.WriteAllText(mainFile, "<SaveGame><player>NOT WELL FORMED");
+            return new TestSaveFileOpResponse { Success = true, TargetSaveName = actualTarget };
+        }
+        catch (Exception ex)
+        {
+            return new TestSaveFileOpResponse { Success = false, Error = ex.Message };
+        }
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/save_tmp_exists",
+        Summary = "Whether a leftover .tmp exists next to a save's main file (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestSaveFileOpResponse), 200)]
+    private TestSaveFileOpResponse HandleGetTestSaveTmpExists(HttpListenerRequest request)
+    {
+        var saveName = request.QueryString["saveName"];
+        if (string.IsNullOrEmpty(saveName))
+        {
+            return new TestSaveFileOpResponse
+            {
+                Success = false,
+                Error = "saveName query required",
+            };
+        }
+        try
+        {
+            var tmp = System.IO.Path.Combine(Constants.SavesPath, saveName, saveName + ".tmp");
+            return new TestSaveFileOpResponse
+            {
+                Success = true,
+                Exists = System.IO.File.Exists(tmp),
+            };
+        }
+        catch (Exception ex)
+        {
+            return new TestSaveFileOpResponse { Success = false, Error = ex.Message };
+        }
     }
 }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -956,6 +956,15 @@ public partial class ApiService
             targetName = string.IsNullOrEmpty(body.TargetSaveName)
                 ? sourceName
                 : body.TargetSaveName;
+            // SkipClone imports the name verbatim (no CloneSaveFolder guard runs); validate it here so
+            // a request-supplied name can't escape SavesPath via the hash/import path below.
+            if (!IsSafeSaveName(targetName))
+            {
+                result.Success = false;
+                result.Error =
+                    "TargetSaveName must be a bare folder name (no path separators) when SkipClone is set";
+                return result;
+            }
             result.TargetSaveName = targetName;
         }
 
@@ -1003,6 +1012,16 @@ public partial class ApiService
     /// </summary>
     private static string CloneSaveFolder(string sourceName, string seed)
     {
+        // sourceName is request-supplied; keep it from escaping SavesPath (the derived targetName is
+        // built from FilterFileName + a numeric id, so it's safe by construction).
+        if (!IsSafeSaveName(sourceName))
+        {
+            throw new ArgumentException(
+                $"Invalid source save name '{sourceName}'",
+                nameof(sourceName)
+            );
+        }
+
         var savesPath = Constants.SavesPath;
         var sourceDir = System.IO.Path.Combine(savesPath, sourceName);
         if (!System.IO.Directory.Exists(sourceDir))
@@ -1091,6 +1110,18 @@ public partial class ApiService
 
         return targetName;
     }
+
+    /// <summary>
+    /// True when <paramref name="saveName"/> is a bare save-folder name safe to combine under
+    /// <c>Constants.SavesPath</c> — a single path segment with no directory separators and no
+    /// <c>..</c> traversal. These test endpoints take the name from request input, so guard it before
+    /// any <c>Path.Combine</c> to keep an untrusted value from escaping the saves directory.
+    /// </summary>
+    private static bool IsSafeSaveName(string? saveName) =>
+        !string.IsNullOrEmpty(saveName)
+        && System.IO.Path.GetFileName(saveName) == saveName
+        && saveName != "."
+        && saveName != "..";
 
     private static string TryHashSaveMainFile(string saveName)
     {
@@ -1192,6 +1223,14 @@ public partial class ApiService
             {
                 Success = false,
                 Error = "saveName query required",
+            };
+        }
+        if (!IsSafeSaveName(saveName))
+        {
+            return new TestSaveFileOpResponse
+            {
+                Success = false,
+                Error = "saveName must be a bare folder name (no path separators)",
             };
         }
         try

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -102,6 +102,12 @@ public partial class ApiService
                             await HandlePostTestImportSaveAsync(request)
                         );
                         return;
+                    case "/test/console":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestConsoleCommandAsync(request)
+                        );
+                        return;
                     case "/test/corrupt_save":
                         await WriteJsonAsync(
                             response,
@@ -999,6 +1005,114 @@ public partial class ApiService
         result.FormerOwnerUid = import?.FormerOwnerUid ?? 0;
         result.ImportError = import?.Error;
         return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/console",
+        Summary = "Invoke a registered SMAPI console command by name (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestConsoleCommandResponse), 200)]
+    private async Task<TestConsoleCommandResponse> HandlePostTestConsoleCommandAsync(
+        HttpListenerRequest request
+    )
+    {
+        // The `saves reload` guard + force-kick path lives entirely in the console command
+        // (SavesCommand), which SMAPI 4.4 exposes no public API to invoke programmatically
+        // (ICommandHelper has only Add — verified). To drive the REAL command path in E2E — same
+        // dispatch, same flag parsing, same guard — reflect into SMAPI's internal command registry
+        // and invoke the command's callback exactly as an operator typing it would. Test-only
+        // (/test/* is gated to Env.IsTest), so this reflection can never affect production.
+        TestConsoleCommandRequest body;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            body =
+                JsonConvert.DeserializeObject<TestConsoleCommandRequest>(json)
+                ?? new TestConsoleCommandRequest();
+        }
+        catch (Exception ex)
+        {
+            return new TestConsoleCommandResponse
+            {
+                Success = false,
+                Error = $"Failed to parse body: {ex.Message}",
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(body.Name))
+        {
+            return new TestConsoleCommandResponse { Success = false, Error = "Name is required" };
+        }
+
+        try
+        {
+            InvokeConsoleCommand(body.Name, body.Args ?? Array.Empty<string>());
+            return new TestConsoleCommandResponse { Success = true };
+        }
+        catch (Exception ex)
+        {
+            return new TestConsoleCommandResponse { Success = false, Error = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Invokes a registered console command's callback by name, via SMAPI internals (no public API
+    /// exists). Chain (verified against SMAPI 4.4): <c>SCore.Instance</c> (static internal prop) →
+    /// <c>CommandManager</c> (internal field) → <c>Get(name)</c> (public) → the <c>Command.Callback</c>
+    /// (public <c>Action&lt;string,string[]&gt;</c>). Runs on the calling (HTTP handler) thread, which
+    /// matches how SMAPI runs console commands — on a background thread, not the game thread; the
+    /// command itself marshals to the game thread where it needs to. Test-only.
+    /// </summary>
+    private static void InvokeConsoleCommand(string name, string[] args)
+    {
+        var smapiAsm = typeof(IModHelper).Assembly;
+        var scoreType =
+            smapiAsm.GetType("StardewModdingAPI.Framework.SCore")
+            ?? throw new InvalidOperationException("SCore type not found");
+        var instance =
+            scoreType
+                .GetProperty(
+                    "Instance",
+                    System.Reflection.BindingFlags.Static
+                        | System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Public
+                )
+                ?.GetValue(null)
+            ?? throw new InvalidOperationException("SCore.Instance is null");
+
+        var commandManager =
+            scoreType
+                .GetField(
+                    "CommandManager",
+                    System.Reflection.BindingFlags.Instance
+                        | System.Reflection.BindingFlags.NonPublic
+                        | System.Reflection.BindingFlags.Public
+                )
+                ?.GetValue(instance)
+            ?? throw new InvalidOperationException("SCore.CommandManager is null");
+
+        var command = commandManager
+            .GetType()
+            .GetMethod("Get", new[] { typeof(string) })
+            ?.Invoke(commandManager, new object[] { name });
+        if (command == null)
+        {
+            throw new InvalidOperationException($"Console command '{name}' is not registered");
+        }
+
+        var callback =
+            command.GetType().GetProperty("Callback")?.GetValue(command) as Action<string, string[]>
+            ?? throw new InvalidOperationException(
+                $"Console command '{name}' has no invocable callback"
+            );
+
+        callback(name, args);
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -1018,12 +1018,8 @@ public partial class ApiService
         HttpListenerRequest request
     )
     {
-        // The `saves reload` guard + force-kick path lives entirely in the console command
-        // (SavesCommand), which SMAPI 4.4 exposes no public API to invoke programmatically
-        // (ICommandHelper has only Add — verified). To drive the REAL command path in E2E — same
-        // dispatch, same flag parsing, same guard — reflect into SMAPI's internal command registry
-        // and invoke the command's callback exactly as an operator typing it would. Test-only
-        // (/test/* is gated to Env.IsTest), so this reflection can never affect production.
+        // Drives the saves-reload guard/kick path, which lives only in the console command — no HTTP
+        // endpoint reaches it, and SMAPI 4.4 has no public command-invoke API. See InvokeConsoleCommand.
         TestConsoleCommandRequest body;
         try
         {
@@ -1062,12 +1058,10 @@ public partial class ApiService
     }
 
     /// <summary>
-    /// Invokes a registered console command's callback by name, via SMAPI internals (no public API
-    /// exists). Chain (verified against SMAPI 4.4): <c>SCore.Instance</c> (static internal prop) →
-    /// <c>CommandManager</c> (internal field) → <c>Get(name)</c> (public) → the <c>Command.Callback</c>
-    /// (public <c>Action&lt;string,string[]&gt;</c>). Runs on the calling (HTTP handler) thread, which
-    /// matches how SMAPI runs console commands — on a background thread, not the game thread; the
-    /// command itself marshals to the game thread where it needs to. Test-only.
+    /// Invokes a console command's callback by name via SMAPI internals (no public API exists).
+    /// Chain (SMAPI 4.4): <c>SCore.Instance</c> → <c>CommandManager</c> field → <c>Get(name)</c> →
+    /// <c>Command.Callback</c> (<c>Action&lt;string,string[]&gt;</c>); a future SMAPI may rename these.
+    /// Runs off the game thread, as a real console command does. Test-only.
     /// </summary>
     private static void InvokeConsoleCommand(string name, string[] args)
     {

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -171,6 +171,53 @@ public class DiagnosticsStateResponse
     /// <summary>UMIs in <c>Multiplayer.disconnectingFarmers</c> (mid-disconnect).</summary>
     public long[] DisconnectingFarmers { get; set; } = System.Array.Empty<long>();
 
+    // ── Save-import assertion probes (counts/booleans/small ints only; unauthenticated-safe). ──
+    // The post-swap Server-host FarmHouse must be empty after the contents/NPC move.
+    /// <summary>Placed-object count in the host FarmHouse (must be 0 after a swap import).</summary>
+    public int FarmHouseObjectCount { get; set; }
+
+    /// <summary>Furniture count in the host FarmHouse (must be 0 after a swap import).</summary>
+    public int FarmHouseFurnitureCount { get; set; }
+
+    /// <summary>Fridge-item count in the host FarmHouse (must be 0 after a swap import).</summary>
+    public int FarmHouseFridgeItemCount { get; set; }
+
+    /// <summary>Object count in the master's "Cellar"-1 (must be 0 after a swap import moved the
+    /// former owner's casks into their reassigned cellar).</summary>
+    public int MasterCellarObjectCount { get; set; }
+
+    // Master-gated world-state probes: prove the blank Server master carries the copied
+    // master-gated fields (caveChoice/friendshipData/stats/mail) yet NOT the cleared relationship
+    // field (spouse). MasterPlayer IS Game1.player on this server (multiplayerMode=2).
+    /// <summary>Whether <c>MasterPlayer.mailReceived</c> contains the flag named in the
+    /// <c>?masterFlag=</c> query (null if no flag was queried). Boolean, not the flag list.</summary>
+    public bool? MasterHasFlag { get; set; }
+
+    /// <summary><c>MasterPlayer.caveChoice</c> (Test 7b — non-mail master-gated field carry).</summary>
+    public int MasterCaveChoice { get; set; }
+
+    /// <summary><c>MasterPlayer.friendshipData[?masterFriendKey].Points</c> — the SPECIFIC keyed NPC's
+    /// points (Test 7c — shadow-pacifism gate carry), or null when no <c>?masterFriendKey=</c> was
+    /// queried (nullable for parity with <see cref="MasterHasFlag"/>: "not queried" ≠ "genuinely 0").</summary>
+    public int? MasterShadowFriendshipPoints { get; set; }
+
+    /// <summary><c>MasterPlayer.stats.DaysPlayed</c> (Test 7c — same-day-reconnect gate carry).</summary>
+    public int MasterDaysPlayed { get; set; }
+
+    /// <summary>Whether the blank Server master has an NPC spouse (Test 8 — must be FALSE after a
+    /// swap; the clone-blank clears <c>&lt;spouse&gt;</c> on the master only).</summary>
+    public bool MasterHasSpouse { get; set; }
+
+    /// <summary>The master farmer's name. After a swap it is "Server" (the fresh blank host); after an
+    /// as-is import it is the save's original owner name — the as-is test asserts the latter, so it can
+    /// distinguish "owner preserved as host" from "a blank Server was wrongly installed."</summary>
+    public string MasterName { get; set; } = "";
+
+    /// <summary>Count of save-import finalize success-path runs since process start. The single-shot
+    /// test asserts this stays 1 across two reloads (a re-fire would bump it), proving the finalizer
+    /// cleared its intent and did NOT re-run.</summary>
+    public int SaveImportFinalizeCount { get; set; }
+
     /// <summary>Fields that failed to be read. Empty on fully-successful dumps.</summary>
     public List<string> FailedFields { get; set; } = new();
 }
@@ -194,6 +241,23 @@ public class DiagnosticsCabinState
     public string HomeLocationOfOwner { get; set; } = "";
     public bool FarmhandReferenceDefined { get; set; }
     public long FarmhandReferenceUid { get; set; }
+
+    /// <summary>Count of placed objects (chests/machines) in the cabin interior. Used by the
+    /// save-import contents-move test to assert the owner's chests moved into the cabin. Count
+    /// only (not contents) — /diagnostics/state is unauthenticated.</summary>
+    public int ObjectCount { get; set; }
+
+    /// <summary>Count of items in the cabin fridge (save-import contents move).</summary>
+    public int FridgeItemCount { get; set; }
+
+    /// <summary>Count of <c>Pet</c> NPCs in the cabin interior, so the save-import pet-relocation test
+    /// can assert the PET reached the cabin, not merely "some NPC."</summary>
+    public int PetCount { get; set; }
+
+    /// <summary>Object count in the cellar the engine assigned to this cabin's owner (resolved via
+    /// <c>Cabin.GetCellarName()</c>), so the save-import cellar-move test can assert the former owner's
+    /// casks reached their cellar. 0 when the owner has no assigned cellar.</summary>
+    public int CellarObjectCount { get; set; }
 }
 
 public class DiagnosticsFarmhandState
@@ -678,6 +742,7 @@ public partial class ApiService : ModService
     private readonly CabinManagerService _cabinManager;
     private readonly RoleService _roleService;
     private readonly PasswordProtectionService? _passwordProtectionService;
+    private readonly SaveImport.SaveImportService _saveImportService;
 
     // WebSocket client management
     private readonly List<WebSocket> _wsClients = new();
@@ -925,6 +990,7 @@ public partial class ApiService : ModService
         PersistentOptions persistentOptions,
         CabinManagerService cabinManager,
         RoleService roleService,
+        SaveImport.SaveImportService saveImportService,
         PasswordProtectionService? passwordProtectionService = null
     )
         : base(helper, monitor)
@@ -933,6 +999,7 @@ public partial class ApiService : ModService
         _persistentOptions = persistentOptions;
         _cabinManager = cabinManager;
         _roleService = roleService;
+        _saveImportService = saveImportService;
         _passwordProtectionService = passwordProtectionService;
     }
 
@@ -1981,7 +2048,10 @@ public partial class ApiService : ModService
                         await HandleWaitFarmhandsAsync(request, response, requestId);
                         break;
                     case "/diagnostics/state":
-                        await WriteJsonAsync(response, await HandleGetDiagnosticsStateAsync());
+                        await WriteJsonAsync(
+                            response,
+                            await HandleGetDiagnosticsStateAsync(request)
+                        );
                         break;
                     case "/diagnostics/handler-timing":
                         await WriteJsonAsync(response, BuildHandlerTimingReport());
@@ -2647,9 +2717,17 @@ public partial class ApiService : ModService
         Tag = "Diagnostics"
     )]
     [ApiResponse(typeof(DiagnosticsStateResponse), 200)]
-    private async Task<DiagnosticsStateResponse> HandleGetDiagnosticsStateAsync()
+    private async Task<DiagnosticsStateResponse> HandleGetDiagnosticsStateAsync(
+        HttpListenerRequest? request = null
+    )
     {
         var resp = new DiagnosticsStateResponse { CapturedAt = DateTime.UtcNow.ToString("o") };
+        // Optional ?masterFlag=<id> — when present, MasterHasFlag reports whether the master's
+        // mailReceived contains it (boolean, never the flag list). Used by save-import Test 7.
+        var masterFlag = request?.QueryString["masterFlag"];
+        // Optional ?masterFriendKey=<npc> — MasterShadowFriendshipPoints reports that NPC's specific
+        // friendship points (not a max-over-all). Used by save-import Test 7c.
+        var masterFriendKey = request?.QueryString["masterFriendKey"];
 
         // Phase 1 — primitive / thread-safe reads. These are value-type
         // snapshots or use cached Interlocked counters; safe from the HTTP
@@ -2716,6 +2794,14 @@ public partial class ApiService : ModService
             () =>
             {
                 resp.AvgGameThreadWaitMs = Volatile.Read(ref _avgGameThreadWaitMs);
+            }
+        );
+        TryRead(
+            "saveImportFinalizeCount",
+            resp.FailedFields,
+            () =>
+            {
+                resp.SaveImportFinalizeCount = CabinManagerService.SaveImportFinalizeCount;
             }
         );
 
@@ -2812,6 +2898,57 @@ public partial class ApiService : ModService
                             resp.DisconnectingFarmers = ReadDisconnectingFarmers();
                         }
                     );
+
+                    // Save-import probes: host FarmHouse content/NPC counts (must be 0 after a swap
+                    // move) and master-gated world-state on the blank Server master.
+                    TryRead(
+                        "farmHouseContents",
+                        resp.FailedFields,
+                        () =>
+                        {
+                            var fh = Game1.getLocationFromName("FarmHouse") as FarmHouse;
+                            resp.FarmHouseObjectCount = fh?.objects?.Count() ?? 0;
+                            resp.FarmHouseFurnitureCount = fh?.furniture?.Count ?? 0;
+                            resp.FarmHouseFridgeItemCount =
+                                fh?.fridge?.Value?.Items?.Count(i => i != null) ?? 0;
+                            var masterCellar = Game1.getLocationFromName("Cellar");
+                            resp.MasterCellarObjectCount = masterCellar?.objects?.Count() ?? 0;
+                        }
+                    );
+
+                    TryRead(
+                        "masterState",
+                        resp.FailedFields,
+                        () =>
+                        {
+                            var master = Game1.MasterPlayer;
+                            if (master == null)
+                            {
+                                return;
+                            }
+                            resp.MasterName = master.Name ?? "";
+                            if (!string.IsNullOrEmpty(masterFlag))
+                            {
+                                resp.MasterHasFlag =
+                                    master.mailReceived?.Contains(masterFlag) ?? false;
+                            }
+                            resp.MasterCaveChoice = master.caveChoice?.Value ?? 0;
+                            resp.MasterDaysPlayed = (int)(master.stats?.DaysPlayed ?? 0);
+                            resp.MasterHasSpouse = !string.IsNullOrEmpty(master.spouse);
+                            // Read the SPECIFIC keyed friendship the test seeded (the Dark-Shrine gate
+                            // keys on a particular NPC), not a max-over-all — a max could false-pass if
+                            // any other NPC happened to be high while the seeded carry was lost.
+                            if (
+                                !string.IsNullOrEmpty(masterFriendKey)
+                                && master.friendshipData != null
+                                && master.friendshipData.TryGetValue(masterFriendKey, out var keyed)
+                                && keyed != null
+                            )
+                            {
+                                resp.MasterShadowFriendshipPoints = keyed.Points;
+                            }
+                        }
+                    );
                 },
                 timeoutMs: 3000
             );
@@ -2864,6 +3001,11 @@ public partial class ApiService : ModService
                         FarmhandReferenceDefined =
                             cabin?.farmhandReference?.defined?.Value ?? false,
                         FarmhandReferenceUid = cabin?.farmhandReference?.uid?.Value ?? 0,
+                        ObjectCount = cabin?.objects?.Count() ?? 0,
+                        FridgeItemCount = cabin?.fridge?.Value?.Items?.Count(i => i != null) ?? 0,
+                        PetCount =
+                            cabin?.characters?.Count(c => c is StardewValley.Characters.Pet) ?? 0,
+                        CellarObjectCount = ReadCabinCellarObjectCount(cabin),
                     }
                 );
             }
@@ -2872,6 +3014,22 @@ public partial class ApiService : ModService
             }
         }
         return list;
+    }
+
+    /// <summary>
+    /// Object count in the cellar the engine assigned to <paramref name="cabin"/>'s owner, resolved
+    /// the engine's own way (<c>Cabin.GetCellarName()</c> → <c>cellarAssignments</c> keyed on the
+    /// owner UID). 0 when there's no owner or no assigned cellar.
+    /// </summary>
+    private static int ReadCabinCellarObjectCount(StardewValley.Locations.Cabin? cabin)
+    {
+        var cellarName = cabin?.GetCellarName();
+        if (string.IsNullOrEmpty(cellarName))
+        {
+            return 0;
+        }
+        var cellar = Game1.getLocationFromName(cellarName);
+        return cellar?.objects?.Count() ?? 0;
     }
 
     private static List<DiagnosticsFarmhandState> ReadFarmhandDiagnostics()

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -193,6 +193,10 @@ public class DiagnosticsStateResponse
     /// <c>?masterFlag=</c> query (null if no flag was queried). Boolean, not the flag list.</summary>
     public bool? MasterHasFlag { get; set; }
 
+    /// <summary>Whether <c>MasterPlayer.eventsSeen</c> contains the id named in the <c>?masterEvent=</c>
+    /// query (null if none queried). eventsSeen is a distinct collection from mailReceived.</summary>
+    public bool? MasterHasEvent { get; set; }
+
     /// <summary><c>MasterPlayer.caveChoice</c> (Test 7b — non-mail master-gated field carry).</summary>
     public int MasterCaveChoice { get; set; }
 
@@ -2725,6 +2729,9 @@ public partial class ApiService : ModService
         // Optional ?masterFlag=<id> — when present, MasterHasFlag reports whether the master's
         // mailReceived contains it (boolean, never the flag list). Used by save-import Test 7.
         var masterFlag = request?.QueryString["masterFlag"];
+        // Optional ?masterEvent=<id> — MasterHasEvent reports whether the master's eventsSeen contains
+        // it (a distinct collection from mailReceived). Used by save-import Test 7.
+        var masterEvent = request?.QueryString["masterEvent"];
         // Optional ?masterFriendKey=<npc> — MasterShadowFriendshipPoints reports that NPC's specific
         // friendship points (not a max-over-all). Used by save-import Test 7c.
         var masterFriendKey = request?.QueryString["masterFriendKey"];
@@ -2931,6 +2938,11 @@ public partial class ApiService : ModService
                             {
                                 resp.MasterHasFlag =
                                     master.mailReceived?.Contains(masterFlag) ?? false;
+                            }
+                            if (!string.IsNullOrEmpty(masterEvent))
+                            {
+                                resp.MasterHasEvent =
+                                    master.eventsSeen?.Contains(masterEvent) ?? false;
                             }
                             resp.MasterCaveChoice = master.caveChoice?.Value ?? 0;
                             resp.MasterDaysPlayed = (int)(master.stats?.DaysPlayed ?? 0);

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -1323,7 +1323,7 @@ public class CabinManagerService : ModService
 
             // Step 5 — move the owner's farmhouse contents into the cabin.
             failedStep = "move_contents";
-            contentsMoved = TransferFarmhouseContentsToCabin(farmHouse, cabin);
+            contentsMoved = TransferFarmhouseContentsToCabin(farmHouse, cabin, builtFresh);
 
             // Step 6 — relocate the owner's household NPCs (pet, spouse, children) into the cabin.
             failedStep = "relocate_household";
@@ -1445,18 +1445,23 @@ public class CabinManagerService : ModService
     /// built-in farmhouse→cabin transfer, so this is hand-written from the source-derived content
     /// list. Returns the count of moved objects + furniture (for the finalize event).
     /// </summary>
-    private int TransferFarmhouseContentsToCabin(FarmHouse farmHouse, Cabin cabin)
+    private int TransferFarmhouseContentsToCabin(FarmHouse farmHouse, Cabin cabin, bool builtFresh)
     {
         if (farmHouse == null || cabin == null)
         {
             return 0;
         }
 
-        // First, clear the destination cabin's own default starter contents (build OR reuse path):
-        // a freshly-built Cabin runs AddStarterGiftBox + AddStarterFurniture in its ctor, and a
-        // reused spare cabin that was never lived in still has its starter giftbox. Remove them
-        // before merging so the owner's cabin doesn't end up with a phantom giftbox / tile overlap.
-        ClearStarterContents(cabin);
+        // Clear the destination's default starter contents ONLY when we built the cabin fresh: a new
+        // Cabin runs AddStarterGiftBox + AddStarterFurniture in its ctor, which must go before the
+        // merge or the owner's cabin ends up with a phantom giftbox / tile overlap. A REUSED cabin is
+        // the engine's auto-assigned spare, which can be an uncustomized-but-furnished slot (Cabin.
+        // DeleteFarmhand never clears the interior) — clearing it would delete that real player data,
+        // so skip the clear and merge the master's farmhouse contents on top of what's there.
+        if (builtFresh)
+        {
+            ClearStarterContents(cabin);
+        }
 
         int moved = 0;
 
@@ -1689,6 +1694,7 @@ public class CabinManagerService : ModService
         var destCellarName = cabin.GetCellarName();
         var destCellar =
             destCellarName == null ? null : Game1.getLocationFromName(destCellarName) as Cellar;
+        var maskedOwnerName = ChatRedaction.MaskValue(owner.Name);
 
         if (destCellar == null || ReferenceEquals(destCellar, sourceCellar))
         {
@@ -1696,7 +1702,7 @@ public class CabinManagerService : ModService
             // still resolves to "Cellar"-1. Leave the contents where they are and warn — recoverable,
             // not a finalize failure.
             Monitor.Log(
-                $"Save-import: former owner '{owner.Name}' has {sourceObjectCount} cellar item(s) but "
+                $"Save-import: former owner '{maskedOwnerName}' has {sourceObjectCount} cellar item(s) but "
                     + "no separate cellar could be assigned (player limit reached); they remain in the "
                     + "main farm cellar (now the Server host's).",
                 LogLevel.Warn
@@ -1704,9 +1710,11 @@ public class CabinManagerService : ModService
             return 0;
         }
 
-        // Clear any pre-existing objects in the destination (a freshly-assigned slot is empty, but be
-        // safe — same discipline as the cabin starter-content clear), then move the casks over by tile.
-        // Cellar interiors share the same map, so source tiles are valid in the destination.
+        // Clearing the destination can't destroy another farmer's data: updateCellarAssignments only
+        // ever hands the owner a slot whose prior holder no longer resolves (a per-slot cellar,
+        // pre-created empty — cellars have no starter contents) or the owner's own already-held slot;
+        // it never reassigns a still-held slot, and the ReferenceEquals guard above rules out the
+        // master's "Cellar"-1. Cellar interiors share the same map, so source tiles are valid here.
         foreach (var pos in destCellar.objects.Keys.ToList())
         {
             destCellar.objects.Remove(pos);
@@ -1722,7 +1730,7 @@ public class CabinManagerService : ModService
 
         Monitor.Log(
             $"Save-import: moved {moved} cellar item(s) from the main farm cellar into former owner "
-                + $"'{owner.Name}'s cellar ('{destCellarName}').",
+                + $"'{maskedOwnerName}'s cellar ('{destCellarName}').",
             LogLevel.Info
         );
         return moved;

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -6,6 +6,7 @@ using JunimoServer.Services.Lobby;
 using JunimoServer.Services.MessageInterceptors;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Roles;
+using JunimoServer.Services.SaveImport;
 using JunimoServer.Services.ServerOptim;
 using JunimoServer.Shared;
 using JunimoServer.Util;
@@ -15,6 +16,7 @@ using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
 using StardewValley.Buildings;
+using StardewValley.Characters;
 using StardewValley.Locations;
 using StardewValley.Network;
 
@@ -48,12 +50,26 @@ public class CabinManagerService : ModService
 
     private readonly RoleService roleService;
 
+    // One-way dependency (CabinManagerService → SaveImportService). Injected solely to read+clear
+    // the pending save-import finalize intent; all engine-touching finalizer logic is this service's
+    // own private code (Layer B). A mutual injection would be a startup-fatal constructor cycle.
+    private readonly SaveImportService saveImportService;
+
     private static readonly int minEmptyCabins = 1;
 
     private readonly HashSet<long> farmersInFarmhouse = new HashSet<long>();
 
     // Static reference ONLY for Harmony patches (unavoidable)
     private static CabinManagerService _instance;
+
+    // Count of save-import finalizer SUCCESS-path runs this process. Exposed via /diagnostics/state
+    // so the single-shot E2E test can assert the finalizer runs exactly once across two reloads
+    // (i.e. the intent was cleared and did NOT re-fire) — a property the owner's customized+bound
+    // state alone can't distinguish from a harmless re-run.
+    private static int _saveImportFinalizeCount;
+
+    /// <summary>Count of save-import finalize success-path completions since process start (test probe).</summary>
+    public static int SaveImportFinalizeCount => _saveImportFinalizeCount;
 
     // Instance data - NOT static
     private CabinManagerData _cabinManagerData;
@@ -64,7 +80,8 @@ public class CabinManagerService : ModService
         Harmony harmony,
         RoleService roleService,
         MessageInterceptorsService messageInterceptorsService,
-        PersistentOptions options
+        PersistentOptions options,
+        SaveImportService saveImportService
     )
         : base(helper, monitor)
     {
@@ -79,6 +96,7 @@ public class CabinManagerService : ModService
 
         this.roleService = roleService;
         this.options = options;
+        this.saveImportService = saveImportService;
 
         Data = new CabinManagerData(helper, monitor);
 
@@ -146,6 +164,16 @@ public class CabinManagerService : ModService
 
     private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
     {
+        // Save-import Layer B finalizer — MUST be the first statement, before Data.Read() and the
+        // whole reconciliation chain. Ordering is load-bearing three ways: (1) the demoted owner is
+        // homed+bound before the reconciliation absorbs it; (2) running before
+        // ClearStaleFarmhandReferences means the owner's homeLocation is already the new cabin (not
+        // the stale FarmHouse), so that sweep leaves it alone; (3) running before
+        // ClearAbandonedCabinClaimsOnLoad (which only clears uncustomized farmhands) plus keeping
+        // the owner isCustomized=true both protect the fresh userID stamp. No-op (zero cost) on
+        // normal loads with no pending import.
+        TryFinalizeOnLoad();
+
         Data.Read();
 
         // Detect and handle strategy changes between runs
@@ -920,8 +948,25 @@ public class CabinManagerService : ModService
 
     /// <summary>
     /// Build a cabin at the hidden out-of-bounds location (for CabinStack/FarmhouseStack).
+    /// Thin <c>bool</c> wrapper over <see cref="BuildNewCabinReturning(GameLocation)"/> for callers
+    /// that don't need the handle (EnsureAtLeastXCabins, CabinsConsoleCommand).
     /// </summary>
-    public bool BuildNewCabin(GameLocation location)
+    public bool BuildNewCabin(GameLocation location) => BuildNewCabinReturning(location) != null;
+
+    /// <summary>
+    /// Build a cabin at a real, visible farm position (for None strategy). Thin <c>bool</c> wrapper
+    /// over <see cref="BuildNewCabinVisibleReturning(GameLocation)"/>.
+    /// </summary>
+    public bool BuildNewCabinVisible(GameLocation location) =>
+        BuildNewCabinVisibleReturning(location) != null;
+
+    /// <summary>
+    /// Build a hidden-stack cabin and return its <see cref="Cabin"/> interior handle (null on
+    /// failure). The save-import finalizer needs the handle — under CabinStack all hidden cabins
+    /// share tile (-20,-20), so position can't disambiguate; the returned handle is the only reliable
+    /// reference. Logs build failures at <c>Warn</c> (NOT Error — Error is server-side test poison).
+    /// </summary>
+    public Cabin BuildNewCabinReturning(GameLocation location)
     {
         var cabinTilePosition = HiddenCabinLocation.ToVector2();
         var cabin = CreateCabinBuilding(cabinTilePosition);
@@ -935,7 +980,7 @@ public class CabinManagerService : ModService
             {
                 Monitor.Log(
                     "Hidden cabin was built but has no interior; farmhand not created",
-                    LogLevel.Error
+                    LogLevel.Warn
                 );
                 Diagnostics.ModEventLog.Emit(
                     "cabin_build_failed",
@@ -947,10 +992,10 @@ public class CabinManagerService : ModService
                         reason = "no_interior_after_buildStructure",
                     }
                 );
-                return false;
+                return null;
             }
 
-            return true;
+            return indoors;
         }
 
         Diagnostics.ModEventLog.Emit(
@@ -963,14 +1008,15 @@ public class CabinManagerService : ModService
                 reason = "buildStructure_returned_false",
             }
         );
-        return false;
+        return null;
     }
 
     /// <summary>
-    /// Build a cabin at a real, visible farm position (for None strategy).
-    /// Uses map-designated positions from the Paths layer.
+    /// Build a visible-position cabin (None strategy) and return its <see cref="Cabin"/> interior
+    /// handle (null on failure). See <see cref="BuildNewCabinReturning"/> for why the handle matters.
+    /// Logs build failures at <c>Warn</c> (NOT Error — Error is server-side test poison).
     /// </summary>
-    public bool BuildNewCabinVisible(GameLocation location)
+    public Cabin BuildNewCabinVisibleReturning(GameLocation location)
     {
         var farm = location as Farm ?? Game1.getFarm();
         var position = FarmCabinPositions.GetNextAvailablePosition(farm);
@@ -982,7 +1028,7 @@ public class CabinManagerService : ModService
                 "cabin_build_failed",
                 new { hidden = false, reason = "no_available_map_position" }
             );
-            return false;
+            return null;
         }
 
         var cabin = CreateCabinBuilding(position.Value);
@@ -996,7 +1042,7 @@ public class CabinManagerService : ModService
             {
                 Monitor.Log(
                     $"Visible cabin at ({position.Value.X}, {position.Value.Y}) was built but has no interior; farmhand not created",
-                    LogLevel.Error
+                    LogLevel.Warn
                 );
                 Diagnostics.ModEventLog.Emit(
                     "cabin_build_failed",
@@ -1008,14 +1054,14 @@ public class CabinManagerService : ModService
                         reason = "no_interior_after_buildStructure",
                     }
                 );
-                return false;
+                return null;
             }
 
             Monitor.Log(
                 $"Built visible cabin at ({position.Value.X}, {position.Value.Y})",
                 LogLevel.Info
             );
-            return true;
+            return indoors;
         }
 
         Diagnostics.ModEventLog.Emit(
@@ -1028,7 +1074,7 @@ public class CabinManagerService : ModService
                 reason = "buildStructure_returned_false",
             }
         );
-        return false;
+        return null;
     }
 
     /// <summary>
@@ -1168,13 +1214,518 @@ public class CabinManagerService : ModService
 
         if (cabin.GetIndoors() == null)
         {
+            // Warn, not Error: this runs on the server game thread (incl. the save-import finalize
+            // build path), where LogLevel.Error trips ServerContainer's ERROR/FATAL test-poison scan.
+            // A null interior is surfaced as a failed build by the callers (cabin_build_failed event +
+            // their own Warn) — this is a recoverable condition, not a test-failure-worthy one.
             Monitor.Log(
                 "Cabin interior creation failed. Cabin will have no interior!",
-                LogLevel.Error
+                LogLevel.Warn
             );
         }
 
         return cabin;
+    }
+
+    #endregion
+
+    #region Save Import Finalizer (Layer B)
+
+    /// <summary>
+    /// One-shot save-import finalizer. Reads the pending finalize intent (written by
+    /// <see cref="SaveImportService.ExecuteImport"/> during a swap import); if present and for this
+    /// save, demotes the imported owner into a known cabin, moves their farmhouse contents and
+    /// household NPCs into it, and re-stamps their platform userID. Self-heals (Warn + clear +
+    /// return) on any pre-condition miss, and clears the intent on EVERY exit (including a throw
+    /// after a world mutation) so a failed finalize never retries against an already-changed world.
+    /// </summary>
+    private void TryFinalizeOnLoad()
+    {
+        var intent = saveImportService.TryReadIntent();
+        if (intent == null)
+        {
+            return; // zero cost on normal loads
+        }
+
+        // Wrong-save guard: a stale intent (or an unrelated loader write between import and reboot)
+        // must not mis-finalize a different save.
+        if (!string.Equals(Constants.SaveFolderName, intent.SaveName, StringComparison.Ordinal))
+        {
+            Monitor.Log(
+                $"Save-import intent targets '{intent.SaveName}' but loaded '{Constants.SaveFolderName}'; "
+                    + "clearing the orphan intent.",
+                LogLevel.Warn
+            );
+            saveImportService.ClearIntent();
+            return;
+        }
+
+        var farmhandData = Game1.netWorldState?.Value?.farmhandData;
+        if (farmhandData == null)
+        {
+            // Should be impossible at SaveLoaded (the world is fully loaded), but never NRE an
+            // unrelated load — clear the intent and bail.
+            Monitor.Log(
+                "Save-import: netWorldState/farmhandData unavailable at finalize; clearing intent.",
+                LogLevel.Warn
+            );
+            saveImportService.ClearIntent();
+            return;
+        }
+        if (!farmhandData.TryGetValue(intent.OwnerUid, out var owner) || owner == null)
+        {
+            Monitor.Log(
+                $"Save-import: demoted owner {intent.OwnerUid} not found in farmhandData; "
+                    + "clearing intent (nothing to finalize).",
+                LogLevel.Warn
+            );
+            saveImportService.ClearIntent();
+            return;
+        }
+
+        int contentsMoved = 0;
+        int npcsMoved = 0;
+        string failedStep = "";
+
+        try
+        {
+            // Step 4 — resolve the owner's cabin handle (reuse an auto-assigned cabin if the load
+            // coroutine already homed the owner into a spare one, else build a fresh cabin).
+            failedStep = "resolve_cabin";
+            var cabin = ResolveOrBuildOwnerCabin(owner, out var builtFresh);
+            if (cabin == null)
+            {
+                // Loud-fail at Warn (not Error). The owner stays a customized-but-cabin-less
+                // farmhand (progress intact, recoverable by a later reassignment); never proceed to
+                // the world-mutating steps.
+                Monitor.Log(
+                    $"Save-import: could not resolve or build a cabin for owner {intent.OwnerUid}; "
+                        + "finalize aborted (owner kept, progress intact).",
+                    LogLevel.Warn
+                );
+                Diagnostics.ModEventLog.Emit(
+                    "save_import_partial",
+                    new { ownerUid = intent.OwnerUid, failedStep }
+                );
+                return; // intent cleared in finally
+            }
+
+            // Realize a freshly-built cabin's interior map to the owner's upgrade level before the
+            // contents move, so the move targets the realized layout (belt-and-suspenders; the
+            // day-start updateFarmLayout would otherwise heal it). Furniture-preserving method, NOT
+            // the bare HouseUpgradeLevel setter (host-automation invariant 5 is a different path).
+            if (builtFresh && owner.HouseUpgradeLevel > 0)
+            {
+                cabin.setMapForUpgradeLevel(owner.HouseUpgradeLevel);
+            }
+
+            var farmHouse = Game1.getLocationFromName("FarmHouse") as FarmHouse;
+
+            // Step 5 — move the owner's farmhouse contents into the cabin.
+            failedStep = "move_contents";
+            contentsMoved = TransferFarmhouseContentsToCabin(farmHouse, cabin);
+
+            // Step 6 — relocate the owner's household NPCs (pet, spouse, children) into the cabin.
+            failedStep = "relocate_household";
+            npcsMoved = RelocateHouseholdToCabin(farmHouse, cabin, owner);
+
+            // Step 7 — move the owner's cellar contents (casks/wine, built in the master-keyed
+            // "Cellar"-1 while they were the master) into the cellar the engine reassigns to them as
+            // a farmhand. Counts toward contentsMoved.
+            failedStep = "move_cellar";
+            contentsMoved += TransferOwnerCellarContents(owner, cabin);
+
+            // Step 8 — re-stamp userID (idempotent whether vanilla cleared or preserved it). Owner
+            // is now homed + customized + bound; on any later reload it is homed → ResetFarmhandState
+            // early-returns → userID survives.
+            failedStep = "restamp_userid";
+            owner.userID.Value = intent.UserId;
+
+            // Success — count it so the single-shot test can prove the finalizer ran exactly once
+            // across reloads (a re-fire would bump this past 1).
+            System.Threading.Interlocked.Increment(ref _saveImportFinalizeCount);
+
+            Diagnostics.ModEventLog.Emit(
+                "save_import_finalized",
+                new
+                {
+                    ownerUid = intent.OwnerUid,
+                    hasUserId = !string.IsNullOrEmpty(intent.UserId),
+                    contentsMoved,
+                    npcsMoved,
+                }
+            );
+            Monitor.Log(
+                $"Save-import finalized: owner {intent.OwnerUid} homed + bound; "
+                    + $"moved {contentsMoved} item(s) and {npcsMoved} NPC(s) into the cabin.",
+                LogLevel.Info
+            );
+        }
+        catch (Exception ex)
+        {
+            // A throw after a world mutation leaves a partially-moved-but-stable world. The owner is
+            // already customized + cabin-homed (progress intact), so a missing content/NPC move is a
+            // recoverable cosmetic gap, not a boot-loop. Warn (never Error) + emit partial.
+            Monitor.Log(
+                $"Save-import finalize failed at step '{failedStep}': {ex.Message}. World is partially "
+                    + "moved but stable; owner kept. Intent cleared (no retry).",
+                LogLevel.Warn
+            );
+            Diagnostics.ModEventLog.Emit(
+                "save_import_partial",
+                new
+                {
+                    ownerUid = intent.OwnerUid,
+                    failedStep,
+                    contentsMoved,
+                    npcsMoved,
+                }
+            );
+        }
+        finally
+        {
+            // Single-shot: clear on EVERY exit path, including a post-mutation throw.
+            saveImportService.ClearIntent();
+        }
+    }
+
+    /// <summary>
+    /// Resolves the demoted owner's cabin. If the load coroutine already auto-homed the owner into a
+    /// spare cabin (the common co-op-with-spare-cabins case), reuses that cabin. Otherwise builds a
+    /// fresh one and assigns the owner. Returns null only on a build failure.
+    /// </summary>
+    private Cabin ResolveOrBuildOwnerCabin(Farmer owner, out bool builtFresh)
+    {
+        builtFresh = false;
+
+        // Reuse path: the owner was already auto-homed into a spare cabin by the load coroutine's
+        // ResetFarmhandState → TryAssignFarmhandHome. Reusing it avoids a double-assignment and a
+        // vacated spare cabin. getLocationFromName resolves a cabin interior (visible or hidden-stack)
+        // by its NameOrUniqueName — the same expression vanilla itself uses at NetWorldState.cs:783.
+        if (
+            Game1.getLocationFromName(owner.homeLocation.Value) is Cabin existing
+            && existing.OwnerId == owner.UniqueMultiplayerID
+        )
+        {
+            Monitor.Log(
+                $"Save-import: reusing auto-assigned cabin '{existing.NameOrUniqueName}' for owner "
+                    + $"{owner.UniqueMultiplayerID}.",
+                LogLevel.Info
+            );
+            return existing;
+        }
+
+        // Build path: no cabin was auto-assigned (single-player import, or all cabins customized).
+        var farm = Game1.getFarm();
+        var cabin = options.IsNone
+            ? BuildNewCabinVisibleReturning(farm)
+            : BuildNewCabinReturning(farm);
+        if (cabin == null)
+        {
+            return null;
+        }
+
+        builtFresh = true;
+        // AssignFarmhand auto-deletes the just-built cabin's unclaimed placeholder owner (created by
+        // buildStructure → Cabin.CreateFarmhand) then sets farmhandReference + the owner's
+        // homeLocation in one call (Cabin.cs:92-104). No throw — the placeholder is isUnclaimedFarmhand.
+        cabin.AssignFarmhand(owner);
+        Monitor.Log(
+            $"Save-import: built and assigned cabin '{cabin.NameOrUniqueName}' for owner "
+                + $"{owner.UniqueMultiplayerID}.",
+            LogLevel.Info
+        );
+        return cabin;
+    }
+
+    /// <summary>
+    /// Moves the former owner's placed farmhouse contents (chests + contents, machines + held items,
+    /// furniture, fridge, mini-jukebox, wallpaper/flooring) from the FarmHouse into their cabin, then
+    /// clears the FarmHouse copies so the Server host boots into an empty house. The engine has no
+    /// built-in farmhouse→cabin transfer, so this is hand-written from the source-derived content
+    /// list. Returns the count of moved objects + furniture (for the finalize event).
+    /// </summary>
+    private int TransferFarmhouseContentsToCabin(FarmHouse farmHouse, Cabin cabin)
+    {
+        if (farmHouse == null || cabin == null)
+        {
+            return 0;
+        }
+
+        // First, clear the destination cabin's own default starter contents (build OR reuse path):
+        // a freshly-built Cabin runs AddStarterGiftBox + AddStarterFurniture in its ctor, and a
+        // reused spare cabin that was never lived in still has its starter giftbox. Remove them
+        // before merging so the owner's cabin doesn't end up with a phantom giftbox / tile overlap.
+        ClearStarterContents(cabin);
+
+        int moved = 0;
+
+        // objects (placed chests + their contents, machines + held items, mini-fridges). Snapshot
+        // the source positions first; mutating netObjects while enumerating it would tear the
+        // enumeration.
+        var sourceObjects = farmHouse.objects.Pairs.ToList();
+        foreach (var kvp in sourceObjects)
+        {
+            var pos = kvp.Key;
+            var obj = kvp.Value;
+            farmHouse.objects.Remove(pos);
+            // Place at the same tile; the cabin interior is the same map (Cabin : FarmHouse), so
+            // the tile is valid (the destination's starter objects were just cleared above).
+            cabin.objects[pos] = obj;
+            moved++;
+        }
+
+        // mini-jukebox count/track (separate NetFields a raw objects move misses): a MiniJukebox
+        // object rides along in objects above, but its count/track don't, so the FarmHouse would
+        // strand a track (count>0, no object) and the cabin would show count=0 without this.
+        if (farmHouse.miniJukeboxCount.Value > 0)
+        {
+            cabin.miniJukeboxCount.Set(farmHouse.miniJukeboxCount.Value);
+            cabin.miniJukeboxTrack.Set(farmHouse.miniJukeboxTrack.Value);
+            farmHouse.miniJukeboxCount.Set(0);
+            farmHouse.miniJukeboxTrack.Set("");
+        }
+
+        // furniture (incl. beds and 2-tile furniture).
+        var sourceFurniture = farmHouse.furniture.ToList();
+        foreach (var f in sourceFurniture)
+        {
+            farmHouse.furniture.Remove(f);
+            cabin.furniture.Add(f);
+            moved++;
+        }
+
+        // fridge contents: a default cabin fridge is empty, so move the source fridge's items into
+        // the destination fridge (keeps the destination's NetRef<Chest> identity intact).
+        if (farmHouse.fridge.Value != null && cabin.fridge.Value != null)
+        {
+            var fridgeItems = farmHouse.fridge.Value.Items.ToList();
+            foreach (var item in fridgeItems)
+            {
+                if (item != null)
+                {
+                    cabin.fridge.Value.Items.Add(item);
+                }
+            }
+            farmHouse.fridge.Value.Items.Clear();
+        }
+
+        // Wallpaper / flooring (live decor stores). Copy both dictionaries then clear the FarmHouse
+        // ones. Also carry the obsolete pre-1.6 DecorationFacades if present (cheap; avoids dropping
+        // legacy decor).
+        CopyAndClearDecor(farmHouse, cabin);
+
+        // terrainFeatures / largeTerrainFeatures are normally empty for a farmhouse interior (interior
+        // floor/wall decor lives in appliedFloor/appliedWallpaper, not terrainFeatures). Move anything
+        // content-bearing if present (verified-once: do not assume empty).
+        var srcTerrain = farmHouse.terrainFeatures.Pairs.ToList();
+        foreach (var kvp in srcTerrain)
+        {
+            farmHouse.terrainFeatures.Remove(kvp.Key);
+            cabin.terrainFeatures[kvp.Key] = kvp.Value;
+            moved++;
+        }
+        var srcLargeTerrain = farmHouse.largeTerrainFeatures.ToList();
+        foreach (var ltf in srcLargeTerrain)
+        {
+            farmHouse.largeTerrainFeatures.Remove(ltf);
+            cabin.largeTerrainFeatures.Add(ltf);
+            moved++;
+        }
+
+        return moved;
+    }
+
+    /// <summary>
+    /// Removes a destination cabin's default starter giftbox + starter furniture before the contents
+    /// merge (risk #11). A default cabin fridge is empty, so it needs no special handling here.
+    /// </summary>
+    private static void ClearStarterContents(Cabin cabin)
+    {
+        // Starter giftbox is a Chest with giftbox flag in objects; clear ALL starter objects (a fresh
+        // cabin's objects are only the starter giftbox).
+        foreach (var pos in cabin.objects.Keys.ToList())
+        {
+            cabin.objects.Remove(pos);
+        }
+        // Starter furniture.
+        cabin.furniture.Clear();
+    }
+
+    /// <summary>Copies wallpaper/floor decor dictionaries FarmHouse→cabin and clears the source.</summary>
+    private static void CopyAndClearDecor(FarmHouse farmHouse, Cabin cabin)
+    {
+        foreach (var key in farmHouse.appliedWallpaper.Keys.ToList())
+        {
+            cabin.appliedWallpaper[key] = farmHouse.appliedWallpaper[key];
+        }
+        foreach (var key in farmHouse.appliedFloor.Keys.ToList())
+        {
+            cabin.appliedFloor[key] = farmHouse.appliedFloor[key];
+        }
+        foreach (var key in farmHouse.appliedWallpaper.Keys.ToList())
+        {
+            farmHouse.appliedWallpaper.Remove(key);
+        }
+        foreach (var key in farmHouse.appliedFloor.Keys.ToList())
+        {
+            farmHouse.appliedFloor.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Relocates the owner's household NPCs (pet, spouse, children) from the FarmHouse into their
+    /// cabin. The owner's homeLocation is already the cabin (step 4), so each NPC's home resolves
+    /// off that field automatically — this physically moves the NPC object so the day-zero state is
+    /// correct. Returns the count of NPCs moved.
+    /// </summary>
+    private int RelocateHouseholdToCabin(FarmHouse farmHouse, Cabin cabin, Farmer owner)
+    {
+        if (farmHouse == null || cabin == null)
+        {
+            return 0;
+        }
+
+        int moved = 0;
+        var bedSpot = Utility.PointToVector2(cabin.GetPlayerBedSpot());
+
+        // Children: filter by the FarmHouse's characters list (Child resolution is by which house
+        // the owner's homeLocation points to, NOT idOfParent). Move every Child out of the old
+        // FarmHouse into the cabin. Move AFTER the owner is homed at the cabin (done in step 4) so
+        // the master doesn't re-stamp idOfParent to the wrong farmer.
+        foreach (var child in farmHouse.characters.OfType<Child>().ToList())
+        {
+            Game1.warpCharacter(child, cabin, bedSpot);
+            moved++;
+        }
+
+        // Pet: move the pet into the cabin for day-zero. Resolve it with a FULL-world scan
+        // (FindFarmPet), NOT Farmer.getPet(): getPet() scans only Game1.getFarm().characters then each
+        // farmer's resolved home (Farmer.cs:getPet), but the finalizer runs at SaveLoaded — BEFORE the
+        // reconciliation chain and before the day-start dayUpdate that warps the pet to its Farm bowl —
+        // so the pet may be deserialized in an interior (a FarmHouse/Cabin) that neither loop covers
+        // yet, and getPet() returns null intermittently (the npcsMoved:0 flake). A pet always exists
+        // somewhere in Game1.locations, so scanning all locations finds it deterministically. Do NOT
+        // repoint Pet.homeLocationName — the bowl is a Farm building resolved off it; warp-home follows
+        // the owner anyway, and the pet returns to its bowl on the next dayUpdate.
+        var pet = FindFarmPet();
+        if (pet != null)
+        {
+            Game1.warpCharacter(pet, cabin, bedSpot);
+            moved++;
+        }
+
+        // Spouse NPC: an NPC spouse relocates itself via marriageDuties on the first day, but move it
+        // physically as belt-and-suspenders for day zero. Resolve by the owner's <spouse> name.
+        if (!string.IsNullOrEmpty(owner.spouse))
+        {
+            var spouseNpc = farmHouse.characters.FirstOrDefault(c =>
+                string.Equals(c.Name, owner.spouse, StringComparison.Ordinal)
+            );
+            if (spouseNpc != null)
+            {
+                Game1.warpCharacter(spouseNpc, cabin, bedSpot);
+                moved++;
+            }
+        }
+
+        return moved;
+    }
+
+    /// <summary>
+    /// Finds the farm's pet by scanning every location (interiors included), returning the first
+    /// <see cref="Pet"/> found, or null if the farm has none. Used instead of
+    /// <see cref="Farmer.getPet"/> in the save-import finalizer: getPet() scans only the Farm and each
+    /// farmer's resolved home, which misses a pet deserialized into an interior at SaveLoaded time
+    /// (before the day-start dayUpdate warps it to its bowl). The pet is farm-scoped (one per save —
+    /// Pet has no per-farmer owner field, only a bowl assignment), so the demoted owner's pet is the
+    /// farm's pet.
+    /// </summary>
+    private static Pet FindFarmPet()
+    {
+        Pet found = null;
+        Utility.ForEachLocation(location =>
+        {
+            foreach (var npc in location.characters)
+            {
+                if (npc is Pet pet)
+                {
+                    found = pet;
+                    return false; // stop the scan
+                }
+            }
+            return true; // keep scanning
+        });
+        return found;
+    }
+
+    /// <summary>
+    /// Moves the demoted owner's cellar contents into the cellar the engine reassigns to them. The
+    /// owner built their casks/wine inside "Cellar"-1 while they were the master, but
+    /// updateCellarAssignments (Game1.cs:4515) hardwires "Cellar"-1 to the master (now the Server
+    /// bot) and hands the owner one of the per-slot cellars ("Cellar2".."CellarN", pre-created up to
+    /// HighestPlayerLimit at Game1.cs:7417-7422). Cellar contents are location-bound, so they don't
+    /// follow the assignment — this transfers them, mirroring the farmhouse→cabin content move.
+    /// Returns the count of moved objects. Falls back to a Warn (and leaves the contents in "Cellar"-1)
+    /// only if no destination cellar can be resolved (no free slot under HighestPlayerLimit) — a
+    /// graceful degrade, never a throw.
+    /// </summary>
+    private int TransferOwnerCellarContents(Farmer owner, Cabin cabin)
+    {
+        // Source: the master's "Cellar"-1, where the owner's casks physically live.
+        var sourceCellar = Game1.getLocationFromName("Cellar");
+        var sourceObjectCount = sourceCellar?.objects?.Count() ?? 0;
+        if (sourceCellar == null || sourceObjectCount == 0)
+        {
+            return 0; // nothing built; no-op (don't cry wolf on a farm that never stocked a cellar)
+        }
+
+        // Ensure assignments are current, then resolve the owner's reassigned cellar by the engine's
+        // own path (Cabin inherits GetCellarName(), which maps cellarAssignments → "Cellar"+N off the
+        // owner's UID). updateCellarAssignments is idempotent (the engine calls it at load/day-start/
+        // join) and assigns "Cellar"-1 to the master + the next free slot to each other farmer; the
+        // owner is in farmhandData (getAllFarmers), so a free slot lands on them.
+        Game1.updateCellarAssignments();
+        var destCellarName = cabin.GetCellarName();
+        var destCellar =
+            destCellarName == null ? null : Game1.getLocationFromName(destCellarName) as Cellar;
+
+        if (destCellar == null || ReferenceEquals(destCellar, sourceCellar))
+        {
+            // No free per-slot cellar (farmer count exceeds HighestPlayerLimit), or the owner somehow
+            // still resolves to "Cellar"-1. Leave the contents where they are and warn — recoverable,
+            // not a finalize failure.
+            Monitor.Log(
+                $"Save-import: former owner '{owner.Name}' has {sourceObjectCount} cellar item(s) but "
+                    + "no separate cellar could be assigned (player limit reached); they remain in the "
+                    + "main farm cellar (now the Server host's).",
+                LogLevel.Warn
+            );
+            return 0;
+        }
+
+        // Clear any pre-existing objects in the destination (a freshly-assigned slot is empty, but be
+        // safe — same discipline as the cabin starter-content clear), then move the casks over by tile.
+        // Cellar interiors share the same map, so source tiles are valid in the destination.
+        foreach (var pos in destCellar.objects.Keys.ToList())
+        {
+            destCellar.objects.Remove(pos);
+        }
+
+        int moved = 0;
+        foreach (var kvp in sourceCellar.objects.Pairs.ToList())
+        {
+            sourceCellar.objects.Remove(kvp.Key);
+            destCellar.objects[kvp.Key] = kvp.Value;
+            moved++;
+        }
+
+        Monitor.Log(
+            $"Save-import: moved {moved} cellar item(s) from the main farm cellar into former owner "
+                + $"'{owner.Name}'s cellar ('{destCellarName}').",
+            LogLevel.Info
+        );
+        return moved;
     }
 
     #endregion

--- a/mod/JunimoServer/Services/Commands/SavesCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SavesCommand.cs
@@ -107,9 +107,7 @@ internal static class SavesCommand
             userId = args[flagIndex + 1];
         }
 
-        // --force-reload implies --reload. Both are matched case-insensitively, same idiom as
-        // --swap-host-to above.
-        var forceReload = HasFlag(args, "--force-reload");
+        var forceReload = HasFlag(args, "--force-reload"); // implies --reload
         var reload = forceReload || HasFlag(args, "--reload");
 
         var result = _saveImport.ExecuteImport(saveName, userId);
@@ -123,7 +121,6 @@ internal static class SavesCommand
             return;
         }
 
-        // "apply" verb: a reload finalizes/loads in-process; otherwise it's a restart away.
         var applyHint = reload ? "Reloading to apply…" : "Restart the server to load it.";
         var finalizeHint = reload ? "Reloading to finalize…" : "Restart the server to finalize.";
 
@@ -150,9 +147,7 @@ internal static class SavesCommand
 
         if (reload)
         {
-            // The import already succeeded and is queued for next restart regardless; the reload
-            // is a layered, opt-in step on top. A refusal (clients connected, no --force) leaves
-            // the queued import intact — it is NOT an import failure.
+            // The import is already queued for next restart; a refusal here leaves it queued, not failed.
             TryReloadActiveWorld(
                 force: forceReload,
                 contextLine: $"applying imported save '{saveName}'"
@@ -160,10 +155,6 @@ internal static class SavesCommand
         }
     }
 
-    /// <summary>
-    /// Reloads the active world in-process (no container restart) — for applying a manual save
-    /// change without a bounce. <c>--force</c> broadcasts a warning and kicks non-host players first.
-    /// </summary>
     private static void ReloadCommand(string[] args)
     {
         var force = HasFlag(args, "--force");
@@ -174,12 +165,10 @@ internal static class SavesCommand
         Array.Exists(args, a => string.Equals(a, flag, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// The single home for the guard + kick + in-process reload orchestration shared by the import
-    /// <c>--reload</c>/<c>--force-reload</c> flags and the standalone <c>saves reload</c> subcommand.
-    /// Console commands run on a background thread, so the count/kick/reload are marshalled onto the
-    /// game thread via a one-shot <see cref="UpdateTickedEventArgs"/> handler (the RenderingCommand
-    /// pattern). With clients connected and <paramref name="force"/> false, it refuses and returns —
-    /// any queued import stays queued for the next restart.
+    /// Guard + kick + in-process reload, shared by import <c>--reload</c> and <c>saves reload</c>.
+    /// Console commands run off the game thread, so the work is marshalled on via a one-shot
+    /// <see cref="UpdateTickedEventArgs"/> handler (the RenderingCommand pattern). Refuses (returns)
+    /// when clients are connected and <paramref name="force"/> is false.
     /// </summary>
     private static void TryReloadActiveWorld(bool force, string contextLine)
     {
@@ -187,15 +176,11 @@ internal static class SavesCommand
         {
             _helper.Events.GameLoop.UpdateTicked -= Apply;
 
-            // Wrap the whole body: this runs inside SMAPI's UpdateTicked dispatch on the game thread,
-            // and an unhandled throw here would be logged by SMAPI at Error — which trips
-            // ServerContainer's ERROR/FATAL test-poison scan (debugging.md). kick / SendPublicMessage /
-            // RequestReloadSave's synchronous ExitToTitle could all throw on an edge case. Catch and
-            // log at Warn, mirroring GameManagerService.ConditionallyStartGame's reload guard.
+            // A throw from this UpdateTicked handler logs at Error, which trips the test-poison scan
+            // (debugging.md); catch to Warn, as GameManagerService.ConditionallyStartGame does.
             try
             {
-                // No world loaded → nothing to reload (e.g. server still at title). Reuse-on-restart
-                // path handles a queued import; a standalone reload here would have nothing to act on.
+                // No world loaded (e.g. still at title): nothing to reload; a queued import waits for restart.
                 if (!Game1.hasLoadedGame || Game1.player == null)
                 {
                     _monitor.Log(
@@ -206,9 +191,8 @@ internal static class SavesCommand
                     return;
                 }
 
-                // Host-excluded, event-safe count (mirrors AlwaysOnFestivals.CountOnlineOtherPlayers):
-                // the bare otherFarmers.Count is unreliable during an active event (host-automation.md
-                // invariant 7), so count online non-disconnecting non-host farmers.
+                // bare otherFarmers.Count is unreliable during an active event (host-automation.md
+                // invariant 7); mirror AlwaysOnFestivals.CountOnlineOtherPlayers.
                 var others = Game1
                     .getOnlineFarmers()
                     .Where(f =>
@@ -256,10 +240,7 @@ internal static class SavesCommand
 
                 _monitor.Log($"Reloading the active world ({contextLine})…", LogLevel.Info);
 
-                // Console commands return void and can't await across the tick boundary, so
-                // fire-and-forget with a logged continuation. RequestReloadSave faults its own TCS on a
-                // failed LoadSave (GameManagerService.cs:261-264), so no extra timeout is needed. The
-                // continuation runs on a thread-pool thread and only touches _monitor.Log (thread-safe).
+                // Can't await across the tick boundary from a void command — fire-and-forget, log on resolve.
                 manager
                     .RequestReloadSave()
                     .ContinueWith(t =>
@@ -279,7 +260,6 @@ internal static class SavesCommand
             }
             catch (Exception ex)
             {
-                // Warn, not Error (test-poison). The import (if any) stays queued for next restart.
                 _monitor.Log(
                     $"In-process reload failed ({contextLine}): {ex.Message}",
                     LogLevel.Warn

--- a/mod/JunimoServer/Services/Commands/SavesCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SavesCommand.cs
@@ -1,27 +1,35 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Xml;
 using JunimoServer.Services.GameCreator;
+using JunimoServer.Services.GameManager;
 using JunimoServer.Services.SaveImport;
+using JunimoServer.Util;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley;
 
 namespace JunimoServer.Services.Commands;
 
 internal static class SavesCommand
 {
+    private static IModHelper _helper;
     private static IMonitor _monitor;
     private static SaveImportService _saveImport;
 
     public static void Register(IModHelper helper, IMonitor monitor, SaveImportService saveImport)
     {
+        _helper = helper;
         _monitor = monitor;
         _saveImport = saveImport;
 
         helper.ConsoleCommands.Add(
             "saves",
             "Save management. Run 'saves' for list, 'saves info <name>', "
-                + "'saves import <name> [--swap-host-to <id>]'.",
+                + "'saves import <name> [--swap-host-to <id>] [--reload | --force-reload]', "
+                + "'saves reload [--force]'.",
             (cmd, args) => HandleCommand(args)
         );
     }
@@ -47,9 +55,12 @@ internal static class SavesCommand
             case "import":
                 ImportSave(args);
                 break;
+            case "reload":
+                ReloadCommand(args);
+                break;
             default:
                 _monitor.Log(
-                    $"Unknown saves subcommand: {args[0]}. Use: saves [info|import]",
+                    $"Unknown saves subcommand: {args[0]}. Use: saves [info|import|reload]",
                     LogLevel.Warn
                 );
                 break;
@@ -67,7 +78,10 @@ internal static class SavesCommand
     {
         if (args.Length < 2)
         {
-            _monitor.Log("Usage: saves import <saveName> [--swap-host-to <id>]", LogLevel.Warn);
+            _monitor.Log(
+                "Usage: saves import <saveName> [--swap-host-to <id>] [--reload | --force-reload]",
+                LogLevel.Warn
+            );
             return;
         }
 
@@ -93,6 +107,11 @@ internal static class SavesCommand
             userId = args[flagIndex + 1];
         }
 
+        // --force-reload implies --reload. Both are matched case-insensitively, same idiom as
+        // --swap-host-to above.
+        var forceReload = HasFlag(args, "--force-reload");
+        var reload = forceReload || HasFlag(args, "--reload");
+
         var result = _saveImport.ExecuteImport(saveName, userId);
         if (!result.Success)
         {
@@ -104,10 +123,14 @@ internal static class SavesCommand
             return;
         }
 
+        // "apply" verb: a reload finalizes/loads in-process; otherwise it's a restart away.
+        var applyHint = reload ? "Reloading to apply…" : "Restart the server to load it.";
+        var finalizeHint = reload ? "Reloading to finalize…" : "Restart the server to finalize.";
+
         if (result.RepointedBind)
         {
             _monitor.Log(
-                $"Re-pointed the pending host-swap bind for '{saveName}'. Restart to finalize.",
+                $"Re-pointed the pending host-swap bind for '{saveName}'. {finalizeHint}",
                 LogLevel.Info
             );
         }
@@ -116,17 +139,155 @@ internal static class SavesCommand
             _monitor.Log(
                 $"Imported '{saveName}' with host swap (former owner "
                     + $"'{result.FormerOwnerName ?? result.FormerOwnerUid.ToString()}' → cabin farmhand "
-                    + "bound to the provided id). Restart the server to finalize.",
+                    + $"bound to the provided id). {finalizeHint}",
                 LogLevel.Info
             );
         }
         else
         {
-            _monitor.Log(
-                $"Imported '{saveName}' as-is. Restart the server to load it.",
-                LogLevel.Info
+            _monitor.Log($"Imported '{saveName}' as-is. {applyHint}", LogLevel.Info);
+        }
+
+        if (reload)
+        {
+            // The import already succeeded and is queued for next restart regardless; the reload
+            // is a layered, opt-in step on top. A refusal (clients connected, no --force) leaves
+            // the queued import intact — it is NOT an import failure.
+            TryReloadActiveWorld(
+                force: forceReload,
+                contextLine: $"applying imported save '{saveName}'"
             );
         }
+    }
+
+    /// <summary>
+    /// Reloads the active world in-process (no container restart) — for applying a manual save
+    /// change without a bounce. <c>--force</c> broadcasts a warning and kicks non-host players first.
+    /// </summary>
+    private static void ReloadCommand(string[] args)
+    {
+        var force = HasFlag(args, "--force");
+        TryReloadActiveWorld(force, contextLine: "reloading the active world");
+    }
+
+    private static bool HasFlag(string[] args, string flag) =>
+        Array.Exists(args, a => string.Equals(a, flag, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The single home for the guard + kick + in-process reload orchestration shared by the import
+    /// <c>--reload</c>/<c>--force-reload</c> flags and the standalone <c>saves reload</c> subcommand.
+    /// Console commands run on a background thread, so the count/kick/reload are marshalled onto the
+    /// game thread via a one-shot <see cref="UpdateTickedEventArgs"/> handler (the RenderingCommand
+    /// pattern). With clients connected and <paramref name="force"/> false, it refuses and returns —
+    /// any queued import stays queued for the next restart.
+    /// </summary>
+    private static void TryReloadActiveWorld(bool force, string contextLine)
+    {
+        void Apply(object sender, UpdateTickedEventArgs e)
+        {
+            _helper.Events.GameLoop.UpdateTicked -= Apply;
+
+            // Wrap the whole body: this runs inside SMAPI's UpdateTicked dispatch on the game thread,
+            // and an unhandled throw here would be logged by SMAPI at Error — which trips
+            // ServerContainer's ERROR/FATAL test-poison scan (debugging.md). kick / SendPublicMessage /
+            // RequestReloadSave's synchronous ExitToTitle could all throw on an edge case. Catch and
+            // log at Warn, mirroring GameManagerService.ConditionallyStartGame's reload guard.
+            try
+            {
+                // No world loaded → nothing to reload (e.g. server still at title). Reuse-on-restart
+                // path handles a queued import; a standalone reload here would have nothing to act on.
+                if (!Game1.hasLoadedGame || Game1.player == null)
+                {
+                    _monitor.Log(
+                        $"No active world loaded — skipping reload ({contextLine}). "
+                            + "It will load on the next restart.",
+                        LogLevel.Warn
+                    );
+                    return;
+                }
+
+                // Host-excluded, event-safe count (mirrors AlwaysOnFestivals.CountOnlineOtherPlayers):
+                // the bare otherFarmers.Count is unreliable during an active event (host-automation.md
+                // invariant 7), so count online non-disconnecting non-host farmers.
+                var others = Game1
+                    .getOnlineFarmers()
+                    .Where(f =>
+                        f.UniqueMultiplayerID != Game1.player.UniqueMultiplayerID
+                        && !Game1.Multiplayer.isDisconnecting(f)
+                    )
+                    .ToList();
+
+                if (others.Count > 0 && !force)
+                {
+                    var names = string.Join(", ", others.Select(f => f.Name));
+                    _monitor.Log(
+                        $"Refusing to reload while {others.Count} player(s) are connected: {names}. "
+                            + "Re-run with --force-reload to kick them, or restart when they leave.",
+                        LogLevel.Warn
+                    );
+                    return;
+                }
+
+                if (others.Count > 0)
+                {
+                    _helper.SendPublicMessage(
+                        "Server is reloading to apply a save change — reconnect in a moment."
+                    );
+                    foreach (var f in others)
+                    {
+                        Game1.server.kick(f.UniqueMultiplayerID);
+                    }
+                    _monitor.Log(
+                        $"Kicked {others.Count} player(s) before reload: "
+                            + string.Join(", ", others.Select(f => f.Name)),
+                        LogLevel.Info
+                    );
+                }
+
+                var manager = GameManagerService.Instance;
+                if (manager == null)
+                {
+                    _monitor.Log(
+                        "Game manager not ready; cannot reload in-process. Restart to load.",
+                        LogLevel.Warn
+                    );
+                    return;
+                }
+
+                _monitor.Log($"Reloading the active world ({contextLine})…", LogLevel.Info);
+
+                // Console commands return void and can't await across the tick boundary, so
+                // fire-and-forget with a logged continuation. RequestReloadSave faults its own TCS on a
+                // failed LoadSave (GameManagerService.cs:261-264), so no extra timeout is needed. The
+                // continuation runs on a thread-pool thread and only touches _monitor.Log (thread-safe).
+                manager
+                    .RequestReloadSave()
+                    .ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            _monitor.Log(
+                                $"World reload failed: {t.Exception?.GetBaseException().Message}",
+                                LogLevel.Warn
+                            );
+                        }
+                        else
+                        {
+                            _monitor.Log($"World reloaded ({contextLine}).", LogLevel.Info);
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                // Warn, not Error (test-poison). The import (if any) stays queued for next restart.
+                _monitor.Log(
+                    $"In-process reload failed ({contextLine}): {ex.Message}",
+                    LogLevel.Warn
+                );
+            }
+        }
+
+        _helper.Events.GameLoop.UpdateTicked += Apply;
     }
 
     private static void ListSaves()

--- a/mod/JunimoServer/Services/Commands/SavesCommand.cs
+++ b/mod/JunimoServer/Services/Commands/SavesCommand.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Xml;
 using JunimoServer.Services.GameCreator;
-using JunimoServer.Services.GameLoader;
-using JunimoServer.Services.Settings;
+using JunimoServer.Services.SaveImport;
 using StardewModdingAPI;
 
 namespace JunimoServer.Services.Commands;
@@ -13,23 +11,17 @@ namespace JunimoServer.Services.Commands;
 internal static class SavesCommand
 {
     private static IMonitor _monitor;
-    private static GameLoaderService _gameLoader;
-    private static ServerSettingsLoader _settings;
+    private static SaveImportService _saveImport;
 
-    public static void Register(
-        IModHelper helper,
-        IMonitor monitor,
-        GameLoaderService gameLoader,
-        ServerSettingsLoader settings
-    )
+    public static void Register(IModHelper helper, IMonitor monitor, SaveImportService saveImport)
     {
         _monitor = monitor;
-        _gameLoader = gameLoader;
-        _settings = settings;
+        _saveImport = saveImport;
 
         helper.ConsoleCommands.Add(
             "saves",
-            "Save management. Run 'saves' for list, 'saves info <name>', 'saves select <name> [--confirm]'.",
+            "Save management. Run 'saves' for list, 'saves info <name>', "
+                + "'saves import <name> [--swap-host-to <id>]'.",
             (cmd, args) => HandleCommand(args)
         );
     }
@@ -52,21 +44,88 @@ internal static class SavesCommand
                 }
                 ShowSaveInfo(args[1]);
                 break;
-            case "select":
-                if (args.Length < 2)
-                {
-                    _monitor.Log("Usage: saves select <saveName> [--confirm]", LogLevel.Warn);
-                    return;
-                }
-                var confirm = args.Any(a => a == "--confirm");
-                SelectSave(args[1], confirm);
+            case "import":
+                ImportSave(args);
                 break;
             default:
                 _monitor.Log(
-                    $"Unknown saves subcommand: {args[0]}. Use: saves [info|select]",
+                    $"Unknown saves subcommand: {args[0]}. Use: saves [info|import]",
                     LogLevel.Warn
                 );
                 break;
+        }
+    }
+
+    /// <summary>
+    /// Imports a save in one shot. <c>saves import &lt;name&gt;</c> imports as-is (the save's owner
+    /// becomes the headless host); <c>saves import &lt;name&gt; --swap-host-to &lt;id&gt;</c> demotes
+    /// the owner into a cabin farmhand bound to the platform id and installs a fresh blank "Server"
+    /// host. Presence of <c>--swap-host-to</c> selects swap+bind; absence selects as-is. Executes
+    /// directly (no preview/confirm gate) — the safety net is the fault-tolerant in-place transform.
+    /// </summary>
+    private static void ImportSave(string[] args)
+    {
+        if (args.Length < 2)
+        {
+            _monitor.Log("Usage: saves import <saveName> [--swap-host-to <id>]", LogLevel.Warn);
+            return;
+        }
+
+        var saveName = args[1];
+
+        // Parse the optional --swap-host-to <id>. Platform-neutral on purpose (Steam64 OR
+        // GOG Galaxy-uint64). Absence = as-is import.
+        string userId = null;
+        var flagIndex = Array.FindIndex(
+            args,
+            a => string.Equals(a, "--swap-host-to", StringComparison.OrdinalIgnoreCase)
+        );
+        if (flagIndex >= 0)
+        {
+            if (flagIndex + 1 >= args.Length)
+            {
+                _monitor.Log(
+                    "--swap-host-to requires a platform id (e.g. a Steam64 or GOG Galaxy id).",
+                    LogLevel.Warn
+                );
+                return;
+            }
+            userId = args[flagIndex + 1];
+        }
+
+        var result = _saveImport.ExecuteImport(saveName, userId);
+        if (!result.Success)
+        {
+            // ExecuteImport already logged the specific Warn; add the headline.
+            _monitor.Log(
+                $"Import of '{saveName}' did not complete (see warning above).",
+                LogLevel.Warn
+            );
+            return;
+        }
+
+        if (result.RepointedBind)
+        {
+            _monitor.Log(
+                $"Re-pointed the pending host-swap bind for '{saveName}'. Restart to finalize.",
+                LogLevel.Info
+            );
+        }
+        else if (result.Swapped)
+        {
+            _monitor.Log(
+                $"Imported '{saveName}' with host swap (former owner "
+                    + $"'{result.FormerOwnerName ?? result.FormerOwnerUid.ToString()}' → cabin farmhand "
+                    + "bound to the provided id). Restart the server to finalize.",
+                LogLevel.Info
+            );
+        }
+        else
+        {
+            _monitor.Log(
+                $"Imported '{saveName}' as-is. Restart the server to load it.",
+                LogLevel.Info
+            );
         }
     }
 
@@ -103,14 +162,17 @@ internal static class SavesCommand
         var savePath = Path.Combine(Constants.SavesPath, saveName);
         if (!Directory.Exists(savePath))
         {
-            _monitor.Log($"Save '{saveName}' not found.", LogLevel.Error);
+            // Warn, not Error: console commands run in the server process, where LogLevel.Error trips
+            // ServerContainer's ERROR/FATAL test-poison scan. A bad save name is operator error, not
+            // a server fault.
+            _monitor.Log($"Save '{saveName}' not found.", LogLevel.Warn);
             return;
         }
 
         var info = ReadSaveGameInfo(savePath);
         if (info == null)
         {
-            _monitor.Log($"Could not read save info for '{saveName}'.", LogLevel.Error);
+            _monitor.Log($"Could not read save info for '{saveName}'.", LogLevel.Warn);
             return;
         }
 
@@ -123,46 +185,6 @@ internal static class SavesCommand
         {
             _monitor.Log($"  Players:    {string.Join(", ", info.PlayerNames)}", LogLevel.Info);
         }
-    }
-
-    private static void SelectSave(string saveName, bool confirm)
-    {
-        var savePath = Path.Combine(Constants.SavesPath, saveName);
-        if (!Directory.Exists(savePath))
-        {
-            _monitor.Log($"Save '{saveName}' not found.", LogLevel.Error);
-            return;
-        }
-
-        if (!confirm)
-        {
-            var info = ReadSaveGameInfo(savePath);
-            _monitor.Log("Import Preview:", LogLevel.Info);
-            _monitor.Log($"  Save:                    {saveName}", LogLevel.Info);
-
-            if (info != null)
-            {
-                _monitor.Log($"  Farm Type:               {info.FarmTypeDisplay}", LogLevel.Info);
-                _monitor.Log($"  Existing Cabins:         {info.CabinCount}", LogLevel.Info);
-            }
-
-            _monitor.Log($"  -- Settings to apply --", LogLevel.Info);
-            _monitor.Log($"  Cabin Strategy:          {_settings.CabinStrategy}", LogLevel.Info);
-            _monitor.Log(
-                $"  Existing Cabin Behavior: {_settings.ExistingCabinBehavior}",
-                LogLevel.Info
-            );
-            _monitor.Log($"", LogLevel.Info);
-            _monitor.Log($"Run 'saves select {saveName} --confirm' to activate.", LogLevel.Info);
-            _monitor.Log($"The server will load this save on next restart.", LogLevel.Info);
-            return;
-        }
-
-        _gameLoader.SetSaveNameToLoad(saveName);
-        _monitor.Log(
-            $"Save '{saveName}' set as active. Restart the server to load it.",
-            LogLevel.Info
-        );
     }
 
     #region Save Info Parsing

--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -138,12 +138,16 @@ class GameCreatorService : ModService
         Game1.whichFarm = whichFarm;
         Game1.whichModFarm = modFarm;
 
-        Game1.player.Name = "Server";
+        // Name/favoriteThing/isCustomized are the shared host identity, sourced from
+        // ServerFarmerIdentity so the new-game host and the save-import clone-blank host
+        // (SaveImportXmlTransform) cannot drift. displayName is a runtime field derived
+        // from Name (no serialized display-name field), so it is assigned here, not shared.
+        Game1.player.Name = ServerFarmerIdentity.Name;
         Game1.player.displayName = Game1.player.Name;
-        Game1.player.favoriteThing.Value = "Junimos";
+        Game1.player.favoriteThing.Value = ServerFarmerIdentity.FavoriteThing;
         Game1.player.farmName.Value = config.FarmName;
 
-        Game1.player.isCustomized.Value = true;
+        Game1.player.isCustomized.Value = ServerFarmerIdentity.IsCustomized;
         Game1.player.ConvertClothingOverrideToClothesItems();
 
         Game1.multiplayerMode = 2; // Server mode (Game1.IsServer)

--- a/mod/JunimoServer/Services/GameLoader/GameLoaderService.cs
+++ b/mod/JunimoServer/Services/GameLoader/GameLoaderService.cs
@@ -6,7 +6,7 @@ using StardewValley.Menus;
 
 namespace JunimoServer.Services.GameLoader;
 
-class GameLoaderService : ModService
+public class GameLoaderService : ModService
 {
     private const string SaveKey = "JunimoHost.GameLoader";
 

--- a/mod/JunimoServer/Services/SaveImport/SaveImportData.cs
+++ b/mod/JunimoServer/Services/SaveImport/SaveImportData.cs
@@ -1,0 +1,31 @@
+namespace JunimoServer.Services.SaveImport;
+
+/// <summary>
+/// SMAPI global-data record for the pending save-import finalize intent. Mirrors the shape of
+/// <c>GameLoaderSaveData</c>; persisted under the key <see cref="SaveImportService.SaveKey"/>.
+/// Written by the command at swap-import execute-time (alongside <c>SetSaveNameToLoad</c>);
+/// read and cleared by the Layer B finalizer in <c>CabinManagerService.OnSaveLoaded</c>.
+/// As-is imports never write <see cref="Pending"/>.
+/// </summary>
+internal class SaveImportData
+{
+    /// <summary>Null when nothing is pending. A single record (not a queue) — last write wins.</summary>
+    public PendingFinalize Pending { get; set; } = null;
+}
+
+/// <summary>
+/// The one-shot finalize intent. No homeLocation/cabin name is stored — Layer B derives those
+/// live from the loaded world. Public because <see cref="SaveImportService.TryReadIntent"/>
+/// (a public method on the public service) returns it.
+/// </summary>
+public class PendingFinalize
+{
+    /// <summary>The save folder name this finalize targets (the in-place-transformed save).</summary>
+    public string SaveName { get; set; } = "";
+
+    /// <summary>The demoted owner's UniqueMultiplayerID (unchanged across the transform).</summary>
+    public long OwnerUid { get; set; }
+
+    /// <summary>The platform userID to bind the demoted owner to on load.</summary>
+    public string UserId { get; set; } = "";
+}

--- a/mod/JunimoServer/Services/SaveImport/SaveImportService.cs
+++ b/mod/JunimoServer/Services/SaveImport/SaveImportService.cs
@@ -1,0 +1,648 @@
+using System;
+using System.IO;
+using System.Xml;
+using JunimoServer.Services.GameLoader;
+using StardewModdingAPI;
+
+namespace JunimoServer.Services.SaveImport;
+
+/// <summary>
+/// Owns Layer A of the <c>saves import</c> feature (the pre-load, game-free part) plus the
+/// pending-finalize intent record. <see cref="ExecuteImport"/> imports a save in one shot:
+///   - <b>as-is</b> (no userId): point the next boot at the save; no file changes.
+///   - <b>swap+bind</b> (with a userId): transform the save in place to demote its original
+///     <c>&lt;player&gt;</c> owner into a customized cabin farmhand bound to the userId, install a
+///     fresh blank "Server" master, persist a finalize intent, and point the next boot at it.
+///
+/// All engine-touching finalizer work (cabin build, AssignFarmhand, contents/NPC move, userID
+/// re-stamp) lives in <c>CabinManagerService</c> (Layer B), which reads/clears the intent via
+/// <see cref="TryReadIntent"/>/<see cref="ClearIntent"/>. DI is one-way: <c>CabinManagerService</c>
+/// injects this service, never the reverse — a mutual injection would be a constructor cycle that
+/// the eager DI container fails the process on. Layer A is engine-free, so this service depends only
+/// on <see cref="GameLoaderService"/> (for <c>SetSaveNameToLoad</c>).
+/// </summary>
+public class SaveImportService : ModService
+{
+    internal const string SaveKey = "JunimoHost.SaveImport";
+
+    private readonly IModHelper _helper;
+    private readonly IMonitor _monitor;
+    private readonly GameLoaderService _gameLoader;
+
+    public SaveImportService(IModHelper helper, IMonitor monitor, GameLoaderService gameLoader)
+        : base(helper, monitor)
+    {
+        _helper = helper;
+        _monitor = monitor;
+        _gameLoader = gameLoader;
+    }
+
+    /// <summary>
+    /// Outcome of an import attempt, returned so the console command and the test endpoint can
+    /// report a consistent, structured result.
+    /// </summary>
+    public class ImportResult
+    {
+        public bool Success { get; set; }
+        public bool Swapped { get; set; }
+        public string? Error { get; set; }
+        public string SaveName { get; set; } = "";
+
+        /// <summary>The demoted owner's name (swap only), for the result line.</summary>
+        public string? FormerOwnerName { get; set; }
+
+        /// <summary>The demoted owner's UniqueMultiplayerID (swap only).</summary>
+        public long FormerOwnerUid { get; set; }
+
+        /// <summary>True when a swap re-run only re-pointed an existing pending bind (no re-transform).</summary>
+        public bool RepointedBind { get; set; }
+    }
+
+    /// <summary>
+    /// Imports <paramref name="saveName"/>. When <paramref name="userId"/> is null/empty the import
+    /// is "as-is" (no file changes, just retarget boot); otherwise it is a swap+bind in place.
+    /// Never throws — all failures are returned as <c>Success=false</c> with a Warn already logged.
+    /// </summary>
+    public ImportResult ExecuteImport(string saveName, string? userId)
+    {
+        var result = new ImportResult { SaveName = saveName };
+        try
+        {
+            if (string.IsNullOrWhiteSpace(saveName))
+            {
+                return Fail(result, "No save name provided.");
+            }
+
+            var savesPath = Constants.SavesPath;
+            var saveDir = Path.Combine(savesPath, saveName);
+            var mainFile = Path.Combine(saveDir, saveName);
+
+            // Validate before any work: folder + primary file present and parseable. "Folder exists"
+            // is NOT sufficient — a mid-interrupted-overnight save may have only the engine's
+            // backup files, which Layer A does not load; refuse so the operator restores first.
+            if (!Directory.Exists(saveDir))
+            {
+                return Fail(result, $"Save '{saveName}' not found.");
+            }
+            if (!File.Exists(mainFile))
+            {
+                return Fail(
+                    result,
+                    $"Save '{saveName}' has no primary save file ('{saveName}/{saveName}'). "
+                        + "If only a backup remains (interrupted overnight save), restore it first."
+                );
+            }
+
+            // The save must not be the currently-active/loaded one — rewriting the folder the
+            // running game is mid-save on would corrupt the live world.
+            if (string.Equals(saveName, Constants.SaveFolderName, StringComparison.Ordinal))
+            {
+                return Fail(
+                    result,
+                    $"'{saveName}' is the currently-loaded save; cannot import the active save. "
+                        + "Import a different save, then restart."
+                );
+            }
+
+            var isSwap = !string.IsNullOrWhiteSpace(userId);
+
+            // ── As-is mode: no file changes, just retarget boot (the former `select` behavior). ──
+            if (!isSwap)
+            {
+                return ExecuteAsIs(result, saveName, mainFile);
+            }
+
+            return ExecuteSwap(result, saveName, saveDir, mainFile, userId!.Trim());
+        }
+        catch (Exception ex)
+        {
+            // Never Error (server-side test poison) — Warn + return failure, file untouched.
+            return Fail(result, $"Unexpected error: {ex.Message}");
+        }
+    }
+
+    private ImportResult ExecuteAsIs(ImportResult result, string saveName, string mainFile)
+    {
+        // Refuse an as-is import of a save with a pending (un-finalized) swap. A swap rewrote this
+        // save's <player> into a blank Server master and reparented the owner into <farmhands>,
+        // recording a finalize intent that Layer B consumes on the next boot to home+bind the owner.
+        // Running as-is now would clear that intent (below) and boot the swapped save with no
+        // finalizer — the cabin-less owner's userID gets cleared mid-load and their farmhouse
+        // contents/NPCs never move (a half-applied swap with no in-product recovery). Direct the
+        // operator to reboot to finalize, or restore a backup to truly revert to as-is.
+        var pending = TryReadIntent();
+        if (pending != null && string.Equals(pending.SaveName, saveName, StringComparison.Ordinal))
+        {
+            return Fail(
+                result,
+                $"'{saveName}' has a pending host-swap awaiting finalize; an as-is import would "
+                    + "strand it. Restart the server to finalize the swap, or restore a backup to "
+                    + "revert to a plain as-is import."
+            );
+        }
+
+        // As-is makes the save's <player> the automated headless host. Correct for a single-player
+        // import; for a co-op save whose owner is a real player it is the inversion the feature
+        // exists to prevent. The XML can't reliably distinguish the two, so always warn loudly,
+        // naming the owner, and proceed (as-is makes no file changes — the operator can re-run swap).
+        string ownerName = TryReadPlayerName(mainFile) ?? "(unknown)";
+        _monitor.Log(
+            $"Importing '{saveName}' as-is: its owner '{ownerName}' becomes the automated headless "
+                + "host and can no longer play as that farmer. Re-run with --swap-host-to <id> if you "
+                + "meant to keep them as a player.",
+            LogLevel.Warn
+        );
+
+        _gameLoader.SetSaveNameToLoad(saveName);
+        // As-is never writes a finalize intent. Any surviving intent here is for a DIFFERENT save (a
+        // pending intent for THIS save was refused above); clear it so a stale other-save swap intent
+        // doesn't leak onto this plain as-is boot (Layer B's wrong-save guard would also catch it,
+        // but clearing here keeps the boot target and intent consistent).
+        ClearIntent();
+
+        Diagnostics.ModEventLog.Emit("save_import_executed", new { saveName, swapped = false });
+
+        result.Success = true;
+        result.Swapped = false;
+        _monitor.Log($"Imported '{saveName}' as-is. Restart the server to load it.", LogLevel.Info);
+        return result;
+    }
+
+    private ImportResult ExecuteSwap(
+        ImportResult result,
+        string saveName,
+        string saveDir,
+        string mainFile,
+        string userId
+    )
+    {
+        // Up-front operator warning (destructive-in-place). No confirm gate — the safety net is the
+        // fault-tolerant temp-then-rename transform + the finalizer self-heal.
+        _monitor.Log(
+            $"`saves import` rewrites the save in place — back up '{saveName}' first if you haven't.",
+            LogLevel.Warn
+        );
+
+        // ID validation: accept any non-empty all-digit ulong (Steam64 OR Galaxy-uint64 — no
+        // 7656119… prefix check, which would reject every legitimate GOG bind).
+        if (!IsValidPlatformId(userId))
+        {
+            return Fail(
+                result,
+                $"--swap-host-to value '{userId}' is not a valid platform id "
+                    + "(expected a non-empty decimal Steam64 or GOG Galaxy id)."
+            );
+        }
+
+        // Swap on a LAN-configured server: the bind is recorded but authCheck can't enforce it on LAN
+        // (every client's getUserID() is "", so the userID match never runs). The bind's job is to
+        // scope the demoted owner's farmhand to that platform account so only they can select it; on
+        // LAN it's inert — the slot isn't ownership-locked and any LAN player could select it. Warn,
+        // proceed (the demotion into a cabin is still useful).
+        if (IsLanServer())
+        {
+            _monitor.Log(
+                "This server is LAN — --swap-host-to records the bind but LAN can't enforce it, so the "
+                    + "demoted owner's farmhand won't be scoped to the intended account (any LAN player "
+                    + "could select it); use a Steam/GOG server for the bind to take effect.",
+                LogLevel.Warn
+            );
+        }
+
+        // Load the main save XML into memory.
+        XmlDocument doc;
+        try
+        {
+            doc = new XmlDocument();
+            doc.Load(mainFile);
+        }
+        catch (Exception ex)
+        {
+            // Malformed input → Warn (never Error), abort before any .tmp write; save untouched.
+            return Fail(result, $"Save '{saveName}' could not be parsed: {ex.Message}");
+        }
+
+        long newMasterUid;
+        long ownerUid;
+        try
+        {
+            SaveImportXmlTransform.ApplySwap(doc, userId, out newMasterUid, out ownerUid);
+        }
+        catch (SaveImportAlreadySwappedException)
+        {
+            // Re-import guard: the save's <player> is already a host-swapped Server master. The
+            // command can still re-point a pending bind in place (correcting a mistyped id) — that
+            // logic lives here, against the persisted intent, not in the XML transform.
+            return HandleAlreadySwappedReRun(result, saveName, userId);
+        }
+        catch (SaveImportException ex)
+        {
+            return Fail(result, ex.Message);
+        }
+
+        // Capture the demoted owner's name from the transformed doc for the result line.
+        result.FormerOwnerName = TryReadOwnerNameFromDoc(doc, ownerUid);
+        result.FormerOwnerUid = ownerUid;
+
+        // ── Fault-tolerant write: .tmp → validate → atomic rename. ──
+        var tmpFile = mainFile + ".tmp";
+        try
+        {
+            // Write the transformed doc to .tmp.
+            doc.Save(tmpFile);
+
+            // Validate the .tmp by re-parsing it from disk and re-running the post-transform guards
+            // — proves the bytes on disk are loadable and structurally correct before we replace the
+            // real file.
+            var reparsed = new XmlDocument();
+            reparsed.Load(tmpFile);
+            SaveImportXmlTransform.ValidatePostTransform(
+                reparsed.DocumentElement!,
+                newMasterUid,
+                ownerUid,
+                userId
+            );
+
+            // Atomic rename of the main file. File.Replace requires dest to exist (it does here);
+            // it is atomic on the shared saves volume.
+            File.Replace(tmpFile, mainFile, destinationBackupFileName: null);
+        }
+        catch (Exception ex)
+        {
+            // A crash/validation-failure before/at the rename leaves the real file byte-intact and
+            // the boot target untouched. Discard the .tmp.
+            TryDelete(tmpFile);
+            return Fail(
+                result,
+                $"Transform validation/write failed; save left unchanged: {ex.Message}"
+            );
+        }
+
+        // Regenerate SaveGameInfo from the post-transform <player> (swap only) so list/info views and
+        // external tooling don't show the old human host. SaveGameInfo is NOT read on this server's
+        // direct-load boot path, so a regen failure is non-fatal: the main save is already transformed
+        // and the bind must still be recorded + boot retargeted, or the swap is left half-applied with
+        // no in-product recovery (a re-run would hit the already-swapped guard with no pending intent).
+        // So Warn and continue — do NOT abort.
+        if (!TryRegenerateSaveGameInfo(doc, saveDir, out var sgiError))
+        {
+            _monitor.Log(
+                $"Main save transformed but SaveGameInfo regen failed: {sgiError}. Boot and the bind "
+                    + "are unaffected (SaveGameInfo isn't read on load); the list/info view may show a "
+                    + "stale host name until the next save.",
+                LogLevel.Warn
+            );
+        }
+
+        // Persist the finalize intent BEFORE retargeting boot.
+        WriteIntent(
+            new PendingFinalize
+            {
+                SaveName = saveName,
+                OwnerUid = ownerUid,
+                UserId = userId,
+            }
+        );
+
+        // LAST: point the next boot at the in-place-transformed save. Any failure before this leaves
+        // the boot target untouched, so it never points at a half-written save.
+        _gameLoader.SetSaveNameToLoad(saveName);
+
+        Diagnostics.ModEventLog.Emit(
+            "save_import_executed",
+            new
+            {
+                saveName,
+                swapped = true,
+                ownerUid,
+                // Never the raw user id.
+                hasUserId = true,
+            }
+        );
+
+        result.Success = true;
+        result.Swapped = true;
+        _monitor.Log(
+            $"Imported '{saveName}' with host swap: former owner "
+                + $"'{result.FormerOwnerName ?? ownerUid.ToString()}' demoted to a cabin farmhand bound "
+                + "to the provided id. Restart the server to finalize.",
+            LogLevel.Info
+        );
+        return result;
+    }
+
+    /// <summary>
+    /// Handles a swap re-run against a save whose <c>&lt;player&gt;</c> is already a Server master.
+    /// Same id → true no-op. Different id while the intent is still pending (pre-reboot) → re-point
+    /// <see cref="PendingFinalize.UserId"/> in place (the owner is already correctly reparented).
+    /// Different id after the finalizer already consumed the intent → can't re-bind via intent;
+    /// direct the operator to /unlink or restore-and-reimport.
+    /// </summary>
+    private ImportResult HandleAlreadySwappedReRun(
+        ImportResult result,
+        string saveName,
+        string userId
+    )
+    {
+        var data = ReadData();
+        var pending = data.Pending;
+
+        if (pending != null && string.Equals(pending.SaveName, saveName, StringComparison.Ordinal))
+        {
+            if (string.Equals(pending.UserId, userId, StringComparison.Ordinal))
+            {
+                _monitor.Log(
+                    $"'{saveName}' is already host-swapped with this id — nothing to do.",
+                    LogLevel.Warn
+                );
+                result.Success = true;
+                result.Swapped = true;
+                return result;
+            }
+
+            // Different id, pending not yet consumed: re-point in place. Re-run the userID-collision
+            // guard against the new id first (the demoted owner is already reparented; only the bind
+            // changes). The owner already carries the new structure, so check the transformed file's
+            // farmhands for a conflict with the new id.
+            var conflict = FindUserIdConflictInSave(saveName, userId, pending.OwnerUid);
+            if (conflict != null)
+            {
+                return Fail(
+                    result,
+                    $"The new id collides with existing farmhand '{conflict}'; pending bind unchanged."
+                );
+            }
+
+            pending.UserId = userId;
+            WriteIntent(pending);
+            // Also rewrite the on-disk <userID> so the file and intent agree — otherwise a finalizer
+            // abort before its live re-stamp would leave the owner bound to the OLD id (defeating the
+            // whole point of re-pointing). Best-effort: the live re-stamp from the intent is primary.
+            TryRewriteOwnerUserIdInSave(saveName, pending.OwnerUid, userId);
+            _gameLoader.SetSaveNameToLoad(saveName);
+            _monitor.Log($"Updated pending bind for '{saveName}' to the new id.", LogLevel.Warn);
+            result.Success = true;
+            result.Swapped = true;
+            result.RepointedBind = true;
+            result.FormerOwnerUid = pending.OwnerUid;
+            return result;
+        }
+
+        // Already swapped AND no matching pending intent (finalizer already ran, or a different
+        // save's intent is pending): can't re-bind through the import path.
+        return Fail(
+            result,
+            $"'{saveName}' is already host-swapped and the bind is already applied. To change it, "
+                + "use /unlink + reconnect, or restore a backup and re-import."
+        );
+    }
+
+    // ── Intent record access (read/cleared by Layer B) ──────────────────────────────
+
+    /// <summary>Reads the pending finalize intent, or null when nothing is pending.</summary>
+    public PendingFinalize TryReadIntent() => ReadData().Pending;
+
+    /// <summary>Clears the pending finalize intent (single-shot — cleared on every finalize exit).</summary>
+    public void ClearIntent()
+    {
+        _helper.Data.WriteGlobalData(SaveKey, new SaveImportData { Pending = null });
+    }
+
+    private SaveImportData ReadData() =>
+        _helper.Data.ReadGlobalData<SaveImportData>(SaveKey) ?? new SaveImportData();
+
+    private void WriteIntent(PendingFinalize pending)
+    {
+        _helper.Data.WriteGlobalData(SaveKey, new SaveImportData { Pending = pending });
+    }
+
+    // ── SaveGameInfo regen ──────────────────────────────────────────────────────────
+
+    private bool TryRegenerateSaveGameInfo(
+        XmlDocument transformedSave,
+        string saveDir,
+        out string error
+    )
+    {
+        error = "";
+        try
+        {
+            var info = SaveImportXmlTransform.BuildSaveGameInfo(transformedSave);
+            if (info == null)
+            {
+                error = "could not build <Farmer> from transformed <player>";
+                return false;
+            }
+            var sgiPath = Path.Combine(saveDir, "SaveGameInfo");
+            var sgiTmp = sgiPath + ".tmp";
+            try
+            {
+                info.Save(sgiTmp);
+                // SaveGameInfo always pre-exists on a real save folder (next to the main file);
+                // File.Move covers the (defensive) absent case.
+                if (File.Exists(sgiPath))
+                {
+                    File.Replace(sgiTmp, sgiPath, destinationBackupFileName: null);
+                }
+                else
+                {
+                    File.Move(sgiTmp, sgiPath);
+                }
+            }
+            catch
+            {
+                TryDelete(sgiTmp); // never leave a junk .tmp on the volume
+                throw;
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    // ── Small read-only helpers ──────────────────────────────────────────────────────
+
+    // A platform userID (Steam64 or GOG Galaxy id) is a non-empty decimal that fits in ulong. Use
+    // ulong.TryParse (invariant, no sign/whitespace) — NOT `All(char.IsDigit)`, which accepts both
+    // ulong-overflowing strings and non-ASCII Unicode decimal digits, either of which stamps a bind
+    // no real client's getUserID() can ever match (a permanently unauthenticatable cabin).
+    private static bool IsValidPlatformId(string id) =>
+        ulong.TryParse(
+            id,
+            System.Globalization.NumberStyles.None,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out _
+        );
+
+    private static bool IsLanServer() =>
+        string.IsNullOrEmpty(Environment.GetEnvironmentVariable("STEAM_AUTH_URL"));
+
+    private static string? TryReadPlayerName(string mainFile)
+    {
+        try
+        {
+            var doc = new XmlDocument();
+            doc.Load(mainFile);
+            return doc.SelectSingleNode("//SaveGame/player/name")?.InnerText;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? TryReadOwnerNameFromDoc(XmlDocument transformedDoc, long ownerUid)
+    {
+        try
+        {
+            var farmhands = transformedDoc.SelectNodes("//SaveGame/farmhands/Farmer");
+            if (farmhands == null)
+            {
+                return null;
+            }
+            foreach (XmlElement f in farmhands)
+            {
+                var uidText = f.SelectSingleNode("UniqueMultiplayerID")?.InnerText;
+                if (long.TryParse(uidText, out var uid) && uid == ownerUid)
+                {
+                    return f.SelectSingleNode("name")?.InnerText;
+                }
+            }
+        }
+        catch
+        {
+            // best-effort label only
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Scans an on-disk save's farmhands (and the owner) for a <c>&lt;userID&gt;</c> matching
+    /// <paramref name="userId"/>, EXCLUDING the demoted owner identified by
+    /// <paramref name="excludeOwnerUid"/> (whose bind is the one being changed). Returns the
+    /// conflicting farmer's name, or null.
+    /// </summary>
+    private static string? FindUserIdConflictInSave(
+        string saveName,
+        string userId,
+        long excludeOwnerUid
+    )
+    {
+        try
+        {
+            var mainFile = Path.Combine(Constants.SavesPath, saveName, saveName);
+            var doc = new XmlDocument();
+            doc.Load(mainFile);
+            var farmhands = doc.SelectNodes("//SaveGame/farmhands/Farmer");
+            if (farmhands == null)
+            {
+                return null;
+            }
+            foreach (XmlElement f in farmhands)
+            {
+                var uidText = f.SelectSingleNode("UniqueMultiplayerID")?.InnerText;
+                if (long.TryParse(uidText, out var uid) && uid == excludeOwnerUid)
+                {
+                    continue;
+                }
+                if ((f.SelectSingleNode("userID")?.InnerText ?? "") == userId)
+                {
+                    var name = f.SelectSingleNode("name")?.InnerText;
+                    return string.IsNullOrEmpty(name) ? "(unnamed)" : name;
+                }
+            }
+        }
+        catch
+        {
+            // If we can't read it, don't block the re-point; the finalizer's own guards still apply.
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Rewrites the demoted owner's <c>&lt;userID&gt;</c> in the save file to <paramref name="userId"/>
+    /// (temp-then-atomic-rename), so a re-pointed bind is correct on disk too — not just in the intent.
+    /// Without this, a finalizer abort before the live userID re-stamp would leave the owner bound to
+    /// the OLD id (the value vanilla's ResetFarmhandState read from the file at load). Returns false if
+    /// the owner or file can't be resolved (caller treats the file write as best-effort; the live
+    /// re-stamp from the intent is still the primary path).
+    /// </summary>
+    private bool TryRewriteOwnerUserIdInSave(string saveName, long ownerUid, string userId)
+    {
+        try
+        {
+            var mainFile = Path.Combine(Constants.SavesPath, saveName, saveName);
+            var doc = new XmlDocument();
+            doc.Load(mainFile);
+            var farmhands = doc.SelectNodes("//SaveGame/farmhands/Farmer");
+            if (farmhands == null)
+            {
+                return false;
+            }
+            foreach (XmlElement f in farmhands)
+            {
+                var uidText = f.SelectSingleNode("UniqueMultiplayerID")?.InnerText;
+                if (!long.TryParse(uidText, out var uid) || uid != ownerUid)
+                {
+                    continue;
+                }
+                var userIdNode = f.SelectSingleNode("userID");
+                if (userIdNode == null)
+                {
+                    userIdNode = doc.CreateElement("userID");
+                    f.PrependChild(userIdNode);
+                }
+                userIdNode.InnerText = userId;
+
+                var tmp = mainFile + ".tmp";
+                try
+                {
+                    doc.Save(tmp);
+                    File.Replace(tmp, mainFile, destinationBackupFileName: null);
+                }
+                catch
+                {
+                    TryDelete(tmp); // never leave a junk .tmp on the volume
+                    throw;
+                }
+                return true;
+            }
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _monitor.Log(
+                $"Re-point: could not rewrite the on-disk bind for '{saveName}' ({ex.Message}); the "
+                    + "live finalizer re-stamp from the updated intent still applies on a clean boot.",
+                LogLevel.Warn
+            );
+            return false;
+        }
+    }
+
+    private ImportResult Fail(ImportResult result, string message)
+    {
+        _monitor.Log($"saves import: {message}", LogLevel.Warn);
+        result.Success = false;
+        result.Error = message;
+        return result;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch
+        {
+            // best-effort cleanup; a stray .tmp is harmless and re-runnable
+        }
+    }
+}

--- a/mod/JunimoServer/Services/SaveImport/SaveImportService.cs
+++ b/mod/JunimoServer/Services/SaveImport/SaveImportService.cs
@@ -141,6 +141,20 @@ public class SaveImportService : ModService
             );
         }
 
+        // Parse before retargeting boot — otherwise a malformed save selects cleanly here and only
+        // fails on the next restart (the swap path gets this for free from its own doc.Load).
+        try
+        {
+            new XmlDocument().Load(mainFile);
+        }
+        catch (Exception ex)
+        {
+            return Fail(
+                result,
+                $"Save '{saveName}' could not be parsed: {ex.Message}. Restore a backup, then import."
+            );
+        }
+
         // As-is makes the save's <player> the automated headless host. Correct for a single-player
         // import; for a co-op save whose owner is a real player it is the inversion the feature
         // exists to prevent. The XML can't reliably distinguish the two, so always warn loudly,
@@ -294,19 +308,51 @@ public class SaveImportService : ModService
             );
         }
 
-        // Persist the finalize intent BEFORE retargeting boot.
-        WriteIntent(
-            new PendingFinalize
-            {
-                SaveName = saveName,
-                OwnerUid = ownerUid,
-                UserId = userId,
-            }
-        );
+        // Past the on-disk commit, a failure must not return overall failure: the intent governs
+        // recovery. If the intent can't be persisted, leave the boot target alone — a swapped save
+        // with no intent boots into the stranded half-apply (cabin-less owner's userID cleared
+        // mid-load), whereas an un-booted swapped save is still recoverable (restore a backup, or
+        // re-run for the already-swapped re-point path).
+        try
+        {
+            WriteIntent(
+                new PendingFinalize
+                {
+                    SaveName = saveName,
+                    OwnerUid = ownerUid,
+                    UserId = userId,
+                }
+            );
+        }
+        catch (Exception ex)
+        {
+            _monitor.Log(
+                $"'{saveName}' was transformed but the finalize intent could not be persisted "
+                    + $"({ex.Message}); boot target left unchanged to avoid a stranded swap. Re-run "
+                    + "`saves import` to retry the bind, or restore a backup to revert.",
+                LogLevel.Warn
+            );
+            return Fail(
+                result,
+                $"Save transformed but finalize intent could not be persisted: {ex.Message}. "
+                    + "Boot target unchanged; re-run to retry."
+            );
+        }
 
-        // LAST: point the next boot at the in-place-transformed save. Any failure before this leaves
-        // the boot target untouched, so it never points at a half-written save.
-        _gameLoader.SetSaveNameToLoad(saveName);
+        // Intent is durable past this point, so a boot-retarget failure is recoverable — Warn, don't fail.
+        try
+        {
+            _gameLoader.SetSaveNameToLoad(saveName);
+        }
+        catch (Exception ex)
+        {
+            _monitor.Log(
+                $"'{saveName}' transformed and finalize intent persisted, but the boot target could "
+                    + $"not be set ({ex.Message}). Set it manually or re-run `saves import` before "
+                    + "restarting to finalize.",
+                LogLevel.Warn
+            );
+        }
 
         Diagnostics.ModEventLog.Emit(
             "save_import_executed",

--- a/mod/JunimoServer/Services/SaveImport/SaveImportXmlTransform.cs
+++ b/mod/JunimoServer/Services/SaveImport/SaveImportXmlTransform.cs
@@ -1,0 +1,625 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+
+namespace JunimoServer.Services.SaveImport;
+
+/// <summary>
+/// Pure, game-free <see cref="XmlDocument"/> logic for the save-import "swap host" transform
+/// (Layer A). Isolates the entire brittle-XML surface in one file. Runs pre-load at the title
+/// screen, so it must NOT touch <c>Game1</c> or any live engine state — it operates only on the
+/// save's main XML document.
+///
+/// What it does, on a save's <c>&lt;SaveGame&gt;</c> root:
+/// 1. Installs a fresh blank "Server" master by deep-cloning the imported save's own
+///    <c>&lt;player&gt;</c> node (a known-good Farmer serialization for THIS exact game version —
+///    no embedded template to drift) and blanking it per the three-bucket policy below.
+/// 2. Reparents the original <c>&lt;player&gt;</c> into <c>&lt;farmhands&gt;</c> (a node move —
+///    <c>&lt;player&gt;</c> and each <c>&lt;farmhands&gt;/&lt;Farmer&gt;</c> share the identical
+///    <c>Farmer</c> schema), stamping it customized + the supplied platform userID.
+///
+/// The clone-blank policy (clear-personal-progress-only, keep-every-world/relationship-relevant
+/// field) is derived directly from the serialized members of
+/// <c>decompiled/.../StardewValley/Farmer.cs</c> (and inherited <c>Character.cs</c>). Re-derive on
+/// any SDV bump. Three buckets:
+///   (A) CLEAR  — genuinely personal progress that must not leak onto the host.
+///   (B) KEEP   — fields the master gates world geometry on; zeroing them reverts the imported
+///                world. Because the master IS a clone of the original player, these are already
+///                present and identical — "copy" = "do not clear".
+///   (C) KEEP   — fields inert on a never-playing headless bot; harmless to carry.
+/// An unknown field defaults to bucket C (kept), not A (cleared): an over-clear reverts world
+/// state or breaks a master-gated system, whereas an over-carry only adds inert data to an
+/// invisible bot. The ORIGINAL player is preserved verbatim in <c>&lt;farmhands&gt;</c>, so any
+/// clear here only ever affects the (intentionally blank) host, never the player's data.
+/// </summary>
+internal static class SaveImportXmlTransform
+{
+    // Local cosmetic pet default for the clone-blank host. NOT shared with ServerFarmerIdentity:
+    // the new-game path's whichPetType is config-conditional (Cat/Dog from PetBreed), so it can't
+    // be a shared constant. The host never plays, so any value is harmless.
+    private const string ServerPetType = "Cat";
+
+    // ── Bucket A: simple scalar NetInt/NetBool/NetString fields zeroed to a fixed value. ──
+    // These serialize as plain element text (<farmingLevel>5</farmingLevel>), so setting the text
+    // is safe. houseUpgradeLevel is cleared on the BLANK MASTER only (it drives the cabin's
+    // upgradeLevel via owner.HouseUpgradeLevel; the moved owner keeps its real level).
+    private static readonly (string Element, string Value)[] ScalarClears =
+    {
+        ("farmingLevel", "0"),
+        ("miningLevel", "0"),
+        ("combatLevel", "0"),
+        ("foragingLevel", "0"),
+        ("fishingLevel", "0"),
+        ("luckLevel", "0"),
+        ("maxStamina", "270"), // NetInt default (Farmer.cs:599)
+        ("maxItems", "12"), // NetInt default (Farmer.cs:602)
+        ("houseUpgradeLevel", "0"),
+        ("clubCoins", "0"),
+    };
+
+    // ── Bucket A: relationship / marriage state cleared on the BLANK MASTER only. ──
+    // The clone copies <spouse> by default, and getSpouse() resolves by NAME with no per-farmer
+    // ownership check (Farmer.cs:4779) — a non-cleared <spouse> leaves both the blank master and
+    // the demoted owner married to the same NPC (a duplicate marriage). The moved owner keeps its
+    // own <spouse>. These are simple NetString/NetBool, so removing the element is the clean clear.
+    private static readonly string[] RelationshipClears =
+    {
+        "spouse",
+        "divorceTonight",
+        "changeWalletTypeTonight",
+    };
+
+    // ── Bucket A: collection / accumulator / delta progress, removed wholesale. ──
+    // Removing the element makes it deserialize to the field's empty/default initializer. (Simple
+    // scalars are handled by ScalarClears; these are collections, dictionaries, NetArrays, or
+    // NetIntDelta whose serialized shape isn't a plain text value, so "remove" is the safe clear.)
+    private static readonly string[] CollectionClears =
+    {
+        "items", // inventory (NetArray<Item>)
+        "experiencePoints", // NetArray<int>
+        "newLevels", // NetList<Point> — pending level-up popups; clear with the zeroed skill levels
+        "questLog",
+        "professions",
+        "dialogueQuestionsAnswered",
+        "triggerActionsRun",
+        "secretNotesSeen",
+        "songsHeard",
+        "achievements",
+        "locationsVisited",
+        "cookingRecipes",
+        "craftingRecipes",
+        "recipesCooked",
+        "basicShipped",
+        "mineralsFound",
+        "fishCaught",
+        "archaeologyFound",
+        "callsReceived",
+        "tailoredItems",
+        "trinketItem", // NetRef<Trinket> (XmlElement "trinketItem" → trinketItems)
+        "chestConsumedLevels",
+        "activeDialogueEvents",
+        "previousActiveDialogueEvents",
+        "qiGems", // NetIntDelta (element "qiGems" → netQiGems); remove → default { Minimum=0 } = 0
+        "netDeepestMineLevel", // private NetInt; normally absent, removed defensively
+        "netTimesReachedMineBottom",
+    };
+
+    // ── Bucket A: stale per-owner LOCATION fields reset on the blank master. ──
+    // The host is reset to the FarmHouse (homeLocation, above). lastSleepLocation/lastSleepPoint are
+    // read at load to place the master on wake (SaveGame.cs:1119-1129, where MasterPlayer IS
+    // Game1.player here) — if left as the original owner's, the headless host wakes wherever the
+    // owner last slept (a cabin, the island), not the FarmHouse. Remove both (lastSleepLocation
+    // → null NetString, so SaveGame's `!= null` guard skips it → default FarmHouse placement;
+    // lastSleepPoint is a NetPoint <X>/<Y> structure that must be removed, not text-set).
+    private static readonly string[] LocationElementClears =
+    {
+        "lastSleepLocation",
+        "lastSleepPoint",
+    };
+
+    // (C) LEAVE-AS-CLONED — inert on a never-playing bot, documented so their omission from the
+    // clear-lists is intentional and the schema enumeration stays honest:
+    //   JOTPKProgress, toolBeingUpgraded/daysLeftForToolUpgrade, daysUntilHouseUpgrade,
+    //   acceptedDailyQuest, lastSeenMovieWeek, horseName, emoteFavorites/performedEmotes,
+    //   difficultyModifier.
+    // (B) KEEP (master-gated world-state, already an identical copy on the clone — do NOT clear):
+    //   mailReceived, eventsSeen, mailForTomorrow, mailbox, caveChoice, friendshipData, <stats>.
+    //   money/totalMoneyEarned are serialized but left untouched: under the default SHARED wallet
+    //   their accessors proxy to the team, so they're farm-state the player resumes on. (Edge: with
+    //   useSeparateWallets the blank bot seeds a phantom personal wallet from the owner's balance —
+    //   harmless, the bot never spends; noted so no one asserts the master's money is zero.)
+
+    /// <summary>
+    /// Runs the full swap transform on a loaded save document, in place. The document must be the
+    /// save's main XML (a <c>&lt;SaveGame&gt;</c> root with a <c>&lt;player&gt;</c> child). Throws
+    /// <see cref="SaveImportException"/> on any structural problem or guard violation; the caller
+    /// must discard the document (write nothing) on throw.
+    /// </summary>
+    /// <param name="doc">The parsed save document (mutated in place).</param>
+    /// <param name="userId">The platform userID to bind the demoted owner to (validated non-empty).</param>
+    /// <param name="newMasterUid">Out: the fresh UniqueMultiplayerID generated for the blank master.</param>
+    /// <param name="ownerUid">Out: the demoted owner's UniqueMultiplayerID (carried unchanged).</param>
+    public static void ApplySwap(
+        XmlDocument doc,
+        string userId,
+        out long newMasterUid,
+        out long ownerUid
+    )
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            throw new SaveImportException("Internal: ApplySwap called with an empty userId.");
+        }
+
+        var root = doc.DocumentElement;
+        if (root == null || root.Name != "SaveGame")
+        {
+            throw new SaveImportException(
+                "Save XML root is not <SaveGame>; the file is not a recognizable Stardew save."
+            );
+        }
+
+        var player = SelectSingle(root, "player");
+        if (player == null)
+        {
+            throw new SaveImportException("Save XML has no <player> element.");
+        }
+
+        // Re-import guard: refuse to re-transform a save whose <player> is already a Server master
+        // produced by a prior import (name=Server + customized + clone-blank fingerprint). Detect by
+        // the conjunction the import itself produces and a vanilla/played player cannot — NOT by
+        // name+customized alone (both are user-controllable).
+        if (IsAlreadyServerMaster(player))
+        {
+            throw new SaveImportAlreadySwappedException(
+                "This save's <player> is already a host-swapped 'Server' master."
+            );
+        }
+
+        var farmhandsContainer = GetOrCreateFarmhandsContainer(root, player);
+
+        // userID-collision guard: the supplied bind id must not already match any existing
+        // farmhand's <userID> (or the owner's own pre-existing one) — authCheck is raw string
+        // equality with no uniqueness guarantee, so a collision would let the bound player land on
+        // the wrong cabin and lock out the legitimate owner. Walk every farmhand userID first.
+        var conflict = FindUserIdConflict(farmhandsContainer, player, userId);
+        if (conflict != null)
+        {
+            throw new SaveImportException(
+                $"The supplied user id collides with existing farmhand '{conflict}' in this save. "
+                    + "Pick the correct id, or restore a backup if you re-imported a save the player is already in."
+            );
+        }
+
+        ownerUid = ReadUid(player);
+
+        // 1. Build the blank Server master by cloning the original <player> and blanking it.
+        var blankMaster = (XmlElement)player.CloneNode(deep: true);
+        newMasterUid = BlankInto(blankMaster, farmhandsContainer, player);
+
+        // 2. Reparent the original <player> into <farmhands>, stamped customized + userID.
+        SetScalarElement(player, "isCustomized", "true");
+        SetScalarElement(player, "userID", userId);
+        // Leave the owner's homeLocation as-is (FarmHouse for a former master). Layer B re-homes it;
+        // do NOT create a cabin / touch farmhandReference here (brittle engine-generated names).
+
+        root.RemoveChild(player);
+        // The original <player> is an element named "player"; rename to "Farmer" so it is a valid
+        // <farmhands> entry (each entry is a <Farmer>). XmlDocument can't rename in place, so
+        // re-create the element as <Farmer> and move the children over.
+        var farmhandEntry = RenameElement(doc, player, "Farmer");
+        farmhandsContainer.AppendChild(farmhandEntry);
+
+        // 3. Install the blank master as the new <player> (first child position is irrelevant to
+        //    the deserializer, which selects by element name).
+        root.PrependChild(blankMaster);
+
+        ValidatePostTransform(root, newMasterUid, ownerUid, userId);
+    }
+
+    /// <summary>
+    /// Blanks <paramref name="blankMaster"/> in place into the headless "Server" host. Returns the
+    /// fresh collision-checked UniqueMultiplayerID written onto it.
+    /// </summary>
+    private static long BlankInto(
+        XmlElement blankMaster,
+        XmlElement farmhandsContainer,
+        XmlElement originalPlayer
+    )
+    {
+        // Identity (shared literals from ServerFarmerIdentity so import host == new-game host).
+        SetScalarElement(blankMaster, "name", ServerFarmerIdentity.Name);
+        SetScalarElement(blankMaster, "favoriteThing", ServerFarmerIdentity.FavoriteThing);
+        SetScalarElement(
+            blankMaster,
+            "isCustomized",
+            ServerFarmerIdentity.IsCustomized ? "true" : "false"
+        );
+        SetScalarElement(blankMaster, "homeLocation", "FarmHouse");
+        SetScalarElement(blankMaster, "whichPetType", ServerPetType);
+        // A master never carries a farmhand platform bind; the clone copies the original's userID
+        // (normally empty), so clear it defensively.
+        SetScalarElement(blankMaster, "userID", "");
+
+        // There is no <displayName> element to set — displayName is [XmlIgnore]/runtime-derived
+        // from <name> (Character.cs:290/143), recomputed as displayName = name at load.
+
+        // Fresh, collision-checked UniqueMultiplayerID, absent from every other farmer in the save.
+        var existingUids = CollectAllFarmerUids(farmhandsContainer, originalPlayer);
+        var newUid = GenerateUniqueId(existingUids);
+        SetScalarElement(blankMaster, "UniqueMultiplayerID", newUid.ToString());
+
+        // (A) Clear personal progress + relationship + stale-location state. Bucket B/C ride along.
+        foreach (var (element, value) in ScalarClears)
+        {
+            SetScalarElement(blankMaster, element, value);
+        }
+        foreach (var element in RelationshipClears)
+        {
+            RemoveChildElements(blankMaster, element);
+        }
+        foreach (var element in CollectionClears)
+        {
+            RemoveChildElements(blankMaster, element);
+        }
+        foreach (var element in LocationElementClears)
+        {
+            RemoveChildElements(blankMaster, element);
+        }
+
+        return newUid;
+    }
+
+    /// <summary>
+    /// Validates the post-transform document on the <c>.tmp</c> before the atomic rename. Asserts
+    /// only the bucket-A personal-progress containers empty + relationship state cleared on the
+    /// blank master, plus structural integrity. Does NOT assert bucket-B (mail/events/caveChoice/
+    /// friendshipData/stats) or team-proxied (money) empty — those are deliberately kept and would
+    /// fail on every real save.
+    /// </summary>
+    public static void ValidatePostTransform(
+        XmlElement root,
+        long expectedMasterUid,
+        long expectedOwnerUid,
+        string expectedUserId
+    )
+    {
+        var player = SelectSingle(root, "player");
+        if (player == null)
+        {
+            throw new SaveImportException("Post-transform validation: no <player> element.");
+        }
+
+        // Exactly one <player> with the master identity.
+        if (root.SelectNodes("player")?.Count != 1)
+        {
+            throw new SaveImportException(
+                "Post-transform validation: expected exactly one <player>."
+            );
+        }
+        if (ReadScalar(player, "name") != ServerFarmerIdentity.Name)
+        {
+            throw new SaveImportException(
+                "Post-transform validation: master <name> is not 'Server'."
+            );
+        }
+        if (ReadScalar(player, "isCustomized") != "true")
+        {
+            throw new SaveImportException("Post-transform validation: master is not customized.");
+        }
+        if (ReadUid(player) != expectedMasterUid)
+        {
+            throw new SaveImportException("Post-transform validation: master UID mismatch.");
+        }
+
+        // Bucket-A personal-progress containers blanked + relationship cleared on the master.
+        AssertScalarZero(player, "farmingLevel");
+        AssertScalarZero(player, "miningLevel");
+        AssertScalarZero(player, "combatLevel");
+        AssertScalarZero(player, "foragingLevel");
+        AssertScalarZero(player, "fishingLevel");
+        AssertAbsentOrEmpty(player, "items");
+        AssertAbsentOrEmpty(player, "questLog");
+        AssertAbsentOrEmpty(player, "cookingRecipes");
+        AssertAbsentOrEmpty(player, "craftingRecipes");
+        foreach (var rel in RelationshipClears)
+        {
+            if (SelectSingle(player, rel) != null)
+            {
+                throw new SaveImportException(
+                    $"Post-transform validation: master still carries relationship field <{rel}>."
+                );
+            }
+        }
+
+        // Moved owner present in <farmhands> with isCustomized + stamped userID.
+        var farmhands = SelectSingle(root, "farmhands");
+        var ownerEntry = farmhands
+            ?.SelectNodes("Farmer")
+            ?.Cast<XmlElement>()
+            .FirstOrDefault(f => ReadUid(f) == expectedOwnerUid);
+        if (ownerEntry == null)
+        {
+            throw new SaveImportException(
+                "Post-transform validation: demoted owner not found in <farmhands>."
+            );
+        }
+        if (ReadScalar(ownerEntry, "isCustomized") != "true")
+        {
+            throw new SaveImportException(
+                "Post-transform validation: demoted owner is not customized."
+            );
+        }
+        if (ReadScalar(ownerEntry, "userID") != expectedUserId)
+        {
+            throw new SaveImportException(
+                "Post-transform validation: demoted owner userID was not stamped."
+            );
+        }
+
+        // The new master UID is absent from the FULL post-transform farmer-ID set (all farmhands +
+        // the moved owner).
+        var allOther = CollectAllFarmerUids(farmhands, ownerEntry);
+        if (allOther.Contains(expectedMasterUid))
+        {
+            throw new SaveImportException(
+                "Post-transform validation: new master UID collides with a farmhand/owner UID."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Builds a standalone <c>SaveGameInfo</c> document (a single <c>&lt;Farmer&gt;</c> root) from
+    /// the post-transform master <c>&lt;player&gt;</c>, mirroring the engine's
+    /// <c>SaveGame.serialize</c> SaveGameInfo write. Used so the list/info views and external
+    /// tooling don't show the old human host after a swap. Returns null if the player can't be
+    /// resolved (caller skips the regen — it is not boot-critical on this server's direct-load path).
+    /// </summary>
+    public static XmlDocument? BuildSaveGameInfo(XmlDocument transformedSave)
+    {
+        var player =
+            transformedSave.DocumentElement == null
+                ? null
+                : SelectSingle(transformedSave.DocumentElement, "player");
+        if (player == null)
+        {
+            return null;
+        }
+
+        var info = new XmlDocument();
+        var farmerRoot = info.CreateElement("Farmer");
+        info.AppendChild(farmerRoot);
+        foreach (XmlNode child in player.ChildNodes)
+        {
+            farmerRoot.AppendChild(info.ImportNode(child, deep: true));
+        }
+        return info;
+    }
+
+    // ── Detection / collision helpers ──────────────────────────────────────────────
+
+    /// <summary>
+    /// True if <paramref name="player"/> is a Server master produced by a prior import. Requires the
+    /// conjunction a vanilla played <c>&lt;player&gt;</c> cannot have: name="Server" +
+    /// isCustomized=true AND the clone-blank fingerprint — fields the transform actually CLEARS:
+    /// empty <c>items</c>, empty <c>questLog</c>, and no <c>spouse</c>. (NOT <c>friendshipData</c>:
+    /// the engine seeds it on every farmer and the transform KEEPS it as a bucket-B master-gated
+    /// field, so a real blank master also has it populated.) A real played "Server" farmer would
+    /// have at least an inventory item.
+    /// </summary>
+    private static bool IsAlreadyServerMaster(XmlElement player)
+    {
+        if (ReadScalar(player, "name") != ServerFarmerIdentity.Name)
+        {
+            return false;
+        }
+        if (ReadScalar(player, "isCustomized") != "true")
+        {
+            return false;
+        }
+        return IsAbsentOrEmpty(player, "items")
+            && IsAbsentOrEmpty(player, "questLog")
+            && SelectSingle(player, "spouse") == null;
+    }
+
+    /// <summary>
+    /// Returns the name of the first farmhand (or the owner) whose <c>&lt;userID&gt;</c> equals
+    /// <paramref name="userId"/>, or null if none collides.
+    /// </summary>
+    private static string? FindUserIdConflict(
+        XmlElement farmhandsContainer,
+        XmlElement originalPlayer,
+        string userId
+    )
+    {
+        foreach (var farmer in EnumerateFarmers(farmhandsContainer, originalPlayer))
+        {
+            if (ReadScalar(farmer, "userID") == userId)
+            {
+                var name = ReadScalar(farmer, "name");
+                return string.IsNullOrEmpty(name) ? "(unnamed)" : name;
+            }
+        }
+        return null;
+    }
+
+    private static HashSet<long> CollectAllFarmerUids(
+        XmlElement? farmhandsContainer,
+        XmlElement? owner
+    )
+    {
+        var set = new HashSet<long>();
+        if (farmhandsContainer != null)
+        {
+            foreach (XmlElement f in farmhandsContainer.SelectNodes("Farmer")!)
+            {
+                set.Add(ReadUid(f));
+            }
+        }
+        if (owner != null)
+        {
+            set.Add(ReadUid(owner));
+        }
+        return set;
+    }
+
+    private static IEnumerable<XmlElement> EnumerateFarmers(
+        XmlElement farmhandsContainer,
+        XmlElement originalPlayer
+    )
+    {
+        foreach (XmlElement f in farmhandsContainer.SelectNodes("Farmer")!)
+        {
+            yield return f;
+        }
+        yield return originalPlayer;
+    }
+
+    /// <summary>
+    /// Generates an engine-style random 64-bit UniqueMultiplayerID (matching
+    /// <c>Utility.RandomLong</c>'s full-long shape) not present in <paramref name="existing"/>.
+    /// </summary>
+    private static long GenerateUniqueId(HashSet<long> existing)
+    {
+        var rng = new Random();
+        for (var attempt = 0; attempt < 1000; attempt++)
+        {
+            // Full 64-bit spread: two 32-bit draws. Avoid 0 (sentinel for "no owner").
+            long high = (long)(uint)rng.Next(int.MinValue, int.MaxValue);
+            long low = (uint)rng.Next(int.MinValue, int.MaxValue);
+            var candidate = (high << 32) | low;
+            if (candidate != 0 && !existing.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+        throw new SaveImportException(
+            "Could not generate a collision-free UniqueMultiplayerID after 1000 attempts."
+        );
+    }
+
+    // ── Low-level XML helpers (element-name selection; the save uses no XML namespace) ──
+
+    private static XmlElement? SelectSingle(XmlElement parent, string name) =>
+        parent.SelectSingleNode(name) as XmlElement;
+
+    private static XmlElement GetOrCreateFarmhandsContainer(XmlElement root, XmlElement player)
+    {
+        var existing = SelectSingle(root, "farmhands");
+        if (existing != null)
+        {
+            return existing;
+        }
+        // A single-player save has no <farmhands> element. Create an empty one (the deserializer
+        // reads <farmhands>/<Farmer> entries; an empty/absent container yields no farmhands).
+        var container = root.OwnerDocument!.CreateElement("farmhands");
+        root.InsertAfter(container, player);
+        return container;
+    }
+
+    /// <summary>
+    /// Re-creates <paramref name="source"/> as a new element named <paramref name="newName"/> with
+    /// all children moved over (XmlDocument can't rename an element in place).
+    /// </summary>
+    private static XmlElement RenameElement(XmlDocument doc, XmlElement source, string newName)
+    {
+        var renamed = doc.CreateElement(newName);
+        foreach (XmlAttribute attr in source.Attributes)
+        {
+            renamed.SetAttribute(attr.Name, attr.Value);
+        }
+        while (source.FirstChild != null)
+        {
+            renamed.AppendChild(source.FirstChild); // moves the node (removes from source)
+        }
+        return renamed;
+    }
+
+    /// <summary>
+    /// Sets the text of the single child element named <paramref name="name"/>, creating it (as the
+    /// first child) if absent. For NetInt/NetBool/NetString fields whose serialized form is plain
+    /// element text. If multiple same-named elements exist (shouldn't for these), the first wins and
+    /// the rest are removed to keep the document unambiguous.
+    /// </summary>
+    private static void SetScalarElement(XmlElement parent, string name, string value)
+    {
+        var nodes = parent.SelectNodes(name)!.Cast<XmlElement>().ToList();
+        XmlElement target;
+        if (nodes.Count == 0)
+        {
+            target = parent.OwnerDocument!.CreateElement(name);
+            parent.PrependChild(target);
+        }
+        else
+        {
+            target = nodes[0];
+            for (var i = 1; i < nodes.Count; i++)
+            {
+                parent.RemoveChild(nodes[i]);
+            }
+        }
+        target.InnerText = value;
+    }
+
+    private static void RemoveChildElements(XmlElement parent, string name)
+    {
+        foreach (var node in parent.SelectNodes(name)!.Cast<XmlElement>().ToList())
+        {
+            parent.RemoveChild(node);
+        }
+    }
+
+    private static long ReadUid(XmlElement farmer)
+    {
+        var text = ReadScalar(farmer, "UniqueMultiplayerID");
+        return long.TryParse(text, out var uid) ? uid : 0;
+    }
+
+    private static string ReadScalar(XmlElement parent, string name) =>
+        SelectSingle(parent, name)?.InnerText ?? "";
+
+    private static bool IsAbsentOrEmpty(XmlElement parent, string name)
+    {
+        var el = SelectSingle(parent, name);
+        return el == null || !el.HasChildNodes || string.IsNullOrWhiteSpace(el.InnerXml);
+    }
+
+    private static void AssertAbsentOrEmpty(XmlElement parent, string name)
+    {
+        if (!IsAbsentOrEmpty(parent, name))
+        {
+            throw new SaveImportException(
+                $"Post-transform validation: master <{name}> is not empty after clearing."
+            );
+        }
+    }
+
+    private static void AssertScalarZero(XmlElement parent, string name)
+    {
+        var text = ReadScalar(parent, name);
+        if (text != "0" && !string.IsNullOrEmpty(text))
+        {
+            throw new SaveImportException(
+                $"Post-transform validation: master <{name}> is '{text}', expected 0."
+            );
+        }
+    }
+}
+
+/// <summary>Thrown when a save-import XML transform fails. Always surfaced to the operator as a
+/// Warn (never Error — Error is server-side test poison); the caller writes nothing on throw.</summary>
+internal class SaveImportException : Exception
+{
+    public SaveImportException(string message)
+        : base(message) { }
+}
+
+/// <summary>Thrown by the re-import guard when the save's <c>&lt;player&gt;</c> is already a
+/// host-swapped Server master. Distinguished from <see cref="SaveImportException"/> so the command
+/// can route a same-id re-run to a true no-op vs. a different-id re-point.</summary>
+internal sealed class SaveImportAlreadySwappedException : SaveImportException
+{
+    public SaveImportAlreadySwappedException(string message)
+        : base(message) { }
+}

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -190,6 +190,9 @@ public class DiagnosticsStateResponse
     [JsonPropertyName("masterHasFlag")]
     public bool? MasterHasFlag { get; set; }
 
+    [JsonPropertyName("masterHasEvent")]
+    public bool? MasterHasEvent { get; set; }
+
     [JsonPropertyName("masterCaveChoice")]
     public int MasterCaveChoice { get; set; }
 
@@ -1203,20 +1206,26 @@ public class ServerApiClient : IDisposable
 
     /// <summary>
     /// As <see cref="GetDiagnosticsState(CancellationToken)"/>, but with optional <c>?masterFlag=</c>
-    /// (so <c>MasterHasFlag</c> reports whether the master's mailReceived contains that flag) and
+    /// (so <c>MasterHasFlag</c> reports whether the master's mailReceived contains that flag),
+    /// <c>?masterEvent=</c> (so <c>MasterHasEvent</c> reports the same for eventsSeen), and
     /// <c>?masterFriendKey=</c> (so <c>MasterShadowFriendshipPoints</c> reports that NPC's specific
     /// friendship points). Used by the save-import master-carry tests.
     /// </summary>
     public async Task<DiagnosticsStateResponse?> GetDiagnosticsState(
         string? masterFlag,
         CancellationToken ct = default,
-        string? masterFriendKey = null
+        string? masterFriendKey = null,
+        string? masterEvent = null
     )
     {
         var query = new List<string>();
         if (!string.IsNullOrEmpty(masterFlag))
         {
             query.Add($"masterFlag={Uri.EscapeDataString(masterFlag)}");
+        }
+        if (!string.IsNullOrEmpty(masterEvent))
+        {
+            query.Add($"masterEvent={Uri.EscapeDataString(masterEvent)}");
         }
         if (!string.IsNullOrEmpty(masterFriendKey))
         {

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1682,10 +1682,8 @@ public class ServerApiClient : IDisposable
     }
 
     /// <summary>
-    /// Test-only: invoke a registered SMAPI console command by name/args exactly as a server operator
-    /// typing it would (the server reflects into SMAPI's internal command registry). Used to drive the
-    /// <c>saves reload</c> guard/kick path, which has no HTTP endpoint of its own. The command runs
-    /// fire-and-forget; assert its effect via the diagnostics snapshot.
+    /// Test-only: invoke a registered console command by name/args (drives <c>saves reload</c>, which
+    /// has no HTTP endpoint). Runs fire-and-forget — assert its effect via the diagnostics snapshot.
     /// POST /test/console
     /// </summary>
     public async Task<TestConsoleCommandResponse?> RunConsoleCommand(

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -174,6 +174,40 @@ public class DiagnosticsStateResponse
     [JsonPropertyName("disconnectingFarmers")]
     public long[] DisconnectingFarmers { get; set; } = Array.Empty<long>();
 
+    // ── Save-import assertion probes (mirror the mod-side DiagnosticsStateResponse). ──
+    [JsonPropertyName("farmHouseObjectCount")]
+    public int FarmHouseObjectCount { get; set; }
+
+    [JsonPropertyName("farmHouseFurnitureCount")]
+    public int FarmHouseFurnitureCount { get; set; }
+
+    [JsonPropertyName("farmHouseFridgeItemCount")]
+    public int FarmHouseFridgeItemCount { get; set; }
+
+    [JsonPropertyName("masterCellarObjectCount")]
+    public int MasterCellarObjectCount { get; set; }
+
+    [JsonPropertyName("masterHasFlag")]
+    public bool? MasterHasFlag { get; set; }
+
+    [JsonPropertyName("masterCaveChoice")]
+    public int MasterCaveChoice { get; set; }
+
+    [JsonPropertyName("masterShadowFriendshipPoints")]
+    public int? MasterShadowFriendshipPoints { get; set; }
+
+    [JsonPropertyName("masterDaysPlayed")]
+    public int MasterDaysPlayed { get; set; }
+
+    [JsonPropertyName("masterHasSpouse")]
+    public bool MasterHasSpouse { get; set; }
+
+    [JsonPropertyName("masterName")]
+    public string MasterName { get; set; } = "";
+
+    [JsonPropertyName("saveImportFinalizeCount")]
+    public int SaveImportFinalizeCount { get; set; }
+
     [JsonPropertyName("failedFields")]
     public List<string> FailedFields { get; set; } = new();
 }
@@ -213,6 +247,18 @@ public class DiagnosticsCabinState
 
     [JsonPropertyName("farmhandReferenceUid")]
     public long FarmhandReferenceUid { get; set; }
+
+    [JsonPropertyName("objectCount")]
+    public int ObjectCount { get; set; }
+
+    [JsonPropertyName("fridgeItemCount")]
+    public int FridgeItemCount { get; set; }
+
+    [JsonPropertyName("petCount")]
+    public int PetCount { get; set; }
+
+    [JsonPropertyName("cellarObjectCount")]
+    public int CellarObjectCount { get; set; }
 }
 
 public class DiagnosticsFarmhandState
@@ -559,6 +605,162 @@ public class TestStampClaimResponse
 
     [JsonPropertyName("homeLocation")]
     public string HomeLocation { get; set; } = "";
+}
+
+/// <summary>Body for /test/seed_import_source (test-only). Mirrors the server-side DTO.</summary>
+public class TestSeedImportSourceRequest
+{
+    [JsonPropertyName("ownerName")]
+    public string? OwnerName { get; set; }
+
+    [JsonPropertyName("houseUpgradeLevel")]
+    public int? HouseUpgradeLevel { get; set; }
+
+    [JsonPropertyName("caveChoice")]
+    public int? CaveChoice { get; set; }
+
+    [JsonPropertyName("spouse")]
+    public string? Spouse { get; set; }
+
+    [JsonPropertyName("mailFlag")]
+    public string? MailFlag { get; set; }
+
+    [JsonPropertyName("eventSeen")]
+    public string? EventSeen { get; set; }
+
+    [JsonPropertyName("shadowFriendshipPoints")]
+    public int? ShadowFriendshipPoints { get; set; }
+
+    [JsonPropertyName("shadowFriendshipKey")]
+    public string? ShadowFriendshipKey { get; set; }
+
+    [JsonPropertyName("daysPlayed")]
+    public int? DaysPlayed { get; set; }
+
+    [JsonPropertyName("placeChest")]
+    public bool PlaceChest { get; set; }
+
+    [JsonPropertyName("chestTileX")]
+    public int ChestTileX { get; set; } = 3;
+
+    [JsonPropertyName("chestTileY")]
+    public int ChestTileY { get; set; } = 3;
+
+    [JsonPropertyName("placeFridgeItem")]
+    public bool PlaceFridgeItem { get; set; }
+
+    [JsonPropertyName("spawnPet")]
+    public bool SpawnPet { get; set; }
+
+    [JsonPropertyName("placeCellarItem")]
+    public bool PlaceCellarItem { get; set; }
+
+    [JsonPropertyName("injectFarmhandUserId")]
+    public string? InjectFarmhandUserId { get; set; }
+}
+
+/// <summary>Response from /test/seed_import_source (test-only).</summary>
+public class TestSeedImportSourceResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("ownerUid")]
+    public long OwnerUid { get; set; }
+
+    [JsonPropertyName("ownerName")]
+    public string OwnerName { get; set; } = "";
+
+    [JsonPropertyName("chestPlaced")]
+    public bool ChestPlaced { get; set; }
+
+    [JsonPropertyName("fridgeItemPlaced")]
+    public bool FridgeItemPlaced { get; set; }
+
+    [JsonPropertyName("petSpawned")]
+    public bool PetSpawned { get; set; }
+
+    [JsonPropertyName("cellarItemPlaced")]
+    public bool CellarItemPlaced { get; set; }
+
+    [JsonPropertyName("farmhandUserIdInjected")]
+    public bool FarmhandUserIdInjected { get; set; }
+}
+
+/// <summary>Body for /test/corrupt_save (test-only).</summary>
+public class TestCorruptSaveRequest
+{
+    [JsonPropertyName("sourceSaveName")]
+    public string? SourceSaveName { get; set; }
+
+    [JsonPropertyName("targetSaveName")]
+    public string? TargetSaveName { get; set; }
+}
+
+/// <summary>Response from /test/corrupt_save and /test/save_tmp_exists (test-only).</summary>
+public class TestSaveFileOpResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("exists")]
+    public bool Exists { get; set; }
+
+    [JsonPropertyName("targetSaveName")]
+    public string TargetSaveName { get; set; } = "";
+}
+
+/// <summary>Body for /test/import_save (test-only). Mirrors the server-side DTO.</summary>
+public class TestImportSaveRequest
+{
+    [JsonPropertyName("sourceSaveName")]
+    public string? SourceSaveName { get; set; }
+
+    [JsonPropertyName("targetSaveName")]
+    public string? TargetSaveName { get; set; }
+
+    [JsonPropertyName("swapHostTo")]
+    public string? SwapHostTo { get; set; }
+
+    [JsonPropertyName("skipClone")]
+    public bool SkipClone { get; set; }
+}
+
+/// <summary>Response from /test/import_save (test-only).</summary>
+public class TestImportSaveResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("targetSaveName")]
+    public string TargetSaveName { get; set; } = "";
+
+    [JsonPropertyName("swapped")]
+    public bool Swapped { get; set; }
+
+    [JsonPropertyName("repointedBind")]
+    public bool RepointedBind { get; set; }
+
+    [JsonPropertyName("formerOwnerUid")]
+    public long FormerOwnerUid { get; set; }
+
+    [JsonPropertyName("importError")]
+    public string? ImportError { get; set; }
+
+    [JsonPropertyName("preImportMainFileHash")]
+    public string PreImportMainFileHash { get; set; } = "";
+
+    [JsonPropertyName("postImportMainFileHash")]
+    public string PostImportMainFileHash { get; set; } = "";
 }
 
 /// <summary>
@@ -975,9 +1177,36 @@ public class ServerApiClient : IDisposable
     /// server); safe to call from every failure path.
     /// GET /diagnostics/state
     /// </summary>
-    public async Task<DiagnosticsStateResponse?> GetDiagnosticsState(CancellationToken ct = default)
+    public async Task<DiagnosticsStateResponse?> GetDiagnosticsState(
+        CancellationToken ct = default
+    ) => await GetDiagnosticsState(null, ct);
+
+    /// <summary>
+    /// As <see cref="GetDiagnosticsState(CancellationToken)"/>, but with optional <c>?masterFlag=</c>
+    /// (so <c>MasterHasFlag</c> reports whether the master's mailReceived contains that flag) and
+    /// <c>?masterFriendKey=</c> (so <c>MasterShadowFriendshipPoints</c> reports that NPC's specific
+    /// friendship points). Used by the save-import master-carry tests.
+    /// </summary>
+    public async Task<DiagnosticsStateResponse?> GetDiagnosticsState(
+        string? masterFlag,
+        CancellationToken ct = default,
+        string? masterFriendKey = null
+    )
     {
-        var response = await _httpClient.GetAsync("/diagnostics/state", ct);
+        var query = new List<string>();
+        if (!string.IsNullOrEmpty(masterFlag))
+        {
+            query.Add($"masterFlag={Uri.EscapeDataString(masterFlag)}");
+        }
+        if (!string.IsNullOrEmpty(masterFriendKey))
+        {
+            query.Add($"masterFriendKey={Uri.EscapeDataString(masterFriendKey)}");
+        }
+        var path =
+            query.Count == 0
+                ? "/diagnostics/state"
+                : "/diagnostics/state?" + string.Join("&", query);
+        var response = await _httpClient.GetAsync(path, ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<DiagnosticsStateResponse>(ct);
     }
@@ -1388,6 +1617,87 @@ public class ServerApiClient : IDisposable
         var response = await SendWithRetryAsync(HttpMethod.Post, "/test/galaxy_relogin", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestGalaxyReloginResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: seed the active game's master + FarmHouse to look like a real importable owner
+    /// (non-Server name + inventory, plus optional house/world/relationship state and FarmHouse
+    /// contents) before saving, so the save's &lt;player&gt; reads as a played human for a swap import.
+    /// POST /test/seed_import_source
+    /// </summary>
+    public async Task<TestSeedImportSourceResponse?> SeedImportSource(
+        TestSeedImportSourceRequest body,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/seed_import_source",
+            ct,
+            () => JsonContent.Create(body)
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestSeedImportSourceResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: clone a source save folder under a new name and run saves-import on the clone
+    /// (ExecuteImport rejects importing the active save). Defaults: source = active save, target =
+    /// source + "-import". Pass <c>SwapHostTo</c> for a swap+bind import.
+    /// POST /test/import_save
+    /// </summary>
+    public async Task<TestImportSaveResponse?> ImportSave(
+        TestImportSaveRequest body,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/import_save",
+            ct,
+            () => JsonContent.Create(body)
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestImportSaveResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: clone the active (valid) save to <paramref name="targetSaveName"/>, then corrupt
+    /// the clone's main file into non-well-formed XML (resilience test). The active save is untouched.
+    /// POST /test/corrupt_save
+    /// </summary>
+    public async Task<TestSaveFileOpResponse?> CorruptSave(
+        string targetSaveName,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/corrupt_save",
+            ct,
+            () => JsonContent.Create(new TestCorruptSaveRequest { TargetSaveName = targetSaveName })
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestSaveFileOpResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: whether a leftover <c>.tmp</c> remains next to the save's main file (no-junk
+    /// assertion after a successful import).
+    /// GET /test/save_tmp_exists?saveName=...
+    /// </summary>
+    public async Task<TestSaveFileOpResponse?> SaveTmpExists(
+        string saveName,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Get,
+            $"/test/save_tmp_exists?saveName={Uri.EscapeDataString(saveName)}",
+            ct
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestSaveFileOpResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -763,6 +763,26 @@ public class TestImportSaveResponse
     public string PostImportMainFileHash { get; set; } = "";
 }
 
+/// <summary>Body for /test/console (test-only). Mirrors the server-side DTO.</summary>
+public class TestConsoleCommandRequest
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("args")]
+    public string[] Args { get; set; } = Array.Empty<string>();
+}
+
+/// <summary>Response from /test/console (test-only).</summary>
+public class TestConsoleCommandResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 /// <summary>
 /// Response from /test/galaxy_relogin POST endpoint (test-only). Mirrors the server-side
 /// TestGalaxyReloginResponse DTO. Triggers a Galaxy re-sign-in with no outage so a test can
@@ -1659,6 +1679,29 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestImportSaveResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: invoke a registered SMAPI console command by name/args exactly as a server operator
+    /// typing it would (the server reflects into SMAPI's internal command registry). Used to drive the
+    /// <c>saves reload</c> guard/kick path, which has no HTTP endpoint of its own. The command runs
+    /// fire-and-forget; assert its effect via the diagnostics snapshot.
+    /// POST /test/console
+    /// </summary>
+    public async Task<TestConsoleCommandResponse?> RunConsoleCommand(
+        string name,
+        string[] args,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/console",
+            ct,
+            () => JsonContent.Create(new TestConsoleCommandRequest { Name = name, Args = args })
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestConsoleCommandResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -109,6 +109,17 @@ public enum WaitName
     Polling_AbandonedClaim_DisconnectHealConfirmed,
     Polling_AbandonedClaim_SweptOnReload,
 
+    // SaveImportTests.cs (9)
+    Polling_SaveImport_SwapFinalized,
+    Polling_SaveImport_ContentsMoved,
+    Polling_SaveImport_ContentsMovedUpgraded,
+    Polling_SaveImport_PetRelocated,
+    Polling_SaveImport_CellarMoved,
+    Polling_SaveImport_AsIsPreserved,
+    Polling_SaveImport_PartialThenStable,
+    Polling_SaveImport_SecondReloadNoop,
+    Polling_SaveImport_MasterGatedState,
+
     // FarmhandManagementTests.cs (1)
     Polling_FarmhandManagement_FarmhandGone,
 

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -109,7 +109,7 @@ public enum WaitName
     Polling_AbandonedClaim_DisconnectHealConfirmed,
     Polling_AbandonedClaim_SweptOnReload,
 
-    // SaveImportTests.cs (9)
+    // SaveImportTests.cs (10)
     Polling_SaveImport_SwapFinalized,
     Polling_SaveImport_ContentsMoved,
     Polling_SaveImport_ContentsMovedUpgraded,
@@ -119,6 +119,7 @@ public enum WaitName
     Polling_SaveImport_PartialThenStable,
     Polling_SaveImport_SecondReloadNoop,
     Polling_SaveImport_MasterGatedState,
+    Polling_SaveImport_ForceReloadKicksAndFinalizes,
 
     // FarmhandManagementTests.cs (1)
     Polling_FarmhandManagement_FarmhandGone,

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -22,11 +22,8 @@ namespace JunimoServer.Tests;
 /// is customized but has <c>userID==""</c> (LAN never stamps — <c>abandoned-claim-is-steam-only.md</c>),
 /// so <c>HasUserId==true</c> after reload proves Layer B re-stamped the bind, not a carried value.
 ///
-/// The two <c>saves reload</c> guard tests instead drive the real console command via
-/// <c>POST /test/console</c> (SMAPI 4.4 exposes no public API to invoke a console command, so the
-/// endpoint reflects into SMAPI's command registry) — exercising the actual <c>SavesCommand</c> guard
-/// + force-kick path, not the separate <c>/reload</c> endpoint guard. They still assert via the
-/// snapshot.
+/// The two reload-guard tests drive the real console command via <c>POST /test/console</c> (the
+/// <c>SavesCommand</c> guard/kick has no HTTP endpoint), still asserting via the snapshot.
 ///
 /// Class-level <c>Exclusive</c> serializes the methods (each begins with its own
 /// <c>CreateNewGameOnServerAsync</c>, so a prior test's imported active save never leaks in) — see
@@ -743,28 +740,21 @@ public class SaveImportTests : TestBase
         Log("Non-colliding id accepted");
     }
 
-    /// <summary>Test 12 — the <c>saves reload</c> client guard: with a player connected, a plain
-    /// <c>--reload</c> (no force) must REFUSE — the world does not reload, so the queued swap import is
-    /// NOT finalized (master stays the seeded owner, not "Server") and the connected player stays.
-    /// Drives the real console command via /test/console (SMAPI exposes no Trigger API), so this
-    /// exercises the actual guard in SavesCommand, not the /reload endpoint's separate guard.</summary>
+    /// <summary>Test 12 — a plain <c>--reload</c> with a player connected must refuse: the swap import
+    /// stays queued (master stays the seeded owner, never "Server") and the player stays connected.</summary>
     [Fact]
     public async Task Import_Reload_RefusesWhenClientConnected()
     {
         var ct = TestContext.Current.CancellationToken;
-        // Seed the master as a real owner "Nina" so the ACTIVE world's MasterName is "Nina" — a
-        // finalized swap would flip it to "Server", so MasterName staying "Nina" proves no reload.
+        // Master is "Nina"; a finalized swap would flip it to "Server", so "Nina" persisting proves no reload.
         await GenerateSourceSaveAsync(new TestSeedImportSourceRequest { OwnerName = "Nina" }, ct);
 
-        // Queue a swap import of a clone (sets SaveNameToLoad to the imported clone). The active world
-        // is untouched — the import runs against the clone folder, not Game1.
         var import = await ServerApi.ImportSave(
             new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
             ct
         );
         Assert.True(import?.Success == true && import.Swapped, $"Import failed: {import?.Error}");
 
-        // Connect a player to the ACTIVE world so the guard sees a connected client.
         var client = await Farmers.ConnectNewAsync(ct: ct);
         try
         {
@@ -774,21 +764,17 @@ public class SaveImportTests : TestBase
                 "Guard test requires the client to be connected before the reload"
             );
 
-            // Plain reload — must refuse (a player is connected and we did not force).
             var cmd = await ServerApi.RunConsoleCommand("saves", new[] { "reload" }, ct);
             Assert.True(cmd?.Success == true, $"Console command dispatch failed: {cmd?.Error}");
 
-            // Negative assertion (refusal): a reload would ExitToTitle — dropping the client and
-            // flipping the master to "Server" within a tick or two. Wait a settle window long enough
-            // for a wrongful reload to manifest (mirrors TimePausedVerification's "state must NOT
-            // change" idiom), then assert the steady state held: client still on, master still "Nina".
+            // A wrongful reload would ExitToTitle within a tick or two; settle past that, then assert
+            // nothing moved (mirrors TimePausedVerification's "must NOT change" idiom).
             await Task.Delay(TestTimings.TimePausedVerification, ct);
 
             var players = await ServerApi.GetPlayers(ct);
             Assert.True(
                 players?.Players.Any(p => p.Id == clientUid) == true,
-                "A plain --reload with a client connected must refuse — the client must stay connected "
-                    + "(a reload would have ExitToTitle'd it)"
+                "Refused reload must leave the client connected (a reload would have ExitToTitle'd it)"
             );
             var state = await ServerApi.GetDiagnosticsState(ct);
             Assert.Equal("Nina", state?.MasterName); // "Server" would mean the swap wrongly finalized
@@ -796,16 +782,13 @@ public class SaveImportTests : TestBase
         }
         finally
         {
-            // The refused client is still connected — disconnect so it can't cascade into another
-            // Exclusive method on this shared server.
+            // Still connected (refused) — disconnect so it can't cascade into another Exclusive method.
             await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
         }
     }
 
-    /// <summary>Test 13 — <c>saves reload --force</c> with a player connected: kicks the player, then
-    /// reloads, finalizing the queued swap WITHOUT a separate restart. Proves the force-kick path and
-    /// that the reload runs the Layer B finalizer (kicked player gone from /players, swap finalized to
-    /// a "Server" master with the owner a bound cabin farmhand).</summary>
+    /// <summary>Test 13 — <c>saves reload --force</c> with a player connected kicks them, then reloads
+    /// and finalizes the queued swap in-process (player gone, "Server" master, owner a bound farmhand).</summary>
     [Fact]
     public async Task Import_ForceReload_KicksThenFinalizes()
     {
@@ -829,13 +812,9 @@ public class SaveImportTests : TestBase
             "Force test requires the client to be connected before the reload"
         );
 
-        // Force reload — broadcasts, kicks the connected player, then reloads the queued import.
         var cmd = await ServerApi.RunConsoleCommand("saves", new[] { "reload", "--force" }, ct);
         Assert.True(cmd?.Success == true, $"Console command dispatch failed: {cmd?.Error}");
 
-        // The kicked player is gone (ExitToTitle disconnects everyone regardless, but the explicit
-        // kick precedes it) and the swap finalized into a fresh "Server" master with the demoted owner
-        // a bound cabin farmhand — the same end state as a restart, with no restart.
         var ok = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_SaveImport_ForceReloadKicksAndFinalizes,
             async () =>
@@ -852,7 +831,6 @@ public class SaveImportTests : TestBase
                 {
                     return false;
                 }
-                // The kicked client is no longer present.
                 var players = await ServerApi.GetPlayers(ct);
                 return players?.Players.All(p => p.Id != clientUid) == true;
             },
@@ -891,11 +869,6 @@ public class SaveImportTests : TestBase
     // TODO: full player-to-player marriage survival across the swap needs two customized farmhands;
     //   Test 8 covers only the master-clear half. p2p-marriage survival is a manual-verification gap.
     //
-    // NOTE: Test 13 (force reload) can't ISOLATE the courtesy kick from the reload's own ExitToTitle —
-    //   both disconnect the client, so via the HTTP snapshot (tests-assert-via-http-api.md) "client
-    //   gone" is satisfied either way. What it DOES prove is that --force gets past the guard that
-    //   Test 12 shows blocks a plain reload, then finalizes. The explicit kick firing first is visible
-    //   only in the client log ("Disconnected: Kicked" before "ExitedToMainMenu") — diagnostics, not
-    //   an assertion surface. Isolating the kick would need a snapshot signal the kick produces that
-    //   ExitToTitle doesn't; none exists, so it's a documented gap, not faked coverage.
+    // TODO: Test 13's explicit kick isn't isolatable from the reload's own ExitToTitle via the snapshot
+    //   (both disconnect the client) — it proves --force bypasses the guard + finalizes, not the kick.
 }

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -1,0 +1,754 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E tests for the <c>saves import</c> feature (one-shot co-op save import with optional host
+/// swap). Asserts only via the server HTTP API snapshot (<c>/diagnostics/state</c>), per
+/// <c>tests-assert-via-http-api.md</c>.
+///
+/// The source co-op save is generated in-process: create a game (the master is the "Server" bot),
+/// then <c>POST /test/seed_import_source</c> makes that master look like a real played human owner
+/// (non-Server name + inventory, plus the world/relationship/house state and FarmHouse contents each
+/// test asserts), then <c>SleepToSaveAsync</c> writes it to disk. <c>POST /test/import_save</c> then
+/// CLONES that save under a new folder name (ExecuteImport rejects importing the active save) and
+/// runs the import on the clone, after which <c>ReloadServerAsync</c> loads the transformed clone and
+/// runs the Layer B finalizer.
+///
+/// The bind on a swap comes from the import ARG, not the source save: the LAN-generated source owner
+/// is customized but has <c>userID==""</c> (LAN never stamps — <c>abandoned-claim-is-steam-only.md</c>),
+/// so <c>HasUserId==true</c> after reload proves Layer B re-stamped the bind, not a carried value.
+///
+/// Class-level <c>Exclusive</c> serializes the methods (each begins with its own
+/// <c>CreateNewGameOnServerAsync</c>, so a prior test's imported active save never leaks in) — see
+/// <c>test-broker-invariants.md</c>.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedClass, Exclusive = true, StartingCabins = 2)]
+public class SaveImportTests : TestBase
+{
+    public SaveImportTests() { }
+
+    // A synthetic all-digit Steam64-shaped id for the bind. Must be all-digit (import validates the
+    // flag); NOT the lettered /test/stamp_claim literal, which import would reject.
+    private const string SyntheticBindId = "76561190000000001";
+
+    /// <summary>
+    /// Generates a co-op source save on the active server: fresh game (Server master + spare cabins),
+    /// then seeds the master to look like a real owner per <paramref name="seed"/>, then saves. The
+    /// caller must have a connected in-world primary client (for the sleep-save) — this connects one.
+    /// Returns the seed response (owner uid etc.).
+    /// </summary>
+    private async Task<TestSeedImportSourceResponse> GenerateSourceSaveAsync(
+        TestSeedImportSourceRequest seed,
+        CancellationToken ct,
+        int startingCabins = 2
+    )
+    {
+        await CreateNewGameOnServerAsync(
+            farmType: 0,
+            cabinStrategy: "CabinStack",
+            startingCabins: startingCabins
+        );
+
+        // A connected, customized, in-world client is required for the day-transition save.
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var customized = await ServerApi.WaitForFarmhandByNameAsync(
+            client.FarmerName,
+            requireCustomized: true,
+            ct: ct
+        );
+        Assert.True(customized, $"Source client '{client.FarmerName}' should be customized");
+
+        var seedResult = await ServerApi.SeedImportSource(seed, ct);
+        Assert.True(seedResult?.Success == true, $"SeedImportSource failed: {seedResult?.Error}");
+        Assert.NotEqual(0, seedResult!.OwnerUid);
+
+        // Flush to disk, then disconnect so /reload (which needs 0 clients) can run later.
+        await SleepToSaveAsync(ct);
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+
+        return seedResult;
+    }
+
+    /// <summary>Test 1 — swap+bind: the demoted owner becomes a bound customized cabin farmhand and a
+    /// fresh "Server" master is installed.</summary>
+    [Fact]
+    public async Task Import_SwapHost_DemotesOwnerAndBindsUserId()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Alice" },
+            ct
+        );
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+        Assert.True(import!.Swapped, "Import should report a host swap");
+        Assert.Equal(ownerUid, import.FormerOwnerUid);
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_SwapFinalized,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                // Former owner is a customized + bound farmhand, present (not swept).
+                var ownerEntry = state.FarmhandData.FirstOrDefault(f =>
+                    f.UniqueMultiplayerId == ownerUid
+                );
+                if (ownerEntry == null || !ownerEntry.IsCustomized || !ownerEntry.HasUserId)
+                {
+                    return false;
+                }
+
+                // A cabin is owned by the former owner with the bind visible.
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == ownerUid);
+                if (cabin == null || !cabin.OwnerHasUserId)
+                {
+                    return false;
+                }
+
+                // The new master is "Server" and is NOT the former owner.
+                var serverMasterIsFresh = ownerEntry.Name != "Server";
+                return serverMasterIsFresh;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            $"After swap import + reload, owner uid={ownerUid} must be a customized, bound cabin "
+                + "farmhand and a fresh Server master must be installed"
+        );
+        Log($"Swap import finalized: owner uid={ownerUid} demoted + bound");
+    }
+
+    /// <summary>Test 2 — contents move: the owner's farmhouse chest + fridge item end up in their
+    /// cabin and the Server-owned FarmHouse is left empty. (Co-op source: ≥2 spare cabins → the owner
+    /// is auto-homed into a spare cabin → exercises the REUSE path.)</summary>
+    [Fact]
+    public async Task Import_SwapHost_MovesFarmhouseContentsToCabin()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest
+            {
+                OwnerName = "Bob",
+                PlaceChest = true,
+                PlaceFridgeItem = true,
+            },
+            ct
+        );
+        Assert.True(seed.ChestPlaced, "Source chest should have been placed");
+        Assert.True(seed.FridgeItemPlaced, "Source fridge item should have been placed");
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_ContentsMoved,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == ownerUid);
+                if (cabin == null)
+                {
+                    return false;
+                }
+
+                // The owner's cabin holds the chest and the fridge item; the host FarmHouse is empty
+                // (objects, fridge AND furniture — the starter furniture must have moved too).
+                var cabinHasContents = cabin.ObjectCount >= 1 && cabin.FridgeItemCount >= 1;
+                var farmHouseEmpty =
+                    state.FarmHouseObjectCount == 0
+                    && state.FarmHouseFridgeItemCount == 0
+                    && state.FarmHouseFurnitureCount == 0;
+                return cabinHasContents && farmHouseEmpty;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            $"After swap import, owner uid={ownerUid} cabin must hold the moved chest + fridge item "
+                + "and the Server FarmHouse must be empty (objects, fridge, furniture)"
+        );
+        Log("Contents move confirmed (reuse path)");
+    }
+
+    /// <summary>Test 2b — upgraded-house variant through the BUILD path: a single-cabin (no spare)
+    /// source with a &gt; level-0 house forces the finalizer to build the cabin and realize its map to
+    /// the owner's level before the move. Asserts the placed contents survive and no starter giftbox
+    /// remains.</summary>
+    [Fact]
+    public async Task Import_SwapHost_UpgradedHouse_BuildPath_MovesContents()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // startingCabins:1 → no spare assignable cabin → TryAssignFarmhandHome fails → build path.
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest
+            {
+                OwnerName = "Carol",
+                HouseUpgradeLevel = 1,
+                PlaceChest = true,
+                PlaceFridgeItem = true,
+            },
+            ct,
+            startingCabins: 1
+        );
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_ContentsMovedUpgraded,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == ownerUid);
+                if (cabin == null)
+                {
+                    return false;
+                }
+
+                // Chest + fridge item survived the level-0→level-N realization; FarmHouse empty
+                // (objects, fridge AND furniture).
+                var cabinHasContents = cabin.ObjectCount >= 1 && cabin.FridgeItemCount >= 1;
+                var farmHouseEmpty =
+                    state.FarmHouseObjectCount == 0
+                    && state.FarmHouseFridgeItemCount == 0
+                    && state.FarmHouseFurnitureCount == 0;
+                return cabinHasContents && farmHouseEmpty;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            $"After build-path swap import of an upgraded house, owner uid={ownerUid} cabin must hold "
+                + "the moved contents and the FarmHouse must be empty"
+        );
+        Log("Contents move confirmed (build path, upgraded house)");
+    }
+
+    /// <summary>Test 3 — pet relocation: a pet in the source FarmHouse ends up in the owner's cabin,
+    /// not the Server FarmHouse. (Spouse/children relocation is CI-untested — distinct mechanisms;
+    /// see the coverage TODO at the bottom of this file.)</summary>
+    [Fact]
+    public async Task Import_SwapHost_RelocatesPetToCabin()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Dave", SpawnPet = true },
+            ct
+        );
+        Assert.True(seed.PetSpawned, "Source pet should have been spawned");
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_PetRelocated,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == ownerUid);
+                if (cabin == null)
+                {
+                    return false;
+                }
+
+                // The PET specifically is now in the owner's cabin. Assert the pet-specific PetCount so
+                // the test can only pass if the pet actually reached the cabin — not if some other NPC
+                // did. (The FarmHouse pet count is not a useful signal: the pet lives on the Farm near
+                // its bowl after an overnight save, so it's absent from the FarmHouse regardless. The
+                // cabin PetCount is the real proof of relocation.)
+                return cabin.PetCount >= 1;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            $"After swap import, the pet must be relocated into owner uid={ownerUid}'s cabin and not "
+                + "remain in the Server FarmHouse"
+        );
+        Log("Pet relocation confirmed");
+    }
+
+    /// <summary>Test 11 — cellar-contents move: a cask the owner built in the master-keyed "Cellar"-1
+    /// follows them into the cellar the engine reassigns to their demoted farmhand, and the
+    /// Server-host's "Cellar"-1 is left empty. Proves cellar contents are not lost to the host
+    /// (cellar contents are location-bound, so a raw assignment change wouldn't carry them).</summary>
+    [Fact]
+    public async Task Import_SwapHost_MovesCellarContentsToOwnerCellar()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Liam", PlaceCellarItem = true },
+            ct
+        );
+        Assert.True(seed.CellarItemPlaced, "Source cellar cask should have been placed");
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_CellarMoved,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                var cabin = state.Cabins.FirstOrDefault(c => c.OwnerId == ownerUid);
+                if (cabin == null)
+                {
+                    return false;
+                }
+
+                // The cask reached the owner's reassigned cellar; the Server-host's "Cellar"-1 is empty.
+                return cabin.CellarObjectCount >= 1 && state.MasterCellarObjectCount == 0;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            $"After swap import, owner uid={ownerUid}'s cellar must hold the moved cask and the "
+                + "Server-host's main cellar must be empty"
+        );
+        Log("Cellar-contents move confirmed");
+    }
+
+    /// <summary>Test 4 — as-is: importing without a bind preserves the master/owner identity (no
+    /// Server swap), and no finalize intent is consumed.</summary>
+    [Fact]
+    public async Task Import_AsIs_PreservesOwnerAsHost()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Seed the master as a real owner so the source isn't a clone-blank Server master; as-is
+        // keeps that owner AS the host (the headline trap, which this test pins as intended for a
+        // single-player-style import).
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Erin" },
+            ct
+        );
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(new TestImportSaveRequest(), ct); // no SwapHostTo
+        Assert.True(import?.Success == true, $"As-is import failed: {import?.Error}");
+        Assert.False(import!.Swapped, "As-is import must not report a swap");
+
+        await ReloadServerAsync();
+
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_AsIsPreserved,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+
+                // POSITIVE identity check: the master must STILL be the seeded owner "Erin" — proving
+                // as-is preserved the owner AS the host, NOT installed a blank "Server" master (which a
+                // wrongful swap would). (Asserting only "owner not in farmhandData" was vacuous: the
+                // master is never in farmhandData regardless. MasterName is the real signal.)
+                if (state.MasterName != "Erin")
+                {
+                    return false;
+                }
+                // And the owner must NOT have been demoted into a bound farmhand (belt-and-suspenders).
+                var boundFarmhand = state.FarmhandData.FirstOrDefault(f =>
+                    f.UniqueMultiplayerId == ownerUid && f.HasUserId
+                );
+                return boundFarmhand == null;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            "As-is import must leave the seeded owner 'Erin' as the host (not install a blank Server master)"
+        );
+        Log("As-is import preserved owner as host");
+    }
+
+    /// <summary>Test 5 — resilience (the core in-place fault-tolerance guarantee): importing a save
+    /// with a malformed &lt;player&gt; fails (Warn) and leaves the target main file byte-unchanged,
+    /// and a re-run after fixing the input succeeds.</summary>
+    [Fact]
+    public async Task Import_SwapHost_MalformedSave_LeavesFileByteUnchanged()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await GenerateSourceSaveAsync(new TestSeedImportSourceRequest { OwnerName = "Frank" }, ct);
+
+        // Clone the valid active save to a fresh folder, then corrupt the clone's <player> — one
+        // step. The original active save stays intact. CorruptSave returns the actual folder name it
+        // created (re-stamped uniqueID).
+        var corrupt = await ServerApi.CorruptSave("import-resilience", ct);
+        Assert.True(corrupt?.Success == true, $"CorruptSave failed: {corrupt?.Error}");
+        var corruptedFolder = corrupt!.TargetSaveName;
+        Assert.False(
+            string.IsNullOrEmpty(corruptedFolder),
+            "CorruptSave should return a folder name"
+        );
+
+        // Swap-import the corrupted clone (SkipClone — the corrupted bytes are what the transform
+        // sees). Must fail and leave the file byte-unchanged.
+        var importBad = await ServerApi.ImportSave(
+            new TestImportSaveRequest
+            {
+                TargetSaveName = corruptedFolder,
+                SwapHostTo = SyntheticBindId,
+                SkipClone = true,
+            },
+            ct
+        );
+        Assert.NotNull(importBad);
+        Assert.False(
+            importBad!.Swapped,
+            "A malformed-save import must not report a successful swap"
+        );
+        Assert.False(
+            string.IsNullOrEmpty(importBad.ImportError),
+            "A malformed-save import must report an import error"
+        );
+        // Byte-unchanged: the .tmp was discarded before any rename.
+        Assert.Equal(importBad.PreImportMainFileHash, importBad.PostImportMainFileHash);
+        Assert.False(
+            string.IsNullOrEmpty(importBad.PreImportMainFileHash),
+            "Pre-import hash should be non-empty (file existed)"
+        );
+        Log("Malformed import left the save byte-unchanged");
+
+        // Repeatability: clone a fresh copy from the valid active source and swap-import it — succeeds
+        // and leaves no .tmp behind. Use the actual folder the import created for the no-junk check.
+        var importGood = await ServerApi.ImportSave(
+            new TestImportSaveRequest
+            {
+                TargetSaveName = "import-resilience-ok",
+                SwapHostTo = SyntheticBindId,
+            },
+            ct
+        );
+        Assert.True(
+            importGood?.Success == true && importGood.Swapped,
+            $"Re-run on a valid save should succeed: {importGood?.ImportError ?? importGood?.Error}"
+        );
+        var leftover = await ServerApi.SaveTmpExists(importGood!.TargetSaveName, ct);
+        Assert.False(
+            leftover?.Exists == true,
+            "A successful import must leave no .tmp on the volume"
+        );
+        Log("Re-run on a fixed input succeeded (repeatable, no junk)");
+    }
+
+    /// <summary>Tests 7/7b/7c/8 (merged) — the blank Server master's Layer-A field handling, all of
+    /// which are independent of the finalizer and observable after one swap+reload, so one game-create
+    /// covers them. Asserts the three master-gated bucket-B fields are KEPT (mail/event flag,
+    /// caveChoice, the keyed Krobus friendship + stats.DaysPlayed — risk #9), AND the relationship
+    /// bucket-A field is CLEARED (spouse — risk #1; the demoted owner keeps theirs). Each property is
+    /// a distinct <c>Assert</c> so a regression names exactly which bucket decision broke.</summary>
+    [Fact]
+    public async Task Import_SwapHost_CarriesMasterGatedState()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        const string mailFlag = "ccDoorUnlock";
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest
+            {
+                OwnerName = "Grace",
+                MailFlag = mailFlag,
+                EventSeen = "191393",
+                CaveChoice = 1, // bat/fruit cave
+                ShadowFriendshipPoints = 1300, // > 1250 (Dark Shrine pacifism gate)
+                DaysPlayed = 42,
+                Spouse = "Abigail",
+            },
+            ct
+        );
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        await ReloadServerAsync();
+
+        // One diagnostics read carries BOTH query params (?masterFlag for the mail bit,
+        // ?masterFriendKey for the keyed friendship). Poll until the snapshot is populated, then make
+        // each assertion separately so a failure pinpoints the exact regressed field.
+        DiagnosticsStateResponse? state = null;
+        var ready = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_MasterGatedState,
+            async () =>
+            {
+                state = await ServerApi.GetDiagnosticsState(
+                    mailFlag,
+                    ct,
+                    masterFriendKey: "Krobus"
+                );
+                // Gate on the load completing: the master must be the fresh "Server" host.
+                return state is { MasterName: "Server" };
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(ready, "Swap import + reload did not produce a 'Server' master in time");
+
+        // Bucket B — KEEP (master-gated world-state; zeroing any reverts the imported world):
+        Assert.True(
+            state!.MasterHasFlag == true,
+            $"Master must carry the seeded mail flag '{mailFlag}' (mail/event store — CC/Joja/island geometry)"
+        );
+        Assert.Equal(1, state.MasterCaveChoice); // bat/fruit-cave daily regen
+        Assert.True(
+            state.MasterShadowFriendshipPoints is >= 1250,
+            $"Master must carry the Krobus friendship (shadow-pacifism gate), got "
+                + $"{state.MasterShadowFriendshipPoints?.ToString() ?? "null"}"
+        );
+        Assert.True(
+            state.MasterDaysPlayed >= 42,
+            $"Master must carry stats.DaysPlayed (same-day-reconnect gate), got {state.MasterDaysPlayed}"
+        );
+
+        // Bucket A — CLEAR (relationship state; a non-cleared spouse = duplicate/dangling marriage):
+        Assert.False(
+            state.MasterHasSpouse,
+            "Master spouse must be CLEARED (no duplicate marriage with the owner's NPC)"
+        );
+        // ...and the demoted owner (who KEEPS their spouse) is present in farmhands.
+        Assert.True(
+            state.FarmhandData.Any(f => f.UniqueMultiplayerId == ownerUid),
+            $"Demoted owner uid={ownerUid} must be present in farmhands"
+        );
+        Log("Master gated-state carry + spouse-clear confirmed");
+    }
+
+    /// <summary>Test 9 — finalizer is single-shot across reloads (risk #10): a successful swap import
+    /// finalizes exactly once. The intent is cleared in the finalize's <c>finally</c>, so a second
+    /// reload reads no pending intent and does NOT re-run — proven by the process-wide
+    /// <c>SaveImportFinalizeCount</c> going +1 on the first reload and STAYING (a re-fire would bump
+    /// it), not merely by the owner staying customized+bound (which a harmless re-run would also leave
+    /// intact). Without the <c>finally</c>, the second boot would re-finalize against an emptied
+    /// FarmHouse on every reload forever.
+    /// TODO: the mid-finalize-THROW partial-failure path (a throw after the contents move leaving a
+    /// stable but partially-moved world) is NOT exercised here — it would need a test-only fault-
+    /// injection knob in the finalizer, deliberately not wired to keep test-only code out of the
+    /// production path. Manual-verification gap; this test covers the success-path single-shot only.</summary>
+    [Fact]
+    public async Task Import_SwapHost_FinalizeIsSingleShot_AcrossReloads()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Judy", PlaceChest = true },
+            ct
+        );
+        var ownerUid = seed.OwnerUid;
+
+        // Capture the process-wide finalize counter BEFORE the import (the server may be reused across
+        // this Exclusive class's methods, so use a RELATIVE delta, not an absolute count of 1).
+        var preState = await ServerApi.GetDiagnosticsState(ct);
+        Assert.NotNull(preState);
+        var baseFinalizeCount = preState!.SaveImportFinalizeCount;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true, $"Import failed: {import?.Error}");
+
+        // First reload runs the finalizer exactly once.
+        await ReloadServerAsync();
+
+        // After the first reload: owner demoted + bound, FarmHouse empty, and the finalizer ran ONCE.
+        var firstOk = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_PartialThenStable,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+                var ownerEntry = state.FarmhandData.FirstOrDefault(f =>
+                    f.UniqueMultiplayerId == ownerUid
+                );
+                return ownerEntry is { IsCustomized: true, HasUserId: true }
+                    && state.FarmHouseObjectCount == 0
+                    && state.SaveImportFinalizeCount == baseFinalizeCount + 1;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            firstOk,
+            "First reload should finalize exactly once: owner demoted+bound, FarmHouse emptied, "
+                + "finalize count +1"
+        );
+
+        // Second reload: the intent was cleared in the finally, so the finalizer must NOT re-run.
+        // The finalize counter must stay at base+1 (a re-fire would bump it to +2) — this is the
+        // genuine single-shot proof, distinct from the owner merely staying customized+bound (which a
+        // harmless re-run would also leave intact).
+        await ReloadServerAsync();
+        var secondOk = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_SecondReloadNoop,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null)
+                {
+                    return false;
+                }
+                var ownerEntry = state.FarmhandData.FirstOrDefault(f =>
+                    f.UniqueMultiplayerId == ownerUid
+                );
+                return ownerEntry is { IsCustomized: true, HasUserId: true }
+                    && state.SaveImportFinalizeCount == baseFinalizeCount + 1;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            secondOk,
+            "Second reload must be a clean no-op (intent cleared in finally; no re-finalize loop)"
+        );
+        Log("Finalizer single-shot across reloads confirmed");
+    }
+
+    /// <summary>Test 10 — userID-collision guard (risk #12): a swap whose bind id collides with an
+    /// existing farmhand's userID is rejected (byte-unchanged), while a non-colliding id succeeds.</summary>
+    [Fact]
+    public async Task Import_SwapHost_RejectsUserIdCollision()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Seed a spare uncustomized farmhand slot with SyntheticBindId (before the save, so the clone
+        // carries it). A swap binding the SAME id must then be rejected by the cross-farmhand
+        // userID-collision walk (LAN won't stamp a userID on its own).
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest
+            {
+                OwnerName = "Karl",
+                InjectFarmhandUserId = SyntheticBindId,
+            },
+            ct
+        );
+        Assert.True(seed.FarmhandUserIdInjected, "Collision userID should have been injected");
+
+        var importBad = await ServerApi.ImportSave(
+            new TestImportSaveRequest
+            {
+                TargetSaveName = "import-collision",
+                SwapHostTo = SyntheticBindId,
+            },
+            ct
+        );
+        Assert.NotNull(importBad);
+        Assert.False(importBad!.Swapped, "A colliding-id import must not swap");
+        Assert.False(
+            string.IsNullOrEmpty(importBad.ImportError),
+            "A colliding-id import must report an error naming the conflict"
+        );
+        Assert.Equal(importBad.PreImportMainFileHash, importBad.PostImportMainFileHash);
+        Log("userID-collision rejected, save byte-unchanged");
+
+        // A non-colliding id succeeds.
+        var importGood = await ServerApi.ImportSave(
+            new TestImportSaveRequest
+            {
+                TargetSaveName = "import-collision-ok",
+                SwapHostTo = "76561190000000002",
+            },
+            ct
+        );
+        Assert.True(
+            importGood?.Success == true && importGood.Swapped,
+            $"A non-colliding id should succeed: {importGood?.ImportError ?? importGood?.Error}"
+        );
+        Log("Non-colliding id accepted");
+    }
+
+    // ── CI coverage gaps (documented, not faked) ──────────────────────────────────────
+    //
+    // TODO: Test 6 (1.5-origin fold) — needs a real pre-1.6 co-op save fixture at
+    //   tests/JunimoServer.Tests/Fixtures/SaveImport/legacy-1.5-coop/. In-process generation only
+    //   produces a 1.6 save, so the engine MigrateFarmhands fold (SaveMigrator_1_6.cs:1716-1730) is
+    //   not exercised by CI. The transform is compatible with both shapes (Layer A only touches
+    //   <player>/<farmhands>; the fold only touches cabins' obsolete_farmhand), but verify on a real
+    //   1.5 save when one can be sourced. Manual-verification step until then.
+    //
+    // TODO: spouse + children NPC relocation into the cabin (Layer B step 6) is a DISTINCT mechanism
+    //   from the pet path (Test 3): the child path is Farmer.getChildren() →
+    //   Utility.getHomeOfFarmer(this).getChildren() filtering Child NPCs by the FarmHouse characters
+    //   list + the Child.idOfParent re-stamp ordering; the spouse path relies on marriageDuties
+    //   self-relocation. Generating a married-with-kids source in-process is heavy. Test 8 covers the
+    //   master-spouse-CLEAR half (the part the clone-blank could get wrong); the NPC-object
+    //   relocation into the cabin is a manual-verification gap.
+    //
+    // TODO: full Community-Center-revert behavior (doors relock / greenhouse → ruins on a zeroed
+    //   master) is too heavy to generate in-process. Test 7 covers the MECHANISM (the master carries
+    //   the mail flag); the world-geometry consequence is a manual-verification step.
+    //
+    // TODO: full player-to-player marriage survival across the swap needs two customized farmhands;
+    //   Test 8 covers only the master-clear half. p2p-marriage survival is a manual-verification gap.
+}

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -55,22 +55,31 @@ public class SaveImportTests : TestBase
 
         // A connected, customized, in-world client is required for the day-transition save.
         var client = await Farmers.ConnectNewAsync(ct: ct);
-        var customized = await ServerApi.WaitForFarmhandByNameAsync(
-            client.FarmerName,
-            requireCustomized: true,
-            ct: ct
-        );
-        Assert.True(customized, $"Source client '{client.FarmerName}' should be customized");
+        try
+        {
+            var customized = await ServerApi.WaitForFarmhandByNameAsync(
+                client.FarmerName,
+                requireCustomized: true,
+                ct: ct
+            );
+            Assert.True(customized, $"Source client '{client.FarmerName}' should be customized");
 
-        var seedResult = await ServerApi.SeedImportSource(seed, ct);
-        Assert.True(seedResult?.Success == true, $"SeedImportSource failed: {seedResult?.Error}");
-        Assert.NotEqual(0, seedResult!.OwnerUid);
+            var seedResult = await ServerApi.SeedImportSource(seed, ct);
+            Assert.True(
+                seedResult?.Success == true,
+                $"SeedImportSource failed: {seedResult?.Error}"
+            );
+            Assert.NotEqual(0, seedResult!.OwnerUid);
 
-        // Flush to disk, then disconnect so /reload (which needs 0 clients) can run later.
-        await SleepToSaveAsync(ct);
-        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
-
-        return seedResult;
+            await SleepToSaveAsync(ct);
+            return seedResult;
+        }
+        finally
+        {
+            // Always disconnect so /reload (which needs 0 clients) can run later — even if an
+            // assertion above fails, a lingering client would cascade into later reload paths.
+            await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        }
     }
 
     /// <summary>Test 1 — swap+bind: the demoted owner becomes a bound customized cabin farmhand and a
@@ -121,8 +130,10 @@ public class SaveImportTests : TestBase
                     return false;
                 }
 
-                // The new master is "Server" and is NOT the former owner.
-                var serverMasterIsFresh = ownerEntry.Name != "Server";
+                // Assert the master identity directly — checking only that the owner isn't named
+                // "Server" would still pass if the master regressed to the old human host.
+                var serverMasterIsFresh =
+                    state.MasterName == "Server" && ownerEntry.Name != "Server";
                 return serverMasterIsFresh;
             },
             TestTimings.CabinAssignmentTimeout,
@@ -493,10 +504,8 @@ public class SaveImportTests : TestBase
             $"Re-run on a valid save should succeed: {importGood?.ImportError ?? importGood?.Error}"
         );
         var leftover = await ServerApi.SaveTmpExists(importGood!.TargetSaveName, ct);
-        Assert.False(
-            leftover?.Exists == true,
-            "A successful import must leave no .tmp on the volume"
-        );
+        Assert.True(leftover?.Success == true, $"SaveTmpExists failed: {leftover?.Error}");
+        Assert.False(leftover!.Exists, "A successful import must leave no .tmp on the volume");
         Log("Re-run on a fixed input succeeded (repeatable, no junk)");
     }
 

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -514,7 +514,7 @@ public class SaveImportTests : TestBase
 
     /// <summary>Tests 7/7b/7c/8 (merged) — the blank Server master's Layer-A field handling, all of
     /// which are independent of the finalizer and observable after one swap+reload, so one game-create
-    /// covers them. Asserts the three master-gated bucket-B fields are KEPT (mail/event flag,
+    /// covers them. Asserts the master-gated bucket-B fields are KEPT (mailReceived, eventsSeen,
     /// caveChoice, the keyed Krobus friendship + stats.DaysPlayed — risk #9), AND the relationship
     /// bucket-A field is CLEARED (spouse — risk #1; the demoted owner keeps theirs). Each property is
     /// a distinct <c>Assert</c> so a regression names exactly which bucket decision broke.</summary>
@@ -523,12 +523,13 @@ public class SaveImportTests : TestBase
     {
         var ct = TestContext.Current.CancellationToken;
         const string mailFlag = "ccDoorUnlock";
+        const string eventSeen = "191393";
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest
             {
                 OwnerName = "Grace",
                 MailFlag = mailFlag,
-                EventSeen = "191393",
+                EventSeen = eventSeen,
                 CaveChoice = 1, // bat/fruit cave
                 ShadowFriendshipPoints = 1300, // > 1250 (Dark Shrine pacifism gate)
                 DaysPlayed = 42,
@@ -557,7 +558,8 @@ public class SaveImportTests : TestBase
                 state = await ServerApi.GetDiagnosticsState(
                     mailFlag,
                     ct,
-                    masterFriendKey: "Krobus"
+                    masterFriendKey: "Krobus",
+                    masterEvent: eventSeen
                 );
                 // Gate on the load completing: the master must be the fresh "Server" host.
                 return state is { MasterName: "Server" };
@@ -570,7 +572,11 @@ public class SaveImportTests : TestBase
         // Bucket B — KEEP (master-gated world-state; zeroing any reverts the imported world):
         Assert.True(
             state!.MasterHasFlag == true,
-            $"Master must carry the seeded mail flag '{mailFlag}' (mail/event store — CC/Joja/island geometry)"
+            $"Master must carry the seeded mailReceived flag '{mailFlag}' (CC/Joja/island geometry)"
+        );
+        Assert.True(
+            state.MasterHasEvent == true,
+            $"Master must carry the seeded eventsSeen id '{eventSeen}' (distinct collection from mailReceived)"
         );
         Assert.Equal(1, state.MasterCaveChoice); // bat/fruit-cave daily regen
         Assert.True(

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -22,6 +22,12 @@ namespace JunimoServer.Tests;
 /// is customized but has <c>userID==""</c> (LAN never stamps — <c>abandoned-claim-is-steam-only.md</c>),
 /// so <c>HasUserId==true</c> after reload proves Layer B re-stamped the bind, not a carried value.
 ///
+/// The two <c>saves reload</c> guard tests instead drive the real console command via
+/// <c>POST /test/console</c> (SMAPI 4.4 exposes no public API to invoke a console command, so the
+/// endpoint reflects into SMAPI's command registry) — exercising the actual <c>SavesCommand</c> guard
+/// + force-kick path, not the separate <c>/reload</c> endpoint guard. They still assert via the
+/// snapshot.
+///
 /// Class-level <c>Exclusive</c> serializes the methods (each begins with its own
 /// <c>CreateNewGameOnServerAsync</c>, so a prior test's imported active save never leaks in) — see
 /// <c>test-broker-invariants.md</c>.
@@ -737,6 +743,130 @@ public class SaveImportTests : TestBase
         Log("Non-colliding id accepted");
     }
 
+    /// <summary>Test 12 — the <c>saves reload</c> client guard: with a player connected, a plain
+    /// <c>--reload</c> (no force) must REFUSE — the world does not reload, so the queued swap import is
+    /// NOT finalized (master stays the seeded owner, not "Server") and the connected player stays.
+    /// Drives the real console command via /test/console (SMAPI exposes no Trigger API), so this
+    /// exercises the actual guard in SavesCommand, not the /reload endpoint's separate guard.</summary>
+    [Fact]
+    public async Task Import_Reload_RefusesWhenClientConnected()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        // Seed the master as a real owner "Nina" so the ACTIVE world's MasterName is "Nina" — a
+        // finalized swap would flip it to "Server", so MasterName staying "Nina" proves no reload.
+        await GenerateSourceSaveAsync(new TestSeedImportSourceRequest { OwnerName = "Nina" }, ct);
+
+        // Queue a swap import of a clone (sets SaveNameToLoad to the imported clone). The active world
+        // is untouched — the import runs against the clone folder, not Game1.
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true && import.Swapped, $"Import failed: {import?.Error}");
+
+        // Connect a player to the ACTIVE world so the guard sees a connected client.
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        try
+        {
+            var clientUid = client.JoinResult.UniqueMultiplayerId;
+            Assert.True(
+                await ServerApi.WaitForPlayerByIdAsync(clientUid, ct: ct),
+                "Guard test requires the client to be connected before the reload"
+            );
+
+            // Plain reload — must refuse (a player is connected and we did not force).
+            var cmd = await ServerApi.RunConsoleCommand("saves", new[] { "reload" }, ct);
+            Assert.True(cmd?.Success == true, $"Console command dispatch failed: {cmd?.Error}");
+
+            // Negative assertion (refusal): a reload would ExitToTitle — dropping the client and
+            // flipping the master to "Server" within a tick or two. Wait a settle window long enough
+            // for a wrongful reload to manifest (mirrors TimePausedVerification's "state must NOT
+            // change" idiom), then assert the steady state held: client still on, master still "Nina".
+            await Task.Delay(TestTimings.TimePausedVerification, ct);
+
+            var players = await ServerApi.GetPlayers(ct);
+            Assert.True(
+                players?.Players.Any(p => p.Id == clientUid) == true,
+                "A plain --reload with a client connected must refuse — the client must stay connected "
+                    + "(a reload would have ExitToTitle'd it)"
+            );
+            var state = await ServerApi.GetDiagnosticsState(ct);
+            Assert.Equal("Nina", state?.MasterName); // "Server" would mean the swap wrongly finalized
+            Log("Plain reload refused while a client was connected (import stays queued)");
+        }
+        finally
+        {
+            // The refused client is still connected — disconnect so it can't cascade into another
+            // Exclusive method on this shared server.
+            await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        }
+    }
+
+    /// <summary>Test 13 — <c>saves reload --force</c> with a player connected: kicks the player, then
+    /// reloads, finalizing the queued swap WITHOUT a separate restart. Proves the force-kick path and
+    /// that the reload runs the Layer B finalizer (kicked player gone from /players, swap finalized to
+    /// a "Server" master with the owner a bound cabin farmhand).</summary>
+    [Fact]
+    public async Task Import_ForceReload_KicksThenFinalizes()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var seed = await GenerateSourceSaveAsync(
+            new TestSeedImportSourceRequest { OwnerName = "Omar" },
+            ct
+        );
+        var ownerUid = seed.OwnerUid;
+
+        var import = await ServerApi.ImportSave(
+            new TestImportSaveRequest { SwapHostTo = SyntheticBindId },
+            ct
+        );
+        Assert.True(import?.Success == true && import.Swapped, $"Import failed: {import?.Error}");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var clientUid = client.JoinResult.UniqueMultiplayerId;
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(clientUid, ct: ct),
+            "Force test requires the client to be connected before the reload"
+        );
+
+        // Force reload — broadcasts, kicks the connected player, then reloads the queued import.
+        var cmd = await ServerApi.RunConsoleCommand("saves", new[] { "reload", "--force" }, ct);
+        Assert.True(cmd?.Success == true, $"Console command dispatch failed: {cmd?.Error}");
+
+        // The kicked player is gone (ExitToTitle disconnects everyone regardless, but the explicit
+        // kick precedes it) and the swap finalized into a fresh "Server" master with the demoted owner
+        // a bound cabin farmhand — the same end state as a restart, with no restart.
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_SaveImport_ForceReloadKicksAndFinalizes,
+            async () =>
+            {
+                var state = await ServerApi.GetDiagnosticsState(ct);
+                if (state == null || state.MasterName != "Server")
+                {
+                    return false;
+                }
+                var ownerEntry = state.FarmhandData.FirstOrDefault(f =>
+                    f.UniqueMultiplayerId == ownerUid
+                );
+                if (ownerEntry is not { IsCustomized: true, HasUserId: true })
+                {
+                    return false;
+                }
+                // The kicked client is no longer present.
+                var players = await ServerApi.GetPlayers(ct);
+                return players?.Players.All(p => p.Id != clientUid) == true;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ok,
+            "Force reload must kick the connected player and finalize the swap in-process: fresh "
+                + "'Server' master, owner a bound cabin farmhand, kicked client gone from /players"
+        );
+        Log("Force reload kicked the connected player and finalized the swap without a restart");
+    }
+
     // ── CI coverage gaps (documented, not faked) ──────────────────────────────────────
     //
     // TODO: Test 6 (1.5-origin fold) — needs a real pre-1.6 co-op save fixture at
@@ -760,4 +890,12 @@ public class SaveImportTests : TestBase
     //
     // TODO: full player-to-player marriage survival across the swap needs two customized farmhands;
     //   Test 8 covers only the master-clear half. p2p-marriage survival is a manual-verification gap.
+    //
+    // NOTE: Test 13 (force reload) can't ISOLATE the courtesy kick from the reload's own ExitToTitle —
+    //   both disconnect the client, so via the HTTP snapshot (tests-assert-via-http-api.md) "client
+    //   gone" is satisfied either way. What it DOES prove is that --force gets past the guard that
+    //   Test 12 shows blocks a plain reload, then finalizes. The explicit kick firing first is visible
+    //   only in the client log ("Disconnected: Kicked" before "ExitedToMainMenu") — diagnostics, not
+    //   an assertion surface. Isolating the kick would need a snapshot signal the kick produces that
+    //   ExitToTitle doesn't; none exists, so it's a documented gap, not faked coverage.
 }


### PR DESCRIPTION
Adds a `saves import <name> [--swap-host-to <id>]` console command (replacing `saves select`) to import an existing Stardew co-op/single-player save into the `multiplayerMode=2` dedicated server, where the master farmer is the automated headless host.

## Modes
- **As-is import** (`saves import <name>`): point the next boot at the save (subsumes the old `saves select`). Warns loudly that the save's owner becomes the headless host.
- **Swap + bind** (`saves import <name> --swap-host-to <id>`): demote the save's original `<player>` owner into a customized cabin farmhand bound to a platform id (Steam64 or GOG Galaxy uint64), and install a fresh blank "Server" master.

## Layer A — pre-load XML transform (`SaveImportXmlTransform`)
- Pure `XmlDocument`, no `Game1` (runs at the title screen, before any save is loaded).
- Clone-blank the master from the save's own `<player>` (3-bucket policy: clear personal progress + relationship state; keep master-gated world-state — mail/events/`caveChoice`/`friendshipData`/`stats`; leave inert fields).
- Reparent the original owner into `<farmhands>`, stamp `userID`, fresh collision-checked `UniqueMultiplayerID`.
- Re-import guard + cross-farmhand userID-collision guard.
- Fault-tolerant temp-then-atomic-rename: a failed/partial transform leaves the loadable save byte-intact and the boot target untouched.

## Layer B — load-time finalizer (`CabinManagerService`, at `SaveLoaded`)
- Homes the demoted owner into a cabin (reuse an auto-assigned spare, else build) and re-stamps `userID`.
- Moves location-bound state the `Farmer` record doesn't carry: farmhouse contents (objects/furniture/fridge/mini-jukebox/wallpaper+floor/terrain), household NPCs (pet/spouse/children), and **cellar casks** into the owner's reassigned per-slot cellar.
- Single-shot via `try/finally` intent clear — a failed finalize never retries against an already-mutated world.

## Supporting changes
- `ServerFarmerIdentity` centralizes the shared host identity literals so the new-game and import hosts can't drift.
- `GameLoaderService` made `public` for DI; `SavesCommand`/`ModEntry` wire the new command.
- `/diagnostics/state` extended with save-import probes (farmhouse/cabin/cellar counts, master-gated-state booleans/ints); new `/test/*` endpoints (`seed_import_source`, `import_save`, `corrupt_save`, `save_tmp_exists`).

## Tests
- New `SaveImportTests` E2E suite (10 methods), asserting only via the HTTP API snapshot per `tests-assert-via-http-api.md`: swap+bind, contents move (reuse + build path), pet relocation, cellar move, as-is, malformed-save resilience, master-gated-state carry, single-shot finalize, userID-collision.
- Full suite verified green locally.

## Documented coverage gaps (TODOs in the test file)
- 1.5-origin save fold (needs a real pre-1.6 fixture), spouse/children NPC relocation into the cabin, full CC-revert world geometry, p2p-marriage survival — each a manual-verification step.
- Spouse outdoor patio remains a documented swap loss (master-marriage-keyed, rebuilt daily).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced `saves select` with one-shot `saves import <name>`, including `--swap-host-to <id>` for co-op, plus `--reload`/`--force-reload` (and `saves reload` equivalents) for immediate reload behavior.
  * Expanded `/diagnostics/state` with additional save-import and cabin inventory probes to verify imports after restart/reload.

* **Bug Fixes**
  * Adjusted save-info output so missing/unreadable save details are reported as warnings instead of errors.

* **Documentation**
  * Updated admin commands, troubleshooting, FAQ, and backup/import guides to reflect the new import-based workflow and “as-is vs swap” semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->