### PR TITLE
fix(tests): non-TTY CI render grouping, cabin-placement collision race, join-convoy front-load

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -49,6 +49,26 @@ public class TestCropsResponse
     public string? Error { get; set; }
 }
 
+/// <summary>One online farmer's server-side tile, from /test/farmers.</summary>
+public class TestFarmer
+{
+    public long Id { get; set; }
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+}
+
+/// <summary>
+/// Response from /test/farmers (test-only). Each online farmer's instantaneous server-side
+/// tile, read from Game1 — the position the placement validator reads, which the periodic
+/// /players snapshot doesn't carry.
+/// </summary>
+public class TestFarmersResponse
+{
+    public bool Success { get; set; }
+    public List<TestFarmer> Farmers { get; set; } = new();
+    public string? Error { get; set; }
+}
+
 /// <summary>
 /// Response from /test/set_date (test-only date jump).
 /// </summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -61,6 +61,9 @@ public partial class ApiService
                     case "/test/festival_state":
                         await WriteJsonAsync(response, await HandleGetTestFestivalStateAsync());
                         return;
+                    case "/test/farmers":
+                        await WriteJsonAsync(response, await HandleGetTestFarmersAsync(request));
+                        return;
                     case "/test/save_tmp_exists":
                         await WriteJsonAsync(response, HandleGetTestSaveTmpExists(request));
                         return;
@@ -230,6 +233,64 @@ public partial class ApiService
                 result.FestivalEndReady = Game1.netReady.GetNumberReady("festivalEnd");
                 result.FestivalEndRequired = Game1.netReady.GetNumberRequired("festivalEnd");
                 result.TimeOfDay = Game1.timeOfDay;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/farmers",
+        Summary = "Farmers in a location, by the server-side collection CabinPlacementValidator reads (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestFarmersResponse), 200)]
+    private async Task<TestFarmersResponse> HandleGetTestFarmersAsync(HttpListenerRequest request)
+    {
+        // ?location=<name> (default "Farm"): which location's farmer collection to report.
+        // CabinPlacementValidator iterates Game1.getFarm().farmers — a FarmerCollection that
+        // filters Game1.otherFarmers by currentLocation == Farm (FarmerCollection.cs:49,58).
+        // A warped farmer's TilePoint replicates globally before its currentLocation does, so a
+        // test must mirror THIS membership (location-filtered + bounding-box tile), not a global
+        // getOnlineFarmers()+TilePoint read, or it sees the farmer in position before the
+        // validator's collection does and issues !cabin too early.
+        var locationName = request.QueryString["location"] ?? "Farm";
+
+        var result = new TestFarmersResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var location = Game1.getLocationFromName(locationName);
+                if (location == null)
+                {
+                    result.Success = true;
+                    return;
+                }
+
+                foreach (var farmer in location.farmers)
+                {
+                    // The validator tests GetBoundingBox().Intersects(tileRect); its center tile
+                    // is what a single-tile occupancy check resolves to.
+                    var center = farmer.GetBoundingBox().Center;
+                    result.Farmers.Add(
+                        new TestFarmer
+                        {
+                            Id = farmer.UniqueMultiplayerID,
+                            TileX = center.X / 64,
+                            TileY = center.Y / 64,
+                        }
+                    );
+                }
+
                 result.Success = true;
             });
         }

--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -4,14 +4,15 @@ using JunimoServer.Tests.Schema.Events;
 namespace JunimoServer.TestRunner.Rendering;
 
 /// <summary>
-/// Streaming renderer for CI environments with vitest/jest-inspired output.
+/// Streaming renderer for CI environments with vitest/jest-inspired output:
+///   Header → Setup phases → Test results (by class) → Failure details → Summary.
 ///
-/// Output structure:
-///   Header → Setup phases (streamed with spinners) → Test classes (streamed) → Failure details → Summary
-///
-/// Setup steps and tests show a braille spinner animation on TTY terminals,
-/// replaced by ✓/✗ when complete. Non-TTY output uses a static ◌ indicator.
-/// On GitHub Actions: groups and ::error:: annotations emitted.
+/// On a TTY, tests stream live with a braille spinner that becomes ✓/✗, class headers
+/// printed as tests arrive. The broker runs classes interleaved, and a non-TTY sink can't
+/// reposition the cursor — so streaming there would re-emit a class header (and its
+/// ::group::) every time execution flips back to that class, duplicating headers and
+/// breaking groups. So non-TTY buffers per-test result lines and emits them grouped by
+/// class once, at run end. Diagnostics/annotations stream live in both modes.
 /// </summary>
 public sealed class CIRenderer : RendererBase
 {
@@ -21,9 +22,15 @@ public sealed class CIRenderer : RendererBase
     private readonly bool _useColor;
     private readonly bool _isTTY;
 
-    // Test class tracking
+    // Test class tracking (TTY streaming only)
     private string? _currentClassName;
     private bool _currentClassHasGitHubGroup;
+
+    // Non-TTY result lines, grouped by short class name for the end-of-run flush.
+    // _bufferedClassOrder fixes first-seen class order (Dictionary's isn't contractual).
+    // Both guarded by _writeLock.
+    private readonly List<string> _bufferedClassOrder = new();
+    private readonly Dictionary<string, List<string>> _bufferedResults = new();
 
     // Failure collection for bottom summary (event + accumulated pipe output)
     private readonly List<(TestFailedEvent Failure, string? Output)> _failures = new();
@@ -99,8 +106,17 @@ public sealed class CIRenderer : RendererBase
 
     public override void OnRunFinished(RunFinishedEvent e)
     {
-        // Close the last class group
-        EndClassGroup();
+        lock (_writeLock)
+        {
+            if (_isTTY)
+            {
+                EndClassGroup();
+            }
+            else
+            {
+                FlushBufferedResultsLocked();
+            }
+        }
 
         _out.WriteLine();
 
@@ -311,6 +327,12 @@ public sealed class CIRenderer : RendererBase
 
     public override void OnTestStarted(TestStartedEvent e)
     {
+        // Non-TTY buffers results at run end — nothing to stream live here.
+        if (!_isTTY)
+        {
+            return;
+        }
+
         var shortClass = GetShortClassName(e.TestClass);
         EmitClassHeaderIfNew(shortClass);
         var shortTest = GetShortTestName(e.DisplayName);
@@ -469,55 +491,31 @@ public sealed class CIRenderer : RendererBase
     protected override void OnTestPassedCore(TestPassedEvent e)
     {
         var shortTest = GetShortTestName(e.DisplayName);
-        var line = $"   {Green("\u2713")} {shortTest}  {Dim(FormatDuration(e.Duration))}";
-        var output = GetAccumulatedOutput(e.DisplayName);
-
-        lock (_writeLock)
+        var lines = new List<string>
         {
-            StopSpinnerLocked();
-            if (_isTTY)
-            {
-                _out.Write("\r\x1b[2K");
-            }
-
-            _out.WriteLine(line);
-
-            // In verbose mode, show test output inline
-            if (Verbose && !string.IsNullOrWhiteSpace(output))
-            {
-                foreach (var ol in output.Split('\n'))
-                {
-                    _out.WriteLine($"     {Dim(ol.TrimEnd())}");
-                }
-            }
-
-            _out.Flush();
-        }
+            $"   {Green("\u2713")} {shortTest}  {Dim(FormatDuration(e.Duration))}",
+        };
+        AppendVerboseOutput(lines, GetAccumulatedOutput(e.DisplayName));
+        EmitResult(GetShortClassName(e.TestClass), lines);
     }
 
     protected override void OnTestFailedCore(TestFailedEvent e)
     {
         var shortTest = GetShortTestName(e.DisplayName);
         var output = GetAccumulatedOutput(e.DisplayName);
+        var lines = new List<string>
+        {
+            $"   {RedBold("\u2717")} {shortTest}  {Dim(FormatDuration(e.Duration))}",
+            $"     {Red($"\u2192 {FirstLine(e.Message)}")}",
+        };
+        AppendVerboseOutput(lines, output);
 
         lock (_writeLock)
         {
-            StopSpinnerLocked();
-            if (_isTTY)
-            {
-                _out.Write("\r\x1b[2K");
-            }
-
-            _out.WriteLine(
-                $"   {RedBold("\u2717")} {shortTest}  {Dim(FormatDuration(e.Duration))}"
-            );
-
-            // Short inline error (first line only)
-            _out.WriteLine($"     {Red($"\u2192 {FirstLine(e.Message)}")}");
-
             _failures.Add((e, output));
 
-            // GitHub Actions error annotation
+            // The GitHub Actions error annotation attaches to the run, not a log position,
+            // so it streams live in both modes (the result line itself may be buffered).
             if (_isGitHubActions)
             {
                 var escapedMsg = e
@@ -525,36 +523,66 @@ public sealed class CIRenderer : RendererBase
                     .Replace("\r", "%0D")
                     .Replace("\n", "%0A");
                 _err.WriteLine($"::error title={e.TestClass}.{e.TestMethod}::{escapedMsg}");
+                _err.Flush();
             }
 
-            // In verbose mode, show test output inline
-            if (Verbose && !string.IsNullOrWhiteSpace(output))
-            {
-                foreach (var line in output.Split('\n'))
-                {
-                    _out.WriteLine($"     {Dim(line.TrimEnd())}");
-                }
-            }
-
-            _out.Flush();
+            EmitResultLocked(GetShortClassName(e.TestClass), lines);
         }
     }
 
     protected override void OnTestSkippedCore(TestSkippedEvent e)
     {
         var shortTest = GetShortTestName(e.DisplayName);
+        EmitResult(
+            GetShortClassName(e.TestClass),
+            [$"   {Yellow("\u25CB")} {shortTest}  {Dim(e.Reason)}"]
+        );
+    }
 
+    /// <summary>Append a test's accumulated output as indented dim lines, when verbose.</summary>
+    private void AppendVerboseOutput(List<string> lines, string? output)
+    {
+        if (!Verbose || string.IsNullOrWhiteSpace(output))
+        {
+            return;
+        }
+
+        foreach (var ol in output.Split('\n'))
+        {
+            lines.Add($"     {Dim(ol.TrimEnd())}");
+        }
+    }
+
+    private void EmitResult(string className, IReadOnlyList<string> lines)
+    {
         lock (_writeLock)
         {
-            StopSpinnerLocked();
-            if (_isTTY)
-            {
-                _out.Write("\r\x1b[2K");
-            }
-
-            _out.WriteLine($"   {Yellow("\u25CB")} {shortTest}  {Dim(e.Reason)}");
-            _out.Flush();
+            EmitResultLocked(className, lines);
         }
+    }
+
+    /// <summary>
+    /// Emit a test's result lines: buffer them for the grouped end-of-run flush (non-TTY),
+    /// or clear the spinner and stream them (TTY). Must be called while holding _writeLock.
+    /// </summary>
+    private void EmitResultLocked(string className, IReadOnlyList<string> lines)
+    {
+        if (!_isTTY)
+        {
+            foreach (var line in lines)
+            {
+                BufferResultLocked(className, line);
+            }
+            return;
+        }
+
+        StopSpinnerLocked();
+        _out.Write("\r\x1b[2K");
+        foreach (var line in lines)
+        {
+            _out.WriteLine(line);
+        }
+        _out.Flush();
     }
 
     // ── Annotations (Plane C) ──
@@ -725,6 +753,49 @@ public sealed class CIRenderer : RendererBase
             _out.WriteLine("::endgroup::");
             _currentClassHasGitHubGroup = false;
         }
+    }
+
+    /// <summary>Buffer one result line under its class. Hold _writeLock.</summary>
+    private void BufferResultLocked(string className, string line)
+    {
+        if (!_bufferedResults.TryGetValue(className, out var lines))
+        {
+            lines = new List<string>();
+            _bufferedResults[className] = lines;
+            _bufferedClassOrder.Add(className);
+        }
+
+        lines.Add(line);
+    }
+
+    /// <summary>
+    /// Emit all buffered results grouped by class (first-seen order), each header and
+    /// ::group:: exactly once. Hold _writeLock.
+    /// </summary>
+    private void FlushBufferedResultsLocked()
+    {
+        foreach (var className in _bufferedClassOrder)
+        {
+            _out.WriteLine();
+            _out.WriteLine($" {Bold(className)}");
+
+            if (_isGitHubActions)
+            {
+                _out.WriteLine($"::group::{className}");
+            }
+
+            foreach (var line in _bufferedResults[className])
+            {
+                _out.WriteLine(line);
+            }
+
+            if (_isGitHubActions)
+            {
+                _out.WriteLine("::endgroup::");
+            }
+        }
+
+        _out.Flush();
     }
 
     // ── Utilities ──

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -183,19 +183,24 @@ public class CabinPlacementValidationTests : TestBase
         await using var farmerB = await Farmers.ConnectSecondFarmerAsync(ct: ct);
 
         // Stand B inside A's prospective footprint.
-        var warpB = await farmerB.Client.Actions.Warp(
-            "Farm",
-            CabinPlacementHelper.ExpectedCabinTile.X + 1,
-            CabinPlacementHelper.ExpectedCabinTile.Y
-        );
+        var footprintTileX = CabinPlacementHelper.ExpectedCabinTile.X + 1;
+        var footprintTileY = CabinPlacementHelper.ExpectedCabinTile.Y;
+        var warpB = await farmerB.Client.Actions.Warp("Farm", footprintTileX, footprintTileY);
         Assert.True(warpB?.Success == true, $"B warp failed: {warpB?.Error}");
-        // WaitForLocationAsync returns non-null only when the location matched ^Farm$ within
-        // the timeout; assert it so a B-not-settled failure surfaces here, not as an opaque
-        // "no rejection" timeout below.
-        var bArrived = await farmerB.Client.WaitForLocationAsync("^Farm$", ct: ct);
+        // The client-side warp lands B instantly in its own view, but the CabinPlacementValidator
+        // reads B's position from the SERVER's farmer collection, which B's position replicates to
+        // only over several ticks. Wait for the server to actually see B on the footprint tile
+        // before issuing !cabin — otherwise the validator reads a stale position, the collision
+        // check misses, the move is silently accepted, and no rejection is ever sent.
+        var bSettled = await ServerApi.WaitForFarmerServerTileAsync(
+            farmerB.Uid,
+            footprintTileX,
+            footprintTileY,
+            ct: ct
+        );
         Assert.True(
-            bArrived is not null,
-            "Farmer B did not reach the Farm before the rejection check"
+            bSettled,
+            "Farmer B's position did not replicate to the server before the rejection check"
         );
 
         var rejected = await PollingHelper.WaitUntilAsync(

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1601,11 +1601,31 @@ public class ServerApiClient : IDisposable
             Helpers.WaitName.Polling_ServerApi_WaitForFarmerServerTile,
             async () =>
             {
-                var response = await _httpClient.GetAsync("/test/farmers", ct);
-                response.EnsureSuccessStatusCode();
-                var farmers = await response.Content.ReadFromJsonAsync<TestFarmersResponse>(ct);
-                var f = farmers?.Farmers.FirstOrDefault(x => x.Id == farmerId);
-                return f != null && f.TileX == tileX && f.TileY == tileY;
+                try
+                {
+                    // Bound each request well under the outer budget: _httpClient.Timeout is 5
+                    // min, so an unbounded request could outlive the poll and hang.
+                    using var reqCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    reqCts.CancelAfter(Helpers.TestTimings.PollingRequestTimeout);
+                    var response = await _httpClient.GetAsync("/test/farmers", reqCts.Token);
+                    response.EnsureSuccessStatusCode();
+                    var farmers = await response.Content.ReadFromJsonAsync<TestFarmersResponse>(
+                        reqCts.Token
+                    );
+                    var f = farmers?.Farmers.FirstOrDefault(x => x.Id == farmerId);
+                    return f != null && f.TileX == tileX && f.TileY == tileY;
+                }
+                catch (Exception ex)
+                    when (ex
+                            is HttpRequestException
+                                or TaskCanceledException
+                                or OperationCanceledException
+                        && !ct.IsCancellationRequested
+                    )
+                {
+                    // Per-request timeout or connection error, retry.
+                    return false;
+                }
             },
             timeout ?? Helpers.TestTimings.NetworkSyncTimeout,
             cancellationToken: ct

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -498,6 +498,32 @@ public class TestCropsResponse
     public string? Error { get; set; }
 }
 
+/// <summary>One farmer's server-side tile from /test/farmers. Mirrors the server-side DTO.</summary>
+public class TestFarmer
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("tileX")]
+    public int TileX { get; set; }
+
+    [JsonPropertyName("tileY")]
+    public int TileY { get; set; }
+}
+
+/// <summary>Response from /test/farmers GET endpoint (test-only). Mirrors the server-side DTO.</summary>
+public class TestFarmersResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("farmers")]
+    public List<TestFarmer> Farmers { get; set; } = new();
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 /// <summary>
 /// Response from /test/festival_state GET endpoint (test-only). Mirrors the server-side
 /// TestFestivalStateResponse DTO — a direct read of the host's festival state.
@@ -1551,6 +1577,39 @@ public class ServerApiClient : IDisposable
         var response = await _httpClient.GetAsync("/test/festival_state", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestFestivalStateResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: poll until farmer <paramref name="farmerId"/> appears at the exact tile
+    /// (<paramref name="tileX"/>,<paramref name="tileY"/>) in the Farm's farmer collection —
+    /// the location-filtered <c>getFarm().farmers</c> that CabinPlacementValidator iterates.
+    /// After a client-side warp the farmer's tile replicates globally before its currentLocation
+    /// does, so it can read as on-tile via a global position lookup while still absent from
+    /// <c>farm.farmers</c>; a test warping a second farmer into a footprint must await THIS
+    /// (membership + tile) before the placement command, else the validator's collision loop
+    /// never sees it and the move is wrongly accepted. GET /test/farmers mirrors that collection.
+    /// </summary>
+    public async Task<bool> WaitForFarmerServerTileAsync(
+        long farmerId,
+        int tileX,
+        int tileY,
+        TimeSpan? timeout = null,
+        CancellationToken ct = default
+    )
+    {
+        return await Helpers.PollingHelper.WaitUntilAsync(
+            Helpers.WaitName.Polling_ServerApi_WaitForFarmerServerTile,
+            async () =>
+            {
+                var response = await _httpClient.GetAsync("/test/farmers", ct);
+                response.EnsureSuccessStatusCode();
+                var farmers = await response.Content.ReadFromJsonAsync<TestFarmersResponse>(ct);
+                var f = farmers?.Farmers.FirstOrDefault(x => x.Id == farmerId);
+                return f != null && f.TileX == tileX && f.TileY == tileY;
+            },
+            timeout ?? Helpers.TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -79,13 +79,14 @@ public enum WaitName
     Polling_GameTestClient_WaitForLocation,
     Polling_GameTestClient_WaitForAuthWarp,
 
-    // ServerApiClient.cs (6)
+    // ServerApiClient.cs (7)
     Polling_ServerApi_WaitForPlayerByName,
     Polling_ServerApi_WaitForPlayerById,
     Polling_ServerApi_WaitForPlayersRemovedByName,
     Polling_ServerApi_WaitForPlayersRemovedById,
     Polling_ServerApi_WaitForFarmhandByName,
     Polling_ServerApi_WaitForFarmhandDeletedByName,
+    Polling_ServerApi_WaitForFarmerServerTile,
 
     // SharedSteamAuth.cs (1)
     Polling_SharedSteamAuth_AccountsReady,

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -2564,10 +2564,95 @@ public sealed class TestResourceBroker : IAsyncDisposable
         var weights = demands.Select(InstancesNeeded).ToList();
         var totalWeight = weights.Sum();
 
-        // If more configs than slots, only top N configs get 1 slot each
+        // More configs than slots: each of the top N configs gets exactly 1 slot;
+        // the rest create on-demand. With one slot apiece, a config whose
+        // non-exclusive demand needs ≥2 instances (InstancesNeeded) cannot keep
+        // its join lane drained — every joining test queues on that instance's
+        // single per-game-loop join gate (ManagedServer._joinGate), producing the
+        // end-of-run join convoy. Reactive expansion can't rescue it: a server
+        // boots in ~41s, so an instance spun up at the tail serves ~0 tests before
+        // the run ends. Front-load instead — give the dominant config a 2nd
+        // prestart instance (its own join gate = a real second lane) by demoting
+        // the smallest single-slot config to on-demand. Total stays ≤ slots, so
+        // no slot over-subscription and no churn (the 2nd instance has the whole
+        // backlog to chew through). Guarded on slots >= 2 so single-slot hosts
+        // (CI) are untouched. See .claude/rules/provision-up-front-when-startup-
+        // exceeds-serviceable-tail.md and PLAN-suite-speedup.md §3.
+        // Scope: only fires when demands.Count > slots. At demands.Count == slots
+        // (e.g. a narrow --filter run) the Hamilton path below caps every config at
+        // 1, so no promotion — the convoy fix targets the saturated full-suite case.
         if (demands.Count > slots)
         {
-            return demands.Take(slots).Select(d => (d, 1)).ToList();
+            var alloc = demands.Take(slots).Select(d => 1).ToList();
+
+            if (slots >= 2)
+            {
+                // Log NonExclusiveTestCount so the ≥2-trigger math is auditable on a
+                // dry run (per PLAN-suite-speedup.md §4.1: confirm the dominant
+                // config's count is ≥ 2×clientsPerInstance before relying on the fix).
+                for (var i = 0; i < slots; i++)
+                {
+                    TestLog.Server(
+                        $"  alloc-candidate {demands[i].Requirements.GetDisplayLabel()}: "
+                            + $"nonExclusive={demands[i].NonExclusiveTestCount}, "
+                            + $"instancesNeeded={weights[i]}"
+                    );
+                }
+
+                // Dominant = the single-slot config whose non-exclusive demand is
+                // largest; it's the only one that can form a convoy. Searched only
+                // within the top-`slots` window: a config that sorts outside it (by
+                // ClassCount, the demands order) already creates on-demand and isn't
+                // a promotion candidate. Relies on the convoy-former ranking inside
+                // the window — true on the full suite, where it's also #1 by class.
+                var dominant = -1;
+                for (var i = 0; i < slots; i++)
+                {
+                    if (
+                        dominant < 0
+                        || demands[i].NonExclusiveTestCount
+                            > demands[dominant].NonExclusiveTestCount
+                    )
+                    {
+                        dominant = i;
+                    }
+                }
+
+                // Donor = the single-slot config with the smallest TestCount that
+                // does NOT itself need a 2nd instance (never demote a config that
+                // would convoy too). It pays only a normal on-demand boot when its
+                // turn comes — the same cost a config ranked just outside the top N
+                // already pays today.
+                var donor = -1;
+                for (var i = 0; i < slots; i++)
+                {
+                    if (i == dominant || weights[i] >= 2)
+                    {
+                        continue;
+                    }
+                    if (donor < 0 || demands[i].TestCount < demands[donor].TestCount)
+                    {
+                        donor = i;
+                    }
+                }
+
+                if (weights[dominant] >= 2 && donor >= 0)
+                {
+                    alloc[dominant] = 2;
+                    alloc[donor] = 0;
+                    TestLog.Server(
+                        $"  promoting {demands[dominant].Requirements.GetDisplayLabel()} to 2 instances "
+                            + $"(demoting {demands[donor].Requirements.GetDisplayLabel()} to on-demand) "
+                            + "to add a second join lane for the dominant config"
+                    );
+                }
+            }
+
+            return demands
+                .Take(slots)
+                .Select((d, i) => (d, alloc[i]))
+                .Where(p => p.Item2 > 0)
+                .ToList();
         }
 
         // Hamilton's method: proportional allocation with largest-remainder distribution


### PR DESCRIPTION
## CI renderer — duplicate group headers on non-TTY

The broker runs test classes interleaved. A non-TTY sink (CI logs) can't reposition the cursor, so the streaming class-header model re-emitted each class header — and its GitHub Actions `::group::` — every time execution flipped back to that class, producing duplicate headers and broken/empty groups (e.g. `FarmMapTypeTests` 10×).

- Non-TTY now buffers per-test result lines and emits them grouped by class **once** at run end — each header and `::group::` appears exactly once.
- TTY streaming (live spinners) unchanged. Diagnostics/annotations and `::error::` still stream live in both modes.
- Collapsed the three `OnTest*Core` handlers onto one `EmitResult` sink (buffer vs. stream) + one verbose-output helper.

## Cabin placement — `AnotherPlayerInFootprint` collision race

The test warped a second farmer into the prospective cabin footprint, then issued `!cabin` expecting an "another player is standing there" rejection. It only waited for the farmer's **client-side** location, so under load `!cabin` ran before the farmer's position reached the server, the validator's collision check missed, the move was wrongly accepted, and no rejection was sent.

Root cause is a resolution mismatch: `CabinPlacementValidator` iterates `getFarm().farmers` — a `FarmerCollection` filtered by `currentLocation == Farm`. A warped farmer's tile replicates globally before its `currentLocation` does.

- New test-only `GET /test/farmers` reports farmers from the **same location-filtered collection** the validator reads, with the tile derived from `GetBoundingBox().Center` (the validator's geometry).
- New `ServerApiClient.WaitForFarmerServerTileAsync` polls until the farmer appears at the footprint tile in that collection; the test awaits it before `!cabin`.
- This was load-dependent — passed in isolation, failed in the full suite.

## Test broker — front-load a second instance to avoid the join convoy

When configs exceed host slots, the dominant config funneled all its joins through a single instance's join gate at the end of the run; reactive expansion can't help (a server boots in ~41s and serves ~0 tests at the tail).

- Promote the dominant single-slot config to a **second prestart instance** (a real second join lane), demoting the smallest single-slot config to on-demand. Total stays ≤ slots. Guarded on `slots >= 2` so single-slot hosts (CI) are untouched.

## Verification

Full E2E suite green: **149 passed, 0 failed, 0 canceled, 6 skipped**, no infrastructure errors. The CI-renderer fix was verified with a standalone harness (each `::group::` emitted once under interleaved events).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a test-only API endpoint to retrieve server-side farmer tile positions (`/test/farmers`).
* **Tests**
  * Improved non-TTY test output to prevent duplicate class headers/group markup.
  * Added test client polling helpers and trace naming to verify exact client/server farmer tile synchronization.
  * Strengthened cabin placement validation by waiting for server-replicated footprint tiles before assertions.
* **Chores**
  * Updated test resource allocation with a convoy-style promotion/demotion rule to improve test efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->