### PR TITLE
fix(docker): repin ffmpeg to a retained month-end BtbN build

### DIFF
--- a/.claude/rules/recorder-anchor-first-frame.md
+++ b/.claude/rules/recorder-anchor-first-frame.md
@@ -79,7 +79,7 @@ The shell preamble in `StartAsync` sleeps until `CLOCK_REALTIME mod (1/fps) == 0
 
 Resist the urge to use strftime-templated filenames.
 
-**Failure mode under `-strftime 1` + `seg_%s.ts` (or any second-resolution template):** ffmpeg 8.1.1 in this image doesn't support sub-second strftime specifiers (`%N`/`%6N` pass through literally). At `fps=1, segment_time=1`, x11grab's startup serializes the first ~6 PTS-seconds of frames into ~1s of wall-clock during encoder warmup. The strftime expands at segment-open time, so the first 6 segments all open at the same wall-clock second and the muxer **overwrites them** — 3 files on disk where 8 should exist, segments 0-4 lost. Concrete evidence (8-frame test recording, `segments.csv`):
+**Failure mode under `-strftime 1` + `seg_%s.ts` (or any second-resolution template):** ffmpeg (8.1 branch) in this image doesn't support sub-second strftime specifiers (`%N`/`%6N` pass through literally). At `fps=1, segment_time=1`, x11grab's startup serializes the first ~6 PTS-seconds of frames into ~1s of wall-clock during encoder warmup. The strftime expands at segment-open time, so the first 6 segments all open at the same wall-clock second and the muxer **overwrites them** — 3 files on disk where 8 should exist, segments 0-4 lost. Concrete evidence (8-frame test recording, `segments.csv`):
 
 ```
 seg_1778763755.ts,0.000000,1.000000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -185,12 +185,13 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ffmpeg 8.1.1. Debian 11 ships 4.3.x with x11grab timing bugs that break the
-# test-recording pipeline; pinning to a date-stamped BtbN release avoids the "latest" tag drift.
-RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
+# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch). Debian 11 ships 4.3.x with x11grab
+# timing bugs that break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
+# daily builds after 14 days (month-end builds live two years), and the "latest" tag drifts.
+RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
+    install -m 0755 /tmp/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
+    install -m 0755 /tmp/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
     rm -rf /tmp/ffmpeg*
 
 # Install tmux (binary download, separate layer for cacheability)

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -139,13 +139,14 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ffmpeg 8.1.1. Debian 11 ships 4.3.x with x11grab timing bugs that break the
-# test-recording pipeline; pinning to a date-stamped BtbN release avoids the "latest" tag drift.
+# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch). Debian 11 ships 4.3.x with x11grab
+# timing bugs that break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
+# daily builds after 14 days (month-end builds live two years), and the "latest" tag drifts.
 # Must match the server image's ffmpeg pin so both ends of the recording pipeline behave identically.
-RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-11-14-22/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1.tar.xz && \
+RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
-    install -m 0755 /tmp/ffmpeg-n8.1.1-12-ge0e38acd2f-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
+    install -m 0755 /tmp/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1/bin/ffmpeg /usr/local/bin/ffmpeg && \
+    install -m 0755 /tmp/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1/bin/ffprobe /usr/local/bin/ffprobe && \
     rm -rf /tmp/ffmpeg*
 
 # System cleanup


### PR DESCRIPTION
- Repin ffmpeg from the pruned `autobuild-2026-06-11-14-22` (now 404) to the month-end `autobuild-2026-06-30-13-34` (`n8.1.2-21`, stable 8.1 branch) on both the server and test-client images
- Encode the pin policy in the Dockerfile comments: month-end BtbN autobuilds only — dailies are pruned after 14 days, month-end builds are retained for two years, and the `latest` tag drifts
- De-version the ffmpeg reference in `.claude/rules/recorder-anchor-first-frame.md` (the strftime limitation is version-agnostic)
- Unblocks #463, whose `ARG TMUX_VERSION` bump invalidated the cached ffmpeg layer and exposed the dead URL; rebase it after this merges


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled FFmpeg toolchain to version 8.1.2 for improved media processing reliability.
  * Refined documentation describing an FFmpeg timestamp-related failure mode to apply to the broader 8.1 branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->