### PR TITLE
fix(newgame): re-roll save id after reload

### DIFF
--- a/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
+++ b/mod/JunimoServer/Services/GameCreator/GameCreatorService.cs
@@ -152,6 +152,20 @@ class GameCreatorService : ModService
 
         Game1.multiplayerMode = 2; // Server mode (Game1.IsServer)
 
+        // Restore the id re-roll vanilla's title-screen new-game does in
+        // ResetGameStateOnTitleScreen (which we skip), so a /newgame after a /reload
+        // doesn't inherit the reloaded save's id and reuse its folder. RandomSeed pins
+        // the id via loadForNewGame, so only re-roll when unset. Fresh Random avoids
+        // Game1.random (deterministic here). Redraw guards the negligible folder collision.
+        if (config.RandomSeed is null)
+        {
+            var rng = new Random();
+            do
+            {
+                Game1.uniqueIDForThisGame = (ulong)Utility.RandomLong(rng);
+            } while (SaveGame.IsNewGameSaveNameCollision(SaveGame.FilterFileName(config.FarmName)));
+        }
+
         // From TitleMenu.createdNewCharacter
         Game1.game1.loadForNewGame();
 

--- a/mod/JunimoServer/Services/SaveImport/SaveImportXmlTransform.cs
+++ b/mod/JunimoServer/Services/SaveImport/SaveImportXmlTransform.cs
@@ -483,12 +483,13 @@ internal static class SaveImportXmlTransform
     private static long GenerateUniqueId(HashSet<long> existing)
     {
         var rng = new Random();
+        var bytes = new byte[8];
         for (var attempt = 0; attempt < 1000; attempt++)
         {
-            // Full 64-bit spread: two 32-bit draws. Avoid 0 (sentinel for "no owner").
-            long high = (long)(uint)rng.Next(int.MinValue, int.MaxValue);
-            long low = (uint)rng.Next(int.MinValue, int.MaxValue);
-            var candidate = (high << 32) | low;
+            // Unbiased full 64-bit draw (matches engine Utility.RandomLong's NextBytes
+            // shape; a two-int rng.Next draw excludes int.MaxValue). Avoid 0 (no-owner sentinel).
+            rng.NextBytes(bytes);
+            var candidate = BitConverter.ToInt64(bytes, 0);
             if (candidate != 0 && !existing.Contains(candidate))
             {
                 return candidate;


### PR DESCRIPTION
Unique-ID generation pair:

- `GameCreatorService`: restore the id re-roll vanilla's title-screen new-game does (we skip `ResetGameStateOnTitleScreen`), so `/newgame` after `/reload` doesn't inherit the reloaded save's `uniqueIDForThisGame` and reuse its save folder. Only when no `RandomSeed` pins the id, with a redraw on folder-name collision.
- `SaveImportXmlTransform`: unbiased full-64-bit replacement-id draw via `NextBytes` (the two-int `rng.Next` draw excluded `int.MaxValue`), matching engine `Utility.RandomLong`'s shape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New games now receive a fresh, collision-free identifier when no random seed is configured, preventing save-name conflicts after reloads.
  * Save imports now generate more reliable unique multiplayer identifiers, reducing the chance of identifier collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->