### PR TITLE
feat(test-ui): add Overview landing page with run summary and orientation

### DIFF
--- a/tests/test-ui/src/App.vue
+++ b/tests/test-ui/src/App.vue
@@ -138,6 +138,16 @@ function showFailedTests() {
 }
 provide("showFailedTests", showFailedTests);
 
+// Switch to Explorer, reopening the sidebar if collapsed (mirrors the icon-sidebar
+// Explorer button) so callers like the Overview don't land on a hidden tree.
+function goToExplorer() {
+    activeView.value = "tests";
+    if (sidebarCollapsed.value) {
+        toggleSidebar();
+    }
+}
+provide("goToExplorer", goToExplorer);
+
 const vncCount = computed(() => store.state.instances?.length ?? 0);
 
 // When collapsed, width is 0 (fully hidden). Dragging uses live value.
@@ -218,7 +228,7 @@ function onResizeStart(e: PointerEvent) {
                 <Icon icon="lucide:layout-dashboard" class="w-5 h-5" />
             </button>
             <button class="icon-sidebar-btn" :class="{ active: activeView === 'tests', hovered: hoveredNav === 'tests' }"
-                    title="Explorer" @click="activeView = 'tests'; if (sidebarCollapsed) toggleSidebar()">
+                    title="Explorer" @click="goToExplorer">
                 <Icon icon="lucide:file-text" class="w-5 h-5" />
             </button>
             <button class="icon-sidebar-btn" :class="{ active: activeView === 'vnc', hovered: hoveredNav === 'vnc' }"

--- a/tests/test-ui/src/App.vue
+++ b/tests/test-ui/src/App.vue
@@ -4,6 +4,7 @@ import { computed, onMounted, onUnmounted, provide, ref, watch } from "vue";
 import AbortBanner from "./components/AbortBanner.vue";
 import InstanceInspect from "./components/InstanceInspect.vue";
 import OutputPanel from "./components/OutputPanel.vue";
+import OverviewPanel from "./components/OverviewPanel.vue";
 import StatusBar from "./components/StatusBar.vue";
 import TestTree from "./components/TestTree.vue";
 import VncGrid from "./components/VncGrid.vue";
@@ -11,6 +12,7 @@ import VncIframePool from "./components/VncIframePool.vue";
 import { useInspectNavigation } from "./composables/useInspectNavigation";
 import { useRouteSync } from "./composables/useRouteSync";
 import { useTestStore } from "./composables/useTestStore";
+import type { ActiveView } from "./composables/useTestUI";
 
 const store = useTestStore();
 provide("store", store);
@@ -66,6 +68,7 @@ const LS_KEY = "app-layout-prefs";
 interface LayoutPrefs {
     sidebarWidth: number;
     sidebarCollapsed: boolean;
+    // No "overview": it's a cold-visit default, not a persisted preference.
     activeView: "tests" | "vnc";
 }
 
@@ -93,7 +96,8 @@ function saveLayoutPrefs() {
             JSON.stringify({
                 sidebarWidth: sidebarWidth.value,
                 sidebarCollapsed: sidebarCollapsed.value,
-                activeView: activeView.value,
+                // Coerce "overview" away so a reload lands on the URL/selection, not the landing page.
+                activeView: activeView.value === "vnc" ? "vnc" : "tests",
             }),
         );
     } catch {
@@ -107,8 +111,9 @@ const sidebarCollapsed = ref(prefs.sidebarCollapsed);
 const isResizing = ref(false);
 const widthBeforeCollapse = ref(prefs.sidebarCollapsed ? 260 : prefs.sidebarWidth);
 
-// View mode: 'tests' (default) or 'vnc'
-const activeView = ref<"tests" | "vnc">(prefs.activeView);
+// View mode: 'tests' (default), 'vnc', or 'overview' (landing page). The cold-visit
+// default to 'overview' is applied by useRouteSync from the initial URL.
+const activeView = ref<ActiveView>(prefs.activeView);
 provide("activeView", activeView);
 
 watch(activeView, saveLayoutPrefs);
@@ -120,6 +125,12 @@ useRouteSync(store, inspect, activeView);
 // Shared filter trigger: StatusBar sets this, TestTree reacts to it
 const filterToStatus = ref<string | null>(null);
 provide("filterToStatus", filterToStatus);
+
+// Cross-component hover link: the Overview's nav cards set this to their target
+// view, and the icon-sidebar buttons light up the matching icon — so hovering a
+// card previews where it leads. Null when nothing is hovered.
+const hoveredNav = ref<ActiveView | null>(null);
+provide("hoveredNav", hoveredNav);
 
 function showFailedTests() {
     activeView.value = "tests";
@@ -202,13 +213,17 @@ function onResizeStart(e: PointerEvent) {
                     @click="toggleSidebar">
                 <Icon icon="lucide:panel-left" class="w-5 h-5" />
             </button>
-            <button class="icon-sidebar-btn" :class="{ active: activeView === 'tests' }"
+            <button class="icon-sidebar-btn" :class="{ active: activeView === 'overview' }"
+                    title="Overview" @click="activeView = 'overview'">
+                <Icon icon="lucide:layout-dashboard" class="w-5 h-5" />
+            </button>
+            <button class="icon-sidebar-btn" :class="{ active: activeView === 'tests', hovered: hoveredNav === 'tests' }"
                     title="Explorer" @click="activeView = 'tests'; if (sidebarCollapsed) toggleSidebar()">
                 <Icon icon="lucide:file-text" class="w-5 h-5" />
             </button>
-            <button class="icon-sidebar-btn" :class="{ active: activeView === 'vnc' }"
-                    title="VNC" @click="activeView = 'vnc'">
-                <Icon icon="lucide:monitor" class="w-5 h-5" />
+            <button class="icon-sidebar-btn" :class="{ active: activeView === 'vnc', hovered: hoveredNav === 'vnc' }"
+                    title="Containers" @click="activeView = 'vnc'">
+                <Icon icon="lucide:container" class="w-5 h-5" />
                 <span v-if="vncCount > 0"
                       class="absolute -top-1 -right-1 text-[9px] min-w-[14px] h-[14px] flex items-center justify-center rounded-full bg-primary text-primary-content font-bold">
                     {{ vncCount }}
@@ -259,7 +274,8 @@ function onResizeStart(e: PointerEvent) {
             <AbortBanner />
             <StatusBar />
             <div class="flex-1 min-h-0 panel-scroll bg-base-100">
-                <OutputPanel v-if="activeView === 'tests'" />
+                <OverviewPanel v-if="activeView === 'overview'" />
+                <OutputPanel v-else-if="activeView === 'tests'" />
                 <VncGrid v-else />
             </div>
         </div>

--- a/tests/test-ui/src/components/OutputPanel.vue
+++ b/tests/test-ui/src/components/OutputPanel.vue
@@ -9,6 +9,7 @@ import { useVncInteractive } from "../composables/useVncInteractive";
 import type { AnnotationSource, InstanceSnapshot, OutputEntry } from "../types/state";
 import type { VideoItem, VideoStatsPoint } from "../types/video";
 import { formatDuration, shortTestName } from "../utils/format";
+import { TERM_HELP } from "../utils/glossary";
 import { instanceStatusDotClass, instanceStatusLabel } from "../utils/instance-status";
 import {
     anchorTimestampMs,
@@ -49,6 +50,12 @@ const sourceLabels: Record<AnnotationSource, string> = {
     mod: "Mod",
     setup: "Setup",
 };
+
+// Chip tooltip: the term definition plus the toggle action it performs.
+function sourceTitle(source: AnnotationSource): string {
+    const action = sourceFilter[source] ? "Hide" : "Show";
+    return `${TERM_HELP[source] ?? ""}\n\n${action} ${sourceLabels[source]} entries.`.trim();
+}
 
 /** Drop entries whose source isn't currently enabled in the filter chip bar. */
 function applySourceFilter(entries: OutputEntry[] | null | undefined): OutputEntry[] {
@@ -1014,7 +1021,7 @@ onUnmounted(() => window.removeEventListener("keydown", onSearchShortcut));
                       :class="sourceFilter[source]
                         ? 'bg-base-content/10 text-base-content/80'
                         : 'bg-base-300/40 text-base-content/30 line-through'"
-                      :title="sourceFilter[source] ? `Hide ${sourceLabels[source]} entries` : `Show ${sourceLabels[source]} entries`"
+                      :title="sourceTitle(source)"
                       @mouseenter="hoveredSource = source"
                       @mouseleave="hoveredSource = null"
                       @click="toggleSourceFilter(source)">

--- a/tests/test-ui/src/components/OverviewPanel.vue
+++ b/tests/test-ui/src/components/OverviewPanel.vue
@@ -266,10 +266,10 @@ function selectFlaky(displayName: string) {
       </section>
 
       <!-- ── Help / orientation block (always visible) ── -->
-      <!-- !mt-6 overrides the wrapper's space-y-8 so the divider has balanced
+      <!-- mt-6! overrides the wrapper's space-y-8 so the divider has balanced
            breathing room (24px above via margin, 24px below via padding) instead
            of the 32px+24px the global gap would stack on top of the border. -->
-      <section class="space-y-4 border-t border-base-content/5 !mt-6 pt-6">
+      <section class="space-y-4 border-t border-base-content/5 mt-6! pt-6">
         <h2 class="text-xs uppercase tracking-widest text-base-content/40 font-semibold">Getting around</h2>
         <!-- Navigation cards: bordered + chevron so they read as clickable, not prose. -->
         <div class="grid sm:grid-cols-2 gap-3 text-sm">

--- a/tests/test-ui/src/components/OverviewPanel.vue
+++ b/tests/test-ui/src/components/OverviewPanel.vue
@@ -6,7 +6,7 @@ import { computed, inject, onBeforeUnmount, type Ref } from "vue";
 // as EmptyState.vue.
 import logoUrl from "../assets/img/logo.svg";
 import { useRunStatus } from "../composables/useRunStatus";
-import { type ActiveView, useShowFailed, useTestUI } from "../composables/useTestUI";
+import { type ActiveView, useGoToExplorer, useShowFailed, useTestUI } from "../composables/useTestUI";
 import type { TestSnapshot } from "../types/state";
 import { formatDateTime, formatDuration, shortTestName } from "../utils/format";
 import { TERM_HELP } from "../utils/glossary";
@@ -15,6 +15,7 @@ import StatusIcon from "./StatusIcon.vue";
 
 const { store, activeView } = useTestUI();
 const { showFailedTests } = useShowFailed();
+const { goToExplorer } = useGoToExplorer();
 const { statusLabel, statusTextClass } = useRunStatus(store);
 
 const sc = store.statusCounts;
@@ -273,7 +274,7 @@ function selectFlaky(displayName: string) {
         <!-- Navigation cards: bordered + chevron so they read as clickable, not prose. -->
         <div class="grid sm:grid-cols-2 gap-3 text-sm">
           <button class="group cursor-pointer flex items-start gap-2.5 text-left rounded-lg border border-base-content/10 bg-base-200/30 p-3 hover:bg-base-200/70 hover:border-base-content/20 transition-colors"
-                  @click="activeView = 'tests'"
+                  @click="goToExplorer()"
                   @mouseenter="setHover('tests')" @mouseleave="setHover(null)">
             <Icon icon="lucide:file-text" class="w-4 h-4 mt-0.5 flex-none text-base-content/40 group-hover:text-base-content/80 transition-colors" />
             <p class="text-base-content/60 flex-1">

--- a/tests/test-ui/src/components/OverviewPanel.vue
+++ b/tests/test-ui/src/components/OverviewPanel.vue
@@ -1,0 +1,322 @@
+<script setup lang="ts">
+import { Icon } from "@iconify/vue";
+import { computed, inject, onBeforeUnmount, type Ref } from "vue";
+// Imported (not a public/ URL) so Vite hashes it and verifies it at build time —
+// resolves under the report's deploy subpath via the relative base. Same pattern
+// as EmptyState.vue.
+import logoUrl from "../assets/img/logo.svg";
+import { useRunStatus } from "../composables/useRunStatus";
+import { type ActiveView, useShowFailed, useTestUI } from "../composables/useTestUI";
+import type { TestSnapshot } from "../types/state";
+import { formatDateTime, formatDuration, shortTestName } from "../utils/format";
+import { TERM_HELP } from "../utils/glossary";
+import EmptyState from "./EmptyState.vue";
+import StatusIcon from "./StatusIcon.vue";
+
+const { store, activeView } = useTestUI();
+const { showFailedTests } = useShowFailed();
+const { statusLabel, statusTextClass } = useRunStatus(store);
+
+const sc = store.statusCounts;
+
+// Lets a nav card light up its matching left-sidebar icon on hover (provided by
+// App.vue). Optional inject — harmless no-op if the panel is ever mounted alone.
+const hoveredNav = inject<Ref<ActiveView | null>>("hoveredNav");
+function setHover(view: ActiveView | null) {
+    if (hoveredNav) {
+        hoveredNav.value = view;
+    }
+}
+// Clear on unmount in case a click navigates away before mouseleave fires, which
+// would otherwise leave a sidebar icon stuck in the hovered color.
+onBeforeUnmount(() => setHover(null));
+
+// Render gates: live progress (pending/running) vs final result, and whether
+// there's any run to summarize at all (else the help block carries the page).
+const isLive = computed(() => store.state.status === "pending" || store.state.status === "running");
+const hasData = computed(() => store.state.totalTests > 0 || store.collections.value.length > 0);
+
+const completedCount = computed(() => sc.passed + sc.failed + sc.skipped + sc.canceled + sc.notDispatched + sc.aborted);
+const progress = computed(() => {
+    const total = store.state.totalTests;
+    return total === 0 ? 0 : Math.round((completedCount.value / total) * 100);
+});
+
+// The count chips shown in the summary, in display order. Slug drives the
+// TERM_HELP tooltip and the color class; only nonzero counts (plus passed) render.
+const COUNT_CHIPS: { key: string; label: string; cls: string }[] = [
+    { key: "passed", label: "passed", cls: "text-success" },
+    { key: "failed", label: "failed", cls: "text-error" },
+    { key: "canceled", label: "canceled", cls: "text-warning" },
+    { key: "aborted", label: "aborted", cls: "text-secondary" },
+    { key: "notDispatched", label: "not dispatched", cls: "text-base-content/50" },
+    { key: "running", label: "running", cls: "text-info" },
+    { key: "queued", label: "queued", cls: "text-primary" },
+    { key: "skipped", label: "skipped", cls: "text-base-content/50" },
+];
+const visibleChips = computed(() => COUNT_CHIPS.filter((c) => c.key === "passed" || (sc[c.key] ?? 0) > 0));
+
+// Recent failures — walk the tree the same way findInitialSelection does. Most
+// recently-executed first so the freshest failure is at the top; capped so the
+// list stays scannable.
+const recentFailures = computed<TestSnapshot[]>(() => {
+    const failed: TestSnapshot[] = [];
+    for (const col of store.collections.value) {
+        for (const cls of col.classes) {
+            for (const test of cls.tests) {
+                if (test.status === "failed") {
+                    failed.push(test);
+                }
+            }
+        }
+    }
+    failed.sort((a, b) => (b.executionOrder ?? -1) - (a.executionOrder ?? -1));
+    return failed.slice(0, 8);
+});
+
+const mostRecentFailure = computed<TestSnapshot | null>(() => recentFailures.value[0] ?? null);
+
+const flakyTests = computed(() => store.state.flakyTests ?? []);
+
+const runMeta = computed(() => store.state.runMetadata?.data ?? null);
+
+// Run facts a tester cares about: what was tested, when, and how long.
+const gitBranch = computed(() => runMeta.value?.git?.branch ?? null);
+const gitSha = computed(() => {
+    const sha = runMeta.value?.git?.sha;
+    return sha ? sha.slice(0, 7) : null;
+});
+// Link the sha to its GitHub commit (full sha for an unambiguous URL). Same repo
+// as the header subtitle link.
+const commitUrl = computed(() => {
+    const sha = runMeta.value?.git?.sha;
+    return sha ? `https://github.com/stardew-valley-dedicated-server/server/commit/${sha}` : null;
+});
+const gitDirty = computed(() => runMeta.value?.git?.dirty === true);
+const startedAt = computed(() => formatDateTime(store.state.runStartTime));
+const totalDuration = computed(() => formatDuration(store.state.durationMs));
+
+// Deeper run metadata for the collapsible "Run details" section: runtime, the env
+// knobs that shaped the run, and the per-config server plan.
+const runtimeLabel = computed(() => {
+    const r = runMeta.value?.runtime;
+    if (!r) {
+        return null;
+    }
+    return [r.os, r.dotnet, r.docker ? `docker ${r.docker}` : null].filter(Boolean).join(" · ");
+});
+const envEntries = computed(() => Object.entries(runMeta.value?.env ?? {}));
+const serverConfigs = computed(() => runMeta.value?.serverConfigs ?? []);
+
+// Selecting a failure mirrors App.vue's navigateToTest: select the test and
+// switch to the Explorer view (the route watcher reflects it into the URL).
+function selectTest(test: TestSnapshot) {
+    store.selectTest(test);
+    activeView.value = "tests";
+}
+
+// Flaky entries carry only a display name; resolve to a tree node so the click
+// can select it. Omit the link when the test isn't in the current tree.
+function selectFlaky(displayName: string) {
+    const t = store.findTest(displayName);
+    if (t) {
+        selectTest(t);
+    }
+}
+</script>
+
+<template>
+  <div class="h-full overflow-auto panel-scroll">
+    <div class="max-w-3xl mx-auto px-8 py-8 space-y-8">
+      <!-- ── Header: brand logo + title ── -->
+      <div class="flex items-center gap-3">
+        <img :src="logoUrl" alt="" class="w-8 h-8 flex-none" />
+        <div>
+          <h1 class="text-xl font-semibold tracking-tight">E2E Test Results</h1>
+          <p class="text-sm text-base-content/50">
+            Automated end-to-end tests for
+            <a href="https://github.com/stardew-valley-dedicated-server/server"
+               target="_blank" rel="noopener"
+               class="text-base-content/70 hover:text-primary underline underline-offset-2 transition-colors">JunimoServer</a>, a Stardew Valley dedicated server.
+          </p>
+        </div>
+      </div>
+
+      <!-- ── Summary block (only when there's a run to summarize) ── -->
+      <section v-if="hasData" class="space-y-4">
+        <!-- Headline result + counts. The full count breakdown (incl. total) lives
+             here so passed/skipped/total read together; the header strip and the
+             facts list below carry the orthogonal data (status word, timing). -->
+        <div class="bg-base-200/50 border border-base-content/5 rounded-lg p-5 space-y-4">
+          <div class="text-lg font-bold capitalize" :class="statusTextClass"
+               :title="`Overall run status: ${statusLabel}`">
+            {{ isLive ? "In progress" : statusLabel }}
+          </div>
+
+          <!-- Live progress bar -->
+          <div v-if="isLive" class="flex items-center gap-2">
+            <div class="flex-1 bg-base-content/20 rounded-full h-1.5">
+              <div class="h-full rounded-full bg-primary transition-[width] duration-300"
+                   :style="{ width: `${progress}%` }" />
+            </div>
+            <span class="text-[11px] text-base-content/50 tabular-nums">{{ completedCount }}/{{ store.state.totalTests }}</span>
+          </div>
+
+          <!-- Count chips + total, dot-separated so adjacent counts never glue. -->
+          <div class="flex items-center gap-x-2.5 gap-y-1 flex-wrap text-sm tabular-nums">
+            <template v-for="(chip, i) in visibleChips" :key="chip.key">
+              <span v-if="i > 0" class="text-base-content/20">·</span>
+              <span class="font-medium" :class="chip.cls" :title="TERM_HELP[chip.key]">
+                {{ sc[chip.key] ?? 0 }} {{ chip.label }}
+              </span>
+            </template>
+            <span v-if="store.state.totalTests > 0" class="text-base-content/20">·</span>
+            <span v-if="store.state.totalTests > 0" class="text-base-content/50">{{ store.state.totalTests }} total</span>
+          </div>
+        </div>
+
+        <!-- Recent failures -->
+        <div v-if="recentFailures.length > 0" class="space-y-2">
+          <div class="flex items-center justify-between">
+            <h2 class="text-xs uppercase tracking-widest text-base-content/40 font-semibold">Recent failures</h2>
+            <button class="text-xs text-error hover:underline cursor-pointer" @click="showFailedTests()">View all {{ sc.failed }} →</button>
+          </div>
+          <button v-for="test in recentFailures" :key="test.displayName"
+                  class="w-full cursor-pointer flex items-center gap-2 px-3 py-2 rounded-md bg-error/5 hover:bg-error/10 text-left transition-colors"
+                  @click="selectTest(test)">
+            <StatusIcon status="failed" :size="14" />
+            <span class="font-mono text-[13px] truncate flex-1">{{ shortTestName(test.displayName) }}</span>
+            <span v-if="test.failureCategory" class="text-[11px] text-base-content/40 flex-none">{{ test.failureCategory }}</span>
+          </button>
+        </div>
+
+        <!-- Flaky tests (needs-attention list) -->
+        <div v-if="flakyTests.length > 0" class="space-y-2">
+          <h2 class="text-xs uppercase tracking-widest text-base-content/40 font-semibold">Flaky tests</h2>
+          <button v-for="f in flakyTests" :key="f.test"
+                  class="w-full cursor-pointer flex items-center gap-2 px-3 py-2 rounded-md bg-warning/5 hover:bg-warning/10 text-left transition-colors"
+                  @click="selectFlaky(f.test)">
+            <Icon icon="lucide:zap" class="w-3.5 h-3.5 text-warning flex-none" />
+            <span class="font-mono text-[13px] truncate flex-1">{{ shortTestName(f.test) }}</span>
+            <span class="text-[11px] text-base-content/40 flex-none tabular-nums">
+              {{ Math.round(f.failRate * 100) }}% over {{ f.recentRuns }} runs
+            </span>
+          </button>
+        </div>
+
+        <!-- Run facts: the metadata the header strip and verdict card don't carry —
+             what was tested, when, and (the single Overview copy of) how long. -->
+        <dl class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs pt-1">
+          <template v-if="gitBranch">
+            <dt class="text-base-content/40 flex items-center gap-1.5">
+              <Icon icon="lucide:git-branch" class="w-3.5 h-3.5" /> Branch
+            </dt>
+            <dd class="font-mono text-base-content/70">
+              {{ gitBranch }}<span v-if="gitSha" class="text-base-content/40"> @ <a
+                 :href="commitUrl!" target="_blank" rel="noopener"
+                 class="hover:text-primary underline underline-offset-2 transition-colors"
+                 title="View this commit on GitHub">{{ gitSha }}</a></span>
+              <span v-if="gitDirty" class="text-warning" title="The working tree had uncommitted changes when the run started."> · uncommitted changes</span>
+            </dd>
+          </template>
+          <template v-if="startedAt">
+            <dt class="text-base-content/40 flex items-center gap-1.5">
+              <Icon icon="lucide:calendar" class="w-3.5 h-3.5" /> Started
+            </dt>
+            <dd class="text-base-content/70 tabular-nums">{{ startedAt }}</dd>
+          </template>
+          <template v-if="!isLive && totalDuration">
+            <dt class="text-base-content/40 flex items-center gap-1.5">
+              <Icon icon="lucide:timer" class="w-3.5 h-3.5" /> Duration
+            </dt>
+            <dd class="text-base-content/70 tabular-nums">{{ totalDuration }}</dd>
+          </template>
+        </dl>
+
+        <!-- Run details: deeper metadata, collapsed by default so it stays out of
+             the way of the at-a-glance summary above. -->
+        <details v-if="runMeta" class="group text-xs">
+          <summary class="cursor-pointer text-base-content/40 hover:text-base-content/70 select-none flex items-center gap-1.5 w-fit">
+            <Icon icon="lucide:chevron-right" class="w-3.5 h-3.5 transition-transform group-open:rotate-90" />
+            Run details
+          </summary>
+          <div class="mt-3 pl-5 space-y-3">
+            <div>
+              <div class="text-base-content/40 uppercase text-[10px] tracking-widest font-semibold mb-1">Run ID</div>
+              <div class="font-mono break-all text-base-content/70">{{ runMeta.runId }}</div>
+            </div>
+            <div v-if="runtimeLabel">
+              <div class="text-base-content/40 uppercase text-[10px] tracking-widest font-semibold mb-1">Runtime</div>
+              <div class="text-base-content/70">{{ runtimeLabel }}</div>
+            </div>
+            <div v-if="envEntries.length > 0">
+              <div class="text-base-content/40 uppercase text-[10px] tracking-widest font-semibold mb-1">Environment</div>
+              <div v-for="[k, v] in envEntries" :key="k" class="font-mono text-base-content/70">{{ k }}={{ v }}</div>
+            </div>
+            <div v-if="serverConfigs.length > 0">
+              <div class="text-base-content/40 uppercase text-[10px] tracking-widest font-semibold mb-1">Server configurations</div>
+              <div v-for="cfg in serverConfigs" :key="cfg.key" class="flex justify-between gap-2 text-base-content/70">
+                <span class="truncate">{{ cfg.label }}</span>
+                <span class="tabular-nums text-base-content/50 flex-none">{{ cfg.testCount }} {{ cfg.testCount === 1 ? "test" : "tests" }}</span>
+              </div>
+            </div>
+          </div>
+        </details>
+      </section>
+
+      <!-- ── Help / orientation block (always visible) ── -->
+      <!-- !mt-6 overrides the wrapper's space-y-8 so the divider has balanced
+           breathing room (24px above via margin, 24px below via padding) instead
+           of the 32px+24px the global gap would stack on top of the border. -->
+      <section class="space-y-4 border-t border-base-content/5 !mt-6 pt-6">
+        <h2 class="text-xs uppercase tracking-widest text-base-content/40 font-semibold">Getting around</h2>
+        <!-- Navigation cards: bordered + chevron so they read as clickable, not prose. -->
+        <div class="grid sm:grid-cols-2 gap-3 text-sm">
+          <button class="group cursor-pointer flex items-start gap-2.5 text-left rounded-lg border border-base-content/10 bg-base-200/30 p-3 hover:bg-base-200/70 hover:border-base-content/20 transition-colors"
+                  @click="activeView = 'tests'"
+                  @mouseenter="setHover('tests')" @mouseleave="setHover(null)">
+            <Icon icon="lucide:file-text" class="w-4 h-4 mt-0.5 flex-none text-base-content/40 group-hover:text-base-content/80 transition-colors" />
+            <p class="text-base-content/60 flex-1">
+              <span class="text-base-content/90 font-medium">Explorer</span> — browse the full test tree, search by
+              name, and filter by status. Each test opens its output, error, and screen recording.
+            </p>
+            <Icon icon="lucide:chevron-right" class="w-4 h-4 mt-0.5 flex-none text-base-content/20 group-hover:text-base-content/50 transition-colors" />
+          </button>
+          <button class="group cursor-pointer flex items-start gap-2.5 text-left rounded-lg border border-base-content/10 bg-base-200/30 p-3 hover:bg-base-200/70 hover:border-base-content/20 transition-colors"
+                  @click="activeView = 'vnc'"
+                  @mouseenter="setHover('vnc')" @mouseleave="setHover(null)">
+            <Icon icon="lucide:container" class="w-4 h-4 mt-0.5 flex-none text-base-content/40 group-hover:text-base-content/80 transition-colors" />
+            <p class="text-base-content/60 flex-1">
+              <span class="text-base-content/90 font-medium">Containers</span> — server and client containers for the
+              run: live screens while it runs, plus past containers, performance charts, and the infrastructure timeline.
+            </p>
+            <Icon icon="lucide:chevron-right" class="w-4 h-4 mt-0.5 flex-none text-base-content/20 group-hover:text-base-content/50 transition-colors" />
+          </button>
+        </div>
+        <!-- Informational hint (not navigation) — kept visually distinct from the cards above. -->
+        <p class="flex items-center gap-1.5 text-xs text-base-content/40">
+          <Icon icon="lucide:keyboard" class="w-3.5 h-3.5 flex-none" />
+          Hover the <span class="font-bold text-base-content/60">?</span> in the top bar to see keyboard shortcuts.
+        </p>
+
+        <!-- Data-driven shortcuts: only render what the current run can point at. -->
+        <div v-if="sc.failed > 0" class="flex flex-wrap gap-2 pt-1">
+          <button class="btn btn-sm btn-outline btn-error gap-1.5"
+                  @click="showFailedTests()">
+            <Icon icon="lucide:list-filter" class="w-3.5 h-3.5" />
+            Jump to {{ sc.failed }} failed {{ sc.failed === 1 ? "test" : "tests" }}
+          </button>
+          <button v-if="mostRecentFailure"
+                  class="btn btn-sm btn-ghost gap-1.5"
+                  @click="selectTest(mostRecentFailure)">
+            <Icon icon="lucide:arrow-right" class="w-3.5 h-3.5" />
+            Most recent failure
+          </button>
+        </div>
+      </section>
+
+      <!-- No-data hint: when there's genuinely nothing to summarize yet. -->
+      <EmptyState v-if="!hasData" label="Waiting for test results…" class="py-8" />
+    </div>
+  </div>
+</template>

--- a/tests/test-ui/src/components/StatusBar.vue
+++ b/tests/test-ui/src/components/StatusBar.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
 import { Icon } from "@iconify/vue";
 import { computed, ref, watch } from "vue";
+import { useRunStatus } from "../composables/useRunStatus";
 import { useShowFailed, useTestUI } from "../composables/useTestUI";
 import { formatDuration } from "../utils/format";
+import { TERM_HELP } from "../utils/glossary";
 
 const { store } = useTestUI();
 const { showFailedTests } = useShowFailed();
 
 // Read counts directly from the store's incrementally-maintained map
 const sc = store.statusCounts;
+
+// Overall run status label + color, shared with OverviewPanel via useRunStatus.
+const { statusLabel, statusTextClass } = useRunStatus(store);
 
 const completedCount = computed(() => sc.passed + sc.failed + sc.skipped + sc.canceled + sc.notDispatched + sc.aborted);
 
@@ -22,50 +27,6 @@ const progress = computed(() => {
 
 // Final elapsed (only set when run finishes; during the run, rAF updates the DOM directly)
 const elapsed = computed(() => formatDuration(store.elapsedMs));
-
-const statusLabel = computed(() => {
-    if (store.state.status === "aborted") {
-        return "aborted";
-    }
-    if (store.state.status === "running") {
-        return "running";
-    }
-    if (store.state.status === "finished") {
-        if (sc.failed > 0) {
-            return "failed";
-        }
-        if (sc.canceled > 0) {
-            return "canceled";
-        }
-        if (sc.passed > 0) {
-            return "passed";
-        }
-        return "no tests ran";
-    }
-    return "pending";
-});
-
-const statusTextClass = computed(() => {
-    if (store.state.status === "running") {
-        return "text-success";
-    }
-    if (store.state.status === "finished") {
-        if (sc.failed > 0) {
-            return "text-error";
-        }
-        if (sc.canceled > 0) {
-            return "text-warning";
-        }
-        if (sc.passed > 0) {
-            return "text-success";
-        }
-        return "text-warning";
-    }
-    if (store.state.status === "aborted") {
-        return "text-warning";
-    }
-    return "text-base-content/50";
-});
 
 // Stop = nuke. Single click force-exits the runner via Program.cs's
 // ForceExitNow path (bulk Docker cleanup by run-id label + Environment.Exit).
@@ -91,17 +52,6 @@ watch(
 );
 
 const shortcutsOpen = ref(false);
-const detailsOpen = ref(false);
-
-const runMeta = computed(() => store.state.runMetadata?.data ?? null);
-const gitLabel = computed(() => {
-    const g = runMeta.value?.git;
-    if (!g) {
-        return null;
-    }
-    const sha = g.sha ? g.sha.slice(0, 7) : "?";
-    return `${g.branch ?? "?"} @ ${sha}${g.dirty ? " ●" : ""}`;
-});
 </script>
 
 <template>
@@ -124,15 +74,15 @@ const gitLabel = computed(() => {
 
     <!-- Counters -->
     <div class="flex items-center gap-2.5 text-xs tabular-nums flex-none">
-      <span class="text-success font-medium">{{ sc.passed }} passed</span>
+      <span class="text-success font-medium" :title="TERM_HELP.passed">{{ sc.passed }} passed</span>
       <span v-if="sc.failed > 0"
             class="text-error font-medium cursor-pointer hover:underline"
-            title="Show failed tests only"
+            :title="`${TERM_HELP.failed}\n\nClick to show failed tests only.`"
             @click="showFailedTests()">{{ sc.failed }} failed</span>
-      <span v-if="sc.canceled > 0" class="text-warning font-medium">{{ sc.canceled }} canceled</span>
-      <span v-if="sc.notDispatched > 0" class="text-base-content/50 font-medium">{{ sc.notDispatched }} not dispatched</span>
-      <span v-if="sc.queued > 0" class="text-primary font-medium">{{ sc.queued }} queued</span>
-      <span v-if="sc.skipped > 0" class="text-base-content/50 font-medium">{{ sc.skipped }} skipped</span>
+      <span v-if="sc.canceled > 0" class="text-warning font-medium" :title="TERM_HELP.canceled">{{ sc.canceled }} canceled</span>
+      <span v-if="sc.notDispatched > 0" class="text-base-content/50 font-medium" :title="TERM_HELP.notDispatched">{{ sc.notDispatched }} not dispatched</span>
+      <span v-if="sc.queued > 0" class="text-primary font-medium" :title="TERM_HELP.queued">{{ sc.queued }} queued</span>
+      <span v-if="sc.skipped > 0" class="text-base-content/50 font-medium" :title="TERM_HELP.skipped">{{ sc.skipped }} skipped</span>
     </div>
 
     <!-- Progress bar (inline) -->
@@ -178,49 +128,6 @@ const gitLabel = computed(() => {
             class="text-xs text-base-content/50 tabular-nums"
             title="Elapsed time">{{ elapsed || '--' }}</span>
     </span>
-
-    <!-- Run details drawer (git, env, runtime, server-config plan) -->
-    <div v-if="runMeta" class="relative flex-none">
-      <button class="flex items-center gap-1.5 px-2 h-6 rounded-md text-xs text-base-content/70 hover:text-base-content hover:bg-base-content/5 transition-colors tabular-nums"
-              title="Run details"
-              @click.stop="detailsOpen = !detailsOpen"
-              @blur="detailsOpen = false">
-        <Icon icon="lucide:git-branch" class="w-3 h-3" />
-        <span v-if="gitLabel">{{ gitLabel }}</span>
-        <Icon icon="lucide:chevron-down" class="w-3 h-3" />
-      </button>
-      <div v-if="detailsOpen"
-           class="absolute right-0 top-full mt-1.5 z-40 bg-base-300 border border-base-content/10 rounded-lg shadow-lg p-3 text-xs space-y-2 w-80 max-h-96 overflow-auto"
-           @mousedown.stop>
-        <div>
-          <div class="text-base-content/50 uppercase text-[10px] tracking-wider mb-1">Run</div>
-          <div class="font-mono break-all">{{ runMeta.runId }}</div>
-        </div>
-        <div v-if="runMeta.git">
-          <div class="text-base-content/50 uppercase text-[10px] tracking-wider mb-1">Git</div>
-          <div>branch: <span class="font-mono">{{ runMeta.git.branch ?? '?' }}</span></div>
-          <div>sha: <span class="font-mono">{{ runMeta.git.sha ?? '?' }}</span></div>
-          <div v-if="runMeta.git.dirty" class="text-warning">dirty working tree</div>
-        </div>
-        <div v-if="runMeta.runtime">
-          <div class="text-base-content/50 uppercase text-[10px] tracking-wider mb-1">Runtime</div>
-          <div v-if="runMeta.runtime.os">{{ runMeta.runtime.os }}</div>
-          <div v-if="runMeta.runtime.dotnet">{{ runMeta.runtime.dotnet }}</div>
-          <div v-if="runMeta.runtime.docker">docker {{ runMeta.runtime.docker }}</div>
-        </div>
-        <div v-if="runMeta.env && Object.keys(runMeta.env).length > 0">
-          <div class="text-base-content/50 uppercase text-[10px] tracking-wider mb-1">Env</div>
-          <div v-for="(v, k) in runMeta.env" :key="k" class="font-mono">{{ k }}={{ v }}</div>
-        </div>
-        <div v-if="runMeta.serverConfigs && runMeta.serverConfigs.length > 0">
-          <div class="text-base-content/50 uppercase text-[10px] tracking-wider mb-1">Server config plan</div>
-          <div v-for="cfg in runMeta.serverConfigs" :key="cfg.key" class="flex justify-between gap-2">
-            <span class="truncate">{{ cfg.label }}</span>
-            <span class="tabular-nums text-base-content/60 flex-none">{{ cfg.testCount }} tests · {{ cfg.prestartedInstanceCount }} prestarted</span>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <!-- Keyboard shortcuts hint (hover + click toggle) -->
     <div class="relative group flex-none">

--- a/tests/test-ui/src/components/TestTree.vue
+++ b/tests/test-ui/src/components/TestTree.vue
@@ -6,6 +6,7 @@ import { useTestSort } from "../composables/useTestSort";
 import { useFilterTrigger, useTestUI } from "../composables/useTestUI";
 import type { ClassSnapshot, TestSnapshot } from "../types/state";
 import { shortTestName } from "../utils/format";
+import { TERM_HELP } from "../utils/glossary";
 import { statusFilterClass } from "../utils/status";
 import EmptyState from "./EmptyState.vue";
 import SortIcon from "./SortIcon.vue";
@@ -24,6 +25,12 @@ const viewMode = ref<"grouped" | "timeline">("grouped");
 const statusCounts = store.statusCounts;
 const { activeFilters, toggleFilter, visibleStatuses, isFiltering, testPassesFilter, setExclusiveFilter } =
     useTestFilter(statusCounts, searchQuery);
+
+// Status-pill tooltip: the term definition plus the toggle action it performs.
+function statusTitle(status: TestStatus): string {
+    const action = activeFilters.value.has(status) ? "Hide" : "Show";
+    return `${TERM_HELP[status] ?? ""}\n\n${action} ${status} tests.`.trim();
+}
 
 // Flaky lookup. Each entry's `test` matches the test name (className.method form),
 // so we match against the test's displayName (xUnit's full display name) endsWith
@@ -672,7 +679,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeyDown));
               activeFilters.has(status) ? 'opacity-100' : 'opacity-30',
               statusFilterClass(status)
             ]"
-            :title="`${activeFilters.has(status) ? 'Hide' : 'Show'} ${status} tests`"
+            :title="statusTitle(status)"
             @click="toggleFilter(status)"
           >
             <StatusIcon :status="status" :size="10" />

--- a/tests/test-ui/src/components/VncGrid.vue
+++ b/tests/test-ui/src/components/VncGrid.vue
@@ -310,9 +310,9 @@ function onSplitDoubleClick() {
     <!-- Empty state (no live and no stopped instances) -->
     <div v-if="!hasAnyEndpoints && !hasStoppedInstances"
          class="flex-1 flex flex-col items-center justify-center text-base-content/30 gap-3">
-      <Icon icon="lucide:monitor" class="w-12 h-12 opacity-20" />
-      <span class="text-sm">No VNC endpoints available yet</span>
-      <span class="text-xs text-base-content/20">VNC viewers appear as server and client containers start</span>
+      <Icon icon="lucide:container" class="w-12 h-12 opacity-20" />
+      <span class="text-sm">No containers yet</span>
+      <span class="text-xs text-base-content/20">Server and client containers appear here as the run starts them</span>
     </div>
 
     <!-- Has instances (live or stopped) -->

--- a/tests/test-ui/src/composables/useRouteSync.ts
+++ b/tests/test-ui/src/composables/useRouteSync.ts
@@ -2,9 +2,10 @@ import { type Ref, watch } from "vue";
 import { type RouteLocationRaw, useRoute, useRouter } from "vue-router";
 import type { useInspectNavigation } from "./useInspectNavigation";
 import type { TestStore } from "./useTestStore";
+import type { ActiveView } from "./useTestUI";
 
 type Inspect = ReturnType<typeof useInspectNavigation>;
-type ActiveView = Ref<"tests" | "vnc">;
+type ActiveViewRef = Ref<ActiveView>;
 
 /**
  * Two-way sync between the URL and the app's in-memory state, with App.vue kept
@@ -19,7 +20,7 @@ type ActiveView = Ref<"tests" | "vnc">;
  * into the URL. A `syncing` guard stops the route→state and state→route
  * watchers from ping-ponging.
  */
-export function useRouteSync(store: TestStore, inspect: Inspect, activeView: ActiveView): void {
+export function useRouteSync(store: TestStore, inspect: Inspect, activeView: ActiveViewRef): void {
     const route = useRoute();
     const router = useRouter();
 
@@ -29,6 +30,16 @@ export function useRouteSync(store: TestStore, inspect: Inspect, activeView: Act
     // Set when a deep-linked test/instance hasn't streamed in yet (live mode); the
     // source-data watcher re-applies the route once the tree/instances populate.
     let pending = false;
+
+    // Cold-visit latch: was the page loaded at the bare root (no test path, no
+    // ?inspect)? Read from the loaded URL, NOT selectedTest — the store's
+    // hydrate-time autoSelect has already mutated selectedTest by now (synchronously
+    // in report mode), so keying off the URL dodges that race: deep-links leave this
+    // false (untouched), a bare root defaults to the Overview.
+    const initialHash = window.location.hash; // "", "#", "#/", or "#/<route>[?query]"
+    const initialPath = initialHash.replace(/^#/, "").split("?")[0] ?? "";
+    const initialQuery = initialHash.includes("?") ? initialHash.slice(initialHash.indexOf("?")) : "";
+    const coldRootVisit = (initialPath === "" || initialPath === "/") && !initialQuery.includes("inspect=");
 
     function withSync(fn: () => void) {
         syncing = true;
@@ -77,7 +88,7 @@ export function useRouteSync(store: TestStore, inspect: Inspect, activeView: Act
             }
         } else {
             store.selectTest(null);
-            activeView.value = name === "vnc" ? "vnc" : "tests";
+            activeView.value = name === "vnc" ? "vnc" : name === "overview" ? "overview" : "tests";
         }
     }
 
@@ -141,7 +152,9 @@ export function useRouteSync(store: TestStore, inspect: Inspect, activeView: Act
         }
         const query = route.query;
         let target: RouteLocationRaw;
-        if (activeView.value === "vnc") {
+        if (activeView.value === "overview") {
+            target = { name: "overview", query };
+        } else if (activeView.value === "vnc") {
             target = { name: "vnc", query };
         } else if (store.selectedTest) {
             target = { name: "test", params: { displayName: store.selectedTest.displayName }, query };
@@ -176,5 +189,18 @@ export function useRouteSync(store: TestStore, inspect: Inspect, activeView: Act
     );
 
     // ── Initial resolve ───────────────────────────────────────────────────────
-    applyFromRoute();
+    if (coldRootVisit) {
+        // Show the Overview and clear the hydrate-time autoSelect (else it strands
+        // the URL at /tests/<name> or pre-empts the view). Inside withSync so the
+        // state→route watcher stays quiet; replace (not push) parks the URL at
+        // /overview without a back-button trap to /.
+        withSync(() => {
+            activeView.value = "overview";
+            store.selectTest(null);
+            applyInspectFromRoute();
+        });
+        router.replace({ name: "overview", query: route.query });
+    } else {
+        applyFromRoute();
+    }
 }

--- a/tests/test-ui/src/composables/useRunStatus.ts
+++ b/tests/test-ui/src/composables/useRunStatus.ts
@@ -1,0 +1,62 @@
+import { type ComputedRef, computed } from "vue";
+import type { TestStore } from "./useTestStore";
+
+/**
+ * Overall run status reduced to a one-word label and a Tailwind text color,
+ * derived from `state.status` plus the failed/canceled/passed counts. Shared by
+ * StatusBar (the header strip) and OverviewPanel (the landing summary) so the two
+ * never drift — the priority order (aborted/running, then failed > canceled >
+ * passed) lives in exactly one place.
+ */
+export function useRunStatus(store: TestStore): {
+    statusLabel: ComputedRef<string>;
+    statusTextClass: ComputedRef<string>;
+} {
+    const sc = store.statusCounts;
+
+    const statusLabel = computed(() => {
+        if (store.state.status === "aborted") {
+            return "aborted";
+        }
+        if (store.state.status === "running") {
+            return "running";
+        }
+        if (store.state.status === "finished") {
+            if (sc.failed > 0) {
+                return "failed";
+            }
+            if (sc.canceled > 0) {
+                return "canceled";
+            }
+            if (sc.passed > 0) {
+                return "passed";
+            }
+            return "no tests ran";
+        }
+        return "pending";
+    });
+
+    const statusTextClass = computed(() => {
+        if (store.state.status === "running") {
+            return "text-success";
+        }
+        if (store.state.status === "finished") {
+            if (sc.failed > 0) {
+                return "text-error";
+            }
+            if (sc.canceled > 0) {
+                return "text-warning";
+            }
+            if (sc.passed > 0) {
+                return "text-success";
+            }
+            return "text-warning";
+        }
+        if (store.state.status === "aborted") {
+            return "text-warning";
+        }
+        return "text-base-content/50";
+    });
+
+    return { statusLabel, statusTextClass };
+}

--- a/tests/test-ui/src/composables/useTestStore.ts
+++ b/tests/test-ui/src/composables/useTestStore.ts
@@ -280,6 +280,18 @@ export function useTestStore(): TestStore {
         state.skipped = snapshot.skipped;
         state.notDispatched = snapshot.notDispatched ?? 0;
         state.durationMs = snapshot.durationMs;
+        // Carry run metadata + flaky list from the snapshot. Live mode also gets
+        // these via WS events (run_metadata / flaky_tests), but snapshot-only modes
+        // (dev mock, static report) never fire those — so hydrate is the sole source
+        // there, and the Overview would otherwise have no metadata to show.
+        // Guard on !== undefined so a reconnect snapshot omitting them can't wipe
+        // values an earlier event set.
+        if (snapshot.runMetadata !== undefined) {
+            state.runMetadata = snapshot.runMetadata;
+        }
+        if (snapshot.flakyTests !== undefined) {
+            state.flakyTests = snapshot.flakyTests;
+        }
 
         // For arrays, mutate in-place (splice+push) rather than replacing the reference.
         // This ensures Vue's reactivity system properly tracks the deep changes.

--- a/tests/test-ui/src/composables/useTestUI.ts
+++ b/tests/test-ui/src/composables/useTestUI.ts
@@ -59,3 +59,14 @@ export function useShowFailed() {
     }
     return { showFailedTests };
 }
+
+/**
+ * Access the goToExplorer callback (switches to Explorer + reopens the sidebar).
+ */
+export function useGoToExplorer() {
+    const goToExplorer = inject<() => void>("goToExplorer");
+    if (!goToExplorer) {
+        throw new Error("useGoToExplorer: goToExplorer not provided");
+    }
+    return { goToExplorer };
+}

--- a/tests/test-ui/src/composables/useTestUI.ts
+++ b/tests/test-ui/src/composables/useTestUI.ts
@@ -10,6 +10,11 @@ import type { TestStore } from "./useTestStore";
 
 export type InspectNavigation = ReturnType<typeof useInspectNavigation>;
 
+/** The app's three top-level views. Single source of truth — widening this here
+ *  flows to App.vue, useRouteSync, and the inject below (a missed site is a
+ *  vue-tsc failure). "overview" is the landing page; not persisted (see App.vue). */
+export type ActiveView = "tests" | "vnc" | "overview";
+
 /**
  * Access the test store and shared UI state.
  * Must be called inside a component that is a descendant of App.vue.
@@ -20,7 +25,7 @@ export function useTestUI() {
         throw new Error("useTestUI: store not provided. Component must be inside App.vue");
     }
 
-    const activeView = inject<Ref<"tests" | "vnc">>("activeView");
+    const activeView = inject<Ref<ActiveView>>("activeView");
     if (!activeView) {
         throw new Error("useTestUI: activeView not provided");
     }

--- a/tests/test-ui/src/router/index.ts
+++ b/tests/test-ui/src/router/index.ts
@@ -18,6 +18,7 @@ const router = createRouter({
     history: createWebHashHistory(),
     routes: [
         { path: "/", name: "tests", component: noRender },
+        { path: "/overview", name: "overview", component: noRender },
         { path: "/tests/:displayName", name: "test", component: noRender },
         { path: "/vnc", name: "vnc", component: noRender },
         { path: "/:pathMatch(.*)*", redirect: "/" },

--- a/tests/test-ui/src/style.css
+++ b/tests/test-ui/src/style.css
@@ -206,11 +206,15 @@ img {
     color: color-mix(in oklch, var(--color-base-content) 30%, transparent);
     transition: all 150ms ease;
     position: relative;
+    cursor: pointer;
 }
 
-.icon-sidebar-btn:hover {
+/* Icon color only on hover (and when an Overview nav card previews this target via
+   .hovered) — no background fill; the filled bg is reserved for the .active
+   selected state below. */
+.icon-sidebar-btn:hover,
+.icon-sidebar-btn.hovered {
     color: color-mix(in oklch, var(--color-base-content) 60%, transparent);
-    background-color: color-mix(in oklch, var(--color-base-content) 5%, transparent);
 }
 
 .icon-sidebar-btn.active {

--- a/tests/test-ui/src/utils/format.ts
+++ b/tests/test-ui/src/utils/format.ts
@@ -12,6 +12,26 @@ export function formatDuration(ms: number | null | undefined): string {
     return `${Math.round(ms)}ms`;
 }
 
+/** Format an ISO timestamp as an absolute local date + time (e.g. "Jun 21, 2026, 14:03").
+ *  Returns "" for null/unparseable input so callers can `v-if` on it. */
+export function formatDateTime(iso: string | null | undefined): string {
+    if (!iso) {
+        return "";
+    }
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) {
+        return "";
+    }
+    return d.toLocaleString([], {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    });
+}
+
 /** Extract short test name from display name. */
 export function shortTestName(displayName: string): string {
     const parenIdx = displayName.indexOf("(");

--- a/tests/test-ui/src/utils/glossary.ts
+++ b/tests/test-ui/src/utils/glossary.ts
@@ -1,0 +1,28 @@
+/**
+ * Single source of truth for the inline definitions surfaced as native `title=`
+ * tooltips on status badges, filter pills, and annotation-source chips. Keyed by
+ * the status/source slug so every surface (StatusBar, TestTree, OutputPanel,
+ * OverviewPanel) shows the same wording. A term that needs a glossary page is a
+ * term that failed — so the definition lives on the label, not in prose.
+ */
+export const TERM_HELP: Record<string, string> = {
+    // ── Test outcomes ──
+    passed: "The test ran and all assertions held.",
+    failed: "The test ran and an assertion or unexpected exception failed it.",
+    canceled:
+        "The test was cut short, not failed — the run was stopping (stop-on-fail cascade or operator stop), so its result is unknown rather than bad.",
+    skipped: "The test was intentionally not run (e.g. a [Fact(Skip=…)] or an unmet condition).",
+    notDispatched:
+        "Discovered but never started — the run ended (aborted or stopped) before the scheduler reached it. Derived as expected − (passed + failed + canceled + skipped).",
+    aborted: "The run was torn down mid-flight; this test never reached a final result.",
+    queued: "Scheduled and waiting for a free test server/client before it can start.",
+    running: "Currently executing.",
+    pending: "Discovered, not yet queued.",
+
+    // ── Annotation sources (per-line origin in the output log) ──
+    body: "Log line written from inside the test method body.",
+    broker: "Log line from the resource broker that pools and assigns the test's server/client containers.",
+    recording: "Log line from the screen-recording pipeline (capture, extraction, encoding).",
+    mod: "Log line relayed from the server/client SMAPI mod inside the container.",
+    setup: "Log line from a setup phase (image build, container start, prestart) that ran before the test.",
+};


### PR DESCRIPTION
Adds an Overview landing page to the E2E test-results UI, giving first-time visitors a run summary and orientation instead of a bare empty state.

## Overview page
- New `OverviewPanel`: run verdict + count breakdown (incl. total), recent failures, flaky tests, and run facts (branch · started · duration).
- Collapsible "Run details" (run id, runtime, environment, server-config plan) — absorbs what the old header drawer showed.
- Navigation/orientation cards (Explorer, Containers) plus a keyboard-shortcuts hint; cards read as clickable (border + chevron + cursor) and preview their target sidebar icon on hover.
- Project name and the commit sha link out to GitHub.

## Routing / first-visit default
- Auto-shows the Overview on a cold visit to the bare root, via a `coldRootVisit` latch read from the initial URL — this dodges the store's hydrate-time `autoSelect` race (which mutates `selectedTest` synchronously in report mode). Deep-links and `?inspect` are untouched, and `overview` is never persisted (a reload lands on the URL/selection, not the landing page).
- Adds the `/overview` route and a single shared `ActiveView` type referenced across `App.vue`, `useRouteSync`, and `useTestUI`.

## Other
- Renames the "VNC" sidebar entry to "Containers" — the view is more than VNC (containers, performance charts, infrastructure timeline, topology); updates its empty-state copy.
- Inline term tooltips via a shared `utils/glossary.ts` on StatusBar counts, TestTree status pills, and OutputPanel source chips.
- Extracts a `useRunStatus` composable shared by StatusBar and OverviewPanel (no more duplicated status label/color logic).
- `hydrateFromSnapshot` now carries `runMetadata`/`flakyTests` so report and dev-mock modes (no WS events) have run metadata.
- Sidebar hover highlights the icon only (no background); `cursor: pointer` on sidebar buttons.

## Verification
- `make build-test-ui` passes (`vue-tsc --noEmit && vite build`).
- Behavior checked against the dev mock and report-mode bundle: cold-load shows Overview without flipping the URL, deep-links/reloads land where they should, tooltips and navigation work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Overview view with run progress, recent failures, flaky tests, and run metadata.
  * Improved navigation with hover-based icon highlighting and smoother jumps to the tests view.
* **Bug Fixes**
  * Prevented the Overview view from being persisted as a user preference; route syncing now reliably handles the Overview state.
* **Enhancements**
  * Expanded consistent glossary-based tooltips for status and source filters.
  * Updated the VNC/containers empty state copy.
* **Chores**
  * Improved date/time formatting and UI state hydration for additional run details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->