### PR TITLE
fix(test-ui): artifact URLs, video cache, jump-to-failure

### DIFF
--- a/tests/test-ui/src/App.vue
+++ b/tests/test-ui/src/App.vue
@@ -135,6 +135,13 @@ provide("hoveredNav", hoveredNav);
 function showFailedTests() {
     activeView.value = "tests";
     filterToStatus.value = "failed";
+    // Also open a failure so the output panel isn't empty — this is the "go to
+    // error" action, not just a tree filter. Picking the freshest failure routes
+    // to /tests/<name>; the TestTree filter (above) narrows the tree to failures.
+    const failure = store.findMostRecentFailure();
+    if (failure) {
+        store.selectTest(failure);
+    }
 }
 provide("showFailedTests", showFailedTests);
 

--- a/tests/test-ui/src/components/InstanceInspect.vue
+++ b/tests/test-ui/src/components/InstanceInspect.vue
@@ -3,6 +3,7 @@ import { Icon } from "@iconify/vue";
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from "vue";
 import { Line } from "vue-chartjs";
 import { useLinkedCharts } from "../composables/useLinkedCharts";
+import { toArtifactUrl } from "../composables/useScreenshotCache";
 import { useSyncedZoom } from "../composables/useSyncedZoom";
 import { useTestUI } from "../composables/useTestUI";
 import type { InstanceHistoryEntry, InstanceSnapshot, SetupStepSnapshot, StatsSnapshotEntry } from "../types/state";
@@ -89,7 +90,7 @@ const props = withDefaults(
         canGoBack: false,
         hasPrev: false,
         hasNext: false,
-        screenshotSrc: (p: string) => `/artifacts/${p}`,
+        screenshotSrc: (p: string) => toArtifactUrl(p),
     },
 );
 

--- a/tests/test-ui/src/components/TestTree.vue
+++ b/tests/test-ui/src/components/TestTree.vue
@@ -59,23 +59,30 @@ watch(searchQuery, (q) => {
     }
 });
 
-// React to external filter trigger (e.g., clicking "failed" in status bar)
-watch(filterToStatus, (status) => {
-    if (!status) {
-        return;
-    }
-    const s = status as TestStatus;
-    if (allStatuses.includes(s)) {
-        setExclusiveFilter(s);
-        // Expand all so filtered results are visible
-        collapsed.value.clear();
-        userCollapsed.value.clear();
-        // Reset keyboard focus so next arrow key starts from the top of filtered results
-        focusedKey.value = null;
-    }
-    // Reset trigger so it can fire again
-    filterToStatus.value = null;
-});
+// React to external filter trigger (e.g., clicking "failed" in status bar).
+// immediate: the Overview sets filterToStatus *before* this tree mounts (the tree
+// is v-if'd on the tests view), so a lazy watcher would miss that pre-set value —
+// the immediate run applies it on mount.
+watch(
+    filterToStatus,
+    (status) => {
+        if (!status) {
+            return;
+        }
+        const s = status as TestStatus;
+        if (allStatuses.includes(s)) {
+            setExclusiveFilter(s);
+            // Expand all so filtered results are visible
+            collapsed.value.clear();
+            userCollapsed.value.clear();
+            // Reset keyboard focus so next arrow key starts from the top of filtered results
+            focusedKey.value = null;
+        }
+        // Reset trigger so it can fire again
+        filterToStatus.value = null;
+    },
+    { immediate: true },
+);
 
 // Filtered collections: remove tests that don't match, then remove empty classes/collections
 const filteredCollections = computed(() => {

--- a/tests/test-ui/src/composables/useScreenshotCache.ts
+++ b/tests/test-ui/src/composables/useScreenshotCache.ts
@@ -5,6 +5,23 @@ import type { OutputEntry } from "../types/state";
  * survive runner shutdown. Key: artifact path, Value: blob URL.
  */
 
+/**
+ * Build the `/artifacts/...` URL the live runner serves for an artifact path.
+ *
+ * The runner emits ABSOLUTE paths (e.g. `D:\...\TestResults\runs\<run>\tests\...\x.mp4`), but its
+ * `/artifacts/` endpoint is a PhysicalFileProvider rooted at `TestResults/`, so it only resolves a
+ * `runs/<run>/...`-relative URL with forward slashes. Prefixing the absolute path verbatim yields
+ * `/artifacts/D:\...` which 404s — the bug that left screenshots and recordings blank in the live UI.
+ * We anchor on the last `/runs/` segment (matching `relativeRunPath` in useTestStore) and normalise
+ * backslashes. Already-relative or bundle paths are returned unchanged.
+ */
+export function toArtifactUrl(path: string): string {
+    const norm = path.replace(/\\/g, "/");
+    const idx = norm.lastIndexOf("/runs/");
+    const relative = idx >= 0 ? norm.slice(idx + 1) : norm; // drop leading '/'
+    return `/artifacts/${relative}`;
+}
+
 export interface ScreenshotCache {
     /** Resolve a screenshot path to a displayable URL (blob URL or /artifacts/ fallback). */
     screenshotSrc: (path: string) => string;
@@ -32,7 +49,7 @@ export function useScreenshotCache(): ScreenshotCache {
             return; // offline report bundle: media sits next to index.html
         }
         fetchPending.add(artifactPath);
-        fetch(`/artifacts/${artifactPath}`)
+        fetch(toArtifactUrl(artifactPath))
             .then((res) => {
                 if (!res.ok) {
                     throw new Error(`${res.status}`);
@@ -71,7 +88,7 @@ export function useScreenshotCache(): ScreenshotCache {
         if (path.startsWith("artifacts/")) {
             return path;
         }
-        return `/artifacts/${path}`;
+        return toArtifactUrl(path);
     }
 
     function cacheScreenshotsFromOutput(output: OutputEntry[] | null) {

--- a/tests/test-ui/src/composables/useTestStore.ts
+++ b/tests/test-ui/src/composables/useTestStore.ts
@@ -100,6 +100,8 @@ export interface TestStore {
     findGlobalStep: (stepName: string) => SetupStepSnapshot | null;
     /** Find a test by display name (for cross-linking from history). */
     findTest: (displayName: string) => TestSnapshot | null;
+    /** The freshest failed test (highest executionOrder), or null if none failed. */
+    findMostRecentFailure: () => TestSnapshot | null;
     /** Send a runtime control command to the runner. WS-first, REST fallback. */
     sendCommand: (cmd: "stop") => Promise<void>;
 }
@@ -422,6 +424,30 @@ export function useTestStore(): TestStore {
             }
         }
         return firstFailed ?? firstRunning ?? mostRecent;
+    }
+
+    // The failure to jump to from "show failed tests" surfaces — the freshest one
+    // (highest executionOrder), matching the Overview's "most recent failure" order.
+    // Falls back to the first failed in tree order when none carry an executionOrder.
+    function findMostRecentFailure(): TestSnapshot | null {
+        let best: TestSnapshot | null = null;
+        let bestOrder = -1;
+        let firstFailed: TestSnapshot | null = null;
+        for (const col of collections.value) {
+            for (const cls of col.classes) {
+                for (const test of cls.tests) {
+                    if (test.status !== "failed") {
+                        continue;
+                    }
+                    firstFailed ??= test;
+                    if (test.executionOrder != null && test.executionOrder > bestOrder) {
+                        bestOrder = test.executionOrder;
+                        best = test;
+                    }
+                }
+            }
+        }
+        return best ?? firstFailed;
     }
 
     function updateTitleFromState() {
@@ -910,7 +936,11 @@ export function useTestStore(): TestStore {
             }
 
             case "recording": {
-                cacheScreenshot(event.recordingPath);
+                // Don't eagerly blob-cache the video — recordings are multi-MB and the <video>
+                // element streams them on demand from the /artifacts/ URL (resolved via
+                // screenshotSrc). Eager-caching every clip would pull tens of MB into memory on a
+                // full run. (Screenshots ARE eagerly cached — they're small and must survive runner
+                // shutdown for the offline view.)
                 const test = findOrCreateTest(event.testCollection, event.testClass, event.displayName);
                 if (test) {
                     test.recordings = test.recordings || [];
@@ -1618,6 +1648,7 @@ export function useTestStore(): TestStore {
         findTest(displayName: string): TestSnapshot | null {
             return findTestByDisplayName(displayName);
         },
+        findMostRecentFailure,
         sendCommand,
     };
 }


### PR DESCRIPTION
- `useScreenshotCache`: `toArtifactUrl` relativizes absolute runner paths (fixes `/artifacts/D:\...` 404s); `InstanceInspect` uses it
- `useTestStore`: `findMostRecentFailure`; stop eagerly blob-caching multi-MB recordings
- `App`: "show failed tests" opens the freshest failure
- `TestTree`: `filterToStatus` watcher `{ immediate: true }`

Verified with `make build-test-ui` (vue-tsc + vite).