### PR TITLE
fix(wedding): host completes ceremonies instead of skipping

### DIFF
--- a/mod/JunimoServer.Shared/WeddingEvent.cs
+++ b/mod/JunimoServer.Shared/WeddingEvent.cs
@@ -1,0 +1,91 @@
+using System;
+using StardewValley;
+
+namespace JunimoServer.Shared;
+
+/// <summary>
+/// Helpers for inspecting a live wedding <see cref="Event"/>, shared by the server mod (host
+/// participation + the test-only wedding_state endpoint) and the test-client mod.
+/// </summary>
+public static class WeddingEvent
+{
+    /// <summary>
+    /// Parse the <c>waitForOtherPlayers &lt;gateId&gt;</c> gate from a wedding event's command list,
+    /// or null if none. Each <see cref="Event.eventCommands"/> element is one space-delimited command
+    /// line; the gate ID is the token after the command name. The vanilla wedding script (Data/Weddings)
+    /// has exactly one such gate, dynamically named <c>weddingEnd&lt;farmerId&gt;</c> — reading it from
+    /// the event itself is the only reliable source, since there is no static name to hard-code.
+    /// </summary>
+    public static string? ExtractWaitGate(Event ev)
+    {
+        var commands = ev?.eventCommands;
+        if (commands == null)
+        {
+            return null;
+        }
+
+        foreach (var line in commands)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var tokens = ArgUtility.SplitBySpace(line);
+            if (
+                tokens.Length >= 2
+                && string.Equals(
+                    tokens[0],
+                    "waitForOtherPlayers",
+                    StringComparison.OrdinalIgnoreCase
+                )
+                && !string.IsNullOrWhiteSpace(tokens[1])
+            )
+            {
+                return tokens[1];
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// True once the event has advanced to (or past) its <c>waitForOtherPlayers</c> command — i.e. the
+    /// cutscene has played through and this instance has reached the wait gate. This is the reliable
+    /// "the ceremony finished playing here" signal: unlike <c>Game1.CurrentEvent == null</c>, it does NOT
+    /// transiently flip during the Town↔Farm exit/entry warps of a back-to-back same-day wedding (where
+    /// <c>CurrentEvent</c> momentarily reads null mid-warp while the event is in fact still running and
+    /// about to resume). Returns false if there is no wait gate or the command index can't be resolved.
+    /// </summary>
+    public static bool HasReachedWaitGate(Event ev)
+    {
+        if (ev?.eventCommands is not { } commands)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < commands.Length; i++)
+        {
+            var line = commands[i];
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            var tokens = ArgUtility.SplitBySpace(line);
+            if (
+                tokens.Length >= 1
+                && string.Equals(
+                    tokens[0],
+                    "waitForOtherPlayers",
+                    StringComparison.OrdinalIgnoreCase
+                )
+            )
+            {
+                return ev.CurrentCommand >= i;
+            }
+        }
+
+        return false;
+    }
+}

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -224,6 +224,7 @@ public class AlwaysOnServer : ModService
                 Game1.player.ignoreCollisions = true;
 
                 PreSeedEarlyGameEvents();
+                PreSeedChoices();
                 HealUpgradedHostFarmhouse();
             }
 
@@ -315,13 +316,10 @@ public class AlwaysOnServer : ModService
         HandleOvernightNamingMenu();
         HandleSkippableEvent();
         HandleMinigame();
-        alwaysOnServerFestivals.HandleFestivalEvents();
         HandleLevelUpMenu();
         // Third-party mod compatibility (see AlwaysOnModCompat)
         modCompat.HandleSpaceCoreLevelUpMenu();
         HandleShippingMenu();
-        HandlePetChoice();
-        HandleCaveChoice();
         HandleCommunityCenterUnlock();
     }
 
@@ -343,6 +341,11 @@ public class AlwaysOnServer : ModService
 
         alwaysOnServerFestivals.HandleFestivalStart();
         alwaysOnServerFestivals.HandleFestivalLeave();
+        // Per-tick: the main-event countdown announce ("Type !event…") and timeout backstop must reach
+        // players promptly. OneSecondUpdateTicked fires every 60 ticks — 12s at SERVER_TPS=5 — which
+        // delayed the announce past clients' wait windows. Countdown/timeout gating is wall-clock based
+        // (DateTime.UtcNow) and one-shot-flagged, so per-tick invocation is safe and more responsive.
+        alwaysOnServerFestivals.HandleFestivalEvents();
     }
 
     private void OnTimeChanged(object sender, TimeChangedEventArgs e)
@@ -530,42 +533,6 @@ public class AlwaysOnServer : ModService
         PlayerIsHidden = !PlayerIsHidden;
     }
 
-    private bool _petChoiceHandled;
-
-    private void HandlePetChoice()
-    {
-        if (!IsAutomating || _petChoiceHandled)
-        {
-            return;
-        }
-
-        if (Game1.player.hasPet())
-        {
-            // Pet already exists (loaded from save). Just rename and mark done.
-            var pet = Game1.player.getPet();
-            pet.Name = Config.PetName;
-            pet.displayName = Config.PetName;
-            _petChoiceHandled = true;
-            return;
-        }
-
-        if (!Config.ShouldCreatePet)
-        {
-            Monitor.Log($"[Automation] Not creating a pet", LogLevel.Info);
-            _petChoiceHandled = true;
-            return;
-        }
-
-        // Call hostActionNamePet directly via reflection, avoiding the throwaway
-        // Event() + namePet() pattern which calls Game1.exitActiveMenu() and
-        // would destroy any active menu (e.g. ReadyCheckDialog from sleep).
-        Monitor.Log($"[Automation] Creating pet '{Config.PetName}'", LogLevel.Info);
-        Helper
-            .Reflection.GetMethod(typeof(Event), "hostActionNamePet")
-            .Invoke(Game1.player, CreateBinaryReader(Config.PetName));
-        _petChoiceHandled = true;
-    }
-
     private static System.IO.BinaryReader CreateBinaryReader(string value)
     {
         var stream = new System.IO.MemoryStream();
@@ -574,30 +541,6 @@ public class AlwaysOnServer : ModService
         writer.Flush();
         stream.Position = 0;
         return new System.IO.BinaryReader(stream);
-    }
-
-    private void HandleCaveChoice()
-    {
-        if (!IsAutomating)
-        {
-            return;
-        }
-
-        // Cave choice unlock
-        if (!Game1.player.eventsSeen.Contains("65"))
-        {
-            Game1.player.eventsSeen.Add("65");
-
-            if (this.Config.FarmCaveChoiceIsMushrooms)
-            {
-                Game1.MasterPlayer.caveChoice.Value = 2;
-                (Game1.getLocationFromName("FarmCave") as FarmCave).setUpMushroomHouse();
-            }
-            else
-            {
-                Game1.MasterPlayer.caveChoice.Value = 1;
-            }
-        }
     }
 
     private void HandleCommunityCenterUnlock()
@@ -1381,6 +1324,66 @@ public class AlwaysOnServer : ModService
         if (!Game1.player.eventsSeen.Contains("980559"))
         {
             Game1.player.eventsSeen.Add("980559");
+        }
+    }
+
+    /// <summary>
+    /// Apply the host's one-time new-game choices (pet, farm cave) deterministically at load. These
+    /// run here — not on the OneSecondUpdateTicked loop, which fires every 12s at SERVER_TPS=5 (see
+    /// one-second-update-ticked-fires-per-game-tick.md) — so the choice is settled before the
+    /// reload/newgame completion contract resolves and before anything (a /test seed, an operator
+    /// command) can write the same state, which the 12s cadence would otherwise race and overwrite.
+    /// Each handler is single-shot on a save-persisted signal (pet existence, eventsSeen "65"), so a
+    /// re-run on /reload is a no-op.
+    /// </summary>
+    private void PreSeedChoices()
+    {
+        HandlePetChoice();
+        HandleCaveChoice();
+    }
+
+    private void HandlePetChoice()
+    {
+        if (Game1.player.hasPet())
+        {
+            // Pet already exists (loaded from save) — just (re)apply the configured name.
+            var pet = Game1.player.getPet();
+            pet.Name = Config.PetName;
+            pet.displayName = Config.PetName;
+            return;
+        }
+
+        if (!Config.ShouldCreatePet)
+        {
+            Monitor.Log($"[Automation] Not creating a pet", LogLevel.Info);
+            return;
+        }
+
+        // Call hostActionNamePet directly via reflection, avoiding the throwaway
+        // Event() + namePet() pattern which calls Game1.exitActiveMenu() and
+        // would destroy any active menu (e.g. ReadyCheckDialog from sleep).
+        Monitor.Log($"[Automation] Creating pet '{Config.PetName}'", LogLevel.Info);
+        Helper
+            .Reflection.GetMethod(typeof(Event), "hostActionNamePet")
+            .Invoke(Game1.player, CreateBinaryReader(Config.PetName));
+    }
+
+    private void HandleCaveChoice()
+    {
+        if (Game1.player.eventsSeen.Contains("65"))
+        {
+            return;
+        }
+        Game1.player.eventsSeen.Add("65");
+
+        if (Config.FarmCaveChoiceIsMushrooms)
+        {
+            Game1.MasterPlayer.caveChoice.Value = 2;
+            (Game1.getLocationFromName("FarmCave") as FarmCave)?.setUpMushroomHouse();
+        }
+        else
+        {
+            Game1.MasterPlayer.caveChoice.Value = 1;
         }
     }
 

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -5,6 +5,7 @@ using HarmonyLib;
 using JunimoServer.Services.ChatCommands;
 using JunimoServer.Services.GameManager;
 using JunimoServer.Services.ServerOptim;
+using JunimoServer.Shared;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
@@ -104,6 +105,18 @@ public class AlwaysOnServer : ModService
             )
         );
 
+        // Guard against a vanilla null-deref in getAvailableWeddingEvent when a farmer is queued for a
+        // wedding but has neither an NPC spouse nor a player spouse at fire time — it would crash the
+        // host's day-start update loop. See WeddingEventGuard.
+        WeddingEventGuard.Initialize(monitor);
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Game1), nameof(Game1.getAvailableWeddingEvent)),
+            prefix: new HarmonyMethod(
+                typeof(WeddingEventGuard),
+                nameof(WeddingEventGuard.GetAvailableWeddingEvent_Prefix)
+            )
+        );
+
         // Keep the host's main farmhouse at level 0 (internal-only). The only way to upgrade it on
         // a dedicated server is an admin debug command at the console/host chat; block those when
         // they target the host farmhouse. See HostFarmhouseUpgradeGuard (#346).
@@ -182,7 +195,8 @@ public class AlwaysOnServer : ModService
         _isShippingMenuActive = false;
         _warpingSleep = false;
         shippingMenuTimeoutTicks = 0;
-        _petChoiceHandled = false;
+        _weddingStartTime = null;
+        _handledWeddingGate = null;
         ServerOptimizerOverrides.SetAutomationInputSuppression(false);
     }
 
@@ -323,6 +337,9 @@ public class AlwaysOnServer : ModService
         HandleAutoPause();
         HandleAutoSleep();
         HandleStuckFarmEvent();
+        // Per-tick (not OnOneSecondUpdateTicked) so the host readies the wedding gate promptly: time is
+        // frozen during a wedding, which throttles the once-per-second tick to many seconds apart.
+        HandleWeddingEvent();
 
         alwaysOnServerFestivals.HandleFestivalStart();
         alwaysOnServerFestivals.HandleFestivalLeave();
@@ -621,10 +638,15 @@ public class AlwaysOnServer : ModService
     }
 
     /// <summary>
-    /// Skip all events to keep the server unblocked.
-    /// On a dedicated server, no one is watching. Skip everything,
-    /// including non-skippable intro events that would block clients.
-    /// EXCEPTION: Festivals are handled separately and should NOT be skipped here.
+    /// Skip events to keep the server unblocked. On a dedicated server no one is watching most
+    /// cutscenes, so we skip them — including non-skippable intro events that would otherwise block
+    /// clients from joining.
+    ///
+    /// Two deliberate exceptions, each handled elsewhere so players can actually experience them:
+    /// festivals (<see cref="AlwaysOnServerFestivals"/>) and weddings (<see cref="HandleWeddingEvent"/>).
+    /// A wedding plays a ceremony for everyone in the session and ends with a "wait for all players"
+    /// ready gate that counts the host; force-skipping it jumps the host past that gate so it never
+    /// readies, and the clients hang at "Waiting for players (N/M)" forever (the reported freeze).
     /// </summary>
     private void HandleSkippableEvent()
     {
@@ -637,6 +659,13 @@ public class AlwaysOnServer : ModService
         // to let players participate in them, so we have
         // special logic inside AlwaysOnFestivals
         if (Game1.CurrentEvent.isFestival)
+        {
+            return;
+        }
+
+        // Weddings are non-skippable and play through for everyone; HandleWeddingEvent lets the host
+        // participate in the ceremony's wait gate instead of skipping past it.
+        if (Game1.CurrentEvent.isWedding)
         {
             return;
         }
@@ -655,6 +684,278 @@ public class AlwaysOnServer : ModService
             Game1.CurrentEvent.skipEvent();
             Game1.CurrentEvent.receiveMouseClick(1, 2);
         }
+    }
+
+    // Wall-clock start of the CURRENT ceremony's wait gate (null when none). Wall-clock, NOT game-time:
+    // time is frozen during a wedding, so a game-time accumulator would never reach the backstop.
+    private DateTime? _weddingStartTime;
+
+    // The wait gate of the ceremony the host has already readied+ended, so it isn't re-handled on the
+    // ticks before the event tears down. Keyed on the gate id (weddingEnd<farmerId>), NOT a bare bool:
+    // on a multi-wedding day the host fires the next ceremony immediately, often before CurrentEvent
+    // ever reads null, so a bool latch would suppress every wedding after the first. A new gate id is a
+    // new ceremony to handle. Null when no wedding is active or none handled yet this ceremony.
+    private string? _handledWeddingGate;
+
+    // Backstop: if the other players never ready the gate (e.g. a client stuck on its own copy), end
+    // the host's ceremony anyway after this long so it can't hold the server open. Only fires once a
+    // co-participant has joined the gate (see HandleWeddingEvent).
+    private const double WeddingEndBackstopSeconds = 20.0;
+
+    /// <summary>
+    /// Complete a wedding ceremony on the host when the other players are ready, instead of skipping it
+    /// — the fix for the deadlock where the host raced past the ceremony's "wait for players" step and
+    /// clients hung at "Waiting for players (N/M)" forever (time is frozen during a wedding, so the whole
+    /// server appeared stuck).
+    ///
+    /// <para>
+    /// A wedding is non-skippable and ends with a <c>waitForOtherPlayers weddingEnd&lt;farmerId&gt;</c>
+    /// step that counts the host. The clients run and watch their own ceremony copies (the wedding isn't
+    /// a synced event — each instance runs its own via <c>checkForEvents</c>) and ready the gate when
+    /// they reach the step. We don't make the host *play through* the dialogue-heavy cutscene: its
+    /// <c>DialogueBox</c> typing/safetyTimer advance in <c>update()</c> (the Update path,
+    /// <c>Game1._update</c> → <c>updateActiveMenu</c> — NOT draw-coupled), but the safetyTimer is 750ms
+    /// (not 0 — <c>IsDedicatedHost</c> is false here, <c>DialogueBox.cs:462</c>) and each <c>speak</c>
+    /// box has its own pacing, so a full ~10-box ceremony takes tens of seconds — too slow/fragile to be
+    /// the host's job. So the host instead readies its slot the moment the other
+    /// players are ready — the same "continue when others do" move <see cref="AlwaysOnServerFestivals"/>
+    /// makes for <c>festivalStart</c>/<c>festivalEnd</c> — then ends its own copy via
+    /// <c>endBehaviors(["End","wedding"])</c>.
+    /// </para>
+    ///
+    /// <para>
+    /// <c>endBehaviors(["End","wedding"])</c> is the engine's own end-the-wedding idiom: the script's
+    /// <c>end wedding</c> command runs exactly this (<c>Event.DefaultCommands.End</c> → <c>endBehaviors</c>),
+    /// and <c>skipEvent</c> uses the same <c>endBehaviors(["End",&lt;tag&gt;])</c> form for every other
+    /// special-ending event. It runs the wedding's real end behaviours — warps the spouse NPC to the
+    /// couple's home and queues the after-wedding dialogue (Event.cs <c>endBehaviors</c> "wedding" case)
+    /// — which a bare <c>skipEvent()</c> (the wedding's default branch passes no tag) would skip.
+    /// </para>
+    ///
+    /// <para>
+    /// Disconnecting watchers don't block the gate (<c>ServerReadyCheck</c> excludes them), and
+    /// lobby/unauthenticated players are excluded from every ready-check by
+    /// <c>LobbyService.IsFarmerRequired_Postfix</c>, so the wait step needs no special-casing here.
+    /// </para>
+    ///
+    /// <para>
+    /// <b>Multiple weddings on one day.</b> The game queues every eligible couple into
+    /// <c>Game1.weddingsToday</c> and fires them one ceremony at a time (<c>getAvailableWeddingEvent</c>
+    /// pops one per <c>checkForEvents</c>). Vanilla only runs <c>checkForEvents</c> on location entry, so
+    /// after the host finishes ceremony 1 and warps to the Farm porch, the single post-warp
+    /// <c>resetForPlayerEntry</c> can miss the next wedding (it races the teardown that clears
+    /// <c>eventUp</c>/<c>CurrentEvent</c>), leaving the host standing still with a queued wedding it never
+    /// starts — and the clients hang on ceremony 2's gate forever. So when no wedding is active but one is
+    /// still queued, the host re-runs <c>checkForEvents</c> itself to deterministically start the next one
+    /// (idempotent — vanilla's own guard prevents a double-start). The handled-gate latch is keyed on the
+    /// gate id, not a bool, because the host can flip straight from one ceremony to the next without
+    /// <c>CurrentEvent</c> ever reading null.
+    /// </para>
+    /// </summary>
+    private void HandleWeddingEvent()
+    {
+        var ev = Game1.CurrentEvent;
+        if (!IsAutomating || ev == null || !ev.isWedding)
+        {
+            _weddingStartTime = null;
+            _handledWeddingGate = null;
+            // No wedding playing, but a queued one may be waiting to fire. Vanilla starts weddings only
+            // on location entry, so after one ceremony ends the next can stall unstarted (see method
+            // summary); kick checkForEvents so the host deterministically begins the next one.
+            StartNextQueuedWeddingIfIdle();
+            return;
+        }
+
+        var gate = WeddingEvent.ExtractWaitGate(ev);
+        if (gate == null)
+        {
+            return; // wait step not in this event's commands (unexpected) — nothing to ready
+        }
+
+        // Already readied+ended this exact ceremony — wait for it to tear down (or for the next
+        // wedding's distinct gate to appear). Keying on the gate, not a bool, is what lets the host
+        // hand off to the next same-day wedding: its weddingEnd<farmerId> differs, so it's not skipped.
+        if (gate == _handledWeddingGate)
+        {
+            return;
+        }
+
+        // A new ceremony (first, or the next one on a multi-wedding day): start its own backstop window.
+        if (_weddingStartTime == null)
+        {
+            _weddingStartTime = DateTime.UtcNow;
+        }
+
+        // Complete the ceremony once the other players are ready on the gate (the festival "continue
+        // when others do" pattern), or once the wall-clock backstop elapses so a client that never
+        // readies can't stall us. The backstop must NOT fire until a co-participant has joined the gate
+        // (required > 1): readying while the host is the only required farmer would lock the gate at 1/1,
+        // and a client reaching its wait step later would find it already finished without it.
+        var othersReady = OthersReadyForWedding(gate);
+        var backstopElapsed =
+            Game1.netReady.GetNumberRequired(gate) > 1
+            && (DateTime.UtcNow - _weddingStartTime.Value).TotalSeconds
+                >= WeddingEndBackstopSeconds;
+
+        if (!othersReady && !backstopElapsed)
+        {
+            return;
+        }
+
+        // Ready the host's slot of the gate so the clients' wait completes...
+        Game1.netReady.SetLocalReady(gate, true);
+
+        // ...then end the host's own copy. endBehaviors(["End","wedding"]) runs the real wedding end
+        // behaviours — warps the spouse NPC to the couple's Farm porch, queues the after-wedding marriage
+        // dialogue (Event.cs "wedding" case), and calls exitEvent (sets eventOver, arms a fade, records
+        // the event's exit warp). The explicit "wedding" tag is required: a bare skipEvent() hits the
+        // wedding's default branch (endBehaviors() with no tag) and skips the spouse warp.
+        ev.endBehaviors(new[] { "End", "wedding" }, Game1.currentLocation);
+
+        // exitEvent only ARMS that fade + warp; the engine resolves them later via onFadeToBlackComplete.
+        // On the render-suppressed host that handler stalls — the queued marriage dialogue surfaces as a
+        // DialogueBox and the fade sits at full alpha — so the host strands on the ceremony's Town temp
+        // map, fully black, dialogue open (the reported "stuck in the black wedding fadeout"). Tear the
+        // ceremony down here instead, the way vanilla skipEvent() cleans up an event no one watches: drop
+        // the menu/dialogue/fade, then eventFinished() to end the event and warp the host off the temp
+        // map. Clearing the fade BEFORE eventFinished() matters — eventFinished()'s warp resolves in place
+        // when no fade is pending; left armed, on a back-to-back multi-wedding day it would defer to the
+        // fade-complete handler and re-enter it on the next ceremony's half-torn-down event, NREing the
+        // update loop. The marriage data is already recorded, so dropping the after-wedding dialogue is
+        // lossless.
+        Game1.exitActiveMenu();
+        Game1.dialogueUp = false;
+        Game1.dialogueTyping = false;
+        Game1.pauseTime = 0f;
+        Game1.player.Halt();
+        Game1.fadeClear();
+        if (Game1.eventOver)
+        {
+            Game1.eventFinished();
+        }
+        // eventFinished() leaves the screen black (fadeToBlackAlpha = 1) expecting a fade-in; force it
+        // clear so the host doesn't sit on a black screen.
+        Game1.fadeClear();
+        Game1.fadeToBlackAlpha = 0f;
+
+        // eventFinished() warped the host onto the open Farm map: the wedding's endBehaviors "wedding"
+        // case sets the exit warp from getHomeOfFarmer(Game1.player).getPorchStandingSpot() (Event.cs
+        // "wedding"), and on the host Game1.player's home is the main FarmHouse, so the host lands at the
+        // farmhouse-porch tile on the Farm rather than in its FarmHouse — out of its normal hidden idle
+        // spot. Return it home, but ONLY once no wedding is still queued: on a multi-wedding day the next
+        // ceremony is started by StartNextQueuedWeddingIfIdle, which needs the host on a non-temporary
+        // location (FarmHouse won't trigger the queued Farm/Town wedding), so warping home between
+        // ceremonies would strand the next wedding unstarted. getAvailableWeddingEvent pops the running
+        // ceremony's farmer from weddingsToday before the event runs (Game1.cs:6096), so a remaining
+        // Count > 0 reliably means "another wedding still queued".
+        if (Game1.weddingsToday is not { Count: > 0 })
+        {
+            WarpHostHomeAfterWeddings();
+        }
+
+        // Mark this ceremony handled and clear the timer so the next wedding's gate starts a fresh
+        // backstop window (CurrentEvent may flip straight to it without ever reading null).
+        _handledWeddingGate = gate;
+        _weddingStartTime = null;
+        Monitor.Log(
+            $"Readied wedding wait gate [{gate}] "
+                + $"({(othersReady ? "other players ready" : "wall-clock backstop")}) and finished the "
+                + "host's ceremony copy (spouse warped home, host event ended, fade cleared).",
+            LogLevel.Info
+        );
+    }
+
+    /// <summary>
+    /// Return the host to its FarmHouse idle spot after the day's last wedding. <c>eventFinished()</c>
+    /// leaves the host on the open Farm map (the wedding exit warp targets the host's farmhouse porch via
+    /// <c>getHomeOfFarmer(Game1.player)</c>), but the host is meant to stay hidden in its FarmHouse — the
+    /// same place <see cref="HandleAutoSleep"/> keeps it. Reuses that handler's home-warp idiom:
+    /// <c>getLocationRequest(home)</c> + <c>warpFarmer</c> into the FarmHouse, then snap to the bed spot
+    /// and <c>Halt()</c>. Master-only and FarmHouse-targeted (no-ops if home doesn't resolve to one).
+    /// </summary>
+    private void WarpHostHomeAfterWeddings()
+    {
+        if (!Game1.IsMasterGame)
+        {
+            return;
+        }
+
+        var home = Game1.player.homeLocation.Value;
+        if (string.IsNullOrEmpty(home))
+        {
+            return;
+        }
+
+        // Already home (a single-tile-warp engine edge case): just snap to the bed and stop.
+        if (
+            Game1.currentLocation is FarmHouse here
+            && string.Equals(here.NameOrUniqueName, home, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            Game1.player.position.Set(Utility.PointToVector2(here.GetPlayerBedSpot()) * 64f);
+            Game1.player.Halt();
+            return;
+        }
+
+        var req = Game1.getLocationRequest(home);
+        req.OnWarp += () =>
+        {
+            if (Game1.currentLocation is FarmHouse fh)
+            {
+                Game1.player.position.Set(Utility.PointToVector2(fh.GetPlayerBedSpot()) * 64f);
+            }
+            Game1.player.Halt();
+            // warpFarmer arms a fade-to-black; on the render-suppressed host the fade-in handler is
+            // draw-coupled and stalls (same reason the teardown above clears the fade by hand), so clear
+            // it on arrival or the host sits on a black screen in its FarmHouse.
+            Game1.fadeClear();
+            Game1.fadeToBlackAlpha = 0f;
+        };
+        // Coords are any valid tile inside the target FarmHouse; the OnWarp callback snaps to the bed
+        // spot. Mirrors HandleAutoSleep's home-warp (and DedicatedServer.cs:415). Issued right after
+        // eventFinished()'s own Farm-exit warpFarmer — performWarpFarmer just overwrites the single
+        // Game1.locationRequest, so this supersedes the Farm exit and the host warps straight home
+        // without first landing on the open Farm.
+        Game1.warpFarmer(req, 5, 9, Game1.player.FacingDirection);
+        Monitor.Log($"Warped host home to {home} after the day's last wedding.", LogLevel.Info);
+    }
+
+    /// <summary>
+    /// When no event is running but a wedding is still queued for today, re-run the host's
+    /// <c>checkForEvents</c> to start the next ceremony. Vanilla only fires weddings on location entry
+    /// (<c>resetForPlayerEntry</c>), so on a multi-wedding day the second ceremony can stall unstarted
+    /// after the first ends — see <see cref="HandleWeddingEvent"/>. Guard conditions mirror vanilla's
+    /// own wedding-start branch (GameLocation.checkForEvents, decompiled GameLocation.cs:15620) so this
+    /// only fires exactly when vanilla would: no event up, a wedding queued, host on a non-temporary
+    /// location. <c>checkForEvents</c> is idempotent here — its guard no-ops if a wedding is already up.
+    /// </summary>
+    private static void StartNextQueuedWeddingIfIdle()
+    {
+        if (
+            !Game1.eventUp
+            && Game1.weddingsToday is { Count: > 0 }
+            && Game1.CurrentEvent == null
+            && Game1.currentLocation is { IsTemporary: false }
+        )
+        {
+            Game1.currentLocation.checkForEvents();
+        }
+    }
+
+    /// <summary>
+    /// True once every other connected player has readied the given wedding wait gate (ready =
+    /// required − 1, host is the only one missing), mirroring <c>DedicatedServer.CheckOthersReady</c>.
+    /// The <c>ready &gt; 0</c> guard prevents excluded players trivially satisfying it.
+    /// </summary>
+    private static bool OthersReadyForWedding(string gate)
+    {
+        int ready = Game1.netReady.GetNumberReady(gate);
+        if (ready <= 0 || Game1.netReady.IsReady(gate))
+        {
+            return false;
+        }
+
+        return ready >= Game1.netReady.GetNumberRequired(gate) - 1;
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/AlwaysOnServer/WeddingEventGuard.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/WeddingEventGuard.cs
@@ -1,0 +1,74 @@
+using StardewModdingAPI;
+using StardewValley;
+
+namespace JunimoServer.Services.AlwaysOn;
+
+/// <summary>
+/// Guards <see cref="Game1.getAvailableWeddingEvent"/> against a vanilla null-dereference that crashes
+/// the host's update loop. The method pulls the next id from <c>Game1.weddingsToday</c> and, when the
+/// farmer has no NPC <c>spouse</c>, assumes a player↔player marriage and dereferences
+/// <c>farmer.team.GetSpouse(...).Value</c> with no null check (Game1.cs:6111-6112). If such a farmer
+/// is queued but has neither an NPC spouse nor a player spouse at fire time, that <c>.Value</c> throws
+/// <c>InvalidOperationException: Nullable object must have a value</c>, which on a headless host
+/// aborts the day-start update and can wedge the server.
+///
+/// <para>
+/// This prefix drops any queued wedding whose farmer can't produce a valid ceremony — no resolvable
+/// farmer, no NPC spouse AND no player spouse — before vanilla reads it, so a single bad entry can't
+/// crash the day transition. A healthy NPC or player wedding is left untouched and fires normally. It
+/// also logs each drop so a stuck/queued-but-unmarried farmhand is visible rather than silent.
+/// </para>
+/// </summary>
+public static class WeddingEventGuard
+{
+    private static IMonitor _monitor;
+
+    public static void Initialize(IMonitor monitor)
+    {
+        _monitor = monitor;
+    }
+
+    // ReSharper disable once InconsistentNaming
+    public static void GetAvailableWeddingEvent_Prefix()
+    {
+        if (!Game1.IsMasterGame || Game1.weddingsToday == null || Game1.weddingsToday.Count == 0)
+        {
+            return;
+        }
+
+        // Walk the queue and drop entries vanilla would crash on. A valid wedding needs either an NPC
+        // spouse (farmer.spouse) or a resolvable player spouse (team.GetSpouse). Anything else makes
+        // getAvailableWeddingEvent's unguarded team.GetSpouse(...).Value throw.
+        Game1.weddingsToday.RemoveAll(id =>
+        {
+            var farmer = Game1.GetPlayer(id);
+            if (farmer == null)
+            {
+                _monitor?.Log(
+                    $"[Wedding] Dropping queued wedding for id {id}: no farmer resolves for it.",
+                    LogLevel.Warn
+                );
+                return true;
+            }
+
+            if (!string.IsNullOrEmpty(farmer.spouse))
+            {
+                return false; // NPC marriage — valid, vanilla returns getWeddingEvent(farmer)
+            }
+
+            var playerSpouse = farmer.team.GetSpouse(farmer.UniqueMultiplayerID);
+            if (!playerSpouse.HasValue)
+            {
+                _monitor?.Log(
+                    $"[Wedding] Dropping queued wedding for {farmer.Name} (id {id}): no NPC spouse and "
+                        + "no player spouse — vanilla getAvailableWeddingEvent would null-deref here. "
+                        + $"isEngaged={farmer.isEngaged()}, online={Game1.getOnlineFarmers().Contains(farmer)}.",
+                    LogLevel.Warn
+                );
+                return true;
+            }
+
+            return false; // player↔player marriage — valid
+        });
+    }
+}

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -334,6 +334,51 @@ public class TestImportSaveRequest
     public bool SkipClone { get; set; }
 }
 
+/// <summary>
+/// Response from GET /test/wedding_state (test-only). A direct read of the host's wedding state so an
+/// E2E test can assert a ceremony is active / has ended and observe each spouse NPC's location, without
+/// proxying through a client's location (which reads the Town "Temp" map during the ceremony).
+/// </summary>
+public class TestWeddingStateResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>True while a wedding event is loaded and running on the host (CurrentEvent.isWedding).</summary>
+    public bool IsWeddingActive { get; set; }
+
+    /// <summary>The host's view of the queried farmhand's spouse (NPC name), or null. Lets a test
+    /// confirm the engagement replicated client→host before the day transition.</summary>
+    public string? FarmhandSpouse { get; set; }
+
+    /// <summary>The spouse NPC's current location. The ceremony's endBehaviors ("wedding" case) warps
+    /// the spouse to the couple's Farm porch, so <c>== "Farm"</c> is a durable, ceremony-only signal
+    /// that this couple's ceremony completed (the pre-ceremony finalizer never moves currentLocation).</summary>
+    public string? SpouseCurrentLocation { get; set; }
+
+    // Post-ceremony host-stuck signals (see HandleGetTestWeddingStateAsync). All four must be clear
+    // after a wedding ends or the host is stuck in the fadeout the multi-wedding fix resolves.
+
+    /// <summary>True while any event is up on the host. Stuck-true after a wedding = event never ended.</summary>
+    public bool EventUp { get; set; }
+
+    /// <summary>True while a fade-to-black is armed. Stuck-true after a wedding = the black fadeout never cleared.</summary>
+    public bool FadeToBlack { get; set; }
+
+    /// <summary>True while a dialogue is up. Stuck-true after a wedding = the after-wedding dialogue is dangling.</summary>
+    public bool DialogueUp { get; set; }
+
+    /// <summary>True while the host is on a temporary event map (e.g. the wedding ceremony Town map).
+    /// Stuck-true after a wedding = the host never warped off the ceremony location.</summary>
+    public bool HostLocationIsTemporary { get; set; }
+
+    /// <summary>The host's current location name. After the day's last wedding the host must be returned
+    /// to its FarmHouse idle spot — not left standing on the open Farm map where the wedding exit warp
+    /// drops it (the exit targets getHomeOfFarmer(Game1.player)'s porch). Lets a test assert the host
+    /// ended at home rather than just "not on a temporary map".</summary>
+    public string? HostCurrentLocation { get; set; }
+}
+
 /// <summary>Body for POST /test/console (test-only): a console command name + args to invoke.</summary>
 public class TestConsoleCommandRequest
 {

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -67,6 +67,12 @@ public partial class ApiService
                     case "/test/save_tmp_exists":
                         await WriteJsonAsync(response, HandleGetTestSaveTmpExists(request));
                         return;
+                    case "/test/wedding_state":
+                        await WriteJsonAsync(
+                            response,
+                            await HandleGetTestWeddingStateAsync(request)
+                        );
+                        return;
                 }
                 break;
             case "POST":
@@ -1415,5 +1421,75 @@ public partial class ApiService
         {
             return new TestSaveFileOpResponse { Success = false, Error = ex.Message };
         }
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/wedding_state",
+        Summary = "Read the host's wedding ceremony state + wait-gate ready counts (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestWeddingStateResponse), 200)]
+    private async Task<TestWeddingStateResponse> HandleGetTestWeddingStateAsync(
+        HttpListenerRequest request
+    )
+    {
+        // ?farmhandId=<id>&npc=<name>: optional, to report whether that farmhand is now married to
+        // the NPC (the post-ceremony assertion). Wedding/gate fields are reported regardless.
+        long.TryParse(request.QueryString["farmhandId"], out var farmhandId);
+        var npc = request.QueryString["npc"];
+
+        var result = new TestWeddingStateResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var ev = Game1.CurrentEvent;
+                result.IsWeddingActive = ev?.isWedding == true;
+
+                // Post-ceremony host-stuck signals: after a wedding the host must not be left mid-event,
+                // faded to black, holding a dialogue, or stranded on a temporary ceremony map. A test
+                // asserts all four are clear to gate the multi-wedding stuck-fadeout regression.
+                result.EventUp = Game1.eventUp;
+                result.FadeToBlack = Game1.fadeToBlack;
+                result.DialogueUp = Game1.dialogueUp;
+                result.HostLocationIsTemporary = Game1.currentLocation?.IsTemporary == true;
+                result.HostCurrentLocation = Game1.currentLocation?.NameOrUniqueName;
+
+                if (farmhandId != 0)
+                {
+                    // The host's view of the farmhand's spouse — used by the test to confirm the
+                    // engagement replicated client→host before the day transition.
+                    var farmhand = Game1.GetPlayer(farmhandId, onlyOnline: true);
+                    if (farmhand != null)
+                    {
+                        result.FarmhandSpouse = farmhand.spouse;
+                    }
+
+                    // The spouse NPC's current location. The ceremony's endBehaviors warps the spouse
+                    // to the couple's Farm porch, so == "Farm" proves that ceremony completed.
+                    if (!string.IsNullOrEmpty(npc))
+                    {
+                        var spouseNpc = Game1.getCharacterFromName(npc);
+                        if (spouseNpc != null)
+                        {
+                            result.SpouseCurrentLocation = spouseNpc
+                                .currentLocation
+                                ?.NameOrUniqueName;
+                        }
+                    }
+                }
+
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
     }
 }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -832,6 +832,10 @@ public partial class ApiService
                 if (body.CaveChoice.HasValue)
                 {
                     master.caveChoice.Value = body.CaveChoice.Value;
+                    // A real played save where the cave was chosen always has event 65 seen. Seed it
+                    // so the host's cave-choice pre-seed treats the choice as already made and never
+                    // applies the server's mushroom default over the seeded value.
+                    master.eventsSeen.Add("65");
                 }
                 if (!string.IsNullOrEmpty(body.Spouse))
                 {

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -1110,6 +1110,17 @@ public class CabinManagerService : ModService
             indoors.DeleteFarmhand();
         }
 
+        // Vanilla Cabin.demolish() resets every villager homed in the cabin to its canonical home
+        // before removal (Cabin.cs:196-203); our raw-remove path skips it, stranding an NPC that
+        // married this cabin's owner — its DefaultMap stays "FarmHouse<guid>", and the next
+        // NPC.dayUpdate warp-home throws KeyNotFoundException (NPC.cs:6105). Reset them the way
+        // vanilla divorce does. Game1.fixProblems' own stranded-spouse heal (Game1.cs:7489) can't
+        // help: its guard matches "cabin"/"FarmHouse" literally and misses our FarmHouse<guid> name.
+        if (indoors != null && !string.IsNullOrEmpty(deletedName))
+        {
+            ResetVillagersHomedAt(indoors, deletedName);
+        }
+
         farm.buildings.Remove(cabinBuilding);
 
         Diagnostics.ModEventLog.Emit(
@@ -1185,6 +1196,60 @@ public class CabinManagerService : ModService
             {
                 f.lastSleepLocation.Value = null;
             }
+        }
+    }
+
+    /// <summary>
+    /// Reset every villager NPC homed at the cabin being destroyed back to its canonical home,
+    /// mirroring vanilla <c>Cabin.demolish()</c> (Cabin.cs:196-203). A marriage to the cabin's
+    /// farmhand owner sets the villager's <c>DefaultMap</c> to "FarmHouse&lt;guid&gt;"
+    /// (NPC.cs:6366); once the cabin is gone, <c>NPC.dayUpdate</c> warps the villager to that
+    /// now-missing location and throws <c>KeyNotFoundException</c> (NPC.cs:6105) on the next day
+    /// transition. The reset is the same one both vanilla divorce paths use
+    /// (<c>reloadDefaultLocation</c> + warp, NPC.cs:3537).
+    ///
+    /// Matched by <c>DefaultMap</c> string OR current-location identity so a spouse mid-schedule
+    /// outside the cabin (e.g. in Town) is still caught — vanilla's in-cabin-only loop would miss
+    /// it. Idempotent and safe on unowned lobby/editing cabins (no villager is homed there, so the
+    /// scan no-ops). Master-only operations (warp + NetField writes); this server is always master
+    /// (multiplayerMode=2).
+    /// </summary>
+    private void ResetVillagersHomedAt(Cabin indoors, string deletedName)
+    {
+        // Collect first, warp after: Game1.warpCharacter mutates the location's `characters`
+        // collection (Game1.cs:9713), which ForEachVillager iterates live — warping inside the
+        // scan would throw "collection modified". Vanilla demolish() snapshots for the same reason
+        // (new List<NPC>(characters), Cabin.cs:196).
+        var stranded = new List<NPC>();
+        Utility.ForEachVillager(npc =>
+        {
+            if (npc.DefaultMap == deletedName || ReferenceEquals(npc.currentLocation, indoors))
+            {
+                stranded.Add(npc);
+            }
+            return true; // scan every villager
+        });
+
+        foreach (var npc in stranded)
+        {
+            // reloadDefaultLocation derives DefaultMap from characterData; a villager with no data
+            // can't resolve a valid home, so skip it (mirrors Cabin.demolish's guard, Cabin.cs:198).
+            if (!Game1.characterData.ContainsKey(npc.Name))
+            {
+                continue;
+            }
+
+            npc.reloadDefaultLocation();
+            npc.ClearSchedule();
+            Game1.warpCharacter(npc, npc.DefaultMap, npc.DefaultPosition / 64f);
+
+            // Warn, never Error: this runs on the server game thread, where LogLevel.Error trips
+            // ServerContainer's ERROR/FATAL test-poison scan.
+            Monitor.Log(
+                $"Reset villager '{npc.Name}' homed at destroyed cabin '{deletedName}' back to "
+                    + $"'{npc.DefaultMap}' (was stranded by a farmhand↔NPC marriage).",
+                LogLevel.Warn
+            );
         }
     }
 

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -226,6 +226,21 @@ public class LeaveFestivalResult
     public string? Error { get; set; }
 }
 
+public class EngageToNpcResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("spouse")]
+    public string? Spouse { get; set; }
+
+    [JsonPropertyName("isEngaged")]
+    public bool IsEngaged { get; set; }
+}
+
 public class PlacePotResult
 {
     [JsonPropertyName("success")]
@@ -390,6 +405,11 @@ public class GameStateResult
 
     [JsonPropertyName("error")]
     public string? Error { get; set; }
+
+    /// <summary>Wedding ceremonies this client has rendered today (one per gate). See
+    /// <see cref="StatusResponse.WeddingsRendered"/>.</summary>
+    [JsonPropertyName("weddingsRendered")]
+    public List<RenderedCeremonyInfo> WeddingsRendered { get; set; } = new();
 }
 
 /// <summary>
@@ -406,8 +426,36 @@ public class StatusResponse
     [JsonPropertyName("farmer")]
     public FarmerInfoResponse? Farmer { get; set; }
 
+    /// <summary>
+    /// Wedding ceremonies this client has played through (rendered) today, one per gate. Empty until a
+    /// ceremony actually plays on this client. The E2E wedding test asserts each client rendered BOTH
+    /// same-day ceremonies — the host-side spouse-warp can't prove a client rendered anything.
+    /// </summary>
+    [JsonPropertyName("weddingsRendered")]
+    public List<RenderedCeremonyInfo> WeddingsRendered { get; set; } = new();
+
     [JsonPropertyName("timestamp")]
     public long Timestamp { get; set; }
+}
+
+/// <summary>One wedding ceremony a client played through and rendered (mirrors the test-client's
+/// <c>RenderedCeremony</c>). Used by the E2E wedding test's per-client render proof.</summary>
+public class RenderedCeremonyInfo
+{
+    [JsonPropertyName("gate")]
+    public string Gate { get; set; } = string.Empty;
+
+    [JsonPropertyName("groomId")]
+    public long GroomId { get; set; }
+
+    [JsonPropertyName("groomName")]
+    public string GroomName { get; set; } = string.Empty;
+
+    [JsonPropertyName("spouse")]
+    public string Spouse { get; set; } = string.Empty;
+
+    [JsonPropertyName("isLocalPlayer")]
+    public bool IsLocalPlayer { get; set; }
 }
 
 public class ConnectionStatusInfo
@@ -627,6 +675,20 @@ public class ActionsClient
     public Task<LeaveFestivalResult?> LeaveFestival()
     {
         return _client.PostAsync<LeaveFestivalResult>("/actions/leave_festival", new { });
+    }
+
+    /// <summary>
+    /// Engage this client's player to an NPC (client-authoritative) so the next day-transition queues
+    /// their wedding. Must be authored on the client — the farmhand's Farmer root is client-owned, so
+    /// a host-side spouse write is overwritten by the client's nightly full-root resend before the
+    /// wedding fires. POST /actions/engage_to_npc
+    /// </summary>
+    public Task<EngageToNpcResult?> EngageToNpc(string npc, int daysUntilWedding = 1)
+    {
+        return _client.PostAsync<EngageToNpcResult>(
+            "/actions/engage_to_npc",
+            new { npc, daysUntilWedding }
+        );
     }
 
     /// <summary>
@@ -1079,6 +1141,7 @@ public class GameTestClient : IDisposable
             IsInGame = status.Connection?.WorldReady ?? false,
             PlayerName = status.Farmer?.Name,
             UniqueId = status.Farmer?.UniqueId,
+            WeddingsRendered = status.WeddingsRendered,
         };
     }
 

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -567,6 +567,49 @@ public class TestFestivalStateResponse
 }
 
 /// <summary>
+/// Response from /test/wedding_state GET endpoint (test-only). Mirrors the server-side
+/// TestWeddingStateResponse DTO — a direct read of the host's wedding ceremony state, used to assert
+/// ceremony-active / ceremony-ended and each spouse's location after, without proxying through a
+/// client's location (which reads the Town "Temp" map during the ceremony).
+/// </summary>
+public class TestWeddingStateResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("isWeddingActive")]
+    public bool IsWeddingActive { get; set; }
+
+    [JsonPropertyName("farmhandSpouse")]
+    public string? FarmhandSpouse { get; set; }
+
+    [JsonPropertyName("spouseCurrentLocation")]
+    public string? SpouseCurrentLocation { get; set; }
+
+    // Post-ceremony host-stuck signals — all four must be clear after a wedding ends (see
+    // TwoFarmhandNpcWeddings_SameDay_BothCompleteWithoutHangingHost).
+    [JsonPropertyName("eventUp")]
+    public bool EventUp { get; set; }
+
+    [JsonPropertyName("fadeToBlack")]
+    public bool FadeToBlack { get; set; }
+
+    [JsonPropertyName("dialogueUp")]
+    public bool DialogueUp { get; set; }
+
+    [JsonPropertyName("hostLocationIsTemporary")]
+    public bool HostLocationIsTemporary { get; set; }
+
+    // The host's current location name. After the last wedding the host must be back in its FarmHouse,
+    // not left on the open Farm map where the wedding exit warp drops it.
+    [JsonPropertyName("hostCurrentLocation")]
+    public string? HostCurrentLocation { get; set; }
+}
+
+/// <summary>
 /// Response from /test/set_date POST endpoint.
 /// </summary>
 public class TestSetDateResponse
@@ -1588,6 +1631,28 @@ public class ServerApiClient : IDisposable
         var response = await _httpClient.GetAsync("/test/festival_state", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestFestivalStateResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: read the host's wedding ceremony state + wait-gate ready counts, and (when
+    /// <paramref name="farmhandId"/>/<paramref name="npc"/> are given) whether that farmhand is now
+    /// married to the NPC. Used by WeddingTests to assert ceremony-ended + married without proxying
+    /// through the client location (which reads "Temp" during the ceremony). GET /test/wedding_state
+    /// </summary>
+    public async Task<TestWeddingStateResponse?> GetWeddingState(
+        long? farmhandId = null,
+        string? npc = null,
+        CancellationToken ct = default
+    )
+    {
+        var query = "/test/wedding_state";
+        if (farmhandId.HasValue && !string.IsNullOrEmpty(npc))
+        {
+            query += $"?farmhandId={farmhandId.Value}&npc={Uri.EscapeDataString(npc)}";
+        }
+        var response = await _httpClient.GetAsync(query, ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestWeddingStateResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -178,4 +178,11 @@ public enum WaitName
     Polling_Festival_EndedNoPlayers,
     Polling_Festival_NextFestivalEndedOnLeave,
     Polling_Festival_MainEventStillActive,
+
+    // WeddingTests.cs (5)
+    Polling_Wedding_EngagementReplicated,
+    Polling_Wedding_BothCeremoniesRan,
+    Polling_Wedding_BothClientsRenderedBoth,
+    Polling_Wedding_HostRecoveredAfterCeremonies,
+    Polling_Wedding_HostReturnedHomeAfterCeremonies,
 }

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
@@ -122,19 +122,119 @@ internal sealed class FarmerTestHelper
 
         var name = GenerateName(namePrefix);
         var clientLease = await _testBase.LeaseClientForHelperAsync(ct);
+        return await JoinSecondFarmerAsync(lease, clientLease, name, ct);
+    }
 
-        // Dispose the lease if the join (or its assert) throws — otherwise it leaks client
-        // capacity and leaves a connected client around during cleanup. On success, the
-        // returned SecondFarmer owns disposal.
+    /// <summary>
+    /// Connects BOTH farmers concurrently and returns once both are joined and visible
+    /// server-side. The two client containers are leased up front (overlapping their cold
+    /// start), then both join sequences run together via <see cref="Task.WhenAll(Task[])"/>.
+    ///
+    /// <para>
+    /// The server's game loop processes one farmhand join at a time, so the two joins can't
+    /// land at the literal same instant — both go through the per-server join gate
+    /// (<c>ManagedServer.AcquireJoinGateAsync</c>), which serializes the game-thread join and
+    /// is what stops a concurrent join bouncing back to farmhand selection
+    /// (<c>isGameAvailable() == false</c>). What overlaps is everything else: the second
+    /// client's lease/cold-start and both clients' menu navigation and character creation. So
+    /// instead of farmhand B's whole sequence starting only after A's fully completes, the two
+    /// are present together within seconds of each other — the scenario weddings/multiplayer
+    /// tests want.
+    /// </para>
+    ///
+    /// <para>
+    /// The primary uses the shared connection helpers (held as the test's <c>GameClient</c>);
+    /// the secondary is wrapped as a <see cref="SecondFarmer"/> over its own lease — scope it
+    /// with <c>await using</c> so it disconnects before the class's <c>/newgame</c> reset.
+    /// Both farmers are tracked for cleanup via <see cref="TrackFarmer"/>.
+    /// </para>
+    /// </summary>
+    public async Task<(
+        ClientConnection Primary,
+        SecondFarmer Secondary
+    )> ConnectBothConcurrentlyAsync(
+        string primaryPrefix = "FarmerA",
+        string secondaryPrefix = "FarmerB",
+        CancellationToken ct = default
+    )
+    {
+        var lease = _testBase.LeaseInternal;
+        if (lease == null)
+        {
+            throw new InvalidOperationException("Server not acquired; cannot connect farmers.");
+        }
+
+        // Lease the secondary client up front, concurrently with ensuring the primary client
+        // is ready. The primary join leases its own client lazily, but pre-warming it here lets
+        // the slow part (a cold client container start) of both leases overlap rather than the
+        // secondary's start waiting on the primary's whole join.
+        var primaryName = GenerateName(primaryPrefix);
+        var secondaryName = GenerateName(secondaryPrefix);
+        await _testBase.GetClientAsyncInternal(ct);
+        var secondaryLease = await _testBase.LeaseClientForHelperAsync(ct);
+
+        // Run both joins together. The join gate inside each path serializes the game-thread
+        // portion; the client-side work overlaps. Use WhenAll so a failure in either still
+        // lets the other settle before we observe it (and so the secondary lease is disposed
+        // on its own failure path inside JoinSecondFarmerAsync).
+        var primaryTask = _testBase.Connect.JoinWithRetryAsync(primaryName, ct: ct);
+        var secondaryTask = JoinSecondFarmerAsync(lease, secondaryLease, secondaryName, ct);
+
+        try
+        {
+            await Task.WhenAll(primaryTask, secondaryTask);
+        }
+        catch
+        {
+            // If only one task faulted, the other may have produced a resource that needs
+            // releasing. JoinSecondFarmerAsync already disposes its own lease on failure; a
+            // successful secondary whose primary failed is disposed here so it doesn't leak.
+            if (secondaryTask.IsCompletedSuccessfully)
+            {
+                await secondaryTask.Result.DisposeAsync();
+            }
+            throw;
+        }
+
+        var primaryResult = primaryTask.Result;
+        _testBase.Connect.AssertJoinSuccess(primaryResult);
+        TrackFarmer(primaryName, primaryResult.UniqueMultiplayerId);
+
+        return (new ClientConnection(primaryName, primaryResult), secondaryTask.Result);
+    }
+
+    /// <summary>
+    /// Joins a second farmer over an already-leased client and wraps it as a
+    /// <see cref="SecondFarmer"/>. The join goes through the server's join gate so it
+    /// serializes correctly against the primary join (the game loop processes one farmhand
+    /// join at a time). Disposes the supplied lease if the join throws; on success the
+    /// returned <see cref="SecondFarmer"/> owns disposal.
+    /// </summary>
+    private async Task<SecondFarmer> JoinSecondFarmerAsync(
+        ResourceLease lease,
+        ClientLease clientLease,
+        string name,
+        CancellationToken ct
+    )
+    {
         try
         {
             var conn = new ConnectionHelper(clientLease.Client, serverApi: _testBase.ServerApi);
-            var join = await conn.JoinWorldViaLanAsync(
-                lease.ServerLanAddress,
-                lease.ServerLanPort,
-                name,
-                cancellationToken: ct
-            );
+            await lease.Managed.AcquireJoinGateAsync(ct);
+            JoinWorldResult join;
+            try
+            {
+                join = await conn.JoinWorldViaLanAsync(
+                    lease.ServerLanAddress,
+                    lease.ServerLanPort,
+                    name,
+                    cancellationToken: ct
+                );
+            }
+            finally
+            {
+                lease.Managed.ReleaseJoinGate();
+            }
             Assert.True(
                 join.Success,
                 $"Second farmer '{name}' failed to join via LAN: {join.Error}"
@@ -222,9 +322,14 @@ internal sealed class FarmerTestHelper
         );
 
         await _testBase.DisconnectAsyncInternal();
+        // Cheap presence re-confirmation only — not a customization gate. The pre-disconnect
+        // wait + disconnect-time saveFarmhand() clone already persisted the customized snapshot,
+        // and a disconnected farmhand stays in farmhandData with isCustomized=true (there's no
+        // post-disconnect window where customization reverts). So requireCustomized:false returns
+        // near-instantly instead of paying the slow customization filter again.
         var persisted = await _testBase.ServerApi.WaitForFarmhandByNameAsync(
             farmerName,
-            requireCustomized: true,
+            requireCustomized: false,
             ct: ct
         );
         Assert.True(

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -578,7 +578,11 @@ public class SaveImportTests : TestBase
             state.MasterHasEvent == true,
             $"Master must carry the seeded eventsSeen id '{eventSeen}' (distinct collection from mailReceived)"
         );
-        Assert.Equal(1, state.MasterCaveChoice); // bat/fruit-cave daily regen
+        Assert.True(
+            state.MasterCaveChoice == 1,
+            $"Master must carry the seeded caveChoice=1 (bat/fruit-cave daily regen); got "
+                + $"{state.MasterCaveChoice} (2 = the server's mushroom-cave default leaked back onto the master)"
+        );
         Assert.True(
             state.MasterShadowFriendshipPoints is >= 1250,
             $"Master must carry the Krobus friendship (shadow-pacifism gate), got "

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -1,0 +1,405 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E coverage for the host's participation in wedding ceremonies (<c>AlwaysOnServer</c>'s wedding
+/// handling).
+///
+/// <para>
+/// <b>The bug (regression gate).</b> A farmhand↔NPC wedding plays as a cutscene for everyone in the
+/// session and ends with a <c>waitForOtherPlayers weddingEnd&lt;farmerId&gt;</c> step: each player
+/// readies and a "Waiting for players (N/M)" dialog holds the ceremony open until all have readied —
+/// and that count includes the host. The mod's <c>HandleSkippableEvent</c> used to force-skip EVERY
+/// non-festival event (the wedding is <c>skippable == false</c>, but it skipped anyway), jumping the
+/// host past the wait step so it never readied. Time is frozen during a wedding, so the clients hung
+/// at "Waiting for players" forever and the whole server appeared stuck. The fix stops skipping the
+/// wedding and has the host ready its slot of the wait gate as soon as the other players are ready on
+/// it (the festival "continue when others do" pattern), with a wall-clock backstop so it can never
+/// permanently stall. The clients still run and watch their own ceremony copies.
+/// </para>
+///
+/// <para>
+/// <b>Two players, two weddings, one day.</b> The game does NOT space weddings across days — both
+/// engagement paths schedule for <c>today + 3</c> and only skip forward past festival/green-rain days
+/// (<c>NPC.cs</c>/<c>FarmerTeam.cs</c> → <c>canHaveWeddingOnDay</c>), with no collision check, and
+/// <c>queueWeddingsForToday</c> adds every eligible farmer to the <c>weddingsToday</c> list. So two
+/// players both getting married the same day is a real, supported state. The test models it faithfully:
+/// <b>two clients joined concurrently from the start</b> (declared <c>Clients = 2</c>, both connects
+/// kicked off together via <c>Farmers.ConnectBothConcurrentlyAsync</c> so they land back-to-back
+/// rather than B waiting on A's whole join — neither a bolt-on), each engaged to its own NPC on the
+/// same day, then a single sleep-through queues both weddings. The host then fires them
+/// <b>one ceremony at a time, back-to-back</b>
+/// (<c>getAvailableWeddingEvent</c> pops one per <c>checkForEvents</c>), and <b>everyone takes part in
+/// each</b>: both clients watch and ready every ceremony's gate, and the host participates in each (its
+/// <c>weddingEnd&lt;farmerId&gt;</c> gate counts all present players). This subsumes the single-wedding
+/// case and guards two things that a naive fix breaks: the per-ceremony reset (a one-shot latch
+/// completes only the first), and starting the second queued wedding (vanilla fires weddings only on
+/// location entry, so the host must re-trigger <c>checkForEvents</c> after the first ends).
+/// </para>
+///
+/// <para>
+/// <b>Setup.</b> <see cref="ActionsClient.EngageToNpc"/> engages a farmhand to an NPC with a
+/// WeddingDate of tomorrow (so <c>queueWeddingsForToday</c>'s <c>CountdownToWedding &lt; 1</c> passes
+/// on the wedding day). The engagement is authored on each CLIENT because a farmhand's <c>Farmer</c>
+/// root is client-authoritative — a host-side spouse write is wiped by the client's nightly full-root
+/// resend before the wedding fires. Both farmhands sleeping triggers the day transition, which queues
+/// and then fires both weddings once each farmhand and the host are in non-temporary locations.
+/// </para>
+///
+/// <para>
+/// <b>Client role — ceremonies must VISIBLY RENDER on each client.</b> The whole point of this E2E is
+/// that each client plays its own copy of BOTH ceremonies as a real cutscene (so the recorded client
+/// video shows them). The test client drives each ceremony through the honest player path — the
+/// <c>WeddingCutscenePlayer</c> tweak clicks each <c>speak</c> dialogue box per tick, so the cutscene
+/// advances and renders frame-by-frame to its <c>waitForOtherPlayers</c> gate (which auto-readies on
+/// arrival), with deliberate ~2.5s pauses at the "couple assembled" and "marriage pronounced" beats so
+/// it's obvious in the video. Each distinct ceremony a client renders is recorded in
+/// <c>/status.weddingsRendered</c> (one entry per <c>weddingEnd&lt;farmerId&gt;</c> gate) — a client
+/// that force-skipped the ceremony would render nothing, so this is the proof the cutscene actually ran.
+/// </para>
+///
+/// <para>
+/// <b>Observation.</b> The primary gate is each client's <c>/status.weddingsRendered</c> reaching 2 —
+/// proof the client rendered both cutscenes. The host-side <see cref="ServerApiClient.GetWeddingState"/>
+/// (<c>/test/wedding_state</c>) is a secondary completion gate: its spouse-warp signal is master-only
+/// (so it proves the HOST finished, not the clients), and <c>IsWeddingActive</c> mirrors
+/// <c>Game1.CurrentEvent.isWedding</c> — false once the last ceremony ends.
+/// </para>
+/// </summary>
+// Two clients connected for the whole test (Clients = 2) — both players are present and getting married
+// together, the scenario under test. Exclusive: this test mutates GLOBAL game state — the calendar
+// (SetDate/SetTime) and Game1.weddingsToday — so it must not run concurrently with another method on the
+// shared server. (Single method today, but Exclusive future-proofs the class and matches FestivalTests.)
+[TestServer(Clients = 2, Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class WeddingTests : TestBase
+{
+    // Land on a non-festival day that allows weddings (canHaveWeddingOnDay excludes festival days).
+    // Spring 2 → weddings fire Spring 3, both ordinary days.
+    private const string WeddingSeason = "spring";
+    private const int EngageDay = 2;
+    private const int WeddingDay = 3;
+
+    // The two NPCs the farmhands marry. Any marriable villagers work; both must be ordinary (not
+    // festival-gated) so the ceremony fires on WeddingDay. Distinct NPCs so the two weddings are
+    // independent end-states to assert.
+    private const string SpouseNpcA = "Abigail";
+    private const string SpouseNpcB = "Penny";
+
+    // How long for both clients to fully RENDER both ceremonies before we consider the server hung.
+    // Each client plays each cutscene through at CLIENT_TPS=5 — every speak box costs ~750ms safetyTimer
+    // (~4 ticks) plus typing, and WeddingCutscenePlayer adds two ~2.5s "make it visible" beats per
+    // ceremony — so two ceremonies × two clients runs minutes, not seconds. Sized well above that; a
+    // genuine hang (a ceremony that never starts/renders, or a host stall) still blows past it.
+    private static readonly TimeSpan CeremoniesResolveTimeout = TimeSpan.FromSeconds(240);
+
+    /// <summary>
+    /// The regression gate: two farmhands marry two different NPCs on the same day with both clients
+    /// connected, the host fires each ceremony in turn and — because it now participates in each
+    /// "wait for players" step instead of skipping past it, resetting between them — both ceremonies
+    /// complete, the day proceeds, and both couples end up married with their spouses moved in.
+    /// Pre-fix the host force-skipped the weddings and the server hung on the first one.
+    /// </summary>
+    [Fact]
+    public async Task TwoFarmhandNpcWeddings_SameDay_BothCompleteWithoutHangingHost()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Land on the day before the weddings.
+        var setDate = await ServerApi.SetDate(WeddingSeason, EngageDay, year: 1, ct);
+        Assert.NotNull(setDate);
+        Assert.True(
+            setDate.Success,
+            $"SetDate({WeddingSeason} {EngageDay}) failed: {setDate.Error}"
+        );
+
+        // Connect BOTH farmhands CONCURRENTLY — both players present together from the start, not A
+        // then B. The two client containers are leased up front (overlapping their cold start) and both
+        // join sequences run together; the per-server join gate serializes only the game-thread join
+        // (the loop processes one farmhand at a time), so B lands right behind A instead of waiting on
+        // A's whole lease+join. The primary is held as the shared GameClient, the second wrapped as a
+        // SecondFarmer; neither is privileged. await using → farmhandB disconnects before the class's
+        // /newgame reset.
+        var (farmhandA, farmhandBConn) = await Farmers.ConnectBothConcurrentlyAsync(
+            primaryPrefix: "WeddingA",
+            secondaryPrefix: "WeddingB",
+            ct: ct
+        );
+        await using var farmhandB = farmhandBConn;
+        var farmhandAId = farmhandA.JoinResult.UniqueMultiplayerId;
+        var farmhandBId = farmhandB.Uid;
+
+        // Both must be present together before any wedding setup — this is the scenario under test
+        // (two players married the same day), so neither engagement/sleep step should begin until the
+        // server confirms both joined. The join sequences already gate on per-player visibility; this
+        // asserts the joint precondition explicitly so a regression to staggered joins fails here, loud.
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(farmhandAId, ct: ct),
+            $"Farmhand A (uid={farmhandAId}) must be present server-side after the concurrent join."
+        );
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(farmhandBId, ct: ct),
+            $"Farmhand B (uid={farmhandBId}) must be present server-side after the concurrent join."
+        );
+
+        // Engage BOTH farmhands to their NPCs the same day, each on its OWN client. Author on the
+        // CLIENT: a farmhand's Farmer root is client-authoritative, so the client resends its full root
+        // each night and would overwrite a host-side spouse write before the wedding fires.
+        var engageA = await GameClient.Actions.EngageToNpc(SpouseNpcA, daysUntilWedding: 1);
+        Assert.NotNull(engageA);
+        Assert.True(engageA.Success, $"EngageToNpc({SpouseNpcA}) failed: {engageA.Error}");
+        Assert.True(
+            engageA.IsEngaged,
+            $"Farmhand A should read as engaged to {SpouseNpcA} (spouse={engageA.Spouse})."
+        );
+
+        var engageB = await farmhandB.Client.Actions.EngageToNpc(SpouseNpcB, daysUntilWedding: 1);
+        Assert.NotNull(engageB);
+        Assert.True(engageB.Success, $"EngageToNpc({SpouseNpcB}) failed: {engageB.Error}");
+        Assert.True(
+            engageB.IsEngaged,
+            $"Farmhand B should read as engaged to {SpouseNpcB} (spouse={engageB.Spouse})."
+        );
+
+        // Wait for BOTH engagements to replicate client→host before sleeping. queueWeddingsForToday
+        // runs on the host and reads the host's view of each farmhand's spouse, so the host must see
+        // both before the day flips — and once it does, each client's nightly full-root resend carries
+        // the same spouse, so it can't wipe it.
+        var hostSeesBothEngagements = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_EngagementReplicated,
+            async () =>
+            {
+                var a = await ServerApi.GetWeddingState(farmhandAId, SpouseNpcA, ct);
+                var b = await ServerApi.GetWeddingState(farmhandBId, SpouseNpcB, ct);
+                return a?.Success == true
+                    && a.FarmhandSpouse == SpouseNpcA
+                    && b?.Success == true
+                    && b.FarmhandSpouse == SpouseNpcB;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            hostSeesBothEngagements,
+            "Host never saw both farmhands engaged — both engagements must replicate client→host "
+                + "before the day transition so queueWeddingsForToday can see them."
+        );
+
+        // Sleep-through to the wedding day. BOTH farmhands must sleep (each is a connected required
+        // player in the day-end ready check) so the day transitions and runs queueWeddingsForToday.
+        // SetClockSpeed(20) accelerates any remaining in-game time so the transition completes fast.
+        var sleepA = await GameClient.Actions.Sleep();
+        Assert.NotNull(sleepA);
+        Assert.True(sleepA.Success, $"Farmhand A sleep failed: {sleepA.Error}");
+        var sleepB = await farmhandB.Client.Actions.Sleep();
+        Assert.NotNull(sleepB);
+        Assert.True(sleepB.Success, $"Farmhand B sleep failed: {sleepB.Error}");
+
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var (dayChanged, disconnected) = await DayChange.WaitAsync(
+                EngageDay,
+                WeddingSeason,
+                year: 1,
+                checkConnection: true,
+                ct
+            );
+            Assert.False(
+                disconnected,
+                "A farmhand disconnected during the sleep-through to the wedding day"
+            );
+            Assert.True(dayChanged, $"Day did not advance to {WeddingSeason} {WeddingDay}");
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+
+        // The weddings fire once the farmhands/host are in non-temporary locations on the new day, ONE
+        // ceremony at a time on the host: getAvailableWeddingEvent pops a single farmer per
+        // checkForEvents, so the two couples get two SEPARATE ceremonies, fired back-to-back. Every
+        // instance — host AND both clients — runs its own copy of each from the synced weddingsToday.
+        //
+        // PROOF that BOTH ceremonies VISIBLY RENDERED ON EACH CLIENT. The host-side spouse warp alone
+        // is NOT sufficient: the ceremony's endBehaviors "wedding" spouse warp is master-only (Event.cs
+        // `if (!Game1.IsMasterGame) break;`), so "spouse on Farm" only proves the HOST ran the ceremony
+        // — it's blind to whether the clients rendered anything. To actually trust this E2E, each client
+        // must play its OWN copy of BOTH ceremonies as a cutscene. The test client drives each ceremony
+        // through the honest player path (WeddingCutscenePlayer clicks the dialogue boxes so the cutscene
+        // renders frame-by-frame) and records each distinct ceremony it played in /status.weddingsRendered
+        // (keyed by the per-wedding weddingEnd<farmerId> gate). So the real gate is: BOTH clients have
+        // rendered BOTH ceremonies. A regression that skips a ceremony, runs only one, or fails to start
+        // the 2nd leaves a client short of 2 and times out here.
+        var bothClientsRenderedBoth = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_BothClientsRenderedBoth,
+            async () =>
+            {
+                var aState = await GameClient.GetState();
+                var bState = await farmhandB.Client.GetState();
+                return aState?.WeddingsRendered.Count >= 2 && bState?.WeddingsRendered.Count >= 2;
+            },
+            timeout: CeremoniesResolveTimeout,
+            cancellationToken: ct
+        );
+        if (!bothClientsRenderedBoth)
+        {
+            var aState = await GameClient.GetState();
+            var bState = await farmhandB.Client.GetState();
+            string Describe(System.Collections.Generic.List<RenderedCeremonyInfo>? r) =>
+                r == null || r.Count == 0
+                    ? "none"
+                    : string.Join(
+                        ", ",
+                        r.ConvertAll(c => $"{c.Spouse}(gate={c.Gate},local={c.IsLocalPlayer})")
+                    );
+            Assert.Fail(
+                "Both clients did not each render BOTH same-day wedding ceremonies. Each client must play "
+                    + "its own copy of both couples' ceremonies as a visible cutscene "
+                    + "(/status.weddingsRendered, one entry per weddingEnd<farmerId> gate). A client short "
+                    + "of 2 means a ceremony was skipped, never started, or the 2nd queued wedding never "
+                    + "fired on that client.\n"
+                    + $"  client A (farmhand {SpouseNpcA}): rendered {aState?.WeddingsRendered.Count ?? 0} → {Describe(aState?.WeddingsRendered)}\n"
+                    + $"  client B (farmhand {SpouseNpcB}): rendered {bState?.WeddingsRendered.Count ?? 0} → {Describe(bState?.WeddingsRendered)}"
+            );
+        }
+
+        // With both clients having rendered both ceremonies, the host must also have finished both and
+        // warped each spouse home (the master-only endBehaviors "wedding" warp), with no ceremony still
+        // active. This is the host-side completion gate (kept from the original regression: it catches a
+        // host that skipped/stalled even if clients rendered).
+        var hostFinishedBoth = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_BothCeremoniesRan,
+            async () =>
+            {
+                var a = await ServerApi.GetWeddingState(farmhandAId, SpouseNpcA, ct);
+                var b = await ServerApi.GetWeddingState(farmhandBId, SpouseNpcB, ct);
+                var host = await ServerApi.GetWeddingState(ct: ct);
+                return a?.SpouseCurrentLocation == "Farm"
+                    && b?.SpouseCurrentLocation == "Farm"
+                    && host?.IsWeddingActive == false;
+            },
+            timeout: CeremoniesResolveTimeout,
+            cancellationToken: ct
+        );
+        if (!hostFinishedBoth)
+        {
+            var a = await ServerApi.GetWeddingState(farmhandAId, SpouseNpcA, ct);
+            var b = await ServerApi.GetWeddingState(farmhandBId, SpouseNpcB, ct);
+            var host = await ServerApi.GetWeddingState(ct: ct);
+            Assert.Fail(
+                "Both same-day weddings did not both end host-side. Each spouse should be warped to the "
+                    + "Farm by its ceremony's endBehaviors (\"wedding\" case, master-only); a couple whose "
+                    + "spouse never reached the Farm means that ceremony never completed on the host. A "
+                    + "still-active ceremony is the frozen-server symptom from the report.\n"
+                    + $"  {SpouseNpcA}: currentLocation={a?.SpouseCurrentLocation ?? "null"} (expected Farm)\n"
+                    + $"  {SpouseNpcB}: currentLocation={b?.SpouseCurrentLocation ?? "null"} (expected Farm)\n"
+                    + $"  weddingActive={host?.IsWeddingActive}"
+            );
+        }
+
+        // The host must not be left STUCK after the ceremonies — the reported symptom was the host frozen
+        // in the black wedding fadeout with a dangling after-wedding dialogue, on the ceremony's
+        // temporary Town map. "Both spouses on Farm + no active wedding" (above) does NOT catch that: the
+        // spouses warp home and IsWeddingActive clears even while the host is stuck, because endBehaviors
+        // runs the spouse warp before the host's own teardown stalls. So assert the host's recovery
+        // directly: no event up, no fade-to-black, no dialogue up, and off any temporary event map. These
+        // are exactly the four signals that were stuck pre-fix. Poll briefly — the host warps off the
+        // temp map and clears the fade within a tick or two of the last ceremony ending.
+        var hostRecovered = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_HostRecoveredAfterCeremonies,
+            async () =>
+            {
+                var hs = await ServerApi.GetWeddingState(ct: ct);
+                return hs?.Success == true
+                    && !hs.EventUp
+                    && !hs.FadeToBlack
+                    && !hs.DialogueUp
+                    && !hs.HostLocationIsTemporary;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        if (!hostRecovered)
+        {
+            var hs = await ServerApi.GetWeddingState(ct: ct);
+            Assert.Fail(
+                "Host did not recover after the same-day weddings — it is stuck in the post-ceremony "
+                    + "state (the reported black-fadeout-with-dialogue freeze). After the last ceremony "
+                    + "the host must end its event, clear the fade, dismiss the after-wedding dialogue, "
+                    + "and warp off the temporary ceremony map.\n"
+                    + $"  eventUp={hs?.EventUp} (expected false)\n"
+                    + $"  fadeToBlack={hs?.FadeToBlack} (expected false)\n"
+                    + $"  dialogueUp={hs?.DialogueUp} (expected false)\n"
+                    + $"  hostLocationIsTemporary={hs?.HostLocationIsTemporary} (expected false)"
+            );
+        }
+
+        // The host must be returned to its FarmHouse idle spot, not left standing on the open Farm map.
+        // The wedding's endBehaviors ("wedding" case) sets the exit warp from
+        // getHomeOfFarmer(Game1.player).getPorchStandingSpot(), which on the host resolves to the main
+        // farmhouse porch — so eventFinished() drops the host onto the Farm. The mod warps it home after
+        // the day's last ceremony; assert that here (separate from hostRecovered: "not stuck" is distinct
+        // from "back home", and the home-warp lands a tick or two after the temp map clears).
+        var hostHome = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_HostReturnedHomeAfterCeremonies,
+            async () =>
+            {
+                var hs = await ServerApi.GetWeddingState(ct: ct);
+                return hs?.Success == true
+                    && hs.HostCurrentLocation?.StartsWith(
+                        "FarmHouse",
+                        System.StringComparison.Ordinal
+                    ) == true;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        if (!hostHome)
+        {
+            var hs = await ServerApi.GetWeddingState(ct: ct);
+            Assert.Fail(
+                "Host was not returned to its FarmHouse after the same-day weddings — it is left on the "
+                    + "open Farm map where the wedding exit warp drops it (the exit targets the host's "
+                    + "farmhouse porch via getHomeOfFarmer(Game1.player)). After the last ceremony the host "
+                    + "must warp back to its FarmHouse idle spot.\n"
+                    + $"  hostCurrentLocation={hs?.HostCurrentLocation ?? "null"} (expected to start with \"FarmHouse\")"
+            );
+        }
+
+        // Both MARRIAGES proven before anyone disconnects: the host's view of each farmhand's spouse is
+        // the chosen NPC (the engagement became a marriage). Combined with both spouses warped to the
+        // Farm (above), this is the durable married-state both couples reached. Disconnect happens only
+        // after this — the await using on farmhandB runs at scope exit, after every gate here.
+        var marriedA = await ServerApi.GetWeddingState(farmhandAId, SpouseNpcA, ct);
+        var marriedB = await ServerApi.GetWeddingState(farmhandBId, SpouseNpcB, ct);
+        Assert.True(
+            marriedA?.FarmhandSpouse == SpouseNpcA,
+            $"Farmhand A is not married to {SpouseNpcA} (host sees spouse={marriedA?.FarmhandSpouse ?? "null"})."
+        );
+        Assert.True(
+            marriedB?.FarmhandSpouse == SpouseNpcB,
+            $"Farmhand B is not married to {SpouseNpcB} (host sees spouse={marriedB?.FarmhandSpouse ?? "null"})."
+        );
+
+        // Both farmhands must still be connected — proving the day genuinely proceeded rather than a
+        // client dropping. (Farmhand B is disposed by the await using at scope exit, after this.)
+        var farmhandBState = await farmhandB.Client.GetState();
+        Assert.True(
+            farmhandBState?.IsConnected == true,
+            "Farmhand B disconnected before the weddings completed — the day did not proceed cleanly."
+        );
+
+        LogSuccess(
+            $"Both same-day weddings rendered on BOTH clients as separate cutscenes: farmhand A↔{SpouseNpcA} "
+                + $"and B↔{SpouseNpcB}. Each client played its own copy of both ceremonies "
+                + "(/status.weddingsRendered == 2 each), the host finished both wait gates in turn and "
+                + "recovered, both spouses warped to the Farm, and both marriages are confirmed — no hang. "
+                + "Neither client disconnected until both marriages were proven."
+        );
+    }
+}

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -155,6 +155,66 @@ public class ActionsController
     }
 
     /// <summary>
+    /// Engage THIS client's player to an NPC so the next day-transition queues their wedding. The
+    /// engagement (spouse + an Engaged friendship with a WeddingDate) must be authored on the client,
+    /// not the host: a farmhand's <see cref="Farmer"/> root is client-authoritative, so the client
+    /// resends its full root each night (<c>Multiplayer.sendFarmhand</c> → <c>MarkReassigned</c>) and
+    /// would overwrite any host-side spouse write before the wedding fires. Setting it here makes the
+    /// engagement durable across the nightly sync, exactly as a real player accepting a proposal does.
+    /// <paramref name="daysUntilWedding"/> sets the WeddingDate (default 1 = the next morning).
+    /// </summary>
+    public EngageToNpcResult EngageToNpc(string npc, int daysUntilWedding = 1)
+    {
+        if (!Context.IsWorldReady)
+        {
+            return new EngageToNpcResult { Success = false, Error = "Not in a game world" };
+        }
+
+        if (string.IsNullOrEmpty(npc))
+        {
+            return new EngageToNpcResult { Success = false, Error = "Missing npc name" };
+        }
+
+        var me = Game1.player;
+        var weddingDate = WorldDate.ForDaysPlayed(
+            Game1.Date.TotalDays + (daysUntilWedding < 0 ? 0 : daysUntilWedding)
+        );
+
+        // A real NPC engagement is gated on houseUpgradeLevel >= 1 (NPC.cs RejectMermaidPendant_
+        // NeedHouseUpgrade) because there is no level-0 marriage map: FarmHouse.updateMap derives
+        // "Maps/FarmHouse_marriage" at level 0, which exists in no SDV install (only
+        // FarmHouse1_marriage/FarmHouse2_marriage do). The cabin's upgradeLevel is owner.HouseUpgrade
+        // Level (FarmHouse.upgradeLevel getter), so bumping this farmhand to level 1 makes the host's
+        // updateFarmLayout resolve FarmHouse1_marriage when the marriage applies — no missing-map crash.
+        if (me.HouseUpgradeLevel < 1)
+        {
+            me.HouseUpgradeLevel = 1;
+        }
+
+        me.spouse = npc;
+        if (!me.friendshipData.TryGetValue(npc, out var friendship) || friendship == null)
+        {
+            friendship = new Friendship(2500);
+            me.friendshipData[npc] = friendship;
+        }
+        friendship.Status = FriendshipStatus.Engaged;
+        friendship.Proposer = me.UniqueMultiplayerID;
+        friendship.WeddingDate = weddingDate;
+
+        _monitor.Log(
+            $"[Wedding] Engaged client to {npc}, wedding in {daysUntilWedding} day(s).",
+            LogLevel.Info
+        );
+
+        return new EngageToNpcResult
+        {
+            Success = true,
+            Spouse = me.spouse,
+            IsEngaged = me.isEngaged(),
+        };
+    }
+
+    /// <summary>
     /// Place a Garden Pot at the given tile on the player's current location. The
     /// IndoorPot ctor reads <c>Game1.currentLocation</c> when initializing its inner
     /// HoeDirt, so the player must already be at <paramref name="locationName"/>.
@@ -399,6 +459,20 @@ public class LeaveFestivalResult
 {
     public bool Success { get; set; }
     public string? Error { get; set; }
+}
+
+public class EngageToNpcResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+    public string? Spouse { get; set; }
+    public bool IsEngaged { get; set; }
+}
+
+public class EngageToNpcParams
+{
+    public string Npc { get; set; } = "";
+    public int DaysUntilWedding { get; set; } = 1;
 }
 
 public class WarpParams

--- a/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
+++ b/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
@@ -1,0 +1,355 @@
+using JunimoServer.Shared;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace JunimoTestClient.GameTweaks;
+
+/// <summary>
+/// Drives a wedding ceremony through to completion on a test client the honest way a real player does —
+/// by clicking through each <c>speak</c> dialogue box — so the cutscene actually PLAYS and RENDERS
+/// frame-by-frame instead of being force-skipped.
+///
+/// <para>
+/// <b>Why this exists.</b> A wedding is an <see cref="Event"/> (id "-2") that every instance runs its
+/// own copy of (weddings aren't a synced event — each client pops it from the synced
+/// <c>Game1.weddingsToday</c> via <c>checkForEvents</c>). The cutscene advances time-based EXCEPT at a
+/// <c>speak</c> command: <c>Event.Speak</c> opens a <c>DialogueBox</c>, sets <c>Game1.dialogueUp</c>,
+/// and the event will not advance while a box is open (decompiled Event.cs Speak: early-returns while
+/// <c>dialogueUp</c>). The test client has no human at the mouse, so without an auto-clicker the
+/// ceremony parks on its first dialogue box forever. The old approach (<c>Event.skipEvent()</c>) jumped
+/// straight to the end behaviours — which means the ceremony was never visibly rendered. This tweak
+/// clicks the box each tick so the cutscene plays through to its <c>waitForOtherPlayers</c> gate, which
+/// then auto-readies (vanilla <c>WaitForOtherPlayers</c> calls <c>SetLocalReady</c> on arrival). The
+/// host completes its own slot of that gate (AlwaysOn.HandleWeddingEvent), so the whole wedding ends.
+/// </para>
+///
+/// <para>
+/// <b>Deliberate visible pauses.</b> So the recorded client video makes it obvious WHAT is happening,
+/// the auto-clicker holds off at key beats: when a ceremony starts (the couple + guests assembled) and
+/// at the final dialogue (the "I now pronounce you…" moment, just before the wait gate). These pauses
+/// are wall-clock holds in the tick handler — the world keeps drawing during them, so they show up as
+/// several seconds of the assembled scene in the video (<see cref="BeatPauseMs"/>).
+/// </para>
+///
+/// <para>
+/// <b>Render proof.</b> Each distinct ceremony (keyed by its <c>weddingEnd&lt;farmerId&gt;</c> gate) is
+/// recorded with the groom + spouse (see <see cref="GetRenderedSnapshot"/>), exposed via the test
+/// client's <c>/status</c> so the E2E test can assert each client rendered BOTH same-day ceremonies —
+/// the thing the host-side spouse-warp signal can't prove (that warp is master-only, Event.cs "wedding"
+/// case).
+/// </para>
+/// </summary>
+public class WeddingCutscenePlayer
+{
+    private readonly IMonitor _monitor;
+
+    // Wall-clock hold at each "make it obvious" beat — long enough that the assembled scene is clearly
+    // visible in the recording, short enough not to pad the run (two beats per ceremony × two ceremonies).
+    // The world keeps rendering during the hold (we just don't click).
+    private const int BeatPauseMs = 1500;
+
+    // The gate id of the ceremony currently being driven, so a new gate is detected as a new ceremony.
+    private string? _activeGate;
+
+    // The ceremony currently being driven, captured when it starts and committed to _renderedCeremonies
+    // only when it COMPLETES. Recording on completion — not start — keeps the /status render count honest:
+    // the count reaches 2 once both cutscenes have actually played through, not the instant the second one
+    // begins. Null between ceremonies.
+    private RenderedCeremony? _activeCeremony;
+
+    // Whether the active ceremony's cutscene has played through to its waitForOtherPlayers gate. This is
+    // the gate for committing a ceremony as complete — NOT a transient CurrentEvent==null. On a
+    // back-to-back same-day wedding the player warps Town→Farm (ceremony 1 exit) then Farm→Town (ceremony
+    // 2 entry), and CurrentEvent reads null mid-warp for a tick while ceremony 2 is in fact still running.
+    // Committing on that null abandoned ceremony 2 (marked it "rendered" the instant it started, so the
+    // auto-clicker stopped driving it), stalling it until the host's wall-clock backstop force-ended it
+    // ~39s later. Latching on HasReachedWaitGate instead means we only treat a null as "ended" once we
+    // actually drove the cutscene to its gate.
+    private bool _activeGateReached;
+
+    // Wall-clock instant until which the auto-clicker pauses (a visible beat). DateTime.MinValue = no
+    // active pause. Wall-clock, not game-time: time is frozen during a wedding, so a game-time timer
+    // would never elapse.
+    private DateTime _pauseUntilUtc = DateTime.MinValue;
+
+    // Whether we've already inserted the pre-gate ("marriage pronounced") pause for the active gate, so
+    // it fires once per ceremony rather than every tick we sit on the final command.
+    private bool _finalBeatPausedForActiveGate;
+
+    // Wall-clock instant a ceremony last ended (CurrentEvent went wedding→not-wedding). Lets the warp
+    // handler add a visible "just teleported home" pause right after the ceremony's exit warp.
+    private DateTime _lastCeremonyEndedUtc = DateTime.MinValue;
+
+    // How long after a ceremony ends we still treat a local warp as "the wedding exit warp".
+    private const int CeremonyEndWarpWindowMs = 4000;
+
+    // One entry per distinct wedding ceremony this client played through (keyed by gate id). Written on
+    // the game thread (OnUpdateTicked), read off it (/status handler) — so guard both with _renderLock
+    // to avoid a torn read / "collection modified" during the snapshot.
+    private readonly Dictionary<string, RenderedCeremony> _renderedCeremonies = new();
+    private readonly object _renderLock = new();
+
+    public WeddingCutscenePlayer(IMonitor monitor)
+    {
+        _monitor = monitor;
+    }
+
+    /// <summary>
+    /// Snapshot of the wedding ceremonies this client has played through (rendered) today, one per gate.
+    /// Read by <c>/status</c> (off the game thread) for the E2E "both ceremonies rendered on this client"
+    /// assertion. Returns a copy so the caller can't observe a concurrent mutation.
+    /// </summary>
+    public List<RenderedCeremony> GetRenderedSnapshot()
+    {
+        lock (_renderLock)
+        {
+            return new List<RenderedCeremony>(_renderedCeremonies.Values);
+        }
+    }
+
+    private bool AlreadyRendered(string gate)
+    {
+        lock (_renderLock)
+        {
+            return _renderedCeremonies.ContainsKey(gate);
+        }
+    }
+
+    /// <summary>Clear the render record for a new session. Call on SaveLoaded (join / new game), NOT on
+    /// DayStarted: same-day weddings fire from <c>checkForEvents</c> on location entry as the day-start
+    /// warps resolve, while <c>OnDayStarted</c> fires on its own tick conditions — there's no ordering
+    /// guarantee between them, so a DayStarted reset can wipe a ceremony already counted this day (seen:
+    /// reset logged 1s AFTER the first ceremony started). SaveLoaded fires once per session, far from any
+    /// wedding day, so it can't race the record it clears.</summary>
+    public void ResetForNewSession()
+    {
+        lock (_renderLock)
+        {
+            if (_renderedCeremonies.Count > 0)
+            {
+                _monitor.Log(
+                    "[Wedding] New session — clearing rendered-ceremony record.",
+                    LogLevel.Trace
+                );
+            }
+            _renderedCeremonies.Clear();
+            _activeGateReached = false;
+        }
+        _activeGate = null;
+        _activeCeremony = null;
+        _pauseUntilUtc = DateTime.MinValue;
+        _finalBeatPausedForActiveGate = false;
+    }
+
+    /// <summary>
+    /// Per-tick driver. Call from <c>UpdateTicked</c> on the game thread. No-op unless a wedding event
+    /// is up on this client.
+    /// </summary>
+    public void OnUpdateTicked()
+    {
+        if (!Context.IsWorldReady)
+        {
+            return;
+        }
+
+        var ev = Game1.CurrentEvent;
+        if (ev is not { isWedding: true })
+        {
+            // No wedding event up right now. This is only a REAL ceremony end if we already drove the
+            // active ceremony to its wait gate (_activeGateReached). Otherwise it's the transient
+            // CurrentEvent==null that occurs mid-warp during a back-to-back same-day wedding's
+            // Town↔Farm exit/entry — the event is still running and about to resume, so committing now
+            // would prematurely mark the ceremony "rendered" and stop us driving it (see _activeGateReached).
+            if (_activeGate != null && _activeGateReached)
+            {
+                CommitActiveCeremony();
+                _lastCeremonyEndedUtc = DateTime.UtcNow;
+                _activeGate = null;
+                _activeCeremony = null;
+                _activeGateReached = false;
+                _pauseUntilUtc = DateTime.MinValue;
+                _finalBeatPausedForActiveGate = false;
+            }
+            // If the gate wasn't reached yet, leave the active-ceremony state intact so driving resumes
+            // when CurrentEvent comes back on the next tick — don't reset anything here.
+            return;
+        }
+
+        var gate = WeddingEvent.ExtractWaitGate(ev);
+        if (gate == null)
+        {
+            return; // no wait gate in this event's commands (unexpected) — nothing to anchor on
+        }
+
+        // New ceremony (first time we've seen this gate)? Capture it (committed to the render record only
+        // when it completes) and open with a visible beat so the assembled couple is on screen before we
+        // start clicking through the dialogue. Guarded on AlreadyRendered, not just gate != _activeGate:
+        // CurrentEvent can briefly flicker wedding→null→same wedding across the exit warp / back-to-back
+        // transition, and we don't want to re-fire the STARTED log + beat (or reset the final-beat latch)
+        // for a ceremony already completed.
+        if (gate != _activeGate && !AlreadyRendered(gate))
+        {
+            // A genuinely different gate means the previous ceremony is over (the engine fired the next
+            // queued wedding). Commit the previous one now — its render count would be lost if
+            // CurrentEvent flipped straight here without ever reading null.
+            _activeGateReached = false;
+            CommitActiveCeremony();
+            _activeGate = gate;
+            _finalBeatPausedForActiveGate = false;
+            CaptureCeremonyStarted(ev, gate);
+            BeginBeatPause("ceremony started (couple assembled)");
+            return;
+        }
+
+        // Re-detected the gate we're already driving (or one already rendered). Latch once the cutscene
+        // has played through to its wait gate — the signal the CurrentEvent==null branch uses to tell a
+        // real ceremony end from a transient mid-warp flicker — then keep clicking it forward.
+        if (!_activeGateReached && WeddingEvent.HasReachedWaitGate(ev))
+        {
+            _activeGateReached = true;
+        }
+        _activeGate = gate;
+
+        // Holding on a visible beat — let the scene render, don't click yet.
+        if (DateTime.UtcNow < _pauseUntilUtc)
+        {
+            return;
+        }
+        _pauseUntilUtc = DateTime.MinValue;
+
+        // No dialogue box up: the cutscene is advancing on its own (move/pause commands). Let it.
+        if (Game1.activeClickableMenu is not DialogueBox box)
+        {
+            return;
+        }
+
+        // A dialogue box is up. If this is the LAST speak before the wait gate (the "marriage
+        // pronounced" beat), pause once so it's obvious in the video, then resume clicking next tick.
+        if (!_finalBeatPausedForActiveGate && IsAtFinalDialogue(ev))
+        {
+            _finalBeatPausedForActiveGate = true;
+            BeginBeatPause("marriage pronounced (final dialogue)");
+            return;
+        }
+
+        // Click the box the way a player does. The box's own gating handles timing: a first click
+        // completes the typed text, a later click (once its safetyTimer elapses) advances/closes it —
+        // so calling this each tick walks the dialogue forward without us re-implementing the timers
+        // (DialogueBox.receiveLeftClick, decompiled DialogueBox.cs).
+        box.receiveLeftClick(0, 0, playSound: false);
+    }
+
+    /// <summary>
+    /// If a ceremony just ended (the local player is warping out of it via the wedding's exit warp),
+    /// hold the player still for a beat so the recorded video lingers on the "teleported home" arrival.
+    /// Call from the local-player Warped handler. No-op outside the post-ceremony window.
+    /// </summary>
+    public void PauseAfterWeddingWarp()
+    {
+        if ((DateTime.UtcNow - _lastCeremonyEndedUtc).TotalMilliseconds > CeremonyEndWarpWindowMs)
+        {
+            return;
+        }
+        // pauseTime freezes the player but the world keeps drawing, so the arrival shows in the video.
+        // Only bump it (don't stack) so two same-day ceremonies don't compound into one long freeze.
+        if (Game1.pauseTime < BeatPauseMs)
+        {
+            Game1.pauseTime = BeatPauseMs;
+        }
+        _monitor.Log(
+            $"[Wedding] visible beat — pausing {BeatPauseMs}ms after the ceremony exit warp (teleported home).",
+            LogLevel.Info
+        );
+    }
+
+    /// <summary>True once the event has reached its final command — the <c>waitForOtherPlayers</c> gate
+    /// is the last thing left, so the dialogue currently up is the ceremony's closing line.</summary>
+    private static bool IsAtFinalDialogue(Event ev)
+    {
+        var commands = ev.eventCommands;
+        if (commands == null || commands.Length == 0)
+        {
+            return false;
+        }
+        // The wait gate is the terminal command in the vanilla wedding script; if we're on (or past)
+        // the second-to-last command with a dialogue up, this is the closing line.
+        return ev.CurrentCommand >= commands.Length - 2;
+    }
+
+    /// <summary>Capture the just-started ceremony into <see cref="_activeCeremony"/>. Not yet added to
+    /// the rendered record — that happens in <see cref="CommitActiveCeremony"/> when the ceremony ends.</summary>
+    private void CaptureCeremonyStarted(Event ev, string gate)
+    {
+        // ev.farmer is the wedding's groom (falls back to Game1.player, never null — decompiled
+        // Event.farmer getter). For the OTHER couple's ceremony on this client it's that other farmer.
+        var groom = ev.farmer;
+        var spouse = groom.spouse ?? "(unknown)";
+        var isLocal = groom.UniqueMultiplayerID == Game1.player?.UniqueMultiplayerID;
+
+        _activeCeremony = new RenderedCeremony
+        {
+            Gate = gate,
+            GroomId = groom.UniqueMultiplayerID,
+            GroomName = groom.Name ?? "(unknown)",
+            Spouse = spouse,
+            IsLocalPlayer = isLocal,
+        };
+
+        _monitor.Log(
+            $"[Wedding] ceremony STARTED gate={gate} groom={groom.Name}({groom.UniqueMultiplayerID}) "
+                + $"spouse={spouse} local={isLocal} localPlayer={Game1.player?.UniqueMultiplayerID} "
+                + $"weddingsTodayRemaining={Game1.weddingsToday?.Count}",
+            LogLevel.Info
+        );
+    }
+
+    /// <summary>Commit the active (now-finished) ceremony to the rendered record. Called when the wedding
+    /// event ends, so the /status render count reflects ceremonies actually PLAYED THROUGH, not just
+    /// started. Idempotent: a CurrentEvent flicker that re-enters here finds the gate already recorded.</summary>
+    private void CommitActiveCeremony()
+    {
+        var ceremony = _activeCeremony;
+        if (ceremony == null)
+        {
+            return;
+        }
+
+        _activeCeremony = null;
+
+        int renderedCount;
+        lock (_renderLock)
+        {
+            _renderedCeremonies[ceremony.Gate] = ceremony;
+            renderedCount = _renderedCeremonies.Count;
+        }
+
+        _monitor.Log(
+            $"[Wedding] ceremony COMPLETED gate={ceremony.Gate} groom={ceremony.GroomName}({ceremony.GroomId}) "
+                + $"spouse={ceremony.Spouse} local={ceremony.IsLocalPlayer} "
+                + $"renderedSoFar={renderedCount}",
+            LogLevel.Info
+        );
+    }
+
+    private void BeginBeatPause(string reason)
+    {
+        _pauseUntilUtc = DateTime.UtcNow.AddMilliseconds(BeatPauseMs);
+        _monitor.Log(
+            $"[Wedding] visible beat — pausing {BeatPauseMs}ms so it shows in the video: {reason}.",
+            LogLevel.Info
+        );
+    }
+}
+
+/// <summary>One wedding ceremony a client played through and rendered, for the /status render proof.</summary>
+public class RenderedCeremony
+{
+    public string Gate { get; set; } = "";
+    public long GroomId { get; set; }
+    public string GroomName { get; set; } = "";
+    public string Spouse { get; set; } = "";
+
+    /// <summary>True if the groom is this client's own player (vs the other couple's ceremony).</summary>
+    public bool IsLocalPlayer { get; set; }
+}

--- a/tests/test-client/HttpServer/ApiDefinitions.cs
+++ b/tests/test-client/HttpServer/ApiDefinitions.cs
@@ -268,6 +268,16 @@ public class ApiDefinitions
 
     [ApiEndpoint(
         "POST",
+        "/actions/engage_to_npc",
+        Summary = "Engage to an NPC",
+        Description = "Engage this client's player to an NPC (client-authoritative) so the next day-transition queues their wedding.",
+        Tag = "Actions"
+    )]
+    [ApiResponse(typeof(EngageToNpcResult), 200)]
+    private void EngageToNpc() { }
+
+    [ApiEndpoint(
+        "POST",
         "/actions/warp",
         Summary = "Warp the player",
         Description = "Queue an asynchronous warp to a location/tile. Caller must poll /status to confirm arrival.",

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -32,6 +32,7 @@ public class ModEntry : Mod
     private SkipIntro? _skipIntro;
     private GodTool? _godTool;
     private QiPlaneSkip? _qiPlaneSkip;
+    private WeddingCutscenePlayer? _weddingPlayer;
 
     // Diagnostics
     private HealthWatchdog? _healthWatchdog;
@@ -82,6 +83,12 @@ public class ModEntry : Mod
 
         _qiPlaneSkip = new QiPlaneSkip(Monitor, _harmony);
         _qiPlaneSkip.Apply();
+
+        // Drives a wedding ceremony through to completion by clicking its dialogue boxes, so the
+        // cutscene actually renders on this client (instead of being force-skipped). Driven per-tick
+        // from OnUpdateTicked; render record reset per session from OnSaveLoaded (not per day — a
+        // day-boundary reset would race the ceremonies, see WeddingCutscenePlayer.ResetForNewSession).
+        _weddingPlayer = new WeddingCutscenePlayer(Monitor);
 
         // Apply Steam/Galaxy auth patches (must be before Steam diagnostics)
         var authService = new ClientAuthService(helper, Monitor, _harmony);
@@ -283,6 +290,11 @@ public class ModEntry : Mod
                 menu = MenuDetector.GetCurrentMenu(),
                 connection = MenuDetector.GetConnectionStatus(),
                 farmer = MenuDetector.GetFarmerInfo(),
+                // Wedding ceremonies this client has played through (rendered) today, one per gate.
+                // The E2E test asserts each client rendered BOTH same-day ceremonies — the host-side
+                // spouse-warp signal can't prove client rendering (that warp is master-only).
+                weddingsRendered = _weddingPlayer?.GetRenderedSnapshot()
+                    ?? new List<RenderedCeremony>(),
                 timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             }
         );
@@ -584,6 +596,23 @@ public class ModEntry : Mod
         _server.Post(
             "actions/leave_festival",
             _ => ExecuteOnGameThread(() => _actionsController!.LeaveFestival())
+        );
+
+        // POST /actions/engage_to_npc - Engage this client's player to an NPC (client-authoritative)
+        _server.Post(
+            "actions/engage_to_npc",
+            req =>
+            {
+                var body = TestApiServer.ReadBody<EngageToNpcParams>(req);
+                if (body == null)
+                {
+                    return new EngageToNpcResult { Success = false, Error = "Missing body" };
+                }
+
+                return ExecuteOnGameThread(() =>
+                    _actionsController!.EngageToNpc(body.Npc, body.DaysUntilWedding)
+                );
+            }
         );
 
         // POST /actions/warp - Queue a warp to the given location/tile (async; caller polls /status to confirm)
@@ -1317,6 +1346,18 @@ public class ModEntry : Mod
                 }
             }
         }
+
+        // Drive a wedding ceremony through to completion (clicks its dialogue boxes so it renders).
+        // No-op unless a wedding event is currently up on this client.
+        try
+        {
+            _weddingPlayer?.OnUpdateTicked();
+        }
+        catch (Exception ex)
+        {
+            Monitor.Log($"Error driving wedding cutscene: {ex.Message}", LogLevel.Error);
+            _errorCapture?.CaptureException("WeddingCutscenePlayer", ex);
+        }
     }
 
     private void OnRendered(object? sender, RenderedEventArgs e)
@@ -1430,6 +1471,10 @@ public class ModEntry : Mod
         Monitor.Log($"Save loaded - Farmer: {StardewValley.Game1.player?.Name}", LogLevel.Trace);
         LogSpawnInfo("SaveLoaded");
 
+        // Clear the wedding render record for the new session (SaveLoaded, not DayStarted — see
+        // ResetForNewSession for why the day-boundary reset would race the ceremonies).
+        _weddingPlayer?.ResetForNewSession();
+
         // Increase chat buffer size for testing (default is 10, which truncates long command outputs)
         // !lobby help produces 15 messages; 20 gives headroom. Sequence-based deduplication
         // makes buffer size less critical than before.
@@ -1444,6 +1489,10 @@ public class ModEntry : Mod
     {
         if (e.IsLocalPlayer)
         {
+            // If this warp is the wedding's exit warp (a ceremony just ended), hold a visible beat so
+            // the recorded video lingers on the "teleported home" arrival. No-op otherwise.
+            _weddingPlayer?.PauseAfterWeddingWarp();
+
             Monitor.Log(
                 $"[Spawn] Player warped: {e.OldLocation?.NameOrUniqueName ?? "null"} -> {e.NewLocation?.NameOrUniqueName ?? "null"}",
                 LogLevel.Debug


### PR DESCRIPTION
Fixes the wedding-skip deadlock: force-skipping a wedding jumped the host past the ceremony's `waitForOtherPlayers weddingEnd<farmerId>` gate, so it never readied and clients hung at "Waiting for players" with time frozen.

**Chained on #465** (the E2E needs `DayChangeWaiter` settling on `dayTransitionComplete`). Retarget to `master` + rebase after #465 merges.

Commit 1 — mod wedding fix:
- `AlwaysOn`: exempt weddings from `HandleSkippableEvent`; per-tick `HandleWeddingEvent` readies the host's gate slot once the other players are ready (or a 20s backstop), ends the host's copy via `endBehaviors(["End","wedding"])`, tears down the render-suppressed host's stuck fade/dialogue, starts the next queued same-day wedding, warps the host home after the day's last one
- `WeddingEventGuard` (new): prefix on `getAvailableWeddingEvent` against a vanilla null-deref when a queued farmer has no spouse at fire time
- `/test/wedding_state` (new test endpoint): ceremony state + wait-gate counts + post-ceremony stuck signals

Commit 2 — E2E coverage:
- `WeddingTests` (new): two farmhands, two NPCs, both same-day ceremonies must complete without hanging the host; per-client render proof via `weddingsRendered`
- test-client: `WeddingCutscenePlayer` (new) plays ceremony copies; `/actions/engage_to_npc` (client-authoritative — a host-side spouse write is overwritten by the client's nightly full-root resend)
- `FarmerTestHelper`: `ConnectBothConcurrentlyAsync` + `JoinSecondFarmerAsync` + `requireCustomized:false` disconnect speedup

Commit 3 — riders (same session, distinct fixes):
- pet/cave choices move off the 12s `OneSecondUpdateTicked` loop to a SaveLoaded pre-seed (`PreSeedChoices`); `HandleFestivalEvents` moves per-tick
- `/test/seed`: caveChoice also writes `eventsSeen "65"` so the pre-seed never overrides the seeded value
- `CabinManager.ResetVillagersHomedAt`: re-home an NPC spouse stranded when its cabin is destroyed