### PR TITLE
feat(cabin): !cabin reset, door-dead dummy cabin, and multi-player cabin tests

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -97,7 +97,6 @@ COPY ./mod /src/mod
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet build /src/mod/JunimoServer/JunimoServer.csproj \
     --configuration ${BUILD_CONFIGURATION} \
-    --no-restore \
     /p:GamePath=/game \
     -o /output/JunimoServer
 

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -85,7 +85,6 @@ COPY ./mod/JunimoServer.Shared /src/mod/JunimoServer.Shared
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet build /src/tests/test-client/JunimoTestClient.csproj \
     --configuration ${BUILD_CONFIGURATION} \
-    --no-restore \
     /p:GamePath=/game \
     /p:EnableModDeploy=false \
     -o /output/JunimoTestClient \

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -547,6 +547,34 @@ public class CabinManagerService : ModService
             {
                 cabin.Relocate(StackLocation.Create(_cabinManagerData).ToPoint());
             }
+            else if (cabin != null && !cabin.IsInHiddenStack())
+            {
+                // This peer's own cabin is NOT in the hidden stack (they moved it via
+                // /cabin, or it imported visible under KeepExisting), so they'd otherwise
+                // see an empty spot at the shared StackLocation where everyone else sees a
+                // cabin. Render one hidden-stack cabin there as a *door-dead* dummy so the
+                // empty spot is filled without exposing another player's home.
+                //
+                // Both routes (!cabin-moved and KeepExisting-imported-visible) reach this
+                // branch through the identical `!IsInHiddenStack()` precondition, which is all
+                // this branch reads — the saved-position intent map is not consulted here. So
+                // the !cabin-moved E2E test (DummyCabin_AfterMoveAndReconnect...) covers the
+                // KeepExisting route by equivalence; a separate KeepExisting test would
+                // exercise the same dummy code with heavier strategy-setup, not new coverage.
+                //
+                // FirstOrDefault + null-guard are load-bearing defense: a First/. would turn
+                // the (effectively unreachable on a real join — EnsureAtLeastXCabins replenishes
+                // the hidden pool before locationIntroduction) zero-candidate case into a broken
+                // join handshake. IsInHiddenStack() checks (-20,-20) only, so lobby cabins at
+                // (-21,-21) are excluded automatically.
+                var dummy = farm.buildings.FirstOrDefault(b =>
+                    b.isCabin && b != cabin && b.IsInHiddenStack()
+                );
+                if (dummy != null)
+                {
+                    PlaceDoorDeadDummyCabin(dummy);
+                }
+            }
         }
 
         // Update the outgoing message
@@ -555,6 +583,31 @@ public class CabinManagerService : ModService
             farm.Root,
             forceCurrentLocation
         );
+    }
+
+    /// <summary>
+    /// Renders a hidden-stack cabin at the shared StackLocation as a door-dead dummy, mutating
+    /// only the per-peer message copy passed in. The cabin fills the empty spot the peer would
+    /// otherwise see, but its door is a no-op — stepping on it does nothing, so it never exposes
+    /// the real owner's home.
+    ///
+    /// How the door is killed sure-fire: Building.doAction only warps the player inside when
+    /// GetIndoors() != null (decompiled Building.cs:950). GetIndoors() reads indoors.Value then
+    /// nonInstancedIndoorsName; null both → no interior → no entry. The client never re-creates
+    /// the interior: LoadFromBuildingData's createIndoors is gated on `hasLoaded || forConstruction`
+    /// (Building.cs:523), and hasLoaded is only ever set on the master (Building.load() early-returns
+    /// `if (!Game1.IsMasterGame)`), so on a farmhand client hasLoaded stays false and the nulled
+    /// interior survives deserialization. humanDoor IS reset from data on the client, but that's
+    /// irrelevant once GetIndoors() is null. This mutates the deserialized copy only (NetRoot.Connect
+    /// builds a fresh graph), so master state and other peers are untouched.
+    /// </summary>
+    private void PlaceDoorDeadDummyCabin(Building dummy)
+    {
+        dummy.SetPosition(StackLocation.Create(_cabinManagerData).ToPoint());
+        // Kill the door: null both interior references so GetIndoors() returns null on the client.
+        // No need to set interior warps — there is no interior to warp into anymore.
+        dummy.indoors.Value = null;
+        dummy.nonInstancedIndoorsName.Value = null;
     }
 
     private void OnLocationDeltaMessage(MessageContext context)

--- a/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
@@ -40,11 +40,11 @@ public static class CabinPlacementValidator
                     continue;
                 }
 
-                if (!IsTileBuildable(farm, cabin, tile, buildableRect, out failureReason))
-                {
-                    return false;
-                }
-
+                // Farmer collision is checked BEFORE buildability: a standing farmer also
+                // trips IsTileBuildable's CanItemBePlacedHere (CollisionMask.All +
+                // useFarmerTile:true), so checking buildability first would always report the
+                // generic "blocked by terrain or object" and make this specific message
+                // unreachable.
                 foreach (var farmer in farm.farmers)
                 {
                     // Skip the AlwaysOn host: it stands parked on the Farm but is
@@ -65,6 +65,11 @@ public static class CabinPlacementValidator
                         failureReason = "another player is standing there";
                         return false;
                     }
+                }
+
+                if (!IsTileBuildable(farm, cabin, tile, buildableRect, out failureReason))
+                {
+                    return false;
                 }
             }
         }

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -1,3 +1,4 @@
+using System;
 using JunimoServer.Services.CabinManager;
 using JunimoServer.Services.ChatCommands;
 using JunimoServer.Services.PersistentOption;
@@ -19,15 +20,24 @@ public static class CabinCommand
     {
         chatCommandsService.RegisterCommand(
             "cabin",
-            "Moves your cabin to the right of your player.\nThis will clear basic debris to make space.",
+            "Moves your cabin to the right of your player.\nThis will clear basic debris to make space.\nUse '!cabin reset' to send your cabin back to the shared stack.",
             (args, msg) =>
             {
                 if (cabinService.options.IsFarmHouseStack)
                 {
+                    // FarmhouseStack rejects both move and reset before any subcommand
+                    // parsing: cabins stay in the farmhouse, so there is nothing to move
+                    // or to send back to a stack.
                     helper.SendPrivateMessage(
                         msg.SourceFarmer,
                         "Can't move cabin. The host has chosen to keep all cabins in the farmhouse."
                     );
+                    return;
+                }
+
+                if (args.Length > 0 && args[0].Equals("reset", StringComparison.OrdinalIgnoreCase))
+                {
+                    ResetCabin(helper, cabinService, msg);
                     return;
                 }
 
@@ -87,5 +97,66 @@ public static class CabinCommand
                 cabin.Relocate(topLeft);
             }
         );
+    }
+
+    /// <summary>
+    /// Sends the player's cabin back to the hidden stack and clears their saved-position
+    /// intent, undoing a prior !cabin placement. Keyed on the cabin's visibility, not on
+    /// whether an intent entry exists: a half-applied reset (intent cleared but cabin still
+    /// visible) is recoverable by re-running the command, with no dependence on a later
+    /// sweep (which only runs under ExistingCabinBehavior=MoveToStack). The FarmhouseStack
+    /// gate is handled by the caller before this runs.
+    /// </summary>
+    private static void ResetCabin(
+        IModHelper helper,
+        CabinManagerService cabinService,
+        ReceivedMessage msg
+    )
+    {
+        var cabin = Game1.getFarm().GetCabin(msg.SourceFarmer);
+
+        if (cabin == null)
+        {
+            helper.SendPrivateMessage(
+                msg.SourceFarmer,
+                "Can't reset cabin. (Your cabin was not found, which should not happen.)"
+            );
+            return;
+        }
+
+        // Clear the intent BEFORE moving the cabin. A throw mid-way then leaves
+        // "no intent + still visible", which a re-run of reset fixes (it's keyed on
+        // visibility); the reverse order could leave "intent + hidden", pinning a hidden
+        // cabin out of every future sweep with no user-visible way to clear it. TryRemove
+        // ignores a miss — the dict is a ConcurrentDictionary and may have no entry under
+        // None (intent is written but never read) or after a half-applied reset.
+        cabinService.Data.PlayerCabinPositions.TryRemove(msg.SourceFarmer, out _);
+        cabinService.Data.Write();
+
+        if (cabinService.options.IsNone)
+        {
+            // None has no hidden stack — cabins live at real visible positions. Clear the
+            // (unread) intent entry, but leave the cabin where it is.
+            helper.SendPrivateMessage(
+                msg.SourceFarmer,
+                "Cabin placement reset. (Under this server's strategy your cabin stays where it is.)"
+            );
+            return;
+        }
+
+        if (cabin.IsInHiddenStack())
+        {
+            helper.SendPrivateMessage(
+                msg.SourceFarmer,
+                "Nothing to reset — your cabin is already in the shared stack."
+            );
+            return;
+        }
+
+        // SetPosition (not Relocate): same call the bulk movers use to send a cabin to the
+        // hidden stack. OnLocationDeltaMessage re-points the cabin's door on the next
+        // location introduction, so warps follow the established path.
+        cabin.SetPosition(CabinManagerService.HiddenCabinLocation);
+        helper.SendPrivateMessage(msg.SourceFarmer, "Cabin reset — it's back in the shared stack.");
     }
 }

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -127,18 +127,49 @@ public class CabinPlacementValidationTests : TestBase
     }
 
     /// <summary>
+    /// !cabin off the Farm is rejected with "Must be on Farm" and records no intent. A
+    /// fresh farmhand spawns inside its cabin interior — already off-Farm — so no warp is
+    /// needed; this asserts the location gate fires before any placement.
+    /// </summary>
+    [Fact]
+    public async Task OffFarm_RejectsAndDoesNotMove()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+        var baseline = await GetOurCabinAsync(ownerId, ct);
+
+        var rejected = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Rejected,
+            () => Chat.AssertResponseAsync("!cabin", "Must be on Farm"),
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(rejected, "Expected a 'Must be on Farm' rejection reply");
+
+        var after = await GetOurCabinAsync(ownerId, ct);
+        Assert.True(after.IsHidden, "Cabin should still be hidden after an off-Farm reject");
+        Assert.Equal((baseline.TileX, baseline.TileY), (after.TileX, after.TileY));
+
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        Assert.DoesNotContain(ownerId, cabins.SavedPositionPlayerIds);
+
+        await Exceptions.AssertNoExceptionsAsync("after off-Farm !cabin");
+    }
+
+    /// <summary>
     /// Another connected, visible farmer standing in the footprint must reject with
     /// "another player is standing there" — and the host (skipped via IsMainPlayer)
     /// must NOT trigger that rejection on its own.
     ///
-    /// Skipped: needs a second concurrently-connected farmer, which the shared
-    /// connection helpers don't support (they bind to the single primary client). The
-    /// body documents the contained mechanism — a second ConnectionHelper over a
-    /// second lease — so enabling it later is mechanical.
+    /// First consumer of the second-farmer helper (plan 02): a second concurrently-
+    /// connected farmer over its own lease. <c>await using</c> disposes it before this
+    /// class's <c>DisposeAsync</c> runs <c>/newgame</c> (409s while any client is connected).
     /// </summary>
-    [Fact(
-        Skip = "Needs a 2nd concurrently-connected farmer (first in suite); deferred — see body for approach"
-    )]
+    [Fact]
     public async Task AnotherPlayerInFootprint_RejectsAndDoesNotMove()
     {
         var ct = TestContext.Current.CancellationToken;
@@ -149,29 +180,16 @@ public class CabinPlacementValidationTests : TestBase
         await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
         var baseline = await GetOurCabinAsync(ownerIdA, ct);
 
-        // Second farmer over its own lease + ConnectionHelper (LAN; Steam not needed).
-        var nameB = Farmers.GenerateName("FarmerB");
-        // Scope leaseB so its client disconnects before this class's DisposeAsync runs
-        // /newgame — that reset returns 409 while any client is still connected, and
-        // ResourceLease.DisposeAsync would otherwise dispose leaseB too late.
-        await using var leaseB = await LeaseClientAsync(ct);
-        var connB = new ConnectionHelper(leaseB.Client, serverApi: ServerApi);
-        var joinB = await connB.JoinWorldViaLanAsync(
-            Lease!.ServerLanAddress,
-            Lease.ServerLanPort,
-            nameB,
-            cancellationToken: ct
-        );
-        Farmers.TrackFarmer(nameB, joinB.UniqueMultiplayerId);
+        await using var farmerB = await Farmers.ConnectSecondFarmerAsync(ct: ct);
 
         // Stand B inside A's prospective footprint.
-        var warpB = await leaseB.Client.Actions.Warp(
+        var warpB = await farmerB.Client.Actions.Warp(
             "Farm",
             CabinPlacementHelper.ExpectedCabinTile.X + 1,
             CabinPlacementHelper.ExpectedCabinTile.Y
         );
         Assert.True(warpB?.Success == true, $"B warp failed: {warpB?.Error}");
-        await leaseB.Client.WaitForLocationAsync("^Farm$", ct: ct);
+        await farmerB.Client.WaitForLocationAsync("^Farm$", ct: ct);
 
         var rejected = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_CabinPlacement_Rejected,

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -189,7 +189,14 @@ public class CabinPlacementValidationTests : TestBase
             CabinPlacementHelper.ExpectedCabinTile.Y
         );
         Assert.True(warpB?.Success == true, $"B warp failed: {warpB?.Error}");
-        await farmerB.Client.WaitForLocationAsync("^Farm$", ct: ct);
+        // WaitForLocationAsync returns non-null only when the location matched ^Farm$ within
+        // the timeout; assert it so a B-not-settled failure surfaces here, not as an opaque
+        // "no rejection" timeout below.
+        var bArrived = await farmerB.Client.WaitForLocationAsync("^Farm$", ct: ct);
+        Assert.True(
+            bArrived is not null,
+            "Farmer B did not reach the Farm before the rejection check"
+        );
 
         var rejected = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_CabinPlacement_Rejected,

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -38,6 +38,22 @@ public class CabinPositionPersistenceTests : TestBase
         {
             try
             {
+                // Disconnect the primary first: /newgame 409s while any client is connected.
+                // Most tests in this class disconnect mid-body, but a few (two-player and the
+                // dummy reconnect tests) leave the primary connected — without this the reset
+                // would 409 and leak CabinStack/None state into the next test. Tolerant: a
+                // no-op throw when already at title must not block the reset.
+                try
+                {
+                    await DisconnectAsync();
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(
+                        $"Primary disconnect during cleanup failed (may already be at title): {ex.Message}"
+                    );
+                }
+
                 await CreateNewGameOnServerAsync(farmType: 0);
             }
             catch (Exception ex)
@@ -197,6 +213,314 @@ public class CabinPositionPersistenceTests : TestBase
 
         Assert.True(cleared, $"Saved-position intent was not cleared for deleted owner {ownerId}");
         Log($"Intent cleared for deleted owner {ownerId}");
+    }
+
+    /// <summary>
+    /// !cabin reset undoes a placement: the cabin returns to the hidden stack and the
+    /// saved-position intent is cleared. The reset must survive a save+reload — under
+    /// MoveToStack the now-unsaved cabin stays hidden (it isn't resurrected), confirming
+    /// the intent really was cleared rather than just the building moved.
+    /// </summary>
+    [Fact]
+    public async Task ResetCabin_ReturnsCabinToStackAndClearsIntent()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        Log($"Cabin placed at ({movedTile.X},{movedTile.Y}) for '{client.FarmerName}'");
+
+        var withIntent = await ServerApi.GetCabins(ct);
+        Assert.NotNull(withIntent);
+        Assert.Contains(ownerId, withIntent.SavedPositionPlayerIds);
+
+        // Resend each poll: /cabins is snapshot-backed, so the hide can lag the reset by a
+        // tick. Resending !cabin reset is idempotent — once hidden it just replies
+        // "nothing to reset".
+        CabinInfoResponse? afterReset = null;
+        CabinsResponse? snapshot = null;
+        var reset = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinReset_CabinHidden,
+            async () =>
+            {
+                await GameClient.SendChat("!cabin reset");
+                snapshot = await ServerApi.GetCabins(ct);
+                afterReset = snapshot?.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+                return afterReset?.IsHidden == true
+                    && snapshot?.SavedPositionPlayerIds.Contains(ownerId) == false;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(reset, "Cabin did not return to the hidden stack after !cabin reset");
+        Log($"Cabin reset to hidden stack; intent cleared for owner {ownerId}");
+
+        await SleepToSaveAsync(ct);
+        // Disconnect before reload: /reload returns 409 while a client is connected.
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, ct);
+        await ReloadServerAsync();
+
+        var afterReload = await GetOurCabinAsync(ownerId, ct);
+        Assert.True(
+            afterReload.IsHidden,
+            $"Cabin resurfaced after reload (at {afterReload.TileX},{afterReload.TileY}); reset did not survive the save"
+        );
+        Log("Cabin stayed hidden across reload after reset");
+    }
+
+    /// <summary>
+    /// Same-pass sweep selectivity: in a single None→CabinStack migration, A's /cabin-placed
+    /// cabin (saved intent) must survive while B's untouched cabin (no intent) is swept to the
+    /// hidden stack. The existing reload tests prove each direction alone; this proves the
+    /// HasSavedPosition filter is selective *within one pass* — catching filter inversion (A
+    /// swept, B kept) and owner-id resolution returning the wrong farmer's key.
+    /// </summary>
+    [Fact]
+    public async Task SameSweep_KeepsPlacedCabin_SweepsUntouchedCabin()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None", startingCabins: 2);
+
+        var clientA = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerIdA = clientA.JoinResult.UniqueMultiplayerId;
+
+        await using var farmerB = await Farmers.ConnectSecondFarmerAsync(ct: ct);
+        // Wait for B's farmhand to be customized so its cabin claim (owner UniqueMultiplayerID)
+        // exists before the sweep resolves HasSavedPosition by owner id.
+        var bCustomized = await ServerApi.WaitForFarmhandByNameAsync(
+            farmerB.FarmerName,
+            requireCustomized: true,
+            ct: ct
+        );
+        Assert.True(bCustomized, $"Farmer B '{farmerB.FarmerName}' never customized");
+
+        // A places via !cabin (records intent); B does nothing.
+        var aTile = await MoveCabinViaCommandAsync(ownerIdA, ct);
+        Log($"A placed cabin at ({aTile.X},{aTile.Y}); B untouched");
+
+        // Disconnect B before sleeping: an idle connected farmer blocks the day-end ready
+        // check. B's claim persists into farmhandData on disconnect and is written by the save.
+        await farmerB.DisconnectAsync();
+        var bPersisted = await ServerApi.WaitForFarmhandByNameAsync(
+            farmerB.FarmerName,
+            requireCustomized: true,
+            ct: ct
+        );
+        Assert.True(bPersisted, $"Farmer B '{farmerB.FarmerName}' not persisted after disconnect");
+
+        await SleepToSaveAsync(ct);
+        // Disconnect A before reload: /reload returns 409 while a client is connected.
+        await Farmers.DisconnectAndWaitForPersistenceAsync(clientA.FarmerName, ct);
+
+        await SwitchCabinStrategyAsync("CabinStack", ct);
+        await ReloadServerAsync();
+
+        // A's saved cabin survived at its tile; B's untouched cabin was swept to the stack.
+        // Poll, don't read once: /reload resolves on master finality, but /cabins is served
+        // from a snapshot refreshed only on the ~1s UpdateTicked timer (ApiService
+        // TakeGameStateSnapshot), which /reload does not force. So the swept state can lag the
+        // reload by a snapshot tick — same reason Deletion_ClearsSavedPositionIntent polls.
+        CabinInfoResponse? aAfter = null;
+        CabinInfoResponse? bAfter = null;
+        CabinsResponse? cabins = null;
+        var settled = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinSweep_PostReloadSettled,
+            async () =>
+            {
+                cabins = await ServerApi.GetCabins(ct);
+                aAfter = cabins?.Cabins.FirstOrDefault(c => c.OwnerId == ownerIdA);
+                bAfter = cabins?.Cabins.FirstOrDefault(c => c.OwnerId == farmerB.Uid);
+                return aAfter is { IsHidden: false }
+                    && (aAfter.TileX, aAfter.TileY) == aTile
+                    && bAfter is { IsHidden: true };
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(
+            settled,
+            $"Post-reload sweep not as expected: A={(aAfter == null ? "null" : $"({aAfter.TileX},{aAfter.TileY}) hidden={aAfter.IsHidden}")}, "
+                + $"B={(bAfter == null ? "null" : $"({bAfter.TileX},{bAfter.TileY}) hidden={bAfter.IsHidden}")}"
+        );
+
+        Assert.NotNull(cabins);
+        Assert.Contains(ownerIdA, cabins.SavedPositionPlayerIds);
+        Assert.DoesNotContain(farmerB.Uid, cabins.SavedPositionPlayerIds);
+        Log("Same-pass sweep kept A's placed cabin and swept B's untouched cabin");
+    }
+
+    /// <summary>
+    /// Two concurrent farmers each place their cabin via !cabin to a distinct, non-overlapping
+    /// tile. Confirms placement is keyed by the sending farmer (msg.SourceFarmer): each owns
+    /// the right tile and both ids appear in SavedPositionPlayerIds.
+    /// </summary>
+    [Fact]
+    public async Task TwoPlayers_PlaceCabinsToDistinctTiles()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var clientA = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerIdA = clientA.JoinResult.UniqueMultiplayerId;
+
+        await using var farmerB = await Farmers.ConnectSecondFarmerAsync(ct: ct);
+
+        // A places at the standard tile.
+        var aTile = await MoveCabinViaCommandAsync(ownerIdA, ct);
+
+        // B places at a second known-clear tile, far enough that footprints can't overlap.
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(
+            farmerB.Client,
+            CabinPlacementHelper.SecondFarmerTileX,
+            CabinPlacementHelper.SecondFarmerTileY,
+            ct
+        );
+        var bExpected = CabinPlacementHelper.ExpectedCabinTileFor(
+            CabinPlacementHelper.SecondFarmerTileX,
+            CabinPlacementHelper.SecondFarmerTileY
+        );
+        CabinInfoResponse? bMoved = null;
+        var bOk = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinStrategy_OurCabinAssigned,
+            async () =>
+            {
+                await farmerB.Client.SendChat("!cabin");
+                bMoved = await GetOurCabinAsync(farmerB.Uid, ct);
+                return !bMoved.IsHidden && (bMoved.TileX, bMoved.TileY) == bExpected;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(bOk, "B's cabin did not move to its expected tile");
+
+        // Two distinct non-hidden tiles, each owned by the right uid.
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        var aCabin = cabins.Cabins.FirstOrDefault(c => c.OwnerId == ownerIdA);
+        var bCabin = cabins.Cabins.FirstOrDefault(c => c.OwnerId == farmerB.Uid);
+        Assert.NotNull(aCabin);
+        Assert.NotNull(bCabin);
+        Assert.False(aCabin!.IsHidden);
+        Assert.False(bCabin!.IsHidden);
+        Assert.Equal(aTile, (aCabin.TileX, aCabin.TileY));
+        Assert.Equal(bExpected, (bCabin.TileX, bCabin.TileY));
+        Assert.NotEqual((aCabin.TileX, aCabin.TileY), (bCabin.TileX, bCabin.TileY));
+
+        Assert.Contains(ownerIdA, cabins.SavedPositionPlayerIds);
+        Assert.Contains(farmerB.Uid, cabins.SavedPositionPlayerIds);
+
+        // Disconnect B before this class's DisposeAsync runs /newgame (409s while connected).
+        await farmerB.DisconnectAsync();
+        await Exceptions.AssertNoExceptionsAsync("after two-player distinct placement");
+        Log($"A at ({aCabin.TileX},{aCabin.TileY}), B at ({bCabin.TileX},{bCabin.TileY})");
+    }
+
+    /// <summary>
+    /// Guard (proxy) for the dummy-cabin cosmetic: a player whose cabin was moved via !cabin
+    /// triggers the new dummy-found branch in OnLocationIntroductionMessage on reconnect. The
+    /// mutation lives only in the per-peer message copy, so /cabins (master) can't see it —
+    /// this asserts the join completes, master's tile for the moved cabin is unchanged (the
+    /// dummy relocate must not touch master state), and no errors fired.
+    /// </summary>
+    [Fact]
+    public async Task DummyCabin_ReconnectAfterMove_JoinSucceedsAndMasterUnchanged()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        Log($"Cabin placed at ({movedTile.X},{movedTile.Y}) for '{client.FarmerName}'");
+
+        // Disconnect and reconnect: the reconnect's location introduction runs the dummy branch.
+        await Farmers.DisconnectAndWaitForSlotAsync(ownerId, client.FarmerName, ct);
+        await Farmers.ReconnectAsync(client.FarmerName, ct: ct);
+
+        // Master cabin tile is unchanged — the dummy relocate mutated only the message copy.
+        var afterReconnect = await GetOurCabinAsync(ownerId, ct);
+        Assert.False(afterReconnect.IsHidden, "A's moved cabin should still be visible in master");
+        Assert.Equal(movedTile, (afterReconnect.TileX, afterReconnect.TileY));
+
+        await Exceptions.AssertNoExceptionsAsync("after dummy-branch reconnect");
+        Log("Reconnect with moved cabin completed; master tile unchanged");
+    }
+
+    /// <summary>
+    /// Positive observation for the dummy cabin: after a player moves their cabin via !cabin
+    /// and reconnects, the player's *own client* sees a dummy cabin rendered at the shared
+    /// stack location — so they don't see an empty spot where everyone else's cabin appears —
+    /// AND that dummy is door-dead (HasInterior == false), so stepping on it never exposes the
+    /// real owner's home. Master state (/cabins) can't observe either fact; the test-client's
+    /// /actions/farm_buildings reads the client's own farm view (name/tile/HasInterior).
+    /// The player's own moved cabin stays enterable (HasInterior == true).
+    /// </summary>
+    [Fact]
+    public async Task DummyCabin_AfterMoveAndReconnect_ClientSeesDoorDeadDummyAtStack()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+
+        // Reconnect so the client receives a fresh Farm location introduction (where the
+        // dummy is injected into this peer's copy).
+        await Farmers.DisconnectAndWaitForSlotAsync(ownerId, client.FarmerName, ct);
+        await Farmers.ReconnectAsync(client.FarmerName, ct: ct);
+
+        // Poll the client's own farm view: the dummy can lag the reconnect's location intro.
+        FarmBuildingsResult? view = null;
+        FarmBuildingInfo? dummy = null;
+        FarmBuildingInfo? ownCabin = null;
+        var sawDummy = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_DummyCabin_VisibleInClientFarm,
+            async () =>
+            {
+                view = await GameClient.Actions.GetFarmBuildings(ct);
+                if (view?.Success != true)
+                {
+                    return false;
+                }
+
+                // Cabins at visible tiles (tileX >= 0): the moved own cabin plus the dummy at
+                // the shared stack. The hidden-stack spare stays at (-20,-20), excluded here.
+                var visible = view.Cabins.Where(c => c.TileX >= 0).ToList();
+                ownCabin = visible.FirstOrDefault(c =>
+                    c.TileX == movedTile.X && c.TileY == movedTile.Y
+                );
+                dummy = visible.FirstOrDefault(c =>
+                    !(c.TileX == movedTile.X && c.TileY == movedTile.Y)
+                );
+                return ownCabin != null && dummy != null;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(
+            sawDummy,
+            "Client did not render a dummy cabin at the shared stack alongside its moved cabin "
+                + $"(saw: {(view == null ? "null" : string.Join(", ", view.Cabins.Select(c => $"({c.TileX},{c.TileY},interior={c.HasInterior})")))})"
+        );
+
+        // The dummy's door must be dead; the player's own cabin must stay enterable.
+        Assert.False(
+            dummy!.HasInterior,
+            "Dummy cabin door is live — it must be door-dead (null interior)"
+        );
+        Assert.True(ownCabin!.HasInterior, "Player's own moved cabin should still be enterable");
+        Log("Client rendered a door-dead dummy cabin at the shared stack after moving its own");
+
+        await Exceptions.AssertNoExceptionsAsync("after dummy positive-observation");
     }
 
     #region Helpers

--- a/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
@@ -1,0 +1,97 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E coverage for the FarmhouseStack strategy's !cabin gate: under FarmhouseStack the
+/// host keeps every cabin in the farmhouse, so !cabin (and !cabin reset) must be rejected
+/// before any placement happens — even when the farmer is standing on the Farm, where the
+/// off-Farm gate would otherwise fire first. This is the first FarmhouseStack E2E coverage,
+/// so a join misbehaving here is a product finding to investigate, not a test bug to mask.
+///
+/// Exclusive + a fresh game per test so the farm starts clean and assertions scope to the
+/// single connected farmer.
+/// </summary>
+[TestServer(Isolation = IsolationMode.SharedAssembly, Exclusive = true)]
+public class CabinStrategyFarmhouseStackTests : TestBase
+{
+    public CabinStrategyFarmhouseStackTests() { }
+
+    public override async ValueTask DisposeAsync()
+    {
+        // Reset to a clean default game so the FarmhouseStack config doesn't leak to a
+        // sibling class reusing this server. Disconnect first: /newgame returns 409 while a
+        // client is connected, and our tests stay connected through the body.
+        if (Lease != null)
+        {
+            try
+            {
+                await DisconnectAsync();
+                await CreateNewGameOnServerAsync(farmType: 0);
+            }
+            catch (Exception ex)
+            {
+                LogWarning($"Server reset failed during cleanup: {ex.Message}");
+            }
+        }
+        await base.DisposeAsync();
+    }
+
+    /// <summary>
+    /// !cabin under FarmhouseStack is rejected with the strategy message, and records no
+    /// intent. The farmer is warped onto the Farm first so the rejection proves the
+    /// *strategy* gate fired, not the off-Farm one — keeping the test honest if the gate
+    /// order ever changes.
+    /// </summary>
+    [Fact]
+    public async Task FarmhouseStack_RejectsCabinMove()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "FarmhouseStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        // Warp onto the Farm so the off-Farm gate can't be the one rejecting us.
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
+        var baseline = await GetOurCabinAsync(ownerId, ct);
+
+        // "keep all cabins" is unique to the FarmhouseStack gate. Match only this fragment,
+        // not the full phrase: the delivered chat message has a double space ("cabins  in")
+        // that a longer substring would straddle.
+        var rejected = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Rejected,
+            () => Chat.AssertResponseAsync("!cabin", "keep all cabins"),
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(rejected, "Expected a FarmhouseStack rejection reply");
+
+        // No move, and no intent written on rejection.
+        var after = await GetOurCabinAsync(ownerId, ct);
+        Assert.True(after.IsHidden, "Cabin should still be hidden under FarmhouseStack");
+        Assert.Equal((baseline.TileX, baseline.TileY), (after.TileX, after.TileY));
+
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        Assert.DoesNotContain(ownerId, cabins.SavedPositionPlayerIds);
+
+        await Exceptions.AssertNoExceptionsAsync("after FarmhouseStack !cabin rejection");
+    }
+
+    #region Helpers
+
+    private async Task<CabinInfoResponse> GetOurCabinAsync(long ownerId, CancellationToken ct)
+    {
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        var ours = cabins.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+        Assert.NotNull(ours);
+        return ours;
+    }
+
+    #endregion
+}

--- a/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
@@ -1,3 +1,5 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
 using JunimoServer.Tests.Infrastructure;
 using Xunit;
 
@@ -25,6 +27,22 @@ public class CabinStrategyNoneTests : TestBase
         {
             try
             {
+                // Disconnect the primary first: /newgame 409s while any client is connected.
+                // The NewGame_* tests connect no client, but NoneStrategy_CabinMovesToFarmerTilePlusOne
+                // leaves the primary connected — without this the reset would 409 and leak None
+                // state. Tolerant: a no-op throw when never connected / already at title must
+                // not block the reset.
+                try
+                {
+                    await DisconnectAsync();
+                }
+                catch (Exception ex)
+                {
+                    LogWarning(
+                        $"Primary disconnect during cleanup failed (may not be connected): {ex.Message}"
+                    );
+                }
+
                 await CreateNewGameOnServerAsync(farmType: 0);
             }
             catch (Exception ex)
@@ -81,4 +99,65 @@ public class CabinStrategyNoneTests : TestBase
 
         Assert.Equal(cabinsResponse.TotalCount, cabinsResponse.AvailableCount);
     }
+
+    /// <summary>
+    /// !cabin under None moves a visible cabin to farmer.Tile + (1,0): None has no hidden
+    /// stack, so the move is between two real map positions. Proves the None happy path of
+    /// the command (otherwise only exercised incidentally by the strategy-switch test).
+    /// </summary>
+    [Fact]
+    public async Task NoneStrategy_CabinMovesToFarmerTilePlusOne()
+    {
+        LogSection("Testing !cabin under None (vanilla) strategy");
+
+        _needsServerReset = true;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None", startingCabins: 1);
+
+        var ct = TestContext.Current.CancellationToken;
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        // Baseline is map-derived under None — never hard-coded.
+        var baseline = await GetOurCabinAsync(ownerId, ct);
+        Assert.False(baseline.IsHidden, "None-strategy cabin should start visible");
+
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
+
+        // Resend each poll: the !cabin handler reads the server's view of the farmer
+        // location, which can lag the client warp by a tick.
+        CabinInfoResponse? moved = null;
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Moved,
+            async () =>
+            {
+                await GameClient.SendChat("!cabin");
+                moved = await GetOurCabinAsync(ownerId, ct);
+                return (moved.TileX, moved.TileY) != (baseline.TileX, baseline.TileY);
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(ok, "Cabin did not move to the farmer tile after !cabin under None");
+        Assert.Equal(CabinPlacementHelper.ExpectedCabinTile, (moved!.TileX, moved.TileY));
+        Assert.Equal("Normal", moved.Type);
+        Assert.False(moved.IsHidden, "Moved None cabin must stay visible");
+
+        await Exceptions.AssertNoExceptionsAsync("after !cabin under None");
+
+        Log($"None-strategy cabin moved to ({moved.TileX},{moved.TileY})");
+    }
+
+    #region Helpers
+
+    private async Task<CabinInfoResponse> GetOurCabinAsync(long ownerId, CancellationToken ct)
+    {
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins);
+        var ours = cabins.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+        Assert.NotNull(ours);
+        return ours;
+    }
+
+    #endregion
 }

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -256,6 +256,34 @@ public class ClearAreaResult
     public string? Error { get; set; }
 }
 
+public class FarmBuildingInfo
+{
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = "";
+
+    [JsonPropertyName("tileX")]
+    public int TileX { get; set; }
+
+    [JsonPropertyName("tileY")]
+    public int TileY { get; set; }
+
+    /// <summary>True if this building has an interior the player can enter (door is live).</summary>
+    [JsonPropertyName("hasInterior")]
+    public bool HasInterior { get; set; }
+}
+
+public class FarmBuildingsResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("cabins")]
+    public List<FarmBuildingInfo> Cabins { get; set; } = new();
+}
+
 public class PlantCropResult
 {
     [JsonPropertyName("success")]
@@ -683,6 +711,15 @@ public class ActionsClient
                 tileY,
             }
         );
+
+    /// <summary>
+    /// List this client's view of the farm's cabins (name + tile). The server rewrites each
+    /// peer's locationIntroduction, so the client's farm can differ from master state — this
+    /// is how a test observes per-peer cabin mutations that /cabins (master) can't see.
+    /// GET /actions/farm_buildings
+    /// </summary>
+    public Task<FarmBuildingsResult?> GetFarmBuildings(CancellationToken ct = default) =>
+        _client.GetAsync<FarmBuildingsResult>("/actions/farm_buildings", ct);
 }
 
 public class ChatClient

--- a/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
@@ -49,8 +49,10 @@ public static class CabinPlacementHelper
     {
         var warp = await client.Actions.Warp("Farm", tileX, tileY);
         Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
+        // WaitForLocationAsync returns non-null only when the client's location matched ^Farm$
+        // within the timeout (null on timeout), so a non-null result confirms the sync.
         var arrived = await client.WaitForLocationAsync("^Farm$", ct: ct);
-        Assert.True(arrived is not null, "Warp to Farm did not complete before clearing footprint");
+        Assert.True(arrived is not null, "Client did not sync to Farm before clearing footprint");
 
         var cleared = await client.Actions.ClearArea("Farm", tileX + 1, tileY, width: 5, height: 4);
         Assert.True(cleared?.Success == true, $"ClearArea failed: {cleared?.Error}");

--- a/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
@@ -15,28 +15,44 @@ public static class CabinPlacementHelper
     public const int FarmerTileX = 40;
     public const int FarmerTileY = 18;
 
+    // A second known-clear western-field tile for a concurrent farmer, far enough below the
+    // primary tile that the two 5x3 footprints (rows FarmerTileY and SecondFarmerTileY) can't
+    // overlap. (41..45, 18) vs (41..45, 30) — 12 rows apart.
+    public const int SecondFarmerTileX = 40;
+    public const int SecondFarmerTileY = 30;
+
     /// <summary>Where !cabin places the cabin's top-left when the farmer stands at the tile above.</summary>
     public static readonly (int X, int Y) ExpectedCabinTile = (FarmerTileX + 1, FarmerTileY);
+
+    /// <summary>Expected cabin top-left for a farmer warped to (<paramref name="tileX"/>,<paramref name="tileY"/>).</summary>
+    public static (int X, int Y) ExpectedCabinTileFor(int tileX, int tileY) => (tileX + 1, tileY);
 
     /// <summary>
     /// Warps the farmer to <see cref="FarmerTileX"/>,<see cref="FarmerTileY"/> and clears the
     /// 5x3 cabin footprint plus the door-front row at farmer.Tile + (1,0). Debris spawn on a
     /// new farm is random per seed, so the clear is load-bearing for a deterministic placement.
     /// </summary>
-    public static async Task WarpAndClearFootprintAsync(GameTestClient client, CancellationToken ct)
+    public static Task WarpAndClearFootprintAsync(GameTestClient client, CancellationToken ct) =>
+        WarpAndClearFootprintAsync(client, FarmerTileX, FarmerTileY, ct);
+
+    /// <summary>
+    /// Warps the farmer to (<paramref name="tileX"/>,<paramref name="tileY"/>) and clears the
+    /// 5x3 cabin footprint plus the door-front row at farmer.Tile + (1,0). Parametrized so two
+    /// concurrent farmers can place to non-overlapping tiles.
+    /// </summary>
+    public static async Task WarpAndClearFootprintAsync(
+        GameTestClient client,
+        int tileX,
+        int tileY,
+        CancellationToken ct
+    )
     {
-        var warp = await client.Actions.Warp("Farm", FarmerTileX, FarmerTileY);
+        var warp = await client.Actions.Warp("Farm", tileX, tileY);
         Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
         var arrived = await client.WaitForLocationAsync("^Farm$", ct: ct);
         Assert.True(arrived is not null, "Warp to Farm did not complete before clearing footprint");
 
-        var cleared = await client.Actions.ClearArea(
-            "Farm",
-            FarmerTileX + 1,
-            FarmerTileY,
-            width: 5,
-            height: 4
-        );
+        var cleared = await client.Actions.ClearArea("Farm", tileX + 1, tileY, width: 5, height: 4);
         Assert.True(cleared?.Success == true, $"ClearArea failed: {cleared?.Error}");
     }
 }

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -95,6 +95,15 @@ public enum WaitName
     Polling_CabinStrategy_FarmerSyncedCabinAndFarmhand,
     Polling_CabinStrategy_FarmerDeletionReflected,
 
+    // CabinPositionPersistenceTests.cs — !cabin reset (1)
+    Polling_CabinReset_CabinHidden,
+
+    // CabinPositionPersistenceTests.cs — dummy cabin at shared stack (1)
+    Polling_DummyCabin_VisibleInClientFarm,
+
+    // CabinPositionPersistenceTests.cs — same-pass sweep reflected in snapshot (1)
+    Polling_CabinSweep_PostReloadSettled,
+
     // AbandonedClaimTests.cs (3)
     Polling_AbandonedClaim_StuckStateReproduced,
     Polling_AbandonedClaim_DisconnectHealConfirmed,

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
@@ -123,17 +123,31 @@ internal sealed class FarmerTestHelper
         var name = GenerateName(namePrefix);
         var clientLease = await _testBase.LeaseClientForHelperAsync(ct);
 
-        var conn = new ConnectionHelper(clientLease.Client, serverApi: _testBase.ServerApi);
-        var join = await conn.JoinWorldViaLanAsync(
-            lease.ServerLanAddress,
-            lease.ServerLanPort,
-            name,
-            cancellationToken: ct
-        );
-        Assert.True(join.Success, $"Second farmer '{name}' failed to join via LAN: {join.Error}");
+        // Dispose the lease if the join (or its assert) throws — otherwise it leaks client
+        // capacity and leaves a connected client around during cleanup. On success, the
+        // returned SecondFarmer owns disposal.
+        try
+        {
+            var conn = new ConnectionHelper(clientLease.Client, serverApi: _testBase.ServerApi);
+            var join = await conn.JoinWorldViaLanAsync(
+                lease.ServerLanAddress,
+                lease.ServerLanPort,
+                name,
+                cancellationToken: ct
+            );
+            Assert.True(
+                join.Success,
+                $"Second farmer '{name}' failed to join via LAN: {join.Error}"
+            );
 
-        TrackFarmer(name, join.UniqueMultiplayerId);
-        return new SecondFarmer(clientLease, join.UniqueMultiplayerId, name);
+            TrackFarmer(name, join.UniqueMultiplayerId);
+            return new SecondFarmer(clientLease, join.UniqueMultiplayerId, name);
+        }
+        catch
+        {
+            await clientLease.DisposeAsync();
+            throw;
+        }
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
@@ -95,6 +95,48 @@ internal sealed class FarmerTestHelper
     }
 
     /// <summary>
+    /// Connects a second concurrent farmer over its own client lease and joins it via LAN.
+    /// The primary farmer keeps using the shared connection helpers; this is the one missing
+    /// primitive for multi-player E2E tests. LAN-only is sufficient — none of the planned
+    /// consumers need a client-stamped userID (which requires Steam). The farmer is tracked
+    /// for cleanup via <see cref="TrackFarmer"/>.
+    ///
+    /// Scope the returned <see cref="SecondFarmer"/> with <c>await using</c> so it
+    /// disconnects before the test class's <c>/newgame</c> reset. No
+    /// <c>[TestServer(Clients = 2)]</c> is needed: the cabin pool replenishes on join
+    /// (EnsureAtLeastXCabins runs in the patched sendAvailableFarmhands path), so the second
+    /// farmer always finds a slot, and a runtime lease avoids splitting the server pool.
+    /// </summary>
+    public async Task<SecondFarmer> ConnectSecondFarmerAsync(
+        string namePrefix = "FarmerB",
+        CancellationToken ct = default
+    )
+    {
+        var lease = _testBase.LeaseInternal;
+        if (lease == null)
+        {
+            throw new InvalidOperationException(
+                "Server not acquired; cannot connect a second farmer."
+            );
+        }
+
+        var name = GenerateName(namePrefix);
+        var clientLease = await _testBase.LeaseClientForHelperAsync(ct);
+
+        var conn = new ConnectionHelper(clientLease.Client, serverApi: _testBase.ServerApi);
+        var join = await conn.JoinWorldViaLanAsync(
+            lease.ServerLanAddress,
+            lease.ServerLanPort,
+            name,
+            cancellationToken: ct
+        );
+        Assert.True(join.Success, $"Second farmer '{name}' failed to join via LAN: {join.Error}");
+
+        TrackFarmer(name, join.UniqueMultiplayerId);
+        return new SecondFarmer(clientLease, join.UniqueMultiplayerId, name);
+    }
+
+    /// <summary>
     /// Reconnects an existing farmer (no name generation, no tracking).
     /// Use after a disconnect when testing reconnect behavior.
     /// </summary>

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/SecondFarmer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/SecondFarmer.cs
@@ -1,0 +1,78 @@
+using JunimoServer.Tests.Clients;
+
+namespace JunimoServer.Tests.Infrastructure.Fixture;
+
+/// <summary>
+/// A second concurrently-connected farmer over its own client lease, for multi-player
+/// E2E tests. The primary farmer uses the shared connection helpers (bound to the single
+/// primary client); this wrapper leases an additional client and joins it via LAN.
+///
+/// <para>
+/// <b>Disposal order.</b> Scope this with <c>await using</c> in the test body so it
+/// disconnects and disposes its lease <em>before</em> the test class's
+/// <c>DisposeAsync</c> runs its <c>/newgame</c> reset — <c>/newgame</c> and <c>/reload</c>
+/// return 409 while any client is connected.
+/// </para>
+///
+/// <para>
+/// <b>Idempotent.</b> Tests often disconnect the second farmer mid-test (an idle connected
+/// farmer blocks the day-end ready check, so it must leave before <c>SleepToSaveAsync</c>),
+/// then <c>await using</c> disposes again at scope exit. <see cref="DisconnectAsync"/> and
+/// <see cref="DisposeAsync"/> are both safe to call more than once.
+/// </para>
+/// </summary>
+internal sealed class SecondFarmer : IAsyncDisposable
+{
+    private readonly ClientLease _lease;
+    private bool _disconnected;
+    private bool _disposed;
+
+    /// <summary>The leased game client for the second farmer.</summary>
+    public GameTestClient Client => _lease.Client;
+
+    /// <summary>The underlying client lease (for warps, actions, etc.).</summary>
+    public ClientLease Lease => _lease;
+
+    /// <summary>Server-assigned UniqueMultiplayerID of the second farmer.</summary>
+    public long Uid { get; }
+
+    /// <summary>The generated farmer name.</summary>
+    public string FarmerName { get; }
+
+    internal SecondFarmer(ClientLease lease, long uid, string farmerName)
+    {
+        _lease = lease;
+        Uid = uid;
+        FarmerName = farmerName;
+    }
+
+    /// <summary>
+    /// Disconnects the second farmer (navigates to title) so it stops blocking the day-end
+    /// ready check, then marks the lease already-disconnected so disposal won't disconnect
+    /// again. Idempotent.
+    /// </summary>
+    public async Task DisconnectAsync()
+    {
+        if (_disconnected)
+        {
+            return;
+        }
+
+        _disconnected = true;
+        await _lease.Container.DisconnectAsync();
+        _lease.AlreadyDisconnected = true;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        // If DisconnectAsync wasn't called, the lease's own DisposeAsync disconnects;
+        // if it was, AlreadyDisconnected makes that a no-op.
+        await _lease.DisposeAsync();
+    }
+}

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -492,6 +492,15 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
     internal Task<GameTestClient> GetClientAsyncInternal(CancellationToken ct = default) =>
         GetClientAsync(ct);
 
+    /// <summary>
+    /// Leases an additional client container for a Fixture/ helper (e.g. a second concurrent
+    /// farmer). Delegates to the protected <see cref="LeaseClientAsync"/> so the
+    /// recording-mark side effect is preserved; the protected method isn't reachable from a
+    /// sibling-namespace helper.
+    /// </summary>
+    internal Task<ClientLease> LeaseClientForHelperAsync(CancellationToken ct = default) =>
+        LeaseClientAsync(ct);
+
     internal Task AcquireServerAsyncInternal(
         ResourceRequirements requirements,
         CancellationToken ct = default,

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -315,6 +315,68 @@ public class ActionsController
             SeedItemId = itemId,
         };
     }
+
+    /// <summary>
+    /// Lists this client's view of the farm's cabin buildings (name + tile). The server
+    /// rewrites each peer's locationIntroduction copy (CabinManagerService), so the client's
+    /// farm can differ from master state — e.g. a dummy cabin relocated to the shared stack
+    /// for a player whose own cabin was moved. /cabins (master state) cannot observe that, so
+    /// this is the positive-observation gate for the per-peer cabin mutations.
+    /// </summary>
+    public FarmBuildingsResult GetFarmBuildings()
+    {
+        if (!Context.IsWorldReady)
+        {
+            return new FarmBuildingsResult { Success = false, Error = "Not in a game world" };
+        }
+
+        var farm = Game1.getFarm();
+        if (farm == null)
+        {
+            return new FarmBuildingsResult { Success = false, Error = "Farm not loaded" };
+        }
+
+        var cabins = new List<FarmBuildingInfo>();
+        foreach (var building in farm.buildings)
+        {
+            if (!building.isCabin)
+            {
+                continue;
+            }
+
+            cabins.Add(
+                new FarmBuildingInfo
+                {
+                    Name = building.GetIndoors()?.NameOrUniqueName ?? "",
+                    TileX = building.tileX.Value,
+                    TileY = building.tileY.Value,
+                    // HasInterior == false means the door is dead: Building.doAction only warps
+                    // the player inside when GetIndoors() != null, so a null interior is an
+                    // unenterable (door-dead) cabin — what the dummy-cabin prop must be.
+                    HasInterior = building.GetIndoors() != null,
+                }
+            );
+        }
+
+        return new FarmBuildingsResult { Success = true, Cabins = cabins };
+    }
+}
+
+public class FarmBuildingInfo
+{
+    public string Name { get; set; } = "";
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+
+    /// <summary>True if this building has an interior the player can enter (door is live).</summary>
+    public bool HasInterior { get; set; }
+}
+
+public class FarmBuildingsResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+    public List<FarmBuildingInfo> Cabins { get; set; } = new();
 }
 
 public class SleepResult

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -648,6 +648,12 @@ public class ModEntry : Mod
             }
         );
 
+        // GET /actions/farm_buildings - List this client's view of the farm's cabins (name + tile)
+        _server.Get(
+            "actions/farm_buildings",
+            _ => ExecuteOnGameThread(() => _actionsController!.GetFarmBuildings())
+        );
+
         // POST /actions/plant_crop - Plant a seed in a HoeDirt or IndoorPot at the given tile
         _server.Post(
             "actions/plant_crop",


### PR DESCRIPTION
Implements the open cabin-management work from `.claude/plans/bugs/cabin/`. All 17 cabin tests pass on real E2E infrastructure.

## Features
- **`!cabin reset`** subcommand — returns the player's cabin to the hidden stack and clears its saved-position intent. Keyed on cabin visibility (not intent existence), so a half-applied reset is recoverable by re-running. Per-strategy behavior for CabinStack / FarmhouseStack / None / no-cabin.
- **Door-dead dummy cabin** — under CabinStack, a player who moved their cabin via `!cabin` (or imported one visible under KeepExisting) saw an empty spot at the shared stack location where everyone else sees a cabin. Now renders one hidden-stack cabin there as a dummy in the per-peer `locationIntroduction` copy, with its interior nulled so its door is a no-op (it never exposes the real owner's home). Master state is untouched.

## Product fix
- **`CabinPlacementValidator`** — reordered the farmer-collision check before the tile-buildability check. A farmer standing in the footprint also trips `CanItemBePlacedHere`, so checking buildability first always reported the generic "blocked by terrain or object" and made the specific "another player is standing there" message unreachable.

## Test infrastructure
- **`SecondFarmer`** helper — connects a second concurrent farmer over its own client lease (LAN); the missing primitive for multi-player E2E tests. Un-skips `AnotherPlayerInFootprint_RejectsAndDoesNotMove` as its first consumer.
- **`/actions/farm_buildings`** test-client endpoint — reports each cabin's name/tile/`HasInterior` from the client's own farm view, so tests can observe per-peer cabin mutations that master state (`/cabins`) can't see.
- New tests: cabin command guard coverage (FarmhouseStack / off-Farm / None), same-pass sweep selectivity, two-players-to-distinct-tiles, `!cabin reset` persistence, dummy-cabin guard + door-dead positive observation.

## Build fix
- Both `docker/Dockerfile` and `docker/Dockerfile.test-client` split `dotnet restore` and `dotnet build --no-restore` across separate `--mount=type=cache` layers; the ephemeral cache mount can drop packages the prior RUN restored, causing intermittent `NETSDK1064`. Restore now happens in the same RUN as the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `!cabin reset` to return cabins to the shared stack and clear saved placement intent.
  * Added an `actions/farm_buildings` endpoint so clients can fetch cabin/building details (position and whether an interior exists).

* **Bug Fixes**
  * Improved cabin placement validation: standing-player collisions are detected before terrain/buildability checks, with more accurate rejection reasons.

* **Improvements**
  * Multi-player moves now show door-dead dummy cabins to prevent empty spots while avoiding exposure of real cabin interiors.
  * Build process now allows dependency restoration during the build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->