### PR TITLE
fix(tests): SSH/transport resilience — heal forwards, skip infra faults, break poison deadlocks

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -104,6 +104,11 @@
 # Set to 0 (or leave unset) to disable rendering and recording for clients.
 # CLIENT_FPS=0
 
+# GalaxyOutageReproTests outage dwell in ms (default: 10000). How long the network stays cut
+# after steam_session_lost is gate-confirmed, so the Galaxy lobby genuinely drops before restore.
+# 2000 is the experimentally-pinned floor that still takes the dead-lobby RE-LOGIN path.
+# SDVD_OUTAGE_DWELL_MS=2000
+
 # Use local Stardew Valley process instead of containerized clients
 # SDVD_HOST_CLIENT=true
 

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -114,6 +114,19 @@ var abortCount = 0;
 AssemblyRunner? activeRunner = null;
 SetupPipeServer? setupPipeRef = null;
 
+// Parent-side child-stall watchdog state. `_childLastProgressUtc` is bumped on every test
+// start or pass (the child is making forward progress); the watchdog aborts the run if it
+// goes silent past the threshold (the child wedged and can't self-rescue). Ticks, read/written
+// via Interlocked. Default 12 min — longer than the child's own 600s broker watchdog +
+// 300s per-test timeout so it only fires when those ALSO failed (a true wedge).
+long _childLastProgressUtc = DateTime.UtcNow.Ticks;
+var ChildStallTimeout = TimeSpan.FromSeconds(
+    int.TryParse(Environment.GetEnvironmentVariable("SDVD_CHILD_STALL_TIMEOUT_S"), out var _cs)
+    && _cs > 0
+        ? _cs
+        : 720
+);
+
 // Shared abort body. `cause` becomes the run_aborted event cause and the
 // summary.json abortReason. Re-entrant: the first call starts the graceful
 // teardown + 15s force-kill safety net; subsequent calls go straight to
@@ -392,6 +405,97 @@ void ForceExitNow(string cause)
 // sibling test run started after us — sequential dev runs are the norm,
 // and the cost of false positives is far smaller than the cost of letting
 // the orphan continue.
+// Bumps the child-progress timestamp. Called from the test start/pass callbacks only — a
+// newly dispatched or passing test means the child is alive and moving, resetting the stall
+// clock. Cancellation/failure callbacks deliberately don't bump (see OnTestPassed wiring).
+void MarkChildProgress() =>
+    System.Threading.Interlocked.Exchange(ref _childLastProgressUtc, DateTime.UtcNow.Ticks);
+
+// Parent-side last-resort watchdog: polls the child-progress timestamp and aborts the run if
+// it goes stale past ChildStallTimeout. Runs in the PARENT so it survives a fully-wedged child
+// (where the in-child broker watchdog can't fire). Routes through `abort` (BeginAbort), which
+// writes summary.json DIRECTLY and then force-kills the child after a bounded graceful window
+// — so the run finalizes even when child disposal is itself hung on Docker-over-a-dead-forward
+// (a bare KillTestChildren would only unblock runner.Run() if its return path were clean, which
+// a hung disposal is not). host-poison-deadlocks-run.md, follow-up 6.
+async Task RunChildStallWatchdogAsync(Action<string> abort, CancellationToken ct)
+{
+    var poll = TimeSpan.FromSeconds(30);
+    try
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(poll, ct);
+            var idle =
+                DateTime.UtcNow
+                - new DateTime(
+                    System.Threading.Interlocked.Read(ref _childLastProgressUtc),
+                    DateTimeKind.Utc
+                );
+            if (idle < ChildStallTimeout)
+            {
+                continue;
+            }
+
+            Console.Error.WriteLine(
+                $"[stall-watchdog] no test progress for {idle.TotalSeconds:F0}s "
+                    + $"(threshold {ChildStallTimeout.TotalSeconds:F0}s) — aborting wedged run."
+            );
+            try
+            {
+                abort("child-stall-watchdog");
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[stall-watchdog] abort failed: {ex.Message}");
+            }
+            return; // one shot — BeginAbort owns finalization + force-kill from here
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        // Normal: the run finished and the finally cancelled us.
+    }
+}
+
+// Parent-side SSH master-health monitor. Polls each OWNED ControlMaster and respawns it (at
+// the same ControlPath) when `ssh -O check` fails — the master's mux wedging under load is
+// the root of the forward drops, and only the owning parent can heal it. Poll cadence is
+// well under a forward-drop's blast (the child's in-flight ForwardHealingHandler retries for
+// ~45s, so a respawn within ~10-15s lets those retries land on the healed forward).
+async Task RunMasterHealthMonitorAsync(TunnelManager tunnels, CancellationToken ct)
+{
+    var poll = TimeSpan.FromSeconds(10);
+    try
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(poll, ct);
+            foreach (var hostId in tunnels.GetOwnedHostIds())
+            {
+                try
+                {
+                    await tunnels.EnsureOwnedMasterHealthyAsync(hostId, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[master-monitor] heal check failed for '{hostId}': {ex.Message}"
+                    );
+                }
+            }
+        }
+    }
+    catch (OperationCanceledException)
+    {
+        // Normal: the run finished.
+    }
+}
+
 void KillTestChildren()
 {
     DateTime ourStart;
@@ -804,8 +908,25 @@ try
             exitCode = info.TestsFailed > 0 ? 1 : (info.TotalErrors > 0 ? 2 : 0);
         },
         OnErrorMessage = callbacks.OnErrorMessage,
-        OnTestStarting = callbacks.OnTestStarting,
-        OnTestPassed = callbacks.OnTestPassed,
+        // Progress signals for the stall-watchdog: a test STARTING (xUnit
+        // dispatched a new one) and a test PASSING are unambiguous forward
+        // motion. We deliberately do NOT bump on failed/skipped/finished —
+        // a StopOnFail cascade cancels every queued test at once, firing a
+        // burst of finished/failed callbacks that are the run's death-throes,
+        // not progress. Bumping on those reset the clock by 12 min in run
+        // 02-12-57Z (host-poison-deadlocks-run.md, follow-up 6). A healthy run
+        // always keeps passing tests (max observed gap between passes: 69s), so
+        // pass+start alone keeps the clock fresh with a wide margin under 720s.
+        OnTestStarting = e =>
+        {
+            MarkChildProgress();
+            callbacks.OnTestStarting(e);
+        },
+        OnTestPassed = e =>
+        {
+            MarkChildProgress();
+            callbacks.OnTestPassed(e);
+        },
         OnTestFailed = callbacks.OnTestFailed,
         OnTestSkipped = callbacks.OnTestSkipped,
         // xUnit "not run" tests (filter mismatch and similar) are recorded as
@@ -817,7 +938,8 @@ try
         // observed for ~3 tests/run under heavy queue contention. The
         // generic handler runs AFTER any specific handler per xunit docs;
         // RunnerCallbacks dedupes via TestDisplayName so a typed callback
-        // followed by the generic doesn't double-dispatch.
+        // followed by the generic doesn't double-dispatch. Intentionally not a
+        // progress signal — see OnTestStarting/OnTestPassed above.
         OnTestFinished = callbacks.OnTestFinished,
     };
 
@@ -836,7 +958,42 @@ try
     await using (var runner = new AssemblyRunner(options))
     {
         activeRunner = runner;
-        await runner.Run();
+
+        // Parent-side stall watchdog. The in-child broker watchdog can't fire when the
+        // child wedges (its own Task.Delay loop freezes with every other thread — observed
+        // 2026-06-26 when the SSH master hit `accept: Resource temporarily unavailable` and
+        // froze all 10 child threads, hanging the run >1h). Only the PARENT stays alive in
+        // that case, so the last-resort finalizer must live here: if no test starts or passes
+        // for ChildStallTimeout, abort the run (write summary.json, then force-kill the child)
+        // so it finalizes (as failures) instead of hanging forever.
+        MarkChildProgress();
+        using var stallCts = new CancellationTokenSource();
+        var stallWatchdog = RunChildStallWatchdogAsync(BeginAbort, stallCts.Token);
+
+        // Parent-side SSH master-health monitor. The ControlMaster is OWNED by this parent
+        // process; the xUnit child only adopts a read-only copy, so it cannot respawn a
+        // wedged master (TryRespawnMasterAsync refuses on !Owned) — which is why every
+        // child-side forward heal no-ops when the master's mux wedges under load. Only the
+        // owner can fix it, and respawning at the SAME deterministic ControlPath makes the
+        // child's adopted entry + in-flight forward re-opens recover transparently.
+        var masterMonitor = RunMasterHealthMonitorAsync(tunnelManager, stallCts.Token);
+
+        try
+        {
+            await runner.Run();
+        }
+        finally
+        {
+            stallCts.Cancel();
+            foreach (var bg in new[] { stallWatchdog, masterMonitor })
+            {
+                try
+                {
+                    await bg;
+                }
+                catch (OperationCanceledException) { }
+            }
+        }
     }
 }
 catch (Exception ex)

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -32,33 +32,24 @@ public class CabinPositionPersistenceTests : TestBase
 
     public override async ValueTask DisposeAsync()
     {
-        // Reset the shared server to a clean default game so the MoveToStack config
-        // and any moved cabins don't leak into sibling tests.
+        // Disconnect the primary so the next test body's own /newgame doesn't 409.
+        // Most tests in this class disconnect mid-body, but a few (two-player and the
+        // dummy reconnect tests) leave the primary connected. No reset /newgame is
+        // needed: this class's config hash (ExistingCabinBehavior=MoveToStack) is
+        // unique to it, so no sibling reuses its server, and every body opens with
+        // its own CreateNewGameOnServerAsync that rebuilds the world from scratch.
         if (Lease != null)
         {
+            // Tolerant: a no-op throw when already at title must not block cleanup.
             try
             {
-                // Disconnect the primary first: /newgame 409s while any client is connected.
-                // Most tests in this class disconnect mid-body, but a few (two-player and the
-                // dummy reconnect tests) leave the primary connected — without this the reset
-                // would 409 and leak CabinStack/None state into the next test. Tolerant: a
-                // no-op throw when already at title must not block the reset.
-                try
-                {
-                    await DisconnectAsync();
-                }
-                catch (Exception ex)
-                {
-                    LogWarning(
-                        $"Primary disconnect during cleanup failed (may already be at title): {ex.Message}"
-                    );
-                }
-
-                await CreateNewGameOnServerAsync(farmType: 0);
+                await DisconnectAsync();
             }
             catch (Exception ex)
             {
-                LogWarning($"Server reset failed during cleanup: {ex.Message}");
+                LogWarning(
+                    $"Primary disconnect during cleanup failed (may already be at title): {ex.Message}"
+                );
             }
         }
         await base.DisposeAsync();

--- a/tests/JunimoServer.Tests/Clients/ForwardHealingHandler.cs
+++ b/tests/JunimoServer.Tests/Clients/ForwardHealingHandler.cs
@@ -1,0 +1,162 @@
+using JunimoServer.Tests.Infrastructure;
+
+namespace JunimoServer.Tests.Clients;
+
+/// <summary>
+/// DelegatingHandler that makes a <see cref="ServerApiClient"/> transparently survive a
+/// transient SSH forward drop. One shared <c>ssh -M</c> master carries every <c>-L</c>
+/// forward, so a master keepalive blip tears them all down at once while the host + daemon
+/// stay alive (reproduced 2026-06-26: Docker stats never stopped). Without healing, every
+/// in-flight request over the dropped forward fails (RST/ConnectionRefused) and the test
+/// dies even though the server is fine and the forward is re-openable.
+///
+/// <para>Two jobs, both transparent to the ~20 call sites above it:</para>
+/// <list type="number">
+///   <item><b>Live base address.</b> A forward heal re-opens on a NEW loopback port (the
+///     old one is dead), so the client must dial the CURRENT port. This handler rewrites
+///     each request's scheme/host/port from <see cref="_liveBaseUrl"/> every send, rather
+///     than trusting <c>HttpClient.BaseAddress</c> (frozen at construction).</item>
+///   <item><b>Heal + retry.</b> On a forward-scoped transport fault it invokes
+///     <see cref="_healAsync"/> (which corroborates the master is alive and re-opens the
+///     forward) and retries the SAME request against the freshly-healed port, bounded by
+///     <see cref="_healRetryBudget"/>. Non-transport faults and success pass straight
+///     through.</item>
+/// </list>
+/// </summary>
+internal sealed class ForwardHealingHandler : DelegatingHandler
+{
+    private readonly Func<string> _liveBaseUrl;
+    private readonly Func<CancellationToken, Task<bool>> _healAsync;
+    private readonly TimeSpan _healRetryBudget;
+    private readonly TimeSpan _retryDelay;
+
+    public ForwardHealingHandler(
+        Func<string> liveBaseUrl,
+        Func<CancellationToken, Task<bool>> healAsync,
+        TimeSpan? healRetryBudget = null,
+        TimeSpan? retryDelay = null
+    )
+    {
+        _liveBaseUrl = liveBaseUrl;
+        _healAsync = healAsync;
+        // Long enough to outlast a master keepalive blip + heal (watchdog cadence ~5s,
+        // -O check retries ~8s, re-open ~1s); short enough not to mask a real outage.
+        _healRetryBudget = healRetryBudget ?? TimeSpan.FromSeconds(45);
+        _retryDelay = retryDelay ?? TimeSpan.FromSeconds(2);
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken
+    )
+    {
+        var deadline = TimeSpan.Zero;
+        while (true)
+        {
+            RebaseToLiveUrl(request);
+            try
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+            catch (Exception ex)
+                when (!cancellationToken.IsCancellationRequested
+                    && TransportFaultClassifier.Classify(ex).ForwardScoped
+                )
+            {
+                // Forward-scoped fault: the -L forward dropped. Heal it and retry the same
+                // request against the new port, within budget. When the budget is exhausted or
+                // the master is genuinely dead, the fault is UNRECOVERABLE transport — i.e.
+                // infrastructure, not a product bug. Throwing it raw makes the test FAIL (and
+                // trip StopOnFail → cascade), so instead convert it to an InfrastructureSkipException:
+                // the test is reported skipped, not failed. A real assertion/crash never reaches
+                // here (Classify returns ForwardScoped=false for it), so genuine bugs still fail.
+                if (deadline >= _healRetryBudget)
+                {
+                    throw new InfrastructureSkipException(
+                        $"Unrecoverable forward-scoped transport fault after {_healRetryBudget.TotalSeconds:F0}s "
+                            + $"heal budget ({ex.GetType().Name}: {ex.Message}). Skipped — not a test defect."
+                    );
+                }
+
+                bool healed;
+                try
+                {
+                    healed = await _healAsync(cancellationToken);
+                }
+                catch
+                {
+                    healed = false;
+                }
+
+                if (!healed)
+                {
+                    throw new InfrastructureSkipException(
+                        $"Forward-scoped transport fault and the ssh master is down (heal failed: "
+                            + $"{ex.GetType().Name}: {ex.Message}). Skipped — not a test defect."
+                    );
+                }
+
+                try
+                {
+                    await Task.Delay(_retryDelay, cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                deadline += _retryDelay;
+
+                // A used HttpRequestMessage can't be re-sent — clone it for the retry.
+                request = await CloneRequestAsync(request);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Rewrites the request URI's scheme/host/port to the current live base URL, preserving
+    /// path + query. Lets the client follow the forward to its new port after a heal without
+    /// touching <c>HttpClient.BaseAddress</c> (which is immutable once a request has been sent).
+    /// </summary>
+    private void RebaseToLiveUrl(HttpRequestMessage request)
+    {
+        var baseUrl = _liveBaseUrl();
+        if (string.IsNullOrEmpty(baseUrl) || request.RequestUri is null)
+        {
+            return;
+        }
+
+        var baseUri = new Uri(baseUrl);
+        var current = request.RequestUri;
+        var pathAndQuery = current.IsAbsoluteUri ? current.PathAndQuery : current.OriginalString;
+        request.RequestUri = new Uri(
+            new Uri($"{baseUri.Scheme}://{baseUri.Authority}"),
+            pathAndQuery
+        );
+    }
+
+    private static async Task<HttpRequestMessage> CloneRequestAsync(HttpRequestMessage original)
+    {
+        var clone = new HttpRequestMessage(original.Method, original.RequestUri)
+        {
+            Version = original.Version,
+        };
+
+        foreach (var header in original.Headers)
+        {
+            clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (original.Content != null)
+        {
+            // Buffer the content so it can be re-read on the retry.
+            var bytes = await original.Content.ReadAsByteArrayAsync();
+            clone.Content = new ByteArrayContent(bytes);
+            foreach (var header in original.Content.Headers)
+            {
+                clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+        }
+
+        return clone;
+    }
+}

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -1034,8 +1034,28 @@ public class GameTestClient : IDisposable
         string baseUrl = "http://localhost:5123",
         TimeSpan? defaultWaitTimeout = null
     )
+        : this(baseUrl, defaultWaitTimeout, liveBaseUrl: null, healAsync: null) { }
+
+    /// <summary>
+    /// Constructs a client that transparently heals a dropped SSH forward (re-opens it +
+    /// retries against the new port) so an in-flight request survives a transient master
+    /// keepalive blip instead of failing the test. <paramref name="liveBaseUrl"/> returns
+    /// the client container's CURRENT base URL; <paramref name="healAsync"/> re-opens the
+    /// client's forward. Both null ⇒ a plain client (unchanged behavior).
+    /// </summary>
+    public GameTestClient(
+        string baseUrl,
+        TimeSpan? defaultWaitTimeout,
+        Func<string>? liveBaseUrl,
+        Func<CancellationToken, Task<bool>>? healAsync
+    )
     {
-        var handler = new TracingHandler("test-client") { InnerHandler = new HttpClientHandler() };
+        HttpMessageHandler inner = new HttpClientHandler();
+        if (liveBaseUrl != null && healAsync != null)
+        {
+            inner = new ForwardHealingHandler(liveBaseUrl, healAsync) { InnerHandler = inner };
+        }
+        var handler = new TracingHandler("test-client") { InnerHandler = inner };
         _httpClient = new HttpClient(handler)
         {
             BaseAddress = new Uri(baseUrl),

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1092,9 +1092,28 @@ public class ServerApiClient : IDisposable
     private readonly string _baseUrl;
 
     public ServerApiClient(string baseUrl)
+        : this(baseUrl, liveBaseUrl: null, healAsync: null) { }
+
+    /// <summary>
+    /// Constructs a client that transparently heals a dropped SSH forward.
+    /// <paramref name="liveBaseUrl"/> returns the server's CURRENT base URL (it changes
+    /// when a forward is re-opened on a new port); <paramref name="healAsync"/> re-opens
+    /// the forward on a forward-scoped fault. Both null ⇒ a plain client (local hosts /
+    /// tests that pass a bare URL) — behaves exactly as before.
+    /// </summary>
+    public ServerApiClient(
+        string baseUrl,
+        Func<string>? liveBaseUrl,
+        Func<CancellationToken, Task<bool>>? healAsync
+    )
     {
         _baseUrl = baseUrl;
-        var handler = new TracingHandler("server") { InnerHandler = new HttpClientHandler() };
+        HttpMessageHandler inner = new HttpClientHandler();
+        if (liveBaseUrl != null && healAsync != null)
+        {
+            inner = new ForwardHealingHandler(liveBaseUrl, healAsync) { InnerHandler = inner };
+        }
+        var handler = new TracingHandler("server") { InnerHandler = inner };
         _httpClient = new HttpClient(handler)
         {
             BaseAddress = new Uri(baseUrl),

--- a/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
@@ -292,6 +292,28 @@ public class GameClientContainer : IAsyncDisposable
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         timeoutCts.CancelAfter(_options.StartupTimeout);
 
+        // Remote hosts only: tighter daemon-responsiveness deadline on docker create+start —
+        // same rationale as ServerContainer.StartAsync. A wedged shared daemon-socket forward
+        // otherwise hangs this call the full StartupTimeout (120s). 75s flags it decisively
+        // (healthy client start is well under that); the trip surfaces as TimeoutException, which
+        // ClientPool's create seam routes through PoisonIfTransportFaultAsync (corroborate via
+        // ssh -O check → heal+retry if the master is alive, poison if dead).
+        using var remoteDaemonCts = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutCts.Token
+        );
+        if (SshDestination is not null)
+        {
+            var remoteStartTimeoutS =
+                int.TryParse(
+                    Environment.GetEnvironmentVariable("SDVD_REMOTE_DAEMON_START_TIMEOUT_S"),
+                    out var s
+                )
+                && s > 0
+                    ? s
+                    : 75;
+            remoteDaemonCts.CancelAfter(TimeSpan.FromSeconds(remoteStartTimeoutS));
+        }
+
         // Start log streaming before container start (same pattern as ServerContainer).
         // Emits each log line to UI via _startupLogCallback during startup phases.
         _containerExitDetected = false;
@@ -340,7 +362,8 @@ public class GameClientContainer : IAsyncDisposable
             // start task continues in the background; cleanup is best-effort.
             // Without this, a 300s per-test timeout can take 360s+ to actually
             // unblock the test body, starving the per-host client-capacity gate.
-            await _container.StartAsync(timeoutCts.Token).WaitAsync(timeoutCts.Token);
+            // remoteDaemonCts == timeoutCts for local hosts; tighter deadline for remote.
+            await _container.StartAsync(remoteDaemonCts.Token).WaitAsync(remoteDaemonCts.Token);
 
             JunimoServer.Tests.Helpers.InfrastructureEventLog.Emit(
                 "container_started",
@@ -353,6 +376,21 @@ public class GameClientContainer : IAsyncDisposable
                     startupMs = _startSw.ElapsedMilliseconds,
                     host_id = HostId,
                 }
+            );
+        }
+        catch (Exception)
+            when (remoteDaemonCts.IsCancellationRequested
+                && !ct.IsCancellationRequested
+                && _startSw.Elapsed < _options.StartupTimeout
+            )
+        {
+            // Remote daemon-responsiveness deadline tripped (not the caller, not the full
+            // StartupTimeout). Surface as TimeoutException so ClientPool's create seam
+            // corroborates via ssh -O check and poisons-fast-or-retries, instead of hanging
+            // to StartupTimeout. Mirrors ServerContainer.StartAsync.
+            throw new TimeoutException(
+                $"client-{_clientIndex} docker start exceeded the remote daemon-responsiveness "
+                    + $"deadline after {_startSw.ElapsedMilliseconds}ms (daemon-socket forward wedged?)."
             );
         }
         catch (Exception) when (ct.IsCancellationRequested)
@@ -467,9 +505,16 @@ public class GameClientContainer : IAsyncDisposable
             VncPort = _vncForward.CoordinatorPort;
         }
 
-        // Reconfigure the API client with the correct URL
+        // Reconfigure the API client with the correct URL. On remote hosts it transparently
+        // heals a dropped SSH forward (re-open + retry on the new port) so an in-flight join /
+        // navigate survives a master keepalive blip instead of failing the test.
         _apiClient.Dispose();
-        var newClient = new GameTestClient(BaseUrl);
+        var newClient = new GameTestClient(
+            BaseUrl,
+            defaultWaitTimeout: null,
+            liveBaseUrl: () => BaseUrl,
+            healAsync: HealApiForwardAsync
+        );
         // Copy the client reference (GameTestClient is a wrapper, we need to update the internal HttpClient)
         typeof(GameTestClient)
             .GetField(
@@ -653,6 +698,91 @@ public class GameClientContainer : IAsyncDisposable
         if (!isEvent)
         {
             _logCallback?.Invoke(line);
+        }
+    }
+
+    private readonly SemaphoreSlim _forwardHealLock = new(1, 1);
+    private long _lastHealedPort;
+
+    /// <summary>
+    /// Re-opens the client's API <c>ssh -L</c> forward on a fresh loopback port and updates
+    /// <see cref="ApiPort"/> / <see cref="BaseUrl"/>. No-op (false) on local hosts or before
+    /// the port is mapped. Mirrors <c>ServerContainer.ReopenApiForwardAsync</c>.
+    /// </summary>
+    public async Task<bool> ReopenApiForwardAsync(CancellationToken ct = default)
+    {
+        if (SshDestination is null || _container is null || ApiPort == 0)
+        {
+            return false;
+        }
+
+        var apiMapped = _container.GetMappedPublicPort(ContainerApiPort);
+        var staleLease = _apiForward;
+        var stalePort = ApiPort;
+
+        var fresh = await _tunnels.OpenAsync(HostId, SshDestination, SshKeyPath, apiMapped, ct);
+        _apiForward = fresh;
+        ApiPort = fresh.CoordinatorPort;
+
+        if (staleLease != null)
+        {
+            try
+            {
+                await staleLease.DisposeAsync();
+            }
+            catch { }
+        }
+
+        InfrastructureEventLog.Emit(
+            "client_api_forward_reopened",
+            new
+            {
+                host_id = HostId,
+                stalePort,
+                freshPort = ApiPort,
+                mappedPort = apiMapped,
+            }
+        );
+        return true;
+    }
+
+    /// <summary>
+    /// Corroborates the master is usable then re-opens the client forward — the heal callback
+    /// wired into <see cref="GameTestClient"/> so an in-flight join/navigate retries against the
+    /// fresh port. Deduped against concurrent callers. Mirrors
+    /// <c>ServerContainer.HealApiForwardAsync</c>.
+    /// </summary>
+    public async Task<bool> HealApiForwardAsync(CancellationToken ct = default)
+    {
+        if (SshDestination is null)
+        {
+            return false;
+        }
+
+        var portBeforeWait = (long)ApiPort;
+        await _forwardHealLock.WaitAsync(ct);
+        try
+        {
+            if (Interlocked.Read(ref _lastHealedPort) != 0 && ApiPort != portBeforeWait)
+            {
+                return true;
+            }
+
+            if (!await _tunnels.EnsureMasterUsableAsync(HostId, ct))
+            {
+                return false;
+            }
+
+            var reopened = await ReopenApiForwardAsync(ct);
+            if (reopened)
+            {
+                Interlocked.Exchange(ref _lastHealedPort, ApiPort);
+            }
+            return reopened;
+        }
+        finally
+        {
+            _forwardHealLock.Release();
         }
     }
 

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -431,6 +431,33 @@ public class ServerContainer : IAsyncDisposable
         );
         timeoutCts.CancelAfter(_options.StartupTimeout);
 
+        // Remote hosts only: a tighter "daemon responsiveness" deadline on the docker
+        // create+start. The Docker.DotNet client has an infinite per-call timeout (the
+        // caller CT is the deadline), so when the shared ssh -L daemon-socket forward wedges
+        // mid-stream this call hangs the full StartupTimeout (180s) before failing —
+        // 180s × every queued test is the slow-collapse seen in run 02-12-57Z. A healthy
+        // remote start is ≤~42s (p90/max across recent runs), so 75s flags a wedge decisively
+        // while staying clear of a slow cold boot. The trip is NOT a hard fail: it surfaces as
+        // TimeoutException, which the broker's create seam routes through
+        // DockerHost.PoisonIfTransportFaultAsync — which `ssh -O check`s the master and, if it's
+        // ALIVE (a genuinely slow boot, not a wedge), heals + RecoveredRetry (the create retries)
+        // rather than poisoning. So a too-tight trip self-corrects; only a dead master poisons.
+        using var remoteDaemonCts = CancellationTokenSource.CreateLinkedTokenSource(
+            timeoutCts.Token
+        );
+        if (SshDestination is not null)
+        {
+            var remoteStartTimeoutS =
+                int.TryParse(
+                    Environment.GetEnvironmentVariable("SDVD_REMOTE_DAEMON_START_TIMEOUT_S"),
+                    out var s
+                )
+                && s > 0
+                    ? s
+                    : 75;
+            remoteDaemonCts.CancelAfter(TimeSpan.FromSeconds(remoteStartTimeoutS));
+        }
+
         try
         {
             _logStreamCts = new CancellationTokenSource();
@@ -468,12 +495,16 @@ public class ServerContainer : IAsyncDisposable
                 }
             );
 
-            // WaitAsync(ct) makes cancellation prompt: when the CT fires we throw
+            // WaitAsync makes cancellation prompt: when the CT fires we throw
             // OperationCanceledException within milliseconds, even if Testcontainers'
             // internal wait strategies are mid-ExecAsync (which doesn't poll the CT
             // and can hold us for tens of seconds on a busy daemon). The container
             // start task continues in the background; cleanup is best-effort.
-            await _serverContainer.StartAsync(timeoutCts.Token).WaitAsync(timeoutCts.Token);
+            // remoteDaemonCts == timeoutCts for local hosts; for remote hosts it trips at
+            // the tighter daemon-responsiveness deadline (see above).
+            await _serverContainer
+                .StartAsync(remoteDaemonCts.Token)
+                .WaitAsync(remoteDaemonCts.Token);
             _logCallback?.Invoke($"Game server started");
 
             JunimoServer.Tests.Helpers.InfrastructureEventLog.Emit(
@@ -487,6 +518,23 @@ public class ServerContainer : IAsyncDisposable
                     startupMs = sw.ElapsedMilliseconds,
                     host_id = HostId,
                 }
+            );
+        }
+        catch (Exception)
+            when (remoteDaemonCts.IsCancellationRequested
+                && !ct.IsCancellationRequested
+                && !_errorCancellation.IsCancellationRequested
+                && sw.Elapsed < _options.StartupTimeout
+            )
+        {
+            // The remote daemon-responsiveness deadline tripped (not the caller, not a fatal
+            // log error, not the full StartupTimeout). The shared daemon-socket forward is
+            // likely wedged. Surface as TimeoutException so the broker's create seam corroborates
+            // via ssh -O check (PoisonIfTransportFaultAsync): a live master heals + retries, a
+            // dead one poisons the host fast — instead of hanging here to StartupTimeout (180s).
+            throw new TimeoutException(
+                $"server-{_serverIndex} docker start exceeded the remote daemon-responsiveness "
+                    + $"deadline after {sw.ElapsedMilliseconds}ms (daemon-socket forward wedged?)."
             );
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
@@ -671,7 +719,11 @@ public class ServerContainer : IAsyncDisposable
         // Only wait for invite code on Steam servers (Galaxy SDK must initialize first)
         var requireInviteCode = _options.WithSteam;
 
-        var client = new ServerApiClient(BaseUrl);
+        var client = new ServerApiClient(
+            BaseUrl,
+            liveBaseUrl: () => BaseUrl,
+            healAsync: HealApiForwardAsync
+        );
         try
         {
             var status = await client.WaitForServerOnline(
@@ -735,11 +787,122 @@ public class ServerContainer : IAsyncDisposable
     }
 
     /// <summary>
-    /// Creates an API client for this server.
+    /// Creates an API client for this server. On remote hosts the client transparently
+    /// heals a dropped SSH forward (re-opens it + retries against the new port) via
+    /// <see cref="BaseUrl"/> (live) and <see cref="HealApiForwardAsync"/>, so an in-flight
+    /// request survives a transient master keepalive blip instead of failing the test.
     /// </summary>
     public ServerApiClient CreateApiClient()
     {
-        return new ServerApiClient(BaseUrl);
+        return new ServerApiClient(
+            BaseUrl,
+            liveBaseUrl: () => BaseUrl,
+            healAsync: HealApiForwardAsync
+        );
+    }
+
+    /// <summary>
+    /// Re-establishes the API <c>ssh -L</c> forward to the same daemon-side mapped
+    /// port, picking a fresh coordinator-side loopback port and updating
+    /// <see cref="ApiPort"/> / <see cref="BaseUrl"/>. A no-op (returns false) on
+    /// local hosts, before <c>StartAsync</c> has mapped the port, or when no SSH
+    /// destination exists.
+    ///
+    /// <para>
+    /// Called by the health watchdog when a probe hits a forward-scoped fault
+    /// (loopback ConnectionRefused) but <c>ssh -O check</c> confirms the master is
+    /// alive: one shared master carries every forward, so a transient keepalive
+    /// blip drops all in-flight <c>-L</c> channels while the host stays reachable.
+    /// Re-opening the forward heals a reused/live server in place instead of
+    /// letting the stale port cascade into a host poison.
+    /// </para>
+    /// </summary>
+    public async Task<bool> ReopenApiForwardAsync(CancellationToken ct = default)
+    {
+        if (SshDestination is null || _serverContainer is null || ApiPort == 0)
+        {
+            return false;
+        }
+
+        var apiMapped = _serverContainer.GetMappedPublicPort(ContainerApiPort);
+        var staleLease = _apiForward;
+        var stalePort = ApiPort;
+
+        // Open the replacement BEFORE disposing the stale lease so a failure to
+        // re-open leaves the old (dead) port in place rather than a null one — the
+        // health watchdog then counts the next probe failure normally.
+        var fresh = await _tunnels.OpenAsync(HostId, SshDestination, SshKeyPath, apiMapped, ct);
+        _apiForward = fresh;
+        ApiPort = fresh.CoordinatorPort;
+
+        if (staleLease != null)
+        {
+            try
+            {
+                await staleLease.DisposeAsync();
+            }
+            catch { }
+        }
+
+        JunimoServer.Tests.Helpers.InfrastructureEventLog.Emit(
+            "server_api_forward_reopened",
+            new
+            {
+                host_id = HostId,
+                stalePort,
+                freshPort = ApiPort,
+                mappedPort = apiMapped,
+            }
+        );
+        return true;
+    }
+
+    private readonly SemaphoreSlim _forwardHealLock = new(1, 1);
+    private long _lastHealedPort;
+
+    /// <summary>
+    /// Corroborates the master is usable (retries <c>-O check</c> + respawns once) and, if
+    /// so, re-opens the API forward — the heal callback wired into <see cref="ServerApiClient"/>
+    /// so an in-flight request that hit a dropped forward retries against the fresh port
+    /// instead of failing the test. Deduplicated: concurrent callers that arrive after a heal
+    /// for the same stale port already completed return true without re-opening again (the
+    /// forward is already fresh). Returns false when the master is genuinely dead — the
+    /// request then surfaces its original fault and the host poisons via the normal path.
+    /// </summary>
+    public async Task<bool> HealApiForwardAsync(CancellationToken ct = default)
+    {
+        if (SshDestination is null)
+        {
+            return false;
+        }
+
+        var portBeforeWait = (long)ApiPort;
+        await _forwardHealLock.WaitAsync(ct);
+        try
+        {
+            // A concurrent caller already re-opened the forward since we hit the fault
+            // (ApiPort moved) — no need to re-open again; the retry will use the fresh port.
+            if (Interlocked.Read(ref _lastHealedPort) != 0 && ApiPort != portBeforeWait)
+            {
+                return true;
+            }
+
+            if (!await _tunnels.EnsureMasterUsableAsync(HostId, ct))
+            {
+                return false;
+            }
+
+            var reopened = await ReopenApiForwardAsync(ct);
+            if (reopened)
+            {
+                Interlocked.Exchange(ref _lastHealedPort, ApiPort);
+            }
+            return reopened;
+        }
+        finally
+        {
+            _forwardHealLock.Release();
+        }
     }
 
     // Matches SMAPI log line prefix: [HH:MM:SS LEVEL Source]

--- a/tests/JunimoServer.Tests/Fixtures/TestSummaryFixture.cs
+++ b/tests/JunimoServer.Tests/Fixtures/TestSummaryFixture.cs
@@ -627,6 +627,16 @@ public class TestSummaryFixture : IAsyncLifetime
             || exceptionType.Contains("Testcontainers")
             || exceptionType.Contains("ServerUnavailableException")
             || exceptionType.Contains("TestRunAbortedException")
+            // Raw transport faults: the E2E harness reaches the server only over the
+            // ssh-forwarded transport, so a Socket/Http/stream fault that surfaces to a test
+            // is infrastructure (a forward/host blip), not a product bug — including a live
+            // server-start wrap like "server-N failed to start: …SocketException", which
+            // carries the SocketException type. (Most such faults are now skipped at acquire
+            // time per AcquireWithInfrastructureSkipAsync; this keeps any that still surface as
+            // a failure correctly bucketed rather than as a "crash".)
+            || exceptionType.Contains("SocketException")
+            || exceptionType.Contains("HttpRequestException")
+            || exceptionType.Contains("EndOfStreamException")
         )
         {
             return "infrastructure";

--- a/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
+++ b/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
@@ -73,11 +73,12 @@ public class GalaxyOutageReproTests : TestBase
     {
         var ct = TestContext.Current.CancellationToken;
 
-        // ── Configurable outage dwell. Default holds the cut long enough that Steam's keepalive
-        // registers the loss (steam_session_lost) before restore. A longer dwell can be set without
+        // ── Configurable outage dwell. This is timing margin held AFTER steam_session_lost is
+        // already gate-confirmed below — it lets the Galaxy lobby genuinely drop before restore,
+        // so recovery exercises a dead-lobby re-login rather than a too-fast flap. Override without
         // a rebuild via SDVD_OUTAGE_DWELL_MS (verify-documented-config-is-consumed.md).
         var dwell = TimeSpan.FromMilliseconds(
-            int.TryParse(TestEnvLoader.Get("SDVD_OUTAGE_DWELL_MS"), out var ms) ? ms : 45_000
+            int.TryParse(TestEnvLoader.Get("SDVD_OUTAGE_DWELL_MS"), out var ms) ? ms : 10_000
         );
         // Steam reconnect after a full outage can take minutes; bound it generously.
         var reconnectBudget = TimeSpan.FromMinutes(5);
@@ -126,8 +127,8 @@ public class GalaxyOutageReproTests : TestBase
             );
             Log("Outage confirmed via Steam: steam_session_lost observed.");
 
-            // ── 4. Hold the outage long enough for Steam's keepalive to register the loss
-            // before restore, and for the Galaxy lobby to drop.
+            // ── 4. Steam's loss is already confirmed above; hold the outage long enough for the
+            // Galaxy lobby to drop before restore.
             Log($"Holding outage for {dwell.TotalSeconds:F0}s…");
             await Task.Delay(dwell, ct);
         }

--- a/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
@@ -542,9 +542,38 @@ internal sealed class ClientPool : IAsyncDisposable
                     }
                 );
                 // Client leasing is a separate mid-run path from server creation;
-                // a tunnel death here must poison too, else it's a blind spot.
-                await _host.PoisonIfTransportFaultAsync(ex);
-                throw;
+                // a tunnel death here must poison too, else it's a blind spot. A
+                // RecoveredRetry means a transient master-wedge that the parent respawned —
+                // retry the client creation once so it lands on the healed forward instead
+                // of failing the test (symmetric with CreateAndResolveAsync).
+                var outcome = await _host.PoisonIfTransportFaultAsync(ex);
+                if (outcome == DockerHost.TransportFaultOutcome.RecoveredRetry && !_host.IsPoisoned)
+                {
+                    InfrastructureEventLog.Emit(
+                        "client_create_retry_after_blip",
+                        new { host_id = _host.Id, error = ex.Message }
+                    );
+                    await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                    client = await CreateClientAsync(requireSteam, ct);
+                    lock (_allClientsLock)
+                    {
+                        _allClients.Add(client);
+                    }
+                    Interlocked.Decrement(ref _inFlightCreations);
+                    if (willAllocateSteam)
+                    {
+                        Interlocked.Decrement(ref _inFlightSteamCreations);
+                    }
+                    inFlightDecremented = true;
+                    InfrastructureEventLog.Emit(
+                        "client_created",
+                        new { clientIndex = client.ClientIndex, reason = "blip_retry" }
+                    );
+                }
+                else
+                {
+                    throw;
+                }
             }
             finally
             {

--- a/tests/JunimoServer.Tests/Infrastructure/DockerHost.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/DockerHost.cs
@@ -303,6 +303,64 @@ public sealed class DockerHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// Re-opens the daemon-socket forward and rebuilds <see cref="ApiClient"/> /
+    /// <see cref="EndpointConfig"/> after a transient master keepalive blip tore the
+    /// forward down (the host stayed alive — <c>ssh -O check</c> passed). Without this the
+    /// host's <c>ApiClient</c> stays pinned to a dead coordinator port and every later
+    /// container op fails with ConnectionRefused even though the daemon is reachable.
+    /// No-op (returns false) for local hosts or before <see cref="InitializeAsync"/> ran.
+    /// Best-effort: opens the replacement before dropping the stale forward so a failure
+    /// leaves the old endpoint in place rather than a null one.
+    /// </summary>
+    internal async Task<bool> HealDaemonForwardAsync(
+        TunnelManager tunnels,
+        CancellationToken ct = default
+    )
+    {
+        if (string.IsNullOrEmpty(SshDestination) || _endpointConfig == null)
+        {
+            return false;
+        }
+
+        var fresh = await tunnels.OpenSocketForwardAsync(
+            Id,
+            SshDestination!,
+            SshKeyPath,
+            RemoteSocketPath,
+            ct
+        );
+
+        ForwardLease? stale;
+        DockerClient? staleClient;
+        lock (_lazyInitLock)
+        {
+            stale = _daemonForward;
+            staleClient = _apiClient;
+            _daemonForward = fresh;
+            var localEndpoint = new Uri($"tcp://localhost:{fresh.CoordinatorPort}");
+            _endpointConfig = DockerEndpointConfig.CreateRemote(localEndpoint);
+            _apiClient = _endpointConfig.CreateDockerClient();
+        }
+
+        try
+        {
+            staleClient?.Dispose();
+        }
+        catch { }
+        if (stale != null)
+        {
+            try
+            {
+                await stale.DisposeAsync();
+            }
+            catch { }
+        }
+
+        InfrastructureEventLog.Emit("host_daemon_forward_healed", new { host_id = Id });
+        return true;
+    }
+
+    /// <summary>
     /// Calibration result for the host's host↔container clock offset.
     /// <c>FromCache</c> is true when this caller observed the value cached
     /// from a prior calibration (no new exec round-trip happened).
@@ -488,28 +546,101 @@ public sealed class DockerHost : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Shared mid-run failure-seam wiring: poison the host iff <paramref name="ex"/>
-    /// was a transport fault. Called from both on-demand container-creation seams
-    /// (<c>TestResourceBroker.CreateAndResolveAsync</c>,
-    /// <c>ClientPool.CreateClientGuardedAsync</c>) so the decision is identical.
-    /// A no-op for application faults; never throws (the probe swallows its own
-    /// errors) — the caller re-throws the original exception afterward.
-    /// </summary>
-    internal async Task PoisonIfTransportFaultAsync(Exception ex)
+    /// <summary>Outcome of <see cref="PoisonIfTransportFaultAsync"/>.</summary>
+    internal enum TransportFaultOutcome
     {
-        var transportReason = TransportFaultClassifier.ClassifyHostTransportFault(ex);
+        /// <summary>Not a transport fault (application error) — caller rethrows.</summary>
+        NotTransport,
 
-        // A bare TimeoutException is ambiguous (slow-but-live server vs dead
-        // tunnel); corroborate via -O check against the master (remote only).
-        // Directly-classified socket/http faults skip this.
-        if (transportReason is null && ex is TimeoutException && SshDestination is not null)
+        /// <summary>A recoverable forward-scoped blip on a still-alive (or respawned) host —
+        /// the host was NOT poisoned and the forwards are healing. The caller should RETRY the
+        /// operation rather than fail; a fresh attempt lands on the healed forward.</summary>
+        RecoveredRetry,
+
+        /// <summary>The host was genuinely gone and got poisoned — caller rethrows; the
+        /// poisoned-host cascade takes over.</summary>
+        Poisoned,
+    }
+
+    /// <summary>
+    /// Shared mid-run failure-seam wiring: classify <paramref name="ex"/> and either poison the
+    /// host (genuine outage), report a recoverable forward blip (host kept, forwards healing —
+    /// caller should retry), or report not-a-transport-fault. Called from both on-demand
+    /// container-creation seams (<c>TestResourceBroker.CreateAndResolveAsync</c>,
+    /// <c>ClientPool.CreateClientGuardedAsync</c>) so the decision is identical. Never throws.
+    /// </summary>
+    internal async Task<TransportFaultOutcome> PoisonIfTransportFaultAsync(Exception ex)
+    {
+        var (transportReason, forwardScoped) = TransportFaultClassifier.Classify(ex);
+
+        // Two paths need corroboration against the master before poisoning the
+        // whole host (remote only — local hosts have no master):
+        //   1. A bare TimeoutException is ambiguous (slow-but-live server vs dead
+        //      tunnel).
+        //   2. A forward-scoped fault (loopback ConnectionRefused / ConnectionReset /
+        //      ConnectionAborted / broken-pipe / EOF). On a loopback -L forward NONE of
+        //      these proves the host died — the connection only ever talks to the local
+        //      forward listener. A transient master keepalive blip drops ALL forwards at
+        //      once while the master + host stay alive (reproduced 2026-06-26: Docker
+        //      stats never stopped). Poisoning the host on this cascades every test on it.
+        // In both cases, a live `ssh -O check` means the host is fine — don't poison; heal
+        // the forwards instead so in-flight/next operations retry against the live daemon.
+        var needsCorroboration =
+            (transportReason is null && ex is TimeoutException) || forwardScoped;
+        if (needsCorroboration && SshDestination is not null)
         {
-            if (!await TunnelManager.Default.IsMasterAliveAsync(Id))
+            var masterAlive = await TunnelManager.Default.IsMasterAliveAsync(Id);
+
+            // Master dead ⇒ try resurrecting it once before condemning the host. One
+            // shared master carries every forward, so a transient master death (fd /
+            // mux-accept-backlog exhaustion — `accept: Resource temporarily unavailable`)
+            // loses the whole host even though the VPS is fine. A successful respawn means
+            // the host is recoverable: don't poison. See host-poison-deadlocks-run.md.
+            if (!masterAlive)
             {
-                transportReason =
-                    $"ssh master for {Id} not responding to -O check after {ex.GetType().Name}";
+                masterAlive = await TunnelManager.Default.TryRespawnMasterAsync(Id);
             }
+
+            if (masterAlive)
+            {
+                // Host reachable ⇒ a forward/timeout blip or a recovered master, not a host
+                // outage. Re-open the daemon-socket forward NOW so the host's ApiClient stops
+                // pointing at the dead port (it is opened once in InitializeAsync and never
+                // re-opened otherwise — without this every later container op fails
+                // ConnectionRefused even though the daemon is reachable). Per-server -L API
+                // forwards heal separately via the ManagedServer health watchdog. Best-effort.
+                try
+                {
+                    await HealDaemonForwardAsync(TunnelManager.Default);
+                }
+                catch (Exception healEx)
+                {
+                    TestLog.Test($"[ssh] daemon forward heal failed on '{Id}': {healEx.Message}");
+                }
+
+                InfrastructureEventLog.Emit(
+                    "host_forward_fault_not_poisoned",
+                    new
+                    {
+                        host_id = Id,
+                        reason = transportReason,
+                        forwardScoped,
+                        detail = "ssh master alive/respawned; forwards healed, host kept",
+                    }
+                );
+                // Recoverable blip: tell the caller to retry rather than fail — a fresh attempt
+                // lands on the healed forward. Only when the fault was actually transport
+                // (forwardScoped, or a corroborated bare timeout); a non-transport bare timeout
+                // would leave transportReason null AND forwardScoped false → NotTransport.
+                return forwardScoped || transportReason is not null
+                    ? TransportFaultOutcome.RecoveredRetry
+                    : TransportFaultOutcome.NotTransport;
+            }
+
+            // Master dead AND respawn failed ⇒ the host really is gone. Stamp a reason for
+            // the bare-timeout path (forward-scoped already has one).
+            transportReason ??=
+                $"ssh master for {Id} not responding to -O check after {ex.GetType().Name}";
         }
 
         if (transportReason is not null)
@@ -527,7 +658,10 @@ public sealed class DockerHost : IAsyncDisposable
                     $"[ssh] best-effort transport poison failed on '{Id}': {poisonEx.Message}"
                 );
             }
+            return TransportFaultOutcome.Poisoned;
         }
+
+        return TransportFaultOutcome.NotTransport;
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/TestLifecycle.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/TestLifecycle.cs
@@ -163,7 +163,29 @@ internal sealed class TestLifecycle
                 && !_testBase.TestCtInternal.IsCancellationRequested
             )
             {
-                await _testBase.AssertNoExceptionsAsyncInternal("at end of test (auto)");
+                try
+                {
+                    await _testBase.AssertNoExceptionsAsyncInternal("at end of test (auto)");
+                }
+                catch (Exception ex) when (TestBase.IsInfrastructureTransportFault(ex))
+                {
+                    // The end-of-test /errors check is best-effort: if its own API call can't
+                    // reach the server (a forward/host transport fault during dispose), we
+                    // simply couldn't run the check — that's infrastructure, not a test
+                    // failure. Swallow it rather than convert a passed test into a transport
+                    // failure that trips StopOnFail (the 2026-06-26 DeletedCabin run, where a
+                    // forward blip during this dispose-phase check failed an otherwise-passing
+                    // test). A real server-logged error still surfaces as an AssertException,
+                    // which is NOT transport and is rethrown.
+                    JunimoServer.Tests.Helpers.InfrastructureEventLog.Emit(
+                        "end_of_test_check_skipped_transport",
+                        new
+                        {
+                            test = _testBase.TestDisplayNameInternal,
+                            error = $"{ex.GetType().Name}: {ex.Message}",
+                        }
+                    );
+                }
             }
 
             // For KeepConnected tests: check if this is the last test, BEFORE cleanup.

--- a/tests/JunimoServer.Tests/Infrastructure/InfrastructureSkipException.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/InfrastructureSkipException.cs
@@ -1,0 +1,20 @@
+namespace JunimoServer.Tests.Infrastructure;
+
+/// <summary>
+/// Thrown from test setup (server acquisition) when the failure is an infrastructure
+/// transport fault — a poisoned host or a Socket/Http/stream fault from the ssh-forwarded
+/// daemon path — rather than a product bug. Uses xUnit's dynamic-skip convention
+/// (<c>$XunitDynamicSkip$</c>) so xUnit reports the test as <b>skipped</b>, not failed:
+/// a skip does not trigger StopOnFail and is not a red failure, so one transport blip on a
+/// shared host no longer cascades an entire class (the 2026-06-25 13-test SaveImport cascade
+/// from a single ConnectionRefused). A real assertion/crash still fails and trips StopOnFail,
+/// so a genuine bug still aborts the run early. Distinct from <see cref="TestRunAbortedException"/>
+/// (run-already-aborted) so the skip reason in reports names the actual cause.
+/// </summary>
+public sealed class InfrastructureSkipException : Exception
+{
+    private const string XunitSkipPrefix = "$XunitDynamicSkip$";
+
+    public InfrastructureSkipException(string message)
+        : base($"{XunitSkipPrefix}{message}") { }
+}

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -1028,7 +1028,40 @@ internal sealed class ManagedServer : IAsyncDisposable
 
                 using var client = Server.CreateApiClient();
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                var health = await client.GetHealth();
+                // Per-probe deadline. ServerApiClient's own HttpClient.Timeout is 5 min
+                // (sized for long-polls), so without this a -L forward that wedges
+                // MID-STREAM (bytes stop flowing on an established channel — no exception
+                // thrown, so ForwardHealingHandler never engages) freezes THIS probe for
+                // 5 min; the loop never reaches the failure counter, no health.check_*
+                // fires, and the server never poisons (observed: run 02-12-57Z,
+                // host-poison-deadlocks-run.md fu6 — zero health events through the wedge).
+                //
+                // The deadline MUST sit ABOVE ForwardHealingHandler's heal-retry budget
+                // (45s): the watchdog's GetHealth() is wrapped by that handler, so a
+                // CATCHABLE forward blip (listener gone → SocketException) is healed in
+                // place within 45s and the probe then succeeds. Cutting the probe at <45s
+                // would abort a legitimate heal and miscount it as a wedge (real /health
+                // calls in run 01-51 took up to ~160s riding a blip+heal to a 200, with a
+                // ~0.5s-fresh snapshot — the server was alive the whole time). 50s clears
+                // the heal budget with margin while still bounding the mid-stream hang far
+                // below 5 min. A probe deadline is NOT shutdown: surface it as
+                // TimeoutException so it flows through the heal/poison-count path below,
+                // not the outer-ct `break`.
+                using var probeCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                probeCts.CancelAfter(ParseEnvInt("SDVD_HEALTH_CHECK_PROBE_TIMEOUT_MS", 50_000));
+                Clients.HealthResponse? health;
+                try
+                {
+                    health = await client.GetHealth(probeCts.Token);
+                }
+                catch (OperationCanceledException)
+                    when (probeCts.IsCancellationRequested && !ct.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        $"/health probe exceeded {ParseEnvInt("SDVD_HEALTH_CHECK_PROBE_TIMEOUT_MS", 50_000)}ms "
+                            + "(forward wedged mid-stream or server unresponsive)"
+                    );
+                }
                 sw.Stop();
 
                 if (health == null)
@@ -1121,6 +1154,21 @@ internal sealed class ManagedServer : IAsyncDisposable
                     consecutiveFailures = 0;
                     continue;
                 }
+
+                // Forward-scoped fault (loopback ConnectionRefused): the per-server
+                // -L forward's listener is gone, which a transient shared-master
+                // keepalive blip drops for every forward at once while the host stays
+                // reachable. If `ssh -O check` confirms the master is alive, re-open
+                // this server's forward in place and DON'T count it toward poison —
+                // healing a reused/live server instead of cascading into a host
+                // poison (the 2026-06-25 13-test cascade). Master dead ⇒ fall through
+                // to normal failure counting (the host really is gone).
+                if (await TryHealForwardScopedFaultAsync(ex, ct))
+                {
+                    consecutiveFailures = 0;
+                    continue;
+                }
+
                 consecutiveFailures++;
                 lastFailureCode = PoisonReasonCode.HealthCheckError;
                 lastFailureReason = $"Health check threw {ex.GetType().Name}: {ex.Message}";
@@ -1157,6 +1205,53 @@ internal sealed class ManagedServer : IAsyncDisposable
                 PoisonServer(lastFailureReason, lastFailureCode);
                 break;
             }
+        }
+    }
+
+    /// <summary>
+    /// When a health probe throws a <i>forward-scoped</i> transport fault (loopback
+    /// ConnectionRefused — the per-server <c>ssh -L</c> listener is gone), corroborate
+    /// the host is still up via <c>ssh -O check</c> and, if so, re-open this server's
+    /// API forward in place. Returns true when the fault was forward-scoped AND
+    /// healed — the caller then resets the failure streak instead of advancing toward
+    /// poison. Returns false for non-forward faults, local hosts, a dead master, or a
+    /// failed re-open (all of which should count normally).
+    /// </summary>
+    private async Task<bool> TryHealForwardScopedFaultAsync(Exception ex, CancellationToken ct)
+    {
+        var (_, forwardScoped) = TransportFaultClassifier.Classify(ex);
+        if (!forwardScoped || Host.SshDestination is null)
+        {
+            return false;
+        }
+
+        // Establish the master is usable before re-opening the forward (retries -O check +
+        // respawns once — see TunnelManager.EnsureMasterUsableAsync). This runs every
+        // health-watchdog cycle while the forward is dead, so even a longer outage heals on
+        // a later cycle rather than the test eating the whole blip.
+        if (!await TunnelManager.Default.EnsureMasterUsableAsync(Host.Id, ct))
+        {
+            return false;
+        }
+
+        try
+        {
+            var reopened = await Server.ReopenApiForwardAsync(ct);
+            if (reopened)
+            {
+                TestLog.Server(
+                    $"{_displayLabel} healed forward-scoped fault "
+                        + $"({ex.GetType().Name}) — re-opened API forward, host kept"
+                );
+            }
+            return reopened;
+        }
+        catch (Exception healEx)
+        {
+            TestLog.Server(
+                $"{_displayLabel} forward re-open failed after {ex.GetType().Name}: {healEx.Message}"
+            );
+            return false;
         }
     }
 
@@ -1212,6 +1307,15 @@ internal sealed class ManagedServer : IAsyncDisposable
             _errorCts.Cancel();
         }
         catch { }
+
+        // Wake same-class exclusive methods queued on _exclusiveClassTurn. That gate is
+        // released only by the prior method's normal cleanup (ReleaseExclusive), which a
+        // poison-killed method never reaches — so its siblings would WaitAsync forever on
+        // the per-test ct (a host/server poison fires no run-wide cancellation). Releasing
+        // the semaphore lets each sibling proceed past the gate and fail fast on the now-
+        // aborted server. See host-poison-deadlocks-run.md.
+        DrainExclusiveGateOnPoison();
+
         try
         {
             _onPoisoned?.Invoke(this);
@@ -1220,6 +1324,42 @@ internal sealed class ManagedServer : IAsyncDisposable
         {
             TestLog.Server($"{_displayLabel} poison callback failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Unblocks every same-class exclusive waiter when the server is poisoned: releases
+    /// the turn semaphore once per queued waiter and resolves any pending exclusive-done
+    /// TCS. Woken waiters re-check the server state (now <c>_aborted</c>) and fail fast
+    /// via the normal poisoned-lease path instead of hanging on the gate. Idempotent and
+    /// best-effort — a double poison or an already-drained gate is a no-op.
+    /// </summary>
+    private void DrainExclusiveGateOnPoison()
+    {
+        TaskCompletionSource? done;
+        int waiters;
+        lock (_exclusiveLock)
+        {
+            waiters = _exclusiveClassWaiters;
+            done = _exclusiveDone;
+            _exclusiveDone = null;
+            _exclusiveOwnerClass = null;
+        }
+
+        // One permit per queued sibling; each decrements _exclusiveClassWaiters as it
+        // wakes. SemaphoreSlim.Release(0) throws, so guard the count.
+        if (waiters > 0)
+        {
+            try
+            {
+                _exclusiveClassTurn.Release(waiters);
+            }
+            catch (SemaphoreFullException) { }
+            catch (ObjectDisposedException) { }
+        }
+
+        // A non-class exclusive holder waits on this TCS; resolve it so it stops waiting
+        // on a server that will never drain. TrySetResult is a no-op if already resolved.
+        done?.TrySetResult();
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/ServerQueue.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ServerQueue.cs
@@ -104,13 +104,34 @@ internal sealed class ServerQueue
     /// <summary>
     /// Resets the queue for server replacement (e.g., after poisoning).
     /// Creates a fresh TCS so new waiters block until the replacement is ready.
-    /// Old waiters attached to the previous TCS via ContinueWith will NOT be
-    /// explicitly woken; they rely on their per-waiter cancellation token for
-    /// cleanup. This is safe because Reset is only called during poison replacement
-    /// or eviction, and those paths call ServerReady/ServerFailed on the new TCS.
+    ///
+    /// <para>
+    /// Old waiters attached to the previous TCS via ContinueWith are NOT woken by the
+    /// no-fault overload; they rely on their per-waiter cancellation token for cleanup.
+    /// That is only safe when the caller WILL re-signal the new TCS (benign reuse /
+    /// eviction). When replacement may never succeed — a poison on the only usable host —
+    /// the old waiters would be orphaned forever (their per-test <c>ct</c> never fires on
+    /// a host poison), wedging the whole run. Use <see cref="Reset(Exception)"/> on those
+    /// paths to fault the orphaned waiters before swapping.
+    /// </para>
     /// </summary>
     public void Reset()
     {
+        _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    /// <summary>
+    /// Faulting reset for the no-replacement / poison-on-last-host case: faults the
+    /// CURRENT TCS with <paramref name="fault"/> first (waking every already-attached
+    /// waiter with the exception so it fails fast instead of orphaning), THEN swaps in a
+    /// fresh TCS for any future waiter. Use whenever a Reset might not be followed by a
+    /// successful <see cref="ServerReady"/> on the new TCS.
+    /// </summary>
+    public void Reset(Exception fault)
+    {
+        // Fault the old TCS in place — TrySetException reaches the orphaned
+        // ContinueWith waiters; a no-op if it already completed.
+        _tcs.TrySetException(fault);
         _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 }

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -186,6 +186,11 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
             _runningTestToken = Lease.Managed.RegisterRunningTest(_testDisplayName);
         }
 
+        // Per-test progress heartbeat for the stall watchdog: a long KeepConnected class
+        // holds one lease across many sequential methods (no acquire/release between them),
+        // so without this its method boundaries would look like a stalled run.
+        TestResourceBroker.Instance.MarkRunProgress();
+
         _budgetCts?.CancelAfter(TestTimeout);
     }
 
@@ -211,12 +216,19 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
         // The gate is inside the broker (after the server is ready but before AddRef),
         // so deferred server creation/eviction proceeds unblocked while waiting tests
         // don't inflate the refcount.
-        Lease = await TestResourceBroker.Instance.AcquireAsync(
-            requirements,
-            testName,
-            ct,
-            priority
-        );
+        //
+        // A failure here is almost always INFRASTRUCTURE, not a product bug: this E2E
+        // harness reaches the server only over the ssh-forwarded transport, so a
+        // ServerUnavailableException (every create attempt failed / host poisoned) or a
+        // raw Socket/Http/stream fault means a forward/host blip, not a test defect.
+        // Letting it propagate as a normal exception makes xUnit mark the test FAILED,
+        // which trips StopOnFail and cascades the entire shared class (the 2026-06-25
+        // 13-test SaveImport cascade from one ConnectionRefused). Instead: retry once (the
+        // broker replaces a poisoned server, so the retry lands on a fresh instance), and
+        // if it STILL faults on transport, skip-as-infrastructure (xUnit reports skipped,
+        // not failed → no StopOnFail, no red). Non-transport faults and run-abort OCEs are
+        // rethrown unchanged so a real crash/assertion still fails fast.
+        Lease = await AcquireWithInfrastructureSkipAsync(requirements, testName, ct, priority);
         PersistentSession.RecordCapacityAcquired(requirements.Clients);
         acquireSw.Stop();
 
@@ -287,6 +299,95 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
         LogTrace($"ServerReady wait: {SetupEventBus.FormatDuration(readySw.Elapsed)}");
 
         ServerStatus = await Lease.Api.GetStatus();
+    }
+
+    /// <summary>
+    /// Broker acquire with infrastructure-skip semantics: retry once on a transport fault
+    /// (the broker replaces a poisoned/failed server, so the retry lands on a fresh instance),
+    /// then convert a persistent transport fault into an <see cref="InfrastructureSkipException"/>
+    /// (xUnit reports the test skipped, not failed → no StopOnFail cascade). A non-transport
+    /// fault or a run-abort cancellation is rethrown unchanged so real crashes still fail fast.
+    /// </summary>
+    private async Task<ResourceLease> AcquireWithInfrastructureSkipAsync(
+        ResourceRequirements requirements,
+        string testName,
+        CancellationToken ct,
+        int priority
+    )
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await TestResourceBroker.Instance.AcquireAsync(
+                    requirements,
+                    testName,
+                    ct,
+                    priority
+                );
+            }
+            catch (Exception ex) when (IsInfrastructureTransportFault(ex, ct))
+            {
+                // First transport fault: retry once on a fresh server before giving up.
+                if (attempt == 1)
+                {
+                    InfrastructureEventLog.Emit(
+                        "server_acquire_retry_after_transport_fault",
+                        new { test = testName, error = $"{ex.GetType().Name}: {ex.Message}" }
+                    );
+                    continue;
+                }
+
+                // Still faulting on transport ⇒ infrastructure, not a product bug. Skip
+                // (xUnit reports skipped, no StopOnFail) rather than fail-and-cascade.
+                InfrastructureEventLog.Emit(
+                    "test_skipped_infrastructure",
+                    new { test = testName, error = $"{ex.GetType().Name}: {ex.Message}" }
+                );
+                throw new InfrastructureSkipException(
+                    $"Infrastructure transport fault acquiring a server ({ex.GetType().Name}: "
+                        + $"{ex.Message}). Skipped — not a test defect."
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// True when an exception from server acquisition is an infrastructure transport fault
+    /// (a poisoned host or a forward/host transport fault) rather than a product bug or a
+    /// run-abort cancellation. A caller-CT cancellation (StopOnFail/Ctrl-C) is NOT a transport
+    /// fault — let it propagate so it's handled as a cancellation, not a skip.
+    /// </summary>
+    private static bool IsInfrastructureTransportFault(Exception ex, CancellationToken ct) =>
+        !ct.IsCancellationRequested && IsInfrastructureTransportFault(ex);
+
+    /// <summary>
+    /// Type-only classification of an exception as an infrastructure transport fault
+    /// (poisoned host / forward-host transport fault / daemon-responsiveness timeout), with no
+    /// cancellation gate. Used where the caller has already excluded run-abort cancellation
+    /// (e.g. the dispose-phase end-of-test check, which only runs when not cancelled).
+    /// </summary>
+    internal static bool IsInfrastructureTransportFault(Exception ex)
+    {
+        if (ex is ServerUnavailableException || ex is InfrastructureSkipException)
+        {
+            return true;
+        }
+
+        // The daemon-responsiveness TimeoutException (a wedged daemon-socket forward) is
+        // unambiguously infrastructure even though Classify() deliberately treats a *generic*
+        // TimeoutException as non-transport. It reaches the test raw when the master stayed alive
+        // (mux-accept exhaustion: forwards wedge but the master process survives, so the broker's
+        // corroboration finds it "alive" and doesn't poison) — exactly the run 02-12-57Z case.
+        if (TransportFaultClassifier.IsDaemonResponsivenessTimeout(ex))
+        {
+            return true;
+        }
+
+        // Reuse the same classifier the broker poison path uses (walks the inner-exception
+        // chain), so the acquire-time skip and the host-poison decision agree on what counts
+        // as transport. A non-null reason means Socket/Http/EOF/broken-pipe etc.
+        return TransportFaultClassifier.Classify(ex).Reason is not null;
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -193,6 +193,25 @@ public sealed class TestResourceBroker : IAsyncDisposable
     /// </summary>
     private readonly CancellationTokenSource _runCts = new();
 
+    // Last-resort run watchdog: a deadlock or un-cancelled wait (e.g. a poisoned host
+    // orphaning waiters) can wedge the whole assembly indefinitely — a >1h hang that
+    // produces no summary.json and must be killed by hand. The watchdog touches
+    // _lastProgressTicks on every acquire/release; if NO progress is seen for
+    // RunStallTimeout while leases are still outstanding, it cancels _runCts to break
+    // the deadlock so blocked tests fail fast and the run finalizes. Conservative by
+    // design — the longest legitimate gap is one server cold-start (~120s StartupTimeout)
+    // plus artifact/cleanup, well under the threshold. Override via SDVD_RUN_STALL_TIMEOUT_S.
+    private long _lastProgressTicks = DateTime.UtcNow.Ticks;
+    private int _outstandingLeases;
+    private int _runStallTripped;
+    private Task? _stallWatchdogTask;
+    private static readonly TimeSpan RunStallTimeout = TimeSpan.FromSeconds(
+        int.TryParse(Environment.GetEnvironmentVariable("SDVD_RUN_STALL_TIMEOUT_S"), out var s)
+        && s > 0
+            ? s
+            : 600
+    );
+
     // Upper bound on how long a poisoned server waits for active leases to
     // release before it force-disposes. Must exceed TestBase's artifact phase
     // budget (screenshot ~15s + log save ~5s + video extract ~10s) plus the
@@ -227,10 +246,101 @@ public sealed class TestResourceBroker : IAsyncDisposable
         using (ExecutionContext.SuppressFlow())
         {
             _prestartTask = Task.Run(StartPrestart);
+            // SuppressFlow (asynclocal-pitfalls.md): the watchdog outlives the
+            // constructing test, so its diagnostic emits must not be attributed to it.
+            _stallWatchdogTask = Task.Run(() => RunStallWatchdogLoop(_runCts.Token));
         }
 
         // Start container stats collection (streams via Docker Engine API)
         ContainerStatsCollector.Start();
+    }
+
+    /// <summary>Records run progress (an acquire/release, or a per-test active transition)
+    /// so the stall watchdog can tell a genuinely-wedged run from one that's merely slow.
+    /// Cheap; called on every lease edge AND every test's queue→active transition — the
+    /// latter is what keeps a long KeepConnected class (one lease, many sequential methods)
+    /// from looking stalled between method boundaries.</summary>
+    internal void MarkRunProgress() =>
+        Interlocked.Exchange(ref _lastProgressTicks, DateTime.UtcNow.Ticks);
+
+    /// <summary>A lease was handed to a test: count it and mark progress so the watchdog's
+    /// "outstanding leases but no movement" stall test has fresh inputs.</summary>
+    private ResourceLease TrackLease(ResourceLease lease)
+    {
+        Interlocked.Increment(ref _outstandingLeases);
+        MarkRunProgress();
+        return lease;
+    }
+
+    /// <summary>
+    /// Last-resort deadlock breaker. Wakes periodically; if leases are outstanding but no
+    /// acquire/release has happened for <see cref="RunStallTimeout"/>, the run is wedged
+    /// (a deadlock or an un-cancelled wait that no per-test ct will ever fire). Cancels
+    /// <c>_runCts</c> once so every in-flight broker op faults and blocked tests fail fast,
+    /// letting xUnit finalize the assembly instead of hanging forever. Idempotent via
+    /// <c>_runStallTripped</c>; exits on its own cancellation (normal disposal).
+    /// </summary>
+    private async Task RunStallWatchdogLoop(CancellationToken ct)
+    {
+        // Poll at a fraction of the timeout so detection latency is bounded but cheap.
+        var pollInterval = TimeSpan.FromSeconds(Math.Max(15, RunStallTimeout.TotalSeconds / 8));
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(pollInterval, ct);
+
+                if (
+                    ShutdownCoordinator.IsShuttingDown
+                    || Volatile.Read(ref _outstandingLeases) <= 0
+                )
+                {
+                    continue;
+                }
+
+                var idle =
+                    DateTime.UtcNow
+                    - new DateTime(Interlocked.Read(ref _lastProgressTicks), DateTimeKind.Utc);
+                if (idle < RunStallTimeout)
+                {
+                    continue;
+                }
+
+                if (Interlocked.Exchange(ref _runStallTripped, 1) != 0)
+                {
+                    return; // already tripped
+                }
+
+                InfrastructureEventLog.Emit(
+                    "run_stall_watchdog_tripped",
+                    new
+                    {
+                        idleSeconds = (long)idle.TotalSeconds,
+                        thresholdSeconds = (long)RunStallTimeout.TotalSeconds,
+                        outstandingLeases = Volatile.Read(ref _outstandingLeases),
+                    }
+                );
+                TestLog.Test(
+                    $"[watchdog] run stalled {idle.TotalSeconds:F0}s with "
+                        + $"{Volatile.Read(ref _outstandingLeases)} lease(s) outstanding — "
+                        + "cancelling run to break the deadlock (see run_stall_watchdog_tripped)."
+                );
+                try
+                {
+                    _runCts.Cancel();
+                }
+                catch { }
+                return;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal disposal.
+        }
+        catch (Exception ex)
+        {
+            TestLog.Test($"[watchdog] stall watchdog loop error: {ex.Message}");
+        }
     }
 
     private Task StartPrestart()
@@ -1167,7 +1277,9 @@ public sealed class TestResourceBroker : IAsyncDisposable
                     TestLog.Test(
                         $"{shortTest} got server {displayLabel} on {host.Id} ({server.RefCount} active tests)"
                     );
-                    return new ResourceLease(server, requirements, testName, clientPool);
+                    return TrackLease(
+                        new ResourceLease(server, requirements, testName, clientPool)
+                    );
                 }
 
                 // Server was evicted or poisoned BEFORE AddRef ran; release the
@@ -1282,10 +1394,33 @@ public sealed class TestResourceBroker : IAsyncDisposable
                     host_id = host.Id,
                 }
             );
-            // Poison the host on a transport fault. This catch runs under the
-            // triggering test's EC (fire-and-forget, no SuppressFlow), so
-            // host_disconnected is attributed to the test that hit the dead host.
-            await host.PoisonIfTransportFaultAsync(ex);
+            // Classify + (maybe) poison the host. This catch runs under the triggering test's
+            // EC (fire-and-forget, no SuppressFlow), so host_disconnected is attributed to the
+            // test that hit the dead host. A RecoveredRetry means the master wedged mid-startup
+            // but was respawned and the forwards are healing — retry the creation once so it
+            // lands on the healed forward instead of failing the test (the 2026-06-26
+            // ModFarmDisambiguation failures: startup threw 0.25s before the forward re-opened).
+            var outcome = await host.PoisonIfTransportFaultAsync(ex);
+            if (outcome == DockerHost.TransportFaultOutcome.RecoveredRetry && !host.IsPoisoned)
+            {
+                InfrastructureEventLog.Emit(
+                    "server_creation_retry_after_blip",
+                    new
+                    {
+                        server = key,
+                        host_id = host.Id,
+                        error = ex.Message,
+                    }
+                );
+                // Brief settle so the parent's respawn + forward re-open complete, then retry.
+                await Task.Delay(TimeSpan.FromSeconds(3), ct);
+                var managed = await CreateServerAsync(key, requirements, host, ct);
+                managed.SetPoisonCallback(OnServerPoisoned);
+                queue.ServerReady();
+                succeeded = true;
+                TestLog.Server($"{displayLabel} ready on {host.Id} (after forward-blip retry)");
+                return managed;
+            }
             throw;
         }
         finally
@@ -1327,7 +1462,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
         var managed = await CreateServerAsync(key, requirements, host, ct);
         managed.AddRef(testName);
         var clientPool = await EnsureClientPoolAsync(host, ct);
-        return new ResourceLease(managed, requirements, testName, clientPool);
+        return TrackLease(new ResourceLease(managed, requirements, testName, clientPool));
     }
 
     private async Task<ManagedServer> CreateServerAsync(
@@ -1559,13 +1694,25 @@ public sealed class TestResourceBroker : IAsyncDisposable
             );
 
             // Only reset the per-host queue if no other healthy instances remain on
-            // this host for this key.
+            // this host for this key. When the HOST itself is poisoned, replacement on
+            // it cannot succeed, so fault the orphaned waiters now (Reset's fresh TCS
+            // would otherwise strand every already-attached waiter until a re-signal
+            // that never comes — the host-poison-deadlocks-run hang). When only the
+            // server is poisoned on a healthy host, replacement can still succeed, so
+            // keep the benign Reset and let it re-signal the new TCS.
             if (
                 _servers.TryGetBest(key, host.Id) == null
                 && _queues.TryGetValue(brokerKey, out var queue)
             )
             {
-                queue.Reset();
+                if (host.IsPoisoned)
+                {
+                    queue.Reset(BuildAcquisitionFault(displayLabel, host, null));
+                }
+                else
+                {
+                    queue.Reset();
+                }
             }
 
             _ = ReplaceServerInBackgroundAsync(key, managed.Requirements, host, managed);
@@ -1582,12 +1729,15 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 _remainingDemand.TryRemove(key, out _);
             }
 
+            // No replacement will run, so any waiter that raced onto this queue must be
+            // faulted rather than left on an orphaned TCS (pending was 0 at the check
+            // above, so this is normally a no-op — but a racing waiter must not hang).
             if (
                 _servers.TryGetBest(key, host.Id) == null
                 && _queues.TryGetValue(brokerKey, out var queue)
             )
             {
-                queue.Reset();
+                queue.Reset(BuildAcquisitionFault(displayLabel, host, null));
             }
 
             _ = DisposeWithoutReplacementAsync(displayLabel, managed);
@@ -1661,10 +1811,19 @@ public sealed class TestResourceBroker : IAsyncDisposable
 
         var queue = _queues.GetOrAdd(brokerKey, _ => new ServerQueue());
         // Ensure queue is in a fresh state for the replacement only if no other
-        // healthy instance exists on this host for this key.
+        // healthy instance exists on this host for this key. A poisoned host can't host
+        // the replacement, so fault any already-attached waiters instead of orphaning
+        // them on a fresh TCS that the failed replacement won't re-signal.
         if (_servers.TryGetBest(key, host.Id) == null && (queue.IsReady || queue.IsFaulted))
         {
-            queue.Reset();
+            if (host.IsPoisoned)
+            {
+                queue.Reset(BuildAcquisitionFault(displayLabel, host, null));
+            }
+            else
+            {
+                queue.Reset();
+            }
         }
 
         _creationsInFlight.AddOrUpdate(brokerKey, 1, (_, v) => v + 1);
@@ -1982,6 +2141,12 @@ public sealed class TestResourceBroker : IAsyncDisposable
 
     internal async Task ReleaseAsync(ManagedServer managed, bool wasExclusive = false)
     {
+        // Pairs with TrackLease at acquire — every ResourceLease routes its release here.
+        // Marking progress on release is what tells the stall watchdog a poison-cancelled
+        // cascade is actively draining (tests failing fast) rather than wedged.
+        Interlocked.Decrement(ref _outstandingLeases);
+        MarkRunProgress();
+
         var remaining = managed.Release();
         var remainingTests = DecrementRemainingDemand(managed.Key);
         var displayLabel = managed.Requirements.GetDisplayLabel();
@@ -2036,7 +2201,11 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 AnnotationLevel.Info,
                 "Server disposed (per-test release)"
             );
-            await managed.DisposeAsync();
+            // Release the slot synchronously so the next test (and TryReuseFreedSlotAsync below, which
+            // gates on ServerCapacity.Available) sees it immediately, then run the heavy container
+            // teardown (recorder stop + extract + retrieve) in the background off this test's critical
+            // path. Mirrors the sibling-sweep pattern below.
+            BackgroundDisposeServer(managed);
             _ = TryReuseFreedSlotAsync(managed.Host);
         }
         else if (remaining <= 0 && GetPendingDemand(managed.Key) <= 0)
@@ -2067,7 +2236,12 @@ public sealed class TestResourceBroker : IAsyncDisposable
                         host_id = host.Id,
                     }
                 );
-                await managed.DisposeAsync();
+                // Background the container teardown (recorder stop + extract + retrieve, ~33s
+                // leaseReleaseMs) off this test's critical path — otherwise a config's last test blocks
+                // on it. The slot is released synchronously inside BackgroundDisposeServer so the
+                // freed-slot reuse below and any waiting config see it immediately. Same pattern as the
+                // sibling sweep that follows.
+                BackgroundDisposeServer(managed);
 
                 // Sweep other idle instances of the same key (any host) that became
                 // orphaned when remainingTests hit 0 but their last ReleaseAsync saw
@@ -2155,6 +2329,31 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 _ = TryReuseFreedSlotAsync(host);
             }
         }
+    }
+
+    /// <summary>
+    /// Releases the server's host slot synchronously, then runs its heavy container teardown (recorder
+    /// stop + per-test clip + full convert/retrieve + container stop) on a background task so it doesn't
+    /// sit on the releasing test's critical path. The synchronous slot release means the next test — and
+    /// the freed-slot reuse / waiting-config checks that gate on <c>ServerCapacity.Available</c> — see the
+    /// slot immediately; <see cref="ManagedServer.ReleaseSlotEarly"/> is idempotent so the backgrounded
+    /// <see cref="ManagedServer.DisposeAsync"/>'s own slot release is a no-op. Same shape as the sibling
+    /// sweep in <see cref="ReleaseAsync"/>. The caller must have already removed <paramref name="managed"/>
+    /// from <c>_servers</c> and emitted <c>server_disposed</c>. Drained at run end via
+    /// <c>Task.WhenAll(_backgroundDisposeTasks)</c> in <see cref="DisposeAsync"/>.
+    /// </summary>
+    private void BackgroundDisposeServer(ManagedServer managed)
+    {
+        try
+        {
+            managed.ReleaseSlotEarly();
+        }
+        catch (Exception ex)
+        {
+            TestLog.Server($"early slot release failed: {ex.Message}");
+        }
+
+        EnqueueBackgroundTask(() => managed.DisposeAsync().AsTask());
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/TransportFaultClassifier.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TransportFaultClassifier.cs
@@ -4,9 +4,11 @@ namespace JunimoServer.Tests.Infrastructure;
 
 /// <summary>
 /// Decides whether an exception was a host <i>transport</i> fault (SSH forward
-/// dropped, daemon socket gone, pipe broken) — which must poison the host (see
+/// dropped, daemon socket gone, pipe broken) — a candidate to poison the host (see
 /// <see cref="DockerHost.Poison"/>) — or an <i>application</i> fault, which must
 /// not (poisoning a healthy host on a slow server would cascade unrelated tests).
+/// A host-scoped transport fault poisons directly; a forward-scoped one (loopback
+/// ConnectionRefused) only after <c>ssh -O check</c> confirms the host is gone.
 /// Both mid-run failure seams consult this one classifier via
 /// <see cref="DockerHost.PoisonIfTransportFaultAsync"/> so the decision matches.
 ///
@@ -21,81 +23,170 @@ namespace JunimoServer.Tests.Infrastructure;
 internal static class TransportFaultClassifier
 {
     /// <summary>
-    /// Returns a non-null reason when <paramref name="ex"/> (or any inner
-    /// exception) indicates the Docker host's transport died. Returns null for
-    /// application-level faults — including a bare <see cref="TimeoutException"/>,
-    /// which is ambiguous (a slow-but-live server times out the same way a dead
-    /// forward does). The caller resolves an ambiguous timeout with a second
-    /// signal (an <c>ssh -O check</c> against the host's master); see
-    /// <c>TestResourceBroker</c> / <c>ClientPool</c>.
+    /// Marker embedded in the message of the daemon-responsiveness `TimeoutException` thrown by
+    /// ServerContainer/GameClientContainer.StartAsync when a remote `docker create+start` exceeds
+    /// the tight daemon deadline (a wedged daemon-socket forward). Unlike a generic
+    /// <see cref="TimeoutException"/> (ambiguous — could be a slow server or a real hang), THIS
+    /// timeout is unambiguously infrastructure: we threw it specifically for a wedged forward. The
+    /// throw sites embed this marker and <see cref="IsDaemonResponsivenessTimeout"/> recognizes it,
+    /// so the acquire-time infrastructure-skip catches it even when the master stayed alive (the
+    /// mux-accept-exhaustion case, where the broker doesn't poison the host).
     /// </summary>
-    public static string? ClassifyHostTransportFault(Exception? ex)
+    public const string DaemonResponsivenessTimeoutMarker =
+        "docker start exceeded the remote daemon-responsiveness deadline";
+
+    /// <summary>
+    /// True when <paramref name="ex"/> (or any inner) is the daemon-responsiveness
+    /// <see cref="TimeoutException"/> identified by <see cref="DaemonResponsivenessTimeoutMarker"/>.
+    /// </summary>
+    public static bool IsDaemonResponsivenessTimeout(Exception? ex)
+    {
+        for (var cur = ex; cur is not null; cur = cur.InnerException)
+        {
+            if (
+                cur is TimeoutException
+                && cur.Message.Contains(DaemonResponsivenessTimeoutMarker, StringComparison.Ordinal)
+            )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Classifies <paramref name="ex"/> (walking the inner-exception chain) into a
+    /// host-transport-fault reason and whether that fault was <i>forward-scoped</i>
+    /// — a loopback "no listener on this port" signal
+    /// (<see cref="SocketError.ConnectionRefused"/> /
+    /// <see cref="HttpRequestError.ConnectionError"/>) — rather than host-scoped.
+    /// Returns <c>(null, false)</c> for application-level faults, including a bare
+    /// <see cref="TimeoutException"/> (ambiguous: a slow-but-live server times out
+    /// the same way a dead forward does — the caller corroborates with
+    /// <c>ssh -O check</c>; see <see cref="DockerHost.PoisonIfTransportFaultAsync"/>).
+    ///
+    /// <para>
+    /// A loopback <c>ConnectionRefused</c> means the local kernel rejected a
+    /// connect to an <b>unbound</b> <c>127.0.0.1</c> port — the per-server
+    /// <c>ssh -L</c> forward's listener is gone, NOT that the remote host died.
+    /// One shared <c>ssh -M</c> master carries every forward, so a transient
+    /// master keepalive blip (<c>ServerAliveCountMax</c> exceeded) tears down all
+    /// in-flight <c>-L</c> channels at once while the master process survives
+    /// (<c>ControlPersist</c>) and the daemon-socket forward keeps working. The
+    /// caller must corroborate a forward-scoped fault with <c>ssh -O check</c>
+    /// before poisoning the whole host — a live master means heal the forward,
+    /// not poison the host. Host-scoped faults (RST, HostUnreachable, broken
+    /// pipe) mean the connection genuinely broke and poison directly.
+    /// </para>
+    /// </summary>
+    public static (string? Reason, bool ForwardScoped) Classify(Exception? ex)
     {
         for (var current = ex; current is not null; current = current.InnerException)
         {
-            var reason = ClassifySingle(current);
-            if (reason is not null)
+            var result = ClassifySingle(current);
+            if (result.Reason is not null)
             {
-                return reason;
+                return result;
             }
         }
-        return null;
+        return (null, false);
     }
 
-    private static string? ClassifySingle(Exception ex) =>
+    private static (string? Reason, bool ForwardScoped) ClassifySingle(Exception ex) =>
         ex switch
         {
-            // Docker.DotNet wraps HttpClient, so a dead forward surfaces as a
-            // SocketException — the unambiguous transport signal.
-            SocketException se when IsTransportSocketError(se.SocketErrorCode) =>
+            // Faults on a LOOPBACK `ssh -L` forward — all forward-scoped, corroborate
+            // with `ssh -O check` before poisoning. The connection only ever talks to the
+            // local forward listener, never the remote host directly, so NONE of these on
+            // their own proves the host died — only a failed -O check does. Reproduced
+            // 2026-06-26: under load the master logs `channel N: read failed ... Broken
+            // pipe` / per-channel resets routinely while the master + forwards + host stay
+            // fully alive (Docker stats never stopped). The fatal case is a master keepalive
+            // drop, which tears down ALL forwards at once — an in-flight request then gets
+            // RST/ConnectionReset/broken-pipe and the next connect gets ConnectionRefused;
+            // they are the SAME event at different moments and all heal by re-opening the
+            // forward (see host-poison-deadlocks-run.md / ServerContainer.ReopenApiForwardAsync).
+            SocketException se when IsForwardScopedSocketError(se.SocketErrorCode) => (
                 $"socket transport fault ({se.SocketErrorCode})",
+                true
+            ),
 
-            // A *connection* HttpRequestError means the daemon was unreachable (vs a
-            // response-status error, which means it answered). A non-connection
-            // HttpRequestException falls through to the inner-chain walk for a wrapped
-            // SocketException; DockerApiException is app-level (the daemon responded).
-            HttpRequestException hre when IsTransportHttpError(hre.HttpRequestError) =>
+            // Remaining socket codes are genuinely host-level (the host/network itself is
+            // unreachable, not just a forward channel) — poison directly, no heal possible.
+            SocketException se when IsHostTransportSocketError(se.SocketErrorCode) => (
+                $"socket transport fault ({se.SocketErrorCode})",
+                false
+            ),
+
+            // ConnectionError is the HttpClient-layer face of the same loopback forward
+            // faults (refused/reset connect to 127.0.0.1:port). Forward-scoped.
+            HttpRequestException hre
+                when hre.HttpRequestError == HttpRequestError.ConnectionError => (
                 $"http transport fault ({hre.HttpRequestError})",
+                true
+            ),
 
-            // Forward closed mid-response. Explicit arm covers a bare EOF (no message);
-            // the IOException arm below catches the message-bearing cases.
-            EndOfStreamException => "daemon stream ended (transport)",
+            // Other *connection* HttpRequestErrors (name resolution, TLS) mean the
+            // daemon was unreachable for a host-level reason; not loopback-recoverable.
+            HttpRequestException hre when IsHostTransportHttpError(hre.HttpRequestError) => (
+                $"http transport fault ({hre.HttpRequestError})",
+                false
+            ),
 
-            IOException io when LooksLikeBrokenConnection(io.Message) =>
+            // Forward closed mid-response: a dropped -L channel, not a dead host.
+            // Forward-scoped — re-open and retry, corroborated by -O check.
+            EndOfStreamException => ("daemon stream ended (transport)", true),
+
+            IOException io when LooksLikeBrokenConnection(io.Message) => (
                 "io transport fault (broken pipe / connection reset)",
+                true
+            ),
 
-            _ => null,
+            _ => (null, false),
         };
 
     /// <summary>
-    /// Socket error codes that mean the connection to the daemon was lost or
-    /// never established — the forward is gone, not a slow-but-live daemon.
+    /// Socket error codes that, on a loopback <c>ssh -L</c> forward, indicate a dropped
+    /// forward CHANNEL rather than a dead host: the connect was refused (no listener after
+    /// a forward drop) or an established connection was reset/aborted (in-flight when the
+    /// forward tore down). All recoverable by re-opening the forward once <c>ssh -O check</c>
+    /// confirms the master is alive — proven survivable in the 2026-06-26 repro.
     /// </summary>
-    private static bool IsTransportSocketError(SocketError code) =>
+    private static bool IsForwardScopedSocketError(SocketError code) =>
         code switch
         {
+            SocketError.ConnectionRefused => true,
             SocketError.ConnectionReset => true,
             SocketError.ConnectionAborted => true,
-            SocketError.ConnectionRefused => true,
-            SocketError.HostUnreachable => true,
-            SocketError.NetworkUnreachable => true,
-            SocketError.NotConnected => true,
-            SocketError.Shutdown => true,
-            // TimedOut at the socket layer (not a bare TimeoutException) means the
-            // peer stopped answering — a dead forward, distinct from a live daemon
-            // taking a long time to produce a response.
+            // Peer stopped answering on the forwarded connection — same drop signature.
             SocketError.TimedOut => true,
             _ => false,
         };
 
     /// <summary>
-    /// <see cref="HttpRequestError"/> values that indicate the transport could
-    /// not carry the request, as opposed to the daemon returning an error status.
+    /// Socket error codes that mean the host/network itself is unreachable — distinct from
+    /// a recoverable loopback-forward drop (<see cref="IsForwardScopedSocketError"/>). These
+    /// poison the host directly: re-opening a forward can't fix an unreachable network.
     /// </summary>
-    private static bool IsTransportHttpError(HttpRequestError error) =>
+    private static bool IsHostTransportSocketError(SocketError code) =>
+        code switch
+        {
+            SocketError.HostUnreachable => true,
+            SocketError.NetworkUnreachable => true,
+            SocketError.NotConnected => true,
+            SocketError.Shutdown => true,
+            _ => false,
+        };
+
+    /// <summary>
+    /// Host-level <see cref="HttpRequestError"/> values (name resolution, TLS)
+    /// that indicate the transport could not carry the request for a reason the
+    /// host itself owns — distinct from a loopback
+    /// <see cref="HttpRequestError.ConnectionError"/> (handled as forward-scoped).
+    /// </summary>
+    private static bool IsHostTransportHttpError(HttpRequestError error) =>
         error switch
         {
-            HttpRequestError.ConnectionError => true,
             HttpRequestError.SecureConnectionError => true,
             HttpRequestError.NameResolutionError => true,
             _ => false,

--- a/tests/JunimoServer.Tests/Infrastructure/TunnelManager.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TunnelManager.cs
@@ -47,6 +47,27 @@ public sealed class TunnelManager : IAsyncDisposable
     private readonly Dictionary<string, HostMaster> _masters = new(StringComparer.Ordinal);
     private string _sshPath = "ssh";
 
+    // Caps concurrent `ssh -O` reuse invocations (forward / cancel / check) that hit one
+    // shared ControlMaster's mux listener. An unbounded burst of these can exhaust the
+    // master's accept backlog / fd budget — the master then logs `accept: Resource
+    // temporarily unavailable`, stops answering, and the whole host is lost (see
+    // host-poison-deadlocks-run.md). The spawn itself is exempt (it has no master yet).
+    // Sized generously; override via SDVD_SSH_OP_CONCURRENCY. Process-wide on Default.
+    private readonly SemaphoreSlim _sshOpGate = new(
+        int.TryParse(Environment.GetEnvironmentVariable("SDVD_SSH_OP_CONCURRENCY"), out var c)
+        && c > 0
+            ? c
+            : 6
+    );
+
+    // ControlMaster keepalive: probe every Interval s; declare the host dead after
+    // CountMax consecutive missed probes (so the forward-drop window is Interval×CountMax).
+    private static readonly int KeepAliveInterval = EnvInt("SDVD_SSH_KEEPALIVE_INTERVAL", 15);
+    private static readonly int KeepAliveCountMax = EnvInt("SDVD_SSH_KEEPALIVE_COUNT", 6);
+
+    private static int EnvInt(string name, int fallback) =>
+        int.TryParse(Environment.GetEnvironmentVariable(name), out var v) && v > 0 ? v : fallback;
+
     /// <summary>
     /// Configures the resolved <c>ssh</c> binary path for every subsequent
     /// invocation. Set by <see cref="HostPool.PreflightAsync"/> after the
@@ -220,11 +241,17 @@ public sealed class TunnelManager : IAsyncDisposable
         psi.ArgumentList.Add("-o");
         psi.ArgumentList.Add("Compression=yes");
         psi.ArgumentList.Add("-o");
-        psi.ArgumentList.Add("ServerAliveInterval=15");
-        // 2 (not OpenSSH's default 3) → master self-exits ~30s after a silent
-        // drop instead of ~45s, shrinking the IsMasterAliveAsync self-heal window.
+        psi.ArgumentList.Add($"ServerAliveInterval={KeepAliveInterval}");
+        // KeepAliveCountMax × Interval = how long a silent control-channel stall must last
+        // before the master tears down every forward. The old 2×15=30s was SHORTER than the
+        // harness's routine long ops (a docker pull/create can be silent for ~90s+), so a
+        // transient stall during normal work dropped all forwards and cascaded a host poison
+        // (reproduced 2026-06-26; the daemon stayed alive the whole time). Widened to 6×15=90s
+        // so a brief blip is ridden out rather than fatal. The corroborate-then-heal path
+        // (PoisonIfTransportFaultAsync) covers the rarer case where it does drop, so a longer
+        // self-exit window is no longer a liability. Override via SDVD_SSH_KEEPALIVE_*.
         psi.ArgumentList.Add("-o");
-        psi.ArgumentList.Add("ServerAliveCountMax=2");
+        psi.ArgumentList.Add($"ServerAliveCountMax={KeepAliveCountMax}");
         psi.ArgumentList.Add("-o");
         psi.ArgumentList.Add("TCPKeepAlive=yes");
         psi.ArgumentList.Add("-o");
@@ -256,7 +283,7 @@ public sealed class TunnelManager : IAsyncDisposable
         psi.ArgumentList.Add("-o");
         psi.ArgumentList.Add($"ControlPath={controlPath}");
         psi.ArgumentList.Add(sshDestination);
-        return await RunSshToCompletionAsync(psi, TimeSpan.FromSeconds(5), ct);
+        return await RunSshOpAsync(psi, TimeSpan.FromSeconds(5), ct);
     }
 
     /// <summary>
@@ -298,11 +325,157 @@ public sealed class TunnelManager : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Confirms the host's ControlMaster is usable, tolerating the transient window where a
+    /// keepalive blip has briefly broken even <c>ssh -O check</c> (the check needs a mux
+    /// channel too, so a single failure right after a drop is a false negative — the master
+    /// usually recovers within seconds while Docker stats keep flowing). Retries the check a
+    /// few times; if it stays down, respawns the master once. Returns false only when the
+    /// master is genuinely unrecoverable, so the caller can stop trying to heal and poison.
+    /// The canonical "is the host actually gone, or just a forward blip?" primitive — used by
+    /// the per-server forward heal and the API-client transparent heal.
+    /// </summary>
+    public async Task<bool> EnsureMasterUsableAsync(string hostId, CancellationToken ct = default)
+    {
+        const int checkAttempts = 4;
+        for (var i = 0; i < checkAttempts; i++)
+        {
+            if (await IsMasterAliveAsync(hostId, ct))
+            {
+                return true;
+            }
+            if (i < checkAttempts - 1)
+            {
+                try
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2), ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    return false;
+                }
+            }
+        }
+
+        // Check kept failing ⇒ master likely genuinely dead; one respawn attempt.
+        return await TryRespawnMasterAsync(hostId, ct);
+    }
+
     private HostMaster? TryGetMaster(string hostId)
     {
         lock (_lock)
         {
             return _masters.TryGetValue(hostId, out var m) ? m : null;
+        }
+    }
+
+    /// <summary>
+    /// Host ids whose ControlMaster this process OWNS (spawned, can respawn). Empty in the
+    /// xUnit child (it only adopts read-only entries). The parent-side master-health monitor
+    /// iterates these — only the owner can heal a wedged master, and crucially the respawn
+    /// reuses the SAME deterministic ControlPath, so the child's adopted entry keeps working
+    /// transparently (no re-publish needed).
+    /// </summary>
+    public IReadOnlyList<string> GetOwnedHostIds()
+    {
+        lock (_lock)
+        {
+            return _masters.Values.Where(m => m.Owned).Select(m => m.HostId).ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Owner-side master health check + heal: if <c>ssh -O check</c> fails (mux wedged or
+    /// process dead), respawn the master at its existing ControlPath. Returns true if the
+    /// master is healthy (already, or after respawn). No-op true for a host this process
+    /// doesn't own. The child CANNOT do this (TryRespawnMasterAsync refuses on !Owned) — that
+    /// is the whole reason this must run in the parent.
+    /// </summary>
+    public async Task<bool> EnsureOwnedMasterHealthyAsync(
+        string hostId,
+        CancellationToken ct = default
+    )
+    {
+        var master = TryGetMaster(hostId);
+        if (master is null || !master.Owned)
+        {
+            return true; // not ours to heal
+        }
+
+        if (await IsMasterAliveAsync(hostId, ct))
+        {
+            return true;
+        }
+
+        // -O check failed ⇒ mux wedged or process gone. Respawn at the same ControlPath so
+        // the child's adopted entry (and its in-flight forward re-opens) recover transparently.
+        EmitSafe("ssh_master_unhealthy_owner", new { host_id = hostId });
+        return await TryRespawnMasterAsync(hostId, ct);
+    }
+
+    /// <summary>
+    /// Attempts to resurrect a dead/unresponsive ControlMaster once: evicts the stale
+    /// entry + socket, then re-runs <see cref="RegisterHostMasterAsync"/> with the
+    /// original destination/key. Returns true if a usable master is back. Used by the
+    /// poison seam before condemning a host — one shared master carries every forward, so
+    /// a transient master death (e.g. <c>accept: Resource temporarily unavailable</c> from
+    /// fd/backlog exhaustion) otherwise loses the whole host even though the VPS is fine.
+    /// Only the owner (parent) can respawn — an adopted child entry has no spawn rights, so
+    /// it returns false and lets the normal poison proceed.
+    /// </summary>
+    public async Task<bool> TryRespawnMasterAsync(string hostId, CancellationToken ct = default)
+    {
+        HostMaster? master = TryGetMaster(hostId);
+        if (master is null)
+        {
+            HydrateFromEnvIfPresent();
+            master = TryGetMaster(hostId);
+        }
+        if (master is null || !master.Owned)
+        {
+            return false;
+        }
+
+        var destination = master.SshDestination;
+        var keyPath = master.SshKeyPath;
+
+        // Best-effort tear down the wedged-but-alive old master first (a mux wedge leaves the
+        // process running but useless), so it doesn't linger orphaned after we re-bind the
+        // ControlPath. Bounded; ignore the result — the file delete below is the hard reset.
+        try
+        {
+            var exitPsi = NewSshPsi();
+            exitPsi.ArgumentList.Add("-O");
+            exitPsi.ArgumentList.Add("exit");
+            exitPsi.ArgumentList.Add("-o");
+            exitPsi.ArgumentList.Add($"ControlPath={master.ControlPath}");
+            exitPsi.ArgumentList.Add(destination);
+            await RunSshOpAsync(exitPsi, TimeSpan.FromSeconds(3), ct);
+        }
+        catch
+        { /* wedged master may not answer -O exit; the socket delete is the fallback */
+        }
+
+        // Evict the dead entry + its socket so RegisterHostMasterAsync's ContainsKey guard
+        // doesn't short-circuit and its `ssh -M` doesn't hit the "socket exists" trap.
+        lock (_lock)
+        {
+            _masters.Remove(hostId);
+        }
+        TryDeleteFile(master.ControlPath);
+
+        EmitSafe("ssh_master_respawn_attempt", new { host_id = hostId });
+        try
+        {
+            await RegisterHostMasterAsync(hostId, destination, keyPath, ct);
+            var alive = await IsMasterAliveAsync(hostId, ct);
+            EmitSafe("ssh_master_respawned", new { host_id = hostId, alive });
+            return alive;
+        }
+        catch (Exception ex)
+        {
+            EmitSafe("ssh_master_respawn_failed", new { host_id = hostId, error = ex.Message });
+            return false;
         }
     }
 
@@ -540,7 +713,7 @@ public sealed class TunnelManager : IAsyncDisposable
         psi.ArgumentList.Add($"127.0.0.1:{coordinatorPort}:{target}");
         psi.ArgumentList.Add(master.SshDestination);
 
-        var (exit, stderr) = await RunSshToCompletionAsync(psi, TimeSpan.FromSeconds(5), ct);
+        var (exit, stderr) = await RunSshOpAsync(psi, TimeSpan.FromSeconds(5), ct);
         if (exit == 0)
         {
             return;
@@ -728,11 +901,7 @@ public sealed class TunnelManager : IAsyncDisposable
         string stderr;
         try
         {
-            (exit, stderr) = await RunSshToCompletionAsync(
-                psi,
-                perCancelTimeout,
-                CancellationToken.None
-            );
+            (exit, stderr) = await RunSshOpAsync(psi, perCancelTimeout, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -769,11 +938,7 @@ public sealed class TunnelManager : IAsyncDisposable
         string stderr;
         try
         {
-            (exit, stderr) = await RunSshToCompletionAsync(
-                psi,
-                perCancelTimeout,
-                CancellationToken.None
-            );
+            (exit, stderr) = await RunSshOpAsync(psi, perCancelTimeout, CancellationToken.None);
         }
         catch (Exception ex)
         {
@@ -874,6 +1039,28 @@ public sealed class TunnelManager : IAsyncDisposable
             CreateNoWindow = true,
         };
         return psi;
+    }
+
+    /// <summary>
+    /// Runs an <c>ssh -O</c> reuse op (forward / cancel / check / exit) under the per-host
+    /// mux-concurrency gate so a burst can't exhaust the shared master's accept backlog.
+    /// The master <c>-M</c> spawn does NOT use this (it has no master to overload yet).
+    /// </summary>
+    private async Task<(int ExitCode, string Stderr)> RunSshOpAsync(
+        ProcessStartInfo psi,
+        TimeSpan timeout,
+        CancellationToken ct
+    )
+    {
+        await _sshOpGate.WaitAsync(ct);
+        try
+        {
+            return await RunSshToCompletionAsync(psi, timeout, ct);
+        }
+        finally
+        {
+            _sshOpGate.Release();
+        }
     }
 
     private static async Task<(int ExitCode, string Stderr)> RunSshToCompletionAsync(


### PR DESCRIPTION
One cluster rooted in the `TransportFaultClassifier` rework (forward-scoped vs host-scoped faults) + `InfrastructureSkipException`.

**Chained on #469** (ContainerRecorder's extract-from-Stopped tolerance must exist before `BackgroundDisposeServer` introduces the teardown race). Retarget to `master` + rebase after #469 merges.

Skip-not-cascade:
- `TransportFaultClassifier`: `Classify() → (Reason, ForwardScoped)`, `IsDaemonResponsivenessTimeout`
- `TestBase`: `AcquireWithInfrastructureSkipAsync`, `IsInfrastructureTransportFault`, `MarkRunProgress()` heartbeat; `TestLifecycle` tolerates a dispose-phase transport blip in the end-of-test `/errors` check
- `TestSummaryFixture`: bucket Socket/Http/EndOfStream faults as `infrastructure`

Forward healing:
- `ForwardHealingHandler` (new) + heal constructors on `ServerApiClient`/`GameTestClient`: transparently re-open a dropped SSH forward and retry against the new port
- `ServerContainer`/`GameClientContainer`: forward re-open + 75s remote-daemon deadline (`SDVD_REMOTE_DAEMON_START_TIMEOUT_S`)
- `TunnelManager`: ssh-op gate, keepalive 90s, `EnsureMasterUsableAsync`/`TryRespawnMasterAsync`
- `DockerHost`: `TransportFaultOutcome`, daemon-forward heal, corroborate-before-poison
- `ManagedServer`: probe deadline, `TryHealForwardScopedFaultAsync`, `DrainExclusiveGateOnPoison`

Deadlock/stall hardening:
- `ServerQueue`: faulting `Reset(Exception)` overload; `TestResourceBroker`: run-stall watchdog, `RecoveredRetry` create-retry, faulting queue resets, `BackgroundDisposeServer`
- `ClientPool`: blip-retry on `RecoveredRetry`
- TestRunner `Program`: child-stall watchdog (`SDVD_CHILD_STALL_TIMEOUT_S`) + SSH-master health monitor

Riders:
- `GalaxyOutageReproTests`: dwell 45s → 10s (post-gate margin) + `SDVD_OUTAGE_DWELL_MS` doc in `.env.test.example`
- `CabinPositionPersistenceTests`: disconnect-only `DisposeAsync` (unique config hash makes the reset redundant)