### PR TITLE
perf(tests): /test/force_save replaces day-transition save in SaveImport

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -314,6 +314,17 @@ public class TestSaveFileOpResponse
     public string TargetSaveName { get; set; } = "";
 }
 
+/// <summary>Response from POST /test/force_save (test-only). Persists the current world to disk
+/// synchronously (no day transition), so save-import source generation can skip SleepToSaveAsync.</summary>
+public class TestForceSaveResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>The save folder the world was written to (Constants.SaveFolderName).</summary>
+    public string SaveFolderName { get; set; } = "";
+}
+
 /// <summary>
 /// Body for POST /test/import_save (test-only). Clones a source save folder under a new name, then
 /// runs saves-import on the clone (ExecuteImport rejects importing the active save, so the clone is

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -123,6 +123,9 @@ public partial class ApiService
                             await HandlePostTestCorruptSaveAsync(request)
                         );
                         return;
+                    case "/test/force_save":
+                        await WriteJsonAsync(response, await HandlePostTestForceSaveAsync());
+                        return;
                 }
                 break;
         }
@@ -1384,6 +1387,63 @@ public partial class ApiService
         {
             return new TestSaveFileOpResponse { Success = false, Error = ex.Message };
         }
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/force_save",
+        Summary = "Persist the current world synchronously, without a day transition (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestForceSaveResponse), 200)]
+    private async Task<TestForceSaveResponse> HandlePostTestForceSaveAsync()
+    {
+        // Flushes in-memory state (seeded Game1 mutations + a connected client's customization) to
+        // the save folder without a sleep/day-transition. Lets save-import source generation shed
+        // the ~full-in-game-day SleepToSaveAsync wait. Mirrors the day-transition save's two steps:
+        //   1. saveFarmhands() clones every connected farmhand's live root into farmhandData
+        //      (Multiplayer.cs:1018-1028 → NetWorldState.SaveFarmhand) — same call the transition
+        //      makes (Game1.cs:8238). A homed/customized connected farmhand survives intact;
+        //      ResetFarmhandState only clears userID/home for a HOMELESS farmhand.
+        //   2. getSaveEnumerator() does the actual file write. SaveGame.Save() normally offloads
+        //      this to a background Task and yields across ticks (SaveGame.cs:296-310), but the
+        //      enumerator itself is fully synchronous (SaveGame.cs:346-546 — the yields are just
+        //      progress markers). Driving it inline writes the save within this one game-thread
+        //      Action, sidestepping the background-task split and the UpdateTicked save-suppression.
+        var result = new TestForceSaveResponse();
+        try
+        {
+            // Full save under load can exceed the 5s default game-thread timeout.
+            await RunOnGameThreadAsync(
+                () =>
+                {
+                    if (Game1.gameMode != 3 || !Game1.IsMasterGame)
+                    {
+                        result.Error =
+                            $"Not in a loaded master game (gameMode={Game1.gameMode}, IsMasterGame={Game1.IsMasterGame})";
+                        return;
+                    }
+
+                    // Game1.multiplayer is protected; reach it via the established reflective accessor.
+                    Helper.GetMultiplayer().saveFarmhands();
+
+                    var save = SaveGame.getSaveEnumerator();
+                    while (save.MoveNext()) { }
+
+                    result.SaveFolderName = Constants.SaveFolderName;
+                    result.Success = true;
+                },
+                timeoutMs: 60000
+            );
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
     }
 
     [ApiEndpoint(

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -793,6 +793,19 @@ public class TestSaveFileOpResponse
     public string TargetSaveName { get; set; } = "";
 }
 
+/// <summary>Response from /test/force_save (test-only).</summary>
+public class TestForceSaveResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("saveFolderName")]
+    public string SaveFolderName { get; set; } = "";
+}
+
 /// <summary>Body for /test/import_save (test-only). Mirrors the server-side DTO.</summary>
 public class TestImportSaveRequest
 {
@@ -1884,6 +1897,19 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestSaveFileOpResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: persist the current world to disk synchronously, without a day transition — flushes
+    /// in-memory seeded state + a connected client's customization the way SleepToSaveAsync does, but
+    /// in one game-thread call instead of a full in-game day.
+    /// POST /test/force_save
+    /// </summary>
+    public async Task<TestForceSaveResponse?> ForceSave(CancellationToken ct = default)
+    {
+        var response = await SendWithRetryAsync(HttpMethod.Post, "/test/force_save", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestForceSaveResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -13,7 +13,8 @@ namespace JunimoServer.Tests;
 /// The source co-op save is generated in-process: create a game (the master is the "Server" bot),
 /// then <c>POST /test/seed_import_source</c> makes that master look like a real played human owner
 /// (non-Server name + inventory, plus the world/relationship/house state and FarmHouse contents each
-/// test asserts), then <c>SleepToSaveAsync</c> writes it to disk. <c>POST /test/import_save</c> then
+/// test asserts), then <c>POST /test/force_save</c> writes it to disk synchronously (no day
+/// transition). <c>POST /test/import_save</c> then
 /// CLONES that save under a new folder name (ExecuteImport rejects importing the active save) and
 /// runs the import on the clone, after which <c>ReloadServerAsync</c> loads the transformed clone and
 /// runs the Layer B finalizer.
@@ -56,7 +57,9 @@ public class SaveImportTests : TestBase
             startingCabins: startingCabins
         );
 
-        // A connected, customized, in-world client is required for the day-transition save.
+        // A connected, customized, in-world client is required: force_save's saveFarmhands() clones
+        // each connected farmhand's live (customized) root into farmhandData, the same capture the
+        // day transition does — so the client must be present and customized when it runs.
         var client = await Farmers.ConnectNewAsync(ct: ct);
         try
         {
@@ -74,7 +77,9 @@ public class SaveImportTests : TestBase
             );
             Assert.NotEqual(0, seedResult!.OwnerUid);
 
-            await SleepToSaveAsync(ct);
+            // Persist synchronously instead of a full in-game day transition (SleepToSaveAsync).
+            var saved = await ServerApi.ForceSave(ct);
+            Assert.True(saved?.Success == true, $"ForceSave failed: {saved?.Error}");
             return seedResult;
         }
         finally


### PR DESCRIPTION
Persist the current world synchronously on the game thread (`saveFarmhands()` + driving `getSaveEnumerator()` inline), without a day transition. Save-import source generation sheds the ~full-in-game-day `SleepToSaveAsync` wait per test class.

- `ApiService.TestEndpoints` (+ Models): `POST /test/force_save` + `TestForceSaveResponse`
- `ServerApiClient`: `ForceSave` wrapper + DTO
- `SaveImportTests`: `SleepToSaveAsync` → `ForceSave`, doc-comment updates