### PR TITLE
feat(test-runner): persist instance stats + recorder robustness

### DIFF
--- a/tests/JunimoServer.TestRunner/Rendering/RunRecorder.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/RunRecorder.cs
@@ -63,6 +63,10 @@ public sealed class RunRecorder
             aborted: aborted,
             abortReason: aborted ? (_externalAbortReason ?? "child_process_terminated") : null
         );
-        _writer.WriteIfNotWritten(view);
+        // Pass State alongside the view: instance stats history lives on
+        // _instances (not projected into the per-test RunArtifactView), and only
+        // TestRunState can serialize it (the InstanceState/-StatsEntry types are
+        // private nested). The writer reads it under TestRunState's own lock.
+        _writer.WriteIfNotWritten(view, State);
     }
 }

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
@@ -44,8 +44,12 @@ public sealed class TestRunArtifactWriter
     /// <summary>
     /// Idempotent. Called from the renderer's <c>DisposeAsync</c>, after the setup
     /// pipe has drained — covers both the graceful path and abnormal child exit.
+    /// <paramref name="state"/> is the live <see cref="TestRunState"/>; it carries
+    /// the per-instance stats history that <see cref="RunArtifactView"/> does not
+    /// (those types are private nested in TestRunState), serialized here under the
+    /// state's own lock.
     /// </summary>
-    public void WriteIfNotWritten(RunArtifactView view)
+    public void WriteIfNotWritten(RunArtifactView view, TestRunState state)
     {
         lock (_lock)
         {
@@ -103,6 +107,17 @@ public sealed class TestRunArtifactWriter
             {
                 Console.Error.WriteLine(
                     $"[ArtifactWriter] run-metadata.json (merged) failed: {ex.Message}"
+                );
+            }
+
+            try
+            {
+                WriteInstanceStats(state);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[ArtifactWriter] instance-stats.jsonl failed: {ex.Message}"
                 );
             }
 
@@ -456,6 +471,22 @@ public sealed class TestRunArtifactWriter
         Directory.CreateDirectory(_runDir!);
         var json = ArtifactPrettyJson.Serialize(merged);
         File.WriteAllText(Path.Combine(_runDir!, RunArtifactNames.RunMetadataJson), json);
+    }
+
+    /// <summary>
+    /// Flushes the runner's in-memory per-instance stats history to
+    /// <c>diagnostics/instance-stats.jsonl</c>. The data is collected live by
+    /// <c>ContainerStatsCollector</c> and otherwise reaches only the UI over the
+    /// WebSocket (<c>SetupEventBus</c> is disk-free); this is the only on-disk
+    /// sink for post-mortem container-load analysis.
+    /// </summary>
+    private void WriteInstanceStats(TestRunState state)
+    {
+        var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
+        Directory.CreateDirectory(diagnosticsDir);
+        state.WriteInstanceStatsJsonl(
+            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceStatsJsonl)
+        );
     }
 
     private void WriteLatestPointer()

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -1482,6 +1482,64 @@ public sealed class TestRunState
     }
 
     /// <summary>
+    /// Writes one compact JSON line per <c>(instance, stats sample)</c> to
+    /// <paramref name="path"/> so the per-container CPU/memory/network/game
+    /// history — collected live by <c>ContainerStatsCollector</c> and otherwise
+    /// only held in memory for the UI — survives into the on-disk artifact tree
+    /// for post-mortem load analysis (e.g. "was the host saturated when its SSH
+    /// tunnel dropped?"). Each line carries the instance identity plus the same
+    /// field set the snapshot projects (see <see cref="BuildSnapshot"/>).
+    /// Instances with no samples are skipped, so the file is empty (or absent if
+    /// the caller skips an empty write) when <c>SDVD_TEST_STATS=none</c>.
+    /// </summary>
+    public void WriteInstanceStatsJsonl(string path)
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            foreach (var inst in _instances.Values)
+            {
+                foreach (var s in inst.StatsHistory)
+                {
+                    lines.Add(
+                        Serialize(
+                            new
+                            {
+                                inst.InstanceId,
+                                inst.HostId,
+                                inst.InstanceType,
+                                inst.ServerKey,
+                                inst.Label,
+                                s.Timestamp,
+                                s.CpuPercent,
+                                s.MemoryMb,
+                                s.CpuCount,
+                                s.TotalMemoryMb,
+                                s.Fps,
+                                s.Tps,
+                                s.AvgTickMs,
+                                s.GameMemoryMb,
+                                s.TargetTps,
+                                s.TargetFps,
+                                s.GcRate,
+                                s.PendingActions,
+                                s.GameThreadWaitMs,
+                                s.NetRxBytesPerSec,
+                                s.NetTxBytesPerSec,
+                                s.BlkReadBytesPerSec,
+                                s.BlkWriteBytesPerSec,
+                                s.MemoryLimitMb,
+                            }
+                        )
+                    );
+                }
+            }
+
+            File.WriteAllLines(path, lines);
+        }
+    }
+
+    /// <summary>
     /// Run-level view for the report's social-media meta tags + OG card. Counts
     /// come from the same test-tree iteration BuildSnapshot uses (the _passed/
     /// _failed fields are only set at run_finished), so they match the published

--- a/tests/JunimoServer.Tests/Helpers/ContainerRecorder.cs
+++ b/tests/JunimoServer.Tests/Helpers/ContainerRecorder.cs
@@ -618,37 +618,20 @@ internal sealed class ContainerRecorder : IAsyncDisposable
         {
             // SIGINT triggers ffmpeg's graceful shutdown: finalize current segment, flush
             // segments.csv, and exit. Prior segments are already on disk; only the active
-            // segment needs the trailer written.
-            await SignalFfmpeg("INT", ct);
-
-            for (var i = 0; i < 20; i++) // up to 10s for graceful finalization
+            // segment needs the trailer written. Send-and-wait in ONE exec (signal, then poll
+            // kill -0 inside the shell), not N C#-side poll execs: each docker exec round-trip
+            // costs ~6s under parallel teardown load, so the cost driver is exec count, not
+            // finalize time (.claude/rules/minimize-exec-count-...). Up to ~10s of in-shell
+            // waiting at sub-second granularity for graceful finalization.
+            if (await SignalAndWaitForExitAsync("INT", iterations: 50, ct))
             {
-                if (_containerDead)
-                {
-                    _state = RecorderState.Stopped;
-                    return;
-                }
-                await Task.Delay(500, ct);
-                var check = await _container.ExecAsync(
-                    new[]
-                    {
-                        "sh",
-                        "-c",
-                        $"pid=$(cat {RecDir}/ffmpeg.pid 2>/dev/null); "
-                            + $"[ -n \"$pid\" ] && kill -0 $pid 2>/dev/null && echo RUNNING || echo DONE",
-                    },
-                    ct
+                _state = RecorderState.Stopped;
+                _log($"[Recording] Stopped in {_displayLabel}");
+                InfrastructureEventLog.Emit(
+                    "recording_stopped",
+                    new { container = _displayLabel, via = "sigint" }
                 );
-                if (check.Stdout.Trim().Contains("DONE"))
-                {
-                    _state = RecorderState.Stopped;
-                    _log($"[Recording] Stopped in {_displayLabel}");
-                    InfrastructureEventLog.Emit(
-                        "recording_stopped",
-                        new { container = _displayLabel, via = "sigint" }
-                    );
-                    return;
-                }
+                return;
             }
 
             if (_containerDead)
@@ -657,38 +640,18 @@ internal sealed class ContainerRecorder : IAsyncDisposable
                 return;
             }
             _log(
-                $"[Recording] WARNING: ffmpeg not responding to SIGINT in {_displayLabel} after 10s, trying SIGTERM"
+                $"[Recording] WARNING: ffmpeg not responding to SIGINT in {_displayLabel} after ~10s, trying SIGTERM"
             );
-            await SignalFfmpeg("TERM", ct);
 
-            for (var i = 0; i < 6; i++) // up to 3s more
+            if (await SignalAndWaitForExitAsync("TERM", iterations: 15, ct)) // ~3s more
             {
-                if (_containerDead)
-                {
-                    _state = RecorderState.Stopped;
-                    return;
-                }
-                await Task.Delay(500, ct);
-                var check = await _container.ExecAsync(
-                    new[]
-                    {
-                        "sh",
-                        "-c",
-                        $"pid=$(cat {RecDir}/ffmpeg.pid 2>/dev/null); "
-                            + $"[ -n \"$pid\" ] && kill -0 $pid 2>/dev/null && echo RUNNING || echo DONE",
-                    },
-                    ct
+                _state = RecorderState.Stopped;
+                _log($"[Recording] Stopped in {_displayLabel} (after SIGTERM)");
+                InfrastructureEventLog.Emit(
+                    "recording_stopped",
+                    new { container = _displayLabel, via = "sigterm" }
                 );
-                if (check.Stdout.Trim().Contains("DONE"))
-                {
-                    _state = RecorderState.Stopped;
-                    _log($"[Recording] Stopped in {_displayLabel} (after SIGTERM)");
-                    InfrastructureEventLog.Emit(
-                        "recording_stopped",
-                        new { container = _displayLabel, via = "sigterm" }
-                    );
-                    return;
-                }
+                return;
             }
 
             if (_containerDead)
@@ -780,10 +743,18 @@ internal sealed class ContainerRecorder : IAsyncDisposable
             return new ExtractionResult(null, null);
         }
 
-        if (_state != RecorderState.Recording)
+        // Extraction reads finalized segments off disk (ReadSegmentListAsync + SelectCoveringSegments),
+        // so it works in BOTH Recording and Stopped: a graceful StopAsync finalizes the active segment and
+        // flushes segments.csv (its documented post-condition — "all segments finalized on disk, ready for
+        // clip extraction"), so a clip whose window touched the former active segment still finds it as a
+        // finalized covering segment. Accepting Stopped matters because the deferred per-test clip extract
+        // (EnqueueBackgroundTask, runs immediately) can RACE the backgrounded server disposal's StopAsync;
+        // if the stop wins, the clip must still extract off the finalized segments. NotStarted/Failed have
+        // no usable segments.
+        if (_state != RecorderState.Recording && _state != RecorderState.Stopped)
         {
             _log(
-                $"[Recording] WARNING: ExtractClipFromLive called but state is {_state} (expected Recording)"
+                $"[Recording] WARNING: ExtractClipFromLive called but state is {_state} (expected Recording or Stopped)"
             );
             InfrastructureEventLog.Emit(
                 "recording_clip_failed",
@@ -1035,6 +1006,12 @@ internal sealed class ContainerRecorder : IAsyncDisposable
         _log($"[Recording] {_displayLabel}: concatenating TS segments -> MP4 (stream copy)");
         var sw = Stopwatch.StartNew();
 
+        // Per-segment `duration` directive for the concat demuxer — load-bearing at fps=1, where a
+        // one-frame TS self-reports 0.5s (1/(2*fps) fallback, no inter-frame delta) and the demuxer
+        // packs frames at that spacing, halving the timeline (2x-fast playback). InvariantCulture so a
+        // comma-decimal host emits `5.000`, not `5,000` (which ffmpeg misparses). Mirrors BuildExtractCommand.
+        var segDurArg = _segmentTime.ToString("0.000", CultureInfo.InvariantCulture);
+
         try
         {
             var result = await _container.ExecAsync(
@@ -1042,7 +1019,7 @@ internal sealed class ContainerRecorder : IAsyncDisposable
                 {
                     "sh",
                     "-c",
-                    $"ls -1 {RecDir}/seg_*.{SegmentExtension} 2>/dev/null | sort | sed \"s|.*|file '&'|\" > {RecDir}/concat_all.txt; "
+                    $"ls -1 {RecDir}/seg_*.{SegmentExtension} 2>/dev/null | sort | sed \"s|.*|file '&'\\nduration {segDurArg}|\" > {RecDir}/concat_all.txt; "
                         + $"if [ ! -s {RecDir}/concat_all.txt ]; then "
                         + $"echo 'No segments found for concatenation' >&2; rm -f {RecDir}/concat_all.txt; exit 1; "
                         + $"fi; "
@@ -1710,9 +1687,17 @@ internal sealed class ContainerRecorder : IAsyncDisposable
         script.Add($"rm -f {listPath} {mergedPath}");
 
         // Pass 1: stream-copy-merge the covering source segments into merged.{ext}.
+        // Each file carries an explicit `duration` directive: at fps=1 a one-frame TS self-reports
+        // duration 0.5s (1/(2*fps) fallback, no inter-frame delta), and the concat demuxer trusts it
+        // to place the next segment — packing every frame at 0.5s and halving the merged timeline (2x
+        // playback, wrong -t window). Only the timestamps were compressed; the frames are fine. Safe
+        // for alignment: the actualFirstFramePts math below is a relative delta plus cover0Epoch
+        // (segments.csv), not the merged stream's absolute PTS. InvariantCulture so a comma-decimal
+        // host emits `5.000`, not the unparseable `5,000`.
+        var segDurArg = _segmentTime.ToString("0.000", CultureInfo.InvariantCulture);
         var listLines = string.Join(
             "\\n",
-            coveringSegments.Select(s => $"file '{s.containerPath}'")
+            coveringSegments.Select(s => $"file '{s.containerPath}'\\nduration {segDurArg}")
         );
         script.Add($"printf '{listLines}\\n' > {listPath}");
         script.Add(
@@ -1871,6 +1856,60 @@ internal sealed class ContainerRecorder : IAsyncDisposable
                 MarkContainerDead();
             }
 
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Sends <paramref name="signal"/> to the recording ffmpeg, then waits IN-CONTAINER for the process
+    /// to exit (one exec, polling <c>kill -0</c> at 0.2s granularity for up to <paramref name="iterations"/>
+    /// ticks). Returns true if ffmpeg exited within the budget, false on timeout. One round-trip, not N
+    /// C#-side poll execs — the cost driver under parallel teardown is the exec count, not the in-shell
+    /// sleep (.claude/rules/minimize-exec-count-and-cut-unconsumed-diagnostic-execs.md).
+    /// Returns true if there is no pid (already gone). Marks the container dead and returns false on a
+    /// container-dead exec error.
+    /// </summary>
+    private async Task<bool> SignalAndWaitForExitAsync(
+        string signal,
+        int iterations,
+        CancellationToken ct = default
+    )
+    {
+        if (_containerDead)
+        {
+            return true; // nothing to wait for
+        }
+
+        try
+        {
+            var result = await _container.ExecAsync(
+                new[]
+                {
+                    "sh",
+                    "-c",
+                    $"pid=$(cat {RecDir}/ffmpeg.pid 2>/dev/null); "
+                        + $"if [ -z \"$pid\" ]; then echo DONE; exit 0; fi; "
+                        + $"kill -{signal} $pid 2>/dev/null; "
+                        + $"for _i in $(seq 1 {iterations}); do "
+                        + $"kill -0 $pid 2>/dev/null || {{ echo DONE; exit 0; }}; "
+                        + $"sleep 0.2; "
+                        + $"done; "
+                        + $"echo RUNNING",
+                },
+                ct
+            );
+            return result.Stdout.Contains("DONE");
+        }
+        catch (Exception ex)
+        {
+            if (IsContainerDeadError(ex))
+            {
+                MarkContainerDead();
+                return true; // container gone → ffmpeg gone
+            }
+            _log(
+                $"[Recording] WARNING: signal/wait {signal} failed in {_displayLabel}: {ex.Message}"
+            );
             return false;
         }
     }

--- a/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
+++ b/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
@@ -6,7 +6,7 @@ namespace JunimoServer.Tests.Helpers;
 ///
 /// Layout under <see cref="TestArtifacts.OutputDir"/> / runs / {id}:
 ///   summary.json, ctrf-report.json, run-metadata.json, run-output.json
-///   diagnostics/infrastructure.jsonl
+///   diagnostics/infrastructure.jsonl, diagnostics/instance-stats.jsonl
 ///   flakiness.jsonl  (also exists at OutputDir for cross-run aggregation)
 ///   tests/{Class}.{Method}/
 ///   _workers/{worker_id}/   (distributed mode only)
@@ -22,6 +22,14 @@ public static class RunArtifactNames
 
     public const string InfrastructureJsonl = "infrastructure.jsonl";
     public const string FlakinessJsonl = "flakiness.jsonl";
+
+    /// <summary>
+    /// Per-instance container/game stats history (one compact JSON line per
+    /// <c>(instance, sample)</c>) under <see cref="DiagnosticsDir"/>. Flushed at
+    /// run-end from the runner's in-memory state for post-mortem load analysis;
+    /// the live UI reads the same data over the WebSocket, not this file.
+    /// </summary>
+    public const string InstanceStatsJsonl = "instance-stats.jsonl";
 
     /// <summary>
     /// Cross-run sidecar (<c>{hostId → bytes}</c>) at <see cref="TestArtifacts.OutputDir"/>


### PR DESCRIPTION
- `TestRunState` / `TestRunArtifactWriter` / `RunRecorder`: write `diagnostics/instance-stats.jsonl` so per-instance stats survive the run; `RunArtifactNames.InstanceStatsJsonl`
- `ContainerRecorder`: single-exec signal-and-wait stop (`docker exec` degrades ~24× under parallel load); per-segment concat `duration` directive (single-frame MPEG-TS segments self-report 0.5s, halving playback time); tolerate extraction from a `Stopped` container

The extract-from-Stopped tolerance is a prerequisite for the transport-resilience PR's `BackgroundDisposeServer` (chained on this branch).