### PR TITLE
fix(lobby): stop lobby redirect poisoning farmhand homes; heal stranded NPC spouses

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -209,6 +209,33 @@ public class TestStampClaimResponse
 }
 
 /// <summary>
+/// Response from POST /test/stamp_lobby_home (test-only). Reproduces the lobby-homed-spouse
+/// poisoned-save shape on a live server: ensures a shared lobby cabin exists (position-classified,
+/// so it works on a passwordless server too), synthesizes a marriage between a cabin-homed farmhand
+/// and the given NPC, then points the farmhand's homeLocation/lastSleepLocation and the NPC's
+/// DefaultMap/DefaultPosition/currentLocation at the lobby interior. Used to verify the
+/// CabinManagerService heal sweeps (DayStarted live heal + SaveLoaded migration) restore both.
+/// </summary>
+public class TestStampLobbyHomeResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>UniqueMultiplayerID of the farmhand whose home fields were poisoned.</summary>
+    public long StampedUid { get; set; }
+
+    /// <summary>The NPC married to the farmhand and stranded in the lobby.</summary>
+    public string Npc { get; set; } = "";
+
+    /// <summary>The lobby cabin interior's NameOrUniqueName both victims now point at.</summary>
+    public string LobbyLocation { get; set; } = "";
+
+    /// <summary>The farmhand's homeLocation before poisoning — the heal must restore exactly this
+    /// (ownership-first reassignment returns them to their own cabin).</summary>
+    public string OriginalHome { get; set; } = "";
+}
+
+/// <summary>
 /// Response from POST /test/galaxy_relogin (test-only). Triggers a Galaxy re-sign-in with no outage,
 /// so a test can verify that re-login while Galaxy is healthy and a client is connected does not
 /// disrupt the live lobby or change the invite code (the no-op safety question for the

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -96,6 +96,12 @@ public partial class ApiService
                     case "/test/stamp_claim":
                         await WriteJsonAsync(response, await HandlePostTestStampClaimAsync());
                         return;
+                    case "/test/stamp_lobby_home":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestStampLobbyHomeAsync(request)
+                        );
+                        return;
                     case "/test/galaxy_relogin":
                         await WriteJsonAsync(response, await HandlePostTestGalaxyReloginAsync());
                         return;
@@ -719,6 +725,149 @@ public partial class ApiService
 
                 result.Error =
                     "No uncustomized, unclaimed cabin slot with an owner entry found to stamp";
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/stamp_lobby_home",
+        Summary = "Poison a farmhand + synthesized NPC spouse with lobby home fields (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestStampLobbyHomeResponse), 200)]
+    private async Task<TestStampLobbyHomeResponse> HandlePostTestStampLobbyHomeAsync(
+        HttpListenerRequest request
+    )
+    {
+        var npcName = request.QueryString["npc"] ?? "Abigail";
+
+        var result = new TestStampLobbyHomeResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var farm = Game1.getFarm();
+                if (farm == null)
+                {
+                    result.Error = "No farm loaded";
+                    return;
+                }
+
+                var npc = Game1.getCharacterFromName(npcName);
+                if (npc == null)
+                {
+                    result.Error = $"NPC '{npcName}' not found";
+                    return;
+                }
+
+                // Reproduce the reporter's save shape: a shared lobby cabin exists (created
+                // while a password was set) even though the server now runs without one.
+                // Classification is position-based, so an ownerless cabin at the shared-lobby
+                // tile IS the lobby for every heal/filter path.
+                var lobbyBuilding = farm.buildings.FirstOrDefault(b =>
+                    b.isCabin && CabinPositions.Classify(b) == CabinRole.SharedLobby
+                );
+                if (lobbyBuilding == null)
+                {
+                    var lobbyTile = CabinPositions.SharedLobby.ToVector2();
+                    lobbyBuilding = _cabinManager.CreateCabinBuilding(lobbyTile);
+                    if (!farm.buildStructure(lobbyBuilding, lobbyTile, Game1.player, true))
+                    {
+                        result.Error = "Failed to build the lobby cabin";
+                        return;
+                    }
+
+                    // Lobby cabins are ownerless by design — drop the farmhand that
+                    // buildStructure's construction handler auto-created.
+                    var freshInterior = lobbyBuilding.GetIndoors<Cabin>();
+                    if (freshInterior?.HasOwner == true)
+                    {
+                        freshInterior.DeleteFarmhand();
+                    }
+                }
+
+                var lobbyIndoors = lobbyBuilding.GetIndoors<Cabin>();
+                if (lobbyIndoors == null)
+                {
+                    result.Error = "Lobby cabin has no interior";
+                    return;
+                }
+                var lobbyName = lobbyIndoors.NameOrUniqueName;
+
+                // Target: first farmhand entry homed at a real (non-lobby) cabin.
+                Farmer target = null;
+                foreach (var farmhandRef in Game1.netWorldState.Value.farmhandData.FieldDict.Values)
+                {
+                    var f = farmhandRef.Value;
+                    if (f == null)
+                    {
+                        continue;
+                    }
+
+                    var home = Game1.getLocationFromName(f.homeLocation.Value) as Cabin;
+                    if (
+                        home?.ParentBuilding != null
+                        && !LobbyService.IsLobbyCabin(home.ParentBuilding)
+                    )
+                    {
+                        target = f;
+                        break;
+                    }
+                }
+                if (target == null)
+                {
+                    result.Error = "No farmhand homed at a real cabin to stamp";
+                    return;
+                }
+
+                result.OriginalHome = target.homeLocation.Value ?? "";
+
+                // Synthesize the marriage (farmhand ↔ NPC) — the reporter's couple shape.
+                // Level >= 1 first: there is no level-0 marriage map (FarmHouse_marriage does
+                // not exist), so a married level-0 farmhouse crashes _newDayAfterFade.
+                if (target.HouseUpgradeLevel < 1)
+                {
+                    target.HouseUpgradeLevel = 1;
+                }
+                target.spouse = npcName;
+                if (
+                    !target.friendshipData.TryGetValue(npcName, out var friendship)
+                    || friendship == null
+                )
+                {
+                    friendship = new Friendship(2500);
+                    target.friendshipData[npcName] = friendship;
+                }
+                friendship.Status = FriendshipStatus.Married;
+                friendship.Proposer = target.UniqueMultiplayerID;
+
+                // Poison the farmhand's durable home + spawn hint — what the old lobby
+                // redirect's client echo baked into saves.
+                target.homeLocation.Value = lobbyName;
+                target.lastSleepLocation.Value = lobbyName;
+
+                // Poison the NPC exactly the way a marriageDuties run against the poisoned
+                // home does: DefaultMap = lobby, position = the level-0 spouse-bed sentinel
+                // ((-1000,-1000), the reporter's "debug where" (-999,-999)).
+                var sentinelBedSpot = lobbyIndoors.getSpouseBedSpot(npcName);
+                npc.DefaultMap = lobbyName;
+                npc.DefaultPosition = Utility.PointToVector2(sentinelBedSpot) * 64f;
+                npc.ClearSchedule();
+                Game1.warpCharacter(npc, lobbyIndoors, Utility.PointToVector2(sentinelBedSpot));
+
+                result.StampedUid = target.UniqueMultiplayerID;
+                result.Npc = npcName;
+                result.LobbyLocation = lobbyName;
+                result.Success = true;
             });
         }
         catch (Exception ex)

--- a/mod/JunimoServer/Services/AuthService/FarmhandSenderService.cs
+++ b/mod/JunimoServer/Services/AuthService/FarmhandSenderService.cs
@@ -389,7 +389,6 @@ public class FarmhandSenderService : ModService
         public string LastSleepLocation;
         public Point LastSleepPoint;
         public bool SleptInTemporaryBed;
-        public string HomeLocation;
     }
 
     /// <summary>
@@ -407,7 +406,6 @@ public class FarmhandSenderService : ModService
             LastSleepLocation = farmhand.lastSleepLocation.Value,
             LastSleepPoint = farmhand.lastSleepPoint.Value,
             SleptInTemporaryBed = farmhand.sleptInTemporaryBed.Value,
-            HomeLocation = farmhand.homeLocation.Value,
         };
     }
 
@@ -424,7 +422,6 @@ public class FarmhandSenderService : ModService
         farmhand.lastSleepLocation.Value = data.LastSleepLocation;
         farmhand.lastSleepPoint.Value = data.LastSleepPoint;
         farmhand.sleptInTemporaryBed.Value = data.SleptInTemporaryBed;
-        farmhand.homeLocation.Value = data.HomeLocation;
     }
 
     /// <summary>
@@ -482,9 +479,14 @@ public class FarmhandSenderService : ModService
         // map property. Setting sleptInTemporaryBed bypasses that bed check.
         farmhand.sleptInTemporaryBed.Value = true;
 
-        // ApplyWakeUpPosition Branch 3 (final fallback): uses homeLocation to find a
-        // FarmHouse bed spot. Point it at the lobby cabin so all three branches converge.
-        farmhand.homeLocation.Value = lobbyLocation;
+        // Deliberately NOT redirected: homeLocation. It's the farmhand's durable home pointer —
+        // the client is authoritative for its own Farmer root and clones it back into
+        // farmhandData via the nightly full-root resend (NetWorldState.SaveFarmhand), and
+        // NPC.marriageDuties reads it raw to home the NPC spouse (offline farmhands included).
+        // Pointing it at the lobby persists the lobby as their home (stranded-spouse bug).
+        // ApplyWakeUpPosition branch 3 (the homeLocation fallback) is reachable only when the
+        // lobby name doesn't resolve client-side, where RequireLocation on a lobby homeLocation
+        // throws anyway — the real cabin is strictly safer in that branch.
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -101,6 +101,7 @@ public class CabinManagerService : ModService
         Data = new CabinManagerData(helper, monitor);
 
         Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+        Helper.Events.GameLoop.DayStarted += OnDayStarted;
 
         // For None strategy, let vanilla handle starting cabins and skip message
         // interception and farmhouse monitoring. Cabins are real and visible.
@@ -200,7 +201,28 @@ public class CabinManagerService : ModService
         // ClearStaleFarmhandReferences, which has already purged cabin-less orphans.
         ClearAbandonedCabinClaimsOnLoad();
 
+        // Heal farmhands whose durable home/spawn fields point at a lobby interior — the
+        // one-shot migration for saves poisoned by the old lobby redirect (which wrote the
+        // lobby into homeLocation; the client's copy echoed it back nightly). Runs before
+        // EnsureAtLeastXCabins so a heal that consumes a cabin gets the pool topped back up.
+        HealLobbyHomedFarmhands(HealContextSaveLoaded);
+
         EnsureAtLeastXCabins();
+
+        // NPC pass after the farmhand pass: married NPCs re-derive their home from the (now
+        // healed) spouse homeLocation.
+        HealLobbyHomedResidents(HealContextSaveLoaded);
+    }
+
+    private void OnDayStarted(object sender, DayStartedEventArgs e)
+    {
+        // Tripwire sweep (see the heal-context tags in the Lobby-Homed Heal region). Ordering
+        // vs. marriageDuties is deliberately not load-bearing: if marriageDuties already ran
+        // with a poisoned value this morning, the NPC pass pulls the spouse back and the
+        // farmhand pass fixes the source for tomorrow; if the sweep ran first, marriageDuties
+        // reads healed values and the NPC pass no-ops.
+        HealLobbyHomedFarmhands(HealContextDayStarted);
+        HealLobbyHomedResidents(HealContextDayStarted);
     }
 
     private void ClearStaleFarmhandReferences()
@@ -1232,24 +1254,9 @@ public class CabinManagerService : ModService
 
         foreach (var npc in stranded)
         {
-            // reloadDefaultLocation derives DefaultMap from characterData; a villager with no data
-            // can't resolve a valid home, so skip it (mirrors Cabin.demolish's guard, Cabin.cs:198).
-            if (!Game1.characterData.ContainsKey(npc.Name))
-            {
-                continue;
-            }
-
-            npc.reloadDefaultLocation();
-            npc.ClearSchedule();
-            Game1.warpCharacter(npc, npc.DefaultMap, npc.DefaultPosition / 64f);
-
-            // Warn, never Error: this runs on the server game thread, where LogLevel.Error trips
-            // ServerContainer's ERROR/FATAL test-poison scan.
-            Monitor.Log(
-                $"Reset villager '{npc.Name}' homed at destroyed cabin '{deletedName}' back to "
-                    + $"'{npc.DefaultMap}' (was stranded by a farmhand↔NPC marriage).",
-                LogLevel.Warn
-            );
+            // The deleted cabin's farmhand is already removed from farmhandData, so a spouse
+            // NPC resolves getSpouse() == null and takes the unmarried branch (village home).
+            ReHomeNpc(npc, $"destroyed cabin '{deletedName}'", LogLevel.Warn);
         }
     }
 
@@ -1258,7 +1265,7 @@ public class CabinManagerService : ModService
     /// Uses load() for save-deserialization-style initialization (no construction
     /// animations or sounds), then verifies the interior was actually created.
     /// </summary>
-    private Building CreateCabinBuilding(Vector2 tilePosition)
+    public Building CreateCabinBuilding(Vector2 tilePosition)
     {
         var cabin = new Building("Cabin", tilePosition);
         cabin.skinId.Value = "Log Cabin";
@@ -1290,6 +1297,515 @@ public class CabinManagerService : ModService
         }
 
         return cabin;
+    }
+
+    #endregion
+
+    #region Lobby-Homed Heal
+
+    // Context tags for the heal passes. SaveLoaded is the one-shot migration for saves poisoned
+    // by the old lobby redirect (heals expected on the first boot after deploy, logged at Info);
+    // DayStarted is a tripwire whose steady state is zero heals (logged at Warn so an unknown
+    // ingress route surfaces as a signal); Join is PasswordProtectionService's per-join repair.
+    public const string HealContextSaveLoaded = "save_loaded";
+    public const string HealContextDayStarted = "day_started";
+    public const string HealContextJoin = "join";
+
+    private static LogLevel HealLogLevel(string context) =>
+        context == HealContextDayStarted ? LogLevel.Warn : LogLevel.Info;
+
+    /// <summary>
+    /// Ensures a farmhand's durable home fields point at a real (non-lobby) cabin and — in
+    /// the sweep contexts only, never at join — scrubs lobby-poisoned spawn hints. Shared
+    /// core behind the load/day-start sweeps and PasswordProtectionService's join-time
+    /// repair. Reassignment is ownership-first: the
+    /// farmhand's own cabin (matched by owner or farmhandReference) wins over vanilla
+    /// TryAssignFarmhandHome, whose building-order scan could hand an owning farmhand a fresh
+    /// cabin instead of their own.
+    ///
+    /// Field writes only — never warps a live player (an unauthenticated player standing in the
+    /// lobby must stay there until they authenticate). Quiet when there is nothing to fix.
+    /// </summary>
+    public void EnsureFarmhandRealHome(Farmer farmer, string context)
+    {
+        if (farmer == null || farmer.IsMainPlayer)
+        {
+            return; // the host's home is the main FarmHouse by design
+        }
+
+        // Resolve by building iteration, never getLocationFromName: the location-lookup cache
+        // is flushed during day transitions and may not have re-learned structure interiors
+        // (same rationale as PasswordProtectionService.FindPlayerCabin).
+        var beforeHome = farmer.homeLocation.Value ?? "";
+        var homeCabin = FindCabinInteriorByName(beforeHome);
+        var homeValid = homeCabin != null && !LobbyService.IsLobbyCabin(homeCabin.ParentBuilding);
+
+        string reassignPath = null;
+        if (!homeValid)
+        {
+            var owned = FindOwnedCabin(farmer.UniqueMultiplayerID);
+            if (owned != null)
+            {
+                // Re-link the farmhand to THEIR OWN cabin. AssignFarmhand re-sets
+                // farmhandReference + homeLocation in one call and is idempotent for the owner.
+                owned.AssignFarmhand(farmer);
+                reassignPath = "owned_cabin";
+            }
+            else
+            {
+                // Vanilla assignment. Clear the home first — TryAssignFarmhandHome's first
+                // condition short-circuits on ANY resolvable Cabin, lobby included. Null a
+                // lobby lastSleepLocation too: its lastSleepLocation condition would try it
+                // (LobbyService's CanAssignTo postfix already blocks lobby cabins, but don't
+                // lean on a single defense layer).
+                farmer.homeLocation.Value = "";
+                var staleSleepCabin = FindCabinInteriorByName(farmer.lastSleepLocation.Value);
+                if (
+                    staleSleepCabin != null
+                    && LobbyService.IsLobbyCabin(staleSleepCabin.ParentBuilding)
+                )
+                {
+                    farmer.lastSleepLocation.Value = null;
+                }
+
+                if (Game1.netWorldState.Value.TryAssignFarmhandHome(farmer))
+                {
+                    reassignPath = "vanilla_assign";
+                }
+                else
+                {
+                    // Cabin pool exhausted — build one and retry.
+                    EnsureAtLeastXCabins(1);
+                    if (Game1.netWorldState.Value.TryAssignFarmhandHome(farmer))
+                    {
+                        reassignPath = "built_and_assigned";
+                    }
+                }
+            }
+
+            if (reassignPath == null)
+            {
+                // Total failure (build failed twice, e.g. None strategy with an exhausted
+                // position pool). A married farmhand must never be left with an empty
+                // homeLocation — marriageDuties calls RequireLocation on it raw and would
+                // crash the day loop — so restore the old value if it still resolves
+                // (poisoned-but-stable beats crashing); the next sweep retries.
+                if (FindCabinInteriorByName(beforeHome) != null)
+                {
+                    farmer.homeLocation.Value = beforeHome;
+                }
+                Monitor.Log(
+                    $"Could not reassign a real cabin to farmhand "
+                        + $"'{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID}, "
+                        + $"home='{beforeHome}', context={context}): no cabin available and building one failed.",
+                    LogLevel.Warn
+                );
+                Diagnostics.ModEventLog.Emit(
+                    "farmhand_home_heal_failed",
+                    new
+                    {
+                        farmhandId = farmer.UniqueMultiplayerID,
+                        beforeHome,
+                        context,
+                    }
+                );
+                return;
+            }
+
+            homeCabin = FindCabinInteriorByName(farmer.homeLocation.Value);
+        }
+
+        // Scrub lobby-poisoned spawn hints even when the home itself is valid: a pre-auth
+        // disconnect persists lobby lastSleepLocation/disconnectLocation (plus disconnectDay =
+        // today) on an entry whose homeLocation was already healed at join — a rejoin on a
+        // later passwordless boot would then take wake-up branch 1 (disconnect fields)
+        // straight into the sealed lobby. These are transient hints re-stamped by real
+        // gameplay, so rewriting them is safe — EXCEPT during an active join under password:
+        // there the lobby hints are load-bearing (the client lands in the lobby via wake-up
+        // branches 1-2, and SendServerIntroduction's explicit lobby-location send keys on
+        // disconnectLocation == lobby), so the join context must leave them alone.
+        var scrubbedLastSleep = false;
+        var scrubbedDisconnect = false;
+        if (context != HealContextJoin)
+        {
+            var sleepCabin = FindCabinInteriorByName(farmer.lastSleepLocation.Value);
+            if (sleepCabin != null && LobbyService.IsLobbyCabin(sleepCabin.ParentBuilding))
+            {
+                if (homeCabin != null)
+                {
+                    farmer.lastSleepLocation.Value = homeCabin.NameOrUniqueName;
+                    farmer.lastSleepPoint.Value = homeCabin.GetPlayerBedSpot();
+                }
+                else
+                {
+                    farmer.lastSleepLocation.Value = null;
+                }
+                scrubbedLastSleep = true;
+            }
+
+            // Scrub lobby disconnect hints only while they can still fire: wake-up branch 1
+            // requires disconnectDay == today's DaysPlayed (its own arming condition), so a
+            // stale-day lobby disconnectLocation is inert. It is also PERMANENT residue on a
+            // connected client's root (the client only rewrites disconnect fields on a real
+            // disconnect, and its nightly resend re-imports them) — scrubbing it would fire
+            // the tripwire every single morning for every lobby-joined farmhand.
+            var disconnectCabin = FindCabinInteriorByName(farmer.disconnectLocation.Value);
+            if (
+                disconnectCabin != null
+                && LobbyService.IsLobbyCabin(disconnectCabin.ParentBuilding)
+                && farmer.disconnectDay.Value == (int)Game1.MasterPlayer.stats.DaysPlayed
+            )
+            {
+                farmer.disconnectLocation.Value = null;
+                farmer.disconnectPosition.Value = Vector2.Zero;
+                farmer.disconnectDay.Value = -1;
+                scrubbedDisconnect = true;
+            }
+        }
+
+        if (reassignPath != null || scrubbedLastSleep || scrubbedDisconnect)
+        {
+            Monitor.Log(
+                $"Healed lobby-homed farmhand '{ChatRedaction.MaskValue(farmer.Name)}' "
+                    + $"(id={farmer.UniqueMultiplayerID}, context={context}): "
+                    + $"home '{beforeHome}' -> '{farmer.homeLocation.Value}'"
+                    + (reassignPath != null ? $" via {reassignPath}" : " (spawn hints only)")
+                    + $", lastSleepScrubbed={scrubbedLastSleep}, disconnectScrubbed={scrubbedDisconnect}",
+                HealLogLevel(context)
+            );
+            Diagnostics.ModEventLog.Emit(
+                "farmhand_home_healed",
+                new
+                {
+                    farmhandId = farmer.UniqueMultiplayerID,
+                    beforeHome,
+                    afterHome = farmer.homeLocation.Value ?? "",
+                    path = reassignPath ?? "spawn_hints_only",
+                    scrubbedLastSleep,
+                    scrubbedDisconnect,
+                    context,
+                }
+            );
+        }
+    }
+
+    /// <summary>
+    /// Heals every farmhand entry via <see cref="EnsureFarmhandRealHome"/>. An online farmhand
+    /// exists as TWO Farmer objects — the persisted farmhandData entry (the clone target of the
+    /// nightly SaveFarmhand) and the live otherFarmers root (what getAllFarmhands hands to
+    /// marriageDuties while they're online) — so both are healed, or the missed one stays
+    /// authoritative for its consumer.
+    /// </summary>
+    private void HealLobbyHomedFarmhands(string context)
+    {
+        var farmhandData = Game1.netWorldState?.Value?.farmhandData;
+        if (farmhandData == null)
+        {
+            return;
+        }
+
+        // Snapshot: a heal can build a cabin (EnsureAtLeastXCabins), which adds a fresh
+        // farmhand entry and would tear a live FieldDict enumeration.
+        var entries = farmhandData
+            .FieldDict.Select(kvp => (Uid: kvp.Key, Farmer: kvp.Value.Value))
+            .ToList();
+
+        foreach (var (uid, persisted) in entries)
+        {
+            if (persisted != null)
+            {
+                EnsureFarmhandRealHome(persisted, context);
+            }
+
+            if (
+                Game1.otherFarmers.TryGetValue(uid, out var live)
+                && !ReferenceEquals(live, persisted)
+            )
+            {
+                EnsureFarmhandRealHome(live, context);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Re-homes every NPC stranded by a lobby interior: villagers whose DefaultMap is a
+    /// lobby/editing cabin interior, villagers whose DefaultMap resolves to no location at all
+    /// (stranded by an individual lobby destroyed on an older build — the next dayUpdate warp
+    /// would fail loudly), any villager physically inside a lobby interior, and children/pets
+    /// found in lobby interiors. Runs after the farmhand pass so married NPCs re-derive their
+    /// home from a healed spouse homeLocation.
+    /// </summary>
+    private void HealLobbyHomedResidents(string context)
+    {
+        var farm = Game1.getFarm();
+        if (farm == null)
+        {
+            return;
+        }
+
+        // Snapshot matches first: warpCharacter mutates location.characters during iteration.
+        var stranded = new List<NPC>();
+
+        Utility.ForEachVillager(npc =>
+        {
+            if (IsLobbyOrEditingInterior(npc.currentLocation))
+            {
+                stranded.Add(npc);
+            }
+            else if (!string.IsNullOrEmpty(npc.DefaultMap))
+            {
+                var mapCabin = FindCabinInteriorByName(npc.DefaultMap);
+                var isLobbyMap =
+                    mapCabin != null && LobbyService.IsLobbyCabin(mapCabin.ParentBuilding);
+                // Do NOT scope the unresolvable check to existing lobby interiors — a villager
+                // stranded by a destroyed lobby has no interior left to match.
+                var isDanglingMap =
+                    mapCabin == null && Game1.getLocationFromName(npc.DefaultMap) == null;
+                if (isLobbyMap || isDanglingMap)
+                {
+                    stranded.Add(npc);
+                }
+            }
+            return true; // scan every villager
+        });
+
+        // Children and pets aren't villagers (ForEachVillager filters on IsVillager); catch any
+        // physically stranded inside a lobby/editing interior.
+        foreach (var building in farm.buildings)
+        {
+            if (!building.isCabin || !LobbyService.IsLobbyCabin(building))
+            {
+                continue;
+            }
+
+            var interior = building.GetIndoors<Cabin>();
+            if (interior == null)
+            {
+                continue;
+            }
+
+            foreach (var character in interior.characters)
+            {
+                if (character is Child || character is Pet)
+                {
+                    stranded.Add(character);
+                }
+            }
+        }
+
+        foreach (var npc in stranded)
+        {
+            ReHomeNpc(npc, context, HealLogLevel(context));
+        }
+    }
+
+    /// <summary>
+    /// Re-homes a household NPC out of a lobby or destroyed interior. Married villagers are
+    /// re-pointed at their spouse-farmer's home — DefaultMap AND DefaultPosition together, the
+    /// way the engine pairs them (Game1.prepareSpouseForWedding); a stale DefaultPosition would
+    /// re-land the NPC at the (-1000,-1000) sentinel on the next dayUpdate warp. Unmarried
+    /// villagers re-derive their village home from character data (reloadDefaultLocation has no
+    /// married-gate; the gate is at its data-reload call site). Children go to their parent's
+    /// home, pets to the Farm — never repoint Pet.homeLocationName; the bowl is a Farm building
+    /// resolved off it and the pet returns to it on the next dayUpdate.
+    /// </summary>
+    private void ReHomeNpc(NPC npc, string reason, LogLevel logLevel)
+    {
+        var beforeMap = npc.DefaultMap ?? "";
+        var beforeLocation = npc.currentLocation?.NameOrUniqueName ?? "";
+        string branch;
+
+        if (npc is Child child)
+        {
+            // Game1.GetPlayer resolves offline farmhands via farmhandData.
+            var parent = Game1.GetPlayer(child.idOfParent.Value);
+            var parentHome =
+                parent != null ? ResolveRealFarmhouse(parent.homeLocation.Value) : null;
+            if (parentHome != null)
+            {
+                Game1.warpCharacter(
+                    child,
+                    parentHome,
+                    Utility.PointToVector2(parentHome.GetPlayerBedSpot())
+                );
+            }
+            else
+            {
+                var farm = Game1.getFarm();
+                Game1.warpCharacter(
+                    child,
+                    farm,
+                    Utility.PointToVector2(farm.GetMainFarmHouseEntry())
+                );
+            }
+            branch = "child";
+        }
+        else if (npc is Pet)
+        {
+            var farm = Game1.getFarm();
+            Game1.warpCharacter(npc, farm, Utility.PointToVector2(farm.GetMainFarmHouseEntry()));
+            branch = "pet";
+        }
+        else if (
+            npc.isMarried() // getSpouse() alone also matches engaged couples, who don't move in until the wedding
+            && npc.getSpouse() is Farmer spouse
+            && ResolveRealFarmhouse(spouse.homeLocation.Value) is FarmHouse home
+        )
+        {
+            // The level-0 (-1000,-1000) bed-spot sentinel is exact vanilla parity with
+            // marriageDuties, reachable only via synthesized level-0 marriages.
+            var bedSpot = home.getSpouseBedSpot(npc.Name);
+            npc.DefaultMap = spouse.homeLocation.Value;
+            npc.DefaultPosition = Utility.PointToVector2(bedSpot) * 64f;
+            npc.ClearSchedule();
+            Game1.warpCharacter(npc, home, Utility.PointToVector2(bedSpot));
+            branch = "married";
+        }
+        else if (Game1.characterData.ContainsKey(npc.Name))
+        {
+            // A married NPC lands here only when the spouse home is unresolvable — the village
+            // home beats a crash (never RequireLocation on a bad name).
+            npc.reloadDefaultLocation();
+            var target = Game1.getLocationFromName(npc.DefaultMap);
+            if (target == null)
+            {
+                // reloadDefaultLocation keeps the old DefaultMap when character data has no
+                // matching Home entry; warping would throw. Leave the NPC for a later sweep.
+                Monitor.Log(
+                    $"Cannot re-home NPC '{npc.Name}' ({reason}): DefaultMap "
+                        + $"'{npc.DefaultMap}' does not resolve after reloadDefaultLocation.",
+                    LogLevel.Warn
+                );
+                return;
+            }
+            npc.ClearSchedule();
+            Game1.warpCharacter(npc, target, npc.DefaultPosition / 64f);
+            branch = "unmarried";
+        }
+        else
+        {
+            // No character data — no canonical home to derive (mirrors Cabin.demolish's guard).
+            return;
+        }
+
+        Monitor.Log(
+            $"Re-homed NPC '{npc.Name}' ({branch}, {reason}): map '{beforeMap}' -> "
+                + $"'{npc.DefaultMap}', location '{beforeLocation}' -> "
+                + $"'{npc.currentLocation?.NameOrUniqueName}'",
+            logLevel
+        );
+        Diagnostics.ModEventLog.Emit(
+            "npc_rehomed",
+            new
+            {
+                npcName = npc.Name,
+                branch,
+                beforeMap,
+                afterMap = npc.DefaultMap ?? "",
+                beforeLocation,
+                afterLocation = npc.currentLocation?.NameOrUniqueName ?? "",
+                reason,
+            }
+        );
+    }
+
+    /// <summary>
+    /// Finds a cabin interior by NameOrUniqueName via farm-building iteration (lookup-cache
+    /// independent). Returns lobby/editing interiors too — callers classify via
+    /// LobbyService.IsLobbyCabin on the ParentBuilding.
+    /// </summary>
+    private static Cabin FindCabinInteriorByName(string locationName)
+    {
+        if (string.IsNullOrEmpty(locationName))
+        {
+            return null;
+        }
+
+        var farm = Game1.getFarm();
+        if (farm == null)
+        {
+            return null;
+        }
+
+        foreach (var building in farm.buildings)
+        {
+            if (!building.isCabin)
+            {
+                continue;
+            }
+
+            var cabin = building.GetIndoors<Cabin>();
+            if (cabin != null && cabin.NameOrUniqueName == locationName)
+            {
+                return cabin;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Finds the non-lobby cabin owned by the given player (matched by owner id or a defined
+    /// farmhandReference uid), or null. Mirrors the primary lookup of
+    /// PasswordProtectionService.FindPlayerCabin, which returns a warp handle — this one exists
+    /// so EnsureFarmhandRealHome can re-link fields on the farmhand's own cabin.
+    /// </summary>
+    private static Cabin FindOwnedCabin(long playerId)
+    {
+        var farm = Game1.getFarm();
+        if (farm == null)
+        {
+            return null;
+        }
+
+        foreach (var building in farm.buildings)
+        {
+            if (!building.isCabin || LobbyService.IsLobbyCabin(building))
+            {
+                continue;
+            }
+
+            var cabin = building.GetIndoors<Cabin>();
+            if (cabin == null)
+            {
+                continue;
+            }
+
+            if (cabin.owner?.UniqueMultiplayerID == playerId)
+            {
+                return cabin;
+            }
+
+            if (
+                cabin.farmhandReference.defined.Value
+                && cabin.farmhandReference.uid.Value == playerId
+            )
+            {
+                return cabin;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves a location name to a real (non-lobby) FarmHouse — a player cabin interior or
+    /// the main FarmHouse (host household) — or null. Never resolves lobby/editing interiors.
+    /// </summary>
+    private static FarmHouse ResolveRealFarmhouse(string name)
+    {
+        var cabin = FindCabinInteriorByName(name);
+        if (cabin != null)
+        {
+            return LobbyService.IsLobbyCabin(cabin.ParentBuilding) ? null : cabin;
+        }
+
+        return Game1.getLocationFromName(name) as FarmHouse;
+    }
+
+    private static bool IsLobbyOrEditingInterior(GameLocation location)
+    {
+        return location is Cabin cabin && LobbyService.IsLobbyCabin(cabin.ParentBuilding);
     }
 
     #endregion

--- a/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
+++ b/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using HarmonyLib;
+using JunimoServer.Services.CabinManager;
 using JunimoServer.Services.Lobby;
 using JunimoServer.Shared;
 using JunimoServer.Util;
@@ -23,6 +24,7 @@ public class PasswordProtectionService : ModService
     private readonly IModHelper _helper;
     private readonly IMonitor _monitor;
     private readonly LobbyService _lobbyService;
+    private readonly CabinManagerService _cabinManager;
     private static MethodInfo _sendLocationMethod;
 
     /// <summary>
@@ -56,7 +58,8 @@ public class PasswordProtectionService : ModService
         IModHelper helper,
         IMonitor monitor,
         Harmony harmony,
-        LobbyService lobbyService
+        LobbyService lobbyService,
+        CabinManagerService cabinManager
     )
         : base(helper, monitor)
     {
@@ -73,6 +76,7 @@ public class PasswordProtectionService : ModService
         _helper = helper;
         _monitor = monitor;
         _lobbyService = lobbyService;
+        _cabinManager = cabinManager;
 
         ServerPassword = Env.ServerPassword;
         MaxFailedAttempts = Env.MaxLoginAttempts;
@@ -275,65 +279,15 @@ public class PasswordProtectionService : ModService
     }
 
     /// <summary>
-    /// Ensures the player has a valid, real (non-lobby) cabin assignment after
-    /// vanilla's checkFarmhandRequest approves them. We treat homeLocation as
-    /// vanilla's source of truth: if it resolves to a real non-lobby Cabin, accept
-    /// it and return. Otherwise (empty / stale / lobby cabin), clear it and let
-    /// TryAssignFarmhandHome pick a fresh cabin via AssignFarmhand (which sets
-    /// both farmhandReference and homeLocation).
-    ///
-    /// We deliberately do NOT trigger reassignment based on farmhandReference.uid
-    /// mismatches — that field can be transiently out of sync with farmhandData
-    /// due to vanilla netcode timing. FindPlayerCabin handles ref desync at login.
+    /// Ensures the player has a valid, real (non-lobby) cabin assignment after vanilla's
+    /// checkFarmhandRequest approves them. Delegates to the shared reconciliation core in
+    /// CabinManagerService (ownership-first reassignment), which the load/day-start sweeps
+    /// also use. The join context deliberately skips the sweeps' lobby spawn-hint scrub —
+    /// those hints are what land the joining client in the lobby.
     /// </summary>
     private static void EnsureRealCabinAssignment(Farmer farmer)
     {
-        var home = farmer.homeLocation.Value;
-        string reason;
-        if (string.IsNullOrEmpty(home))
-        {
-            reason = "empty";
-        }
-        else
-        {
-            var currentHome = Game1.getLocationFromName(home);
-            if (currentHome is not Cabin homeCabin)
-            {
-                reason = "stale/missing cabin";
-            }
-            else if (
-                homeCabin.ParentBuilding != null
-                && LobbyService.IsLobbyCabin(homeCabin.ParentBuilding)
-            )
-            {
-                reason = "lobby cabin";
-            }
-            else
-            {
-                return; // happy path: homeLocation resolves to a real non-lobby cabin
-            }
-        }
-
-        _instance._monitor.Log(
-            $"[Auth] Clearing homeLocation '{home}' ({reason}) for '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID})",
-            LogLevel.Info
-        );
-        farmer.homeLocation.Value = "";
-
-        if (Game1.netWorldState.Value.TryAssignFarmhandHome(farmer))
-        {
-            _instance._monitor.Log(
-                $"[Auth] Reassigned '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID}) to real cabin: homeLocation='{farmer.homeLocation.Value}'",
-                LogLevel.Info
-            );
-        }
-        else
-        {
-            _instance._monitor.Log(
-                $"[Auth] TryAssignFarmhandHome failed for '{ChatRedaction.MaskValue(farmer.Name)}' (id={farmer.UniqueMultiplayerID}) - no available cabin",
-                LogLevel.Warn
-            );
-        }
+        _instance._cabinManager.EnsureFarmhandRealHome(farmer, CabinManagerService.HealContextJoin);
     }
 
     private static bool ProcessIncomingMessage_Prefix(IncomingMessage message)

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -684,6 +684,33 @@ public class TestStampClaimResponse
     public string HomeLocation { get; set; } = "";
 }
 
+/// <summary>
+/// Response from /test/stamp_lobby_home POST endpoint (test-only). Mirrors the server-side
+/// TestStampLobbyHomeResponse DTO. Reproduces the lobby-homed-spouse poisoned-save shape: a
+/// farmhand married (synthesized) to an NPC with both their home fields pointing at the shared
+/// lobby cabin interior, so the heal sweeps can be exercised live and across a reload.
+/// </summary>
+public class TestStampLobbyHomeResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("stampedUid")]
+    public long StampedUid { get; set; }
+
+    [JsonPropertyName("npc")]
+    public string Npc { get; set; } = "";
+
+    [JsonPropertyName("lobbyLocation")]
+    public string LobbyLocation { get; set; } = "";
+
+    [JsonPropertyName("originalHome")]
+    public string OriginalHome { get; set; } = "";
+}
+
 /// <summary>Body for /test/seed_import_source (test-only). Mirrors the server-side DTO.</summary>
 public class TestSeedImportSourceRequest
 {
@@ -1819,6 +1846,27 @@ public class ServerApiClient : IDisposable
         var response = await SendWithRetryAsync(HttpMethod.Post, "/test/stamp_claim", ct);
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestStampClaimResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: reproduce the lobby-homed-spouse poisoned-save shape — a farmhand married
+    /// (synthesized) to <paramref name="npc"/> with the farmhand's homeLocation/lastSleepLocation
+    /// and the NPC's DefaultMap/position pointing at the shared lobby cabin interior. Used to
+    /// verify the CabinManagerService heal sweeps restore both live (DayStarted) and across a
+    /// reload (SaveLoaded). POST /test/stamp_lobby_home
+    /// </summary>
+    public async Task<TestStampLobbyHomeResponse?> StampLobbyHome(
+        string npc,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            $"/test/stamp_lobby_home?npc={Uri.EscapeDataString(npc)}",
+            ct
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestStampLobbyHomeResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -185,4 +185,10 @@ public enum WaitName
     Polling_Wedding_BothClientsRenderedBoth,
     Polling_Wedding_HostRecoveredAfterCeremonies,
     Polling_Wedding_HostReturnedHomeAfterCeremonies,
+
+    // LobbyHomedSpouseTests.cs (4)
+    Polling_LobbyHome_EngagementReplicated,
+    Polling_LobbyHome_CeremoniesCompleted,
+    Polling_LobbyHome_SpousesInCabins,
+    Polling_LobbyHome_PoisonHealed,
 }

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
@@ -219,7 +219,13 @@ internal sealed class FarmerTestHelper
     {
         try
         {
-            var conn = new ConnectionHelper(clientLease.Client, serverApi: _testBase.ServerApi);
+            // Carry the server password so the join core's auto-login (!login) runs for the
+            // second farmer too — a password server otherwise leaves it stuck in the lobby.
+            var conn = new ConnectionHelper(
+                clientLease.Client,
+                new ConnectionOptions { ServerPassword = lease.Password },
+                serverApi: _testBase.ServerApi
+            );
             await lease.Managed.AcquireJoinGateAsync(ct);
             JoinWorldResult join;
             try

--- a/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
+++ b/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
@@ -1,0 +1,527 @@
+using JunimoServer.Tests.Clients;
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E regression gates for the lobby-homed-spouses bug: with password protection enabled, the
+/// lobby redirect used to write the lobby cabin into each joining farmhand's durable
+/// <c>homeLocation</c>. The client is authoritative for its own Farmer root, so its nightly
+/// full-root resend cloned the lobby home back into <c>farmhandData</c>, and
+/// <c>NPC.marriageDuties</c> — which reads the spouse-farmer's <c>homeLocation</c> raw every
+/// day-start, for offline farmhands too — re-homed NPC spouses into the ownerless lobby interior,
+/// whose level-0 bed spot renders as the reported <c>(-999,-999)</c>. Nothing healed the persisted
+/// state, and disabling the password disabled the only join-time repair.
+///
+/// <para>
+/// The fix is two-layered: <b>prevention</b> (the redirect no longer writes <c>homeLocation</c>;
+/// the transient spawn hints alone land the client in the lobby) and <b>reconciliation</b>
+/// (CabinManagerService heals lobby-poisoned farmhand homes and re-homes stranded NPCs at
+/// SaveLoaded — the poisoned-save migration — and at DayStarted — a tripwire that should find
+/// nothing once prevention is in place).
+/// </para>
+///
+/// <para>
+/// This class covers the password-ON steady state: two farmhands join through the lobby, marry
+/// NPCs, and their homes plus their spouses' locations must remain their real cabins across
+/// connected nights (each of which fires the client's full-root resend — the poison generator
+/// pre-fix) and across server-only nights after both disconnect (the reporter's 24/7
+/// offline-couple scenario). Assertions are pure API outcomes: a home that never leaves the real
+/// cabin and a spouse NPC that sleeps in it are exactly what the bug broke.
+/// </para>
+/// </summary>
+// Exclusive: mutates global calendar state (SetDate/SetTime/SetClockSpeed) and relies on the
+// server sleeping alone in the offline phase. Two clients — both couples present together,
+// matching the incident report (two farmhands' spouses vanished).
+[TestServer(
+    Clients = 2,
+    Password = "test-password-123",
+    Isolation = IsolationMode.SharedClass,
+    Exclusive = true
+)]
+public class LobbyHomedSpouseSteadyStateTests : TestBase
+{
+    // Land on a non-festival day that allows weddings (canHaveWeddingOnDay excludes festival
+    // days). Spring 2 → weddings fire spring 3.
+    private const string Season = "spring";
+    private const int EngageDay = 2;
+
+    private const string SpouseNpcA = "Abigail";
+    private const string SpouseNpcB = "Penny";
+
+    // Both clients play each ceremony as a real cutscene at CLIENT_TPS=5 — minutes, not seconds
+    // (see WeddingTests.CeremoniesResolveTimeout for the full cost breakdown).
+    private static readonly TimeSpan CeremoniesResolveTimeout = TimeSpan.FromSeconds(240);
+
+    [Fact]
+    public async Task MarriedCouples_UnderPassword_HomesStayRealAcrossNightsAndOffline()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var setDate = await ServerApi.SetDate(Season, EngageDay, year: 1, ct);
+        Assert.NotNull(setDate);
+        Assert.True(setDate.Success, $"SetDate({Season} {EngageDay}) failed: {setDate.Error}");
+
+        // Both farmhands join concurrently THROUGH THE LOBBY (password server): each lands in
+        // the lobby cabin, auto-authenticates via !login, and is warped to its real cabin.
+        var (farmhandA, farmhandBConn) = await Farmers.ConnectBothConcurrentlyAsync(
+            primaryPrefix: "LobbyHomeA",
+            secondaryPrefix: "LobbyHomeB",
+            ct: ct
+        );
+        await using var farmhandB = farmhandBConn;
+        var uidA = farmhandA.JoinResult.UniqueMultiplayerId;
+        var uidB = farmhandB.Uid;
+
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(uidA, ct: ct),
+            $"Farmhand A (uid={uidA}) must be present server-side after the concurrent join."
+        );
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(uidB, ct: ct),
+            $"Farmhand B (uid={uidB}) must be present server-side after the concurrent join."
+        );
+
+        // Capture each farmhand's REAL home right after the join. With prevention in place the
+        // client's copy is born with this value and every later read must still equal it — any
+        // drift (to the lobby or anywhere else) is the regression this test gates.
+        var (homeA, homeB) = await CaptureRealHomesAsync(uidA, uidB, ct);
+
+        // Engage both farmhands on their own clients (client-authoritative roots), wait for the
+        // engagements to replicate, then sleep through to the wedding day.
+        var engageA = await GameClient.Actions.EngageToNpc(SpouseNpcA, daysUntilWedding: 1);
+        Assert.True(
+            engageA?.Success == true && engageA.IsEngaged,
+            $"EngageToNpc({SpouseNpcA}) failed: {engageA?.Error}"
+        );
+        var engageB = await farmhandB.Client.Actions.EngageToNpc(SpouseNpcB, daysUntilWedding: 1);
+        Assert.True(
+            engageB?.Success == true && engageB.IsEngaged,
+            $"EngageToNpc({SpouseNpcB}) failed: {engageB?.Error}"
+        );
+
+        var hostSeesBoth = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_LobbyHome_EngagementReplicated,
+            async () =>
+            {
+                var a = await ServerApi.GetWeddingState(uidA, SpouseNpcA, ct);
+                var b = await ServerApi.GetWeddingState(uidB, SpouseNpcB, ct);
+                return a?.Success == true
+                    && a.FarmhandSpouse == SpouseNpcA
+                    && b?.Success == true
+                    && b.FarmhandSpouse == SpouseNpcB;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(hostSeesBoth, "Both engagements must replicate client→host before sleeping.");
+
+        // Night 1 (wedding night): both sleep, ceremonies fire next morning.
+        await SleepBothAndWaitForMorningAsync(farmhandB, ct);
+
+        // Both ceremonies must complete host-side (endBehaviors warps each spouse to the Farm).
+        var ceremoniesDone = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_LobbyHome_CeremoniesCompleted,
+            async () =>
+            {
+                var a = await ServerApi.GetWeddingState(uidA, SpouseNpcA, ct);
+                var b = await ServerApi.GetWeddingState(uidB, SpouseNpcB, ct);
+                var host = await ServerApi.GetWeddingState(ct: ct);
+                return a?.SpouseCurrentLocation == "Farm"
+                    && b?.SpouseCurrentLocation == "Farm"
+                    && host?.IsWeddingActive == false;
+            },
+            timeout: CeremoniesResolveTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ceremoniesDone,
+            "Both wedding ceremonies must complete (spouses warped to Farm, no active wedding)."
+        );
+
+        var marriedA = await ServerApi.GetWeddingState(uidA, SpouseNpcA, ct);
+        var marriedB = await ServerApi.GetWeddingState(uidB, SpouseNpcB, ct);
+        Assert.True(
+            marriedA?.FarmhandSpouse == SpouseNpcA && marriedB?.FarmhandSpouse == SpouseNpcB,
+            "Both farmhands must be married after the ceremonies "
+                + $"(A spouse={marriedA?.FarmhandSpouse}, B spouse={marriedB?.FarmhandSpouse})."
+        );
+
+        // Wedding morning: homes must still be the captured real cabins (the ceremony and the
+        // day transition around it must not have moved them).
+        await AssertHomesUnchangedAsync(uidA, homeA, uidB, homeB, "wedding morning", ct);
+
+        // Nights 2 and 3, both couples CONNECTED: each night fires the client's full-root
+        // resend — pre-fix, that was the poison generator under password. Each morning the
+        // homes must be unchanged and each spouse NPC must have been homed into the couple's
+        // real cabin by marriageDuties (pre-fix they'd sit in the lobby at (-999,-999)).
+        for (var night = 2; night <= 3; night++)
+        {
+            await SleepBothAndWaitForMorningAsync(farmhandB, ct);
+            await AssertHomesUnchangedAsync(uidA, homeA, uidB, homeB, $"morning {night}", ct);
+            await AssertSpousesInCabinsAsync(uidA, homeA, uidB, homeB, $"morning {night}", ct);
+        }
+
+        // Offline phase (the reporter's 24/7 scenario): both players disconnect, the server
+        // sleeps two nights alone. marriageDuties keeps running for OFFLINE farmhands, reading
+        // the persisted farmhandData homes — which must stay the real cabins.
+        await farmhandB.DisconnectAsync();
+        await DisconnectAsync();
+
+        for (var night = 4; night <= 5; night++)
+        {
+            await AdvanceDayServerOnlyAsync(ct);
+            await AssertHomesUnchangedAsync(
+                uidA,
+                homeA,
+                uidB,
+                homeB,
+                $"offline morning {night}",
+                ct
+            );
+            await AssertSpousesInCabinsAsync(
+                uidA,
+                homeA,
+                uidB,
+                homeB,
+                $"offline morning {night}",
+                ct
+            );
+        }
+
+        LogSuccess(
+            "Both couples stayed healthy under password protection: farmhand homes never left "
+                + $"their real cabins ({homeA}, {homeB}) across the wedding, two connected "
+                + "nights (nightly client full-root resends), and two server-only nights with "
+                + "both players offline — and both NPC spouses woke up inside those cabins every "
+                + "morning instead of the lobby."
+        );
+    }
+
+    /// <summary>
+    /// Reads both farmhands' homeLocation from /diagnostics/state and asserts they are real,
+    /// distinct cabin interiors ("FarmHouse&lt;guid&gt;", never the bare host "FarmHouse").
+    /// </summary>
+    private async Task<(string HomeA, string HomeB)> CaptureRealHomesAsync(
+        long uidA,
+        long uidB,
+        CancellationToken ct
+    )
+    {
+        var diag = await ServerApi.GetDiagnosticsState(ct);
+        Assert.NotNull(diag);
+        var entryA = diag.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == uidA);
+        var entryB = diag.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == uidB);
+        Assert.True(
+            entryA != null && entryB != null,
+            $"Both farmhands must appear in /diagnostics/state farmhandData "
+                + $"(A found={entryA != null}, B found={entryB != null})."
+        );
+
+        foreach (var (entry, label) in new[] { (entryA!, "A"), (entryB!, "B") })
+        {
+            Assert.True(
+                entry.HomeLocation.StartsWith("FarmHouse", StringComparison.Ordinal)
+                    && entry.HomeLocation.Length > "FarmHouse".Length,
+                $"Farmhand {label}'s home after join must be a cabin interior "
+                    + $"(FarmHouse<guid>), got '{entry.HomeLocation}'."
+            );
+        }
+        Assert.True(
+            entryA!.HomeLocation != entryB!.HomeLocation,
+            "The two farmhands must be homed at distinct cabins "
+                + $"(both at '{entryA.HomeLocation}')."
+        );
+
+        return (entryA.HomeLocation, entryB.HomeLocation);
+    }
+
+    private async Task SleepBothAndWaitForMorningAsync(
+        Infrastructure.Fixture.SecondFarmer farmhandB,
+        CancellationToken ct
+    )
+    {
+        var before = await ServerApi.GetStatus(ct);
+        Assert.NotNull(before);
+
+        var sleepA = await GameClient.Actions.Sleep();
+        Assert.True(sleepA?.Success == true, $"Farmhand A sleep failed: {sleepA?.Error}");
+        var sleepB = await farmhandB.Client.Actions.Sleep();
+        Assert.True(sleepB?.Success == true, $"Farmhand B sleep failed: {sleepB?.Error}");
+
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var (dayChanged, disconnected) = await DayChange.WaitAsync(
+                before.Day,
+                before.Season,
+                before.Year,
+                checkConnection: true,
+                ct
+            );
+            Assert.False(disconnected, "A farmhand disconnected during the sleep-through.");
+            Assert.True(
+                dayChanged,
+                $"Day did not advance past {before.Season} {before.Day} Y{before.Year}."
+            );
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+    }
+
+    /// <summary>
+    /// Advances one in-game day with NO clients connected: the host passes out at 2:00 AM
+    /// (same pattern as HostAutomationTests.HostPassesOut_WhenTimeReaches2AM).
+    /// </summary>
+    private async Task AdvanceDayServerOnlyAsync(CancellationToken ct)
+    {
+        var before = await ServerApi.GetStatus(ct);
+        Assert.NotNull(before);
+
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var dayChanged = await DayChange.WaitAsync(before.Day, before.Season, before.Year, ct);
+            Assert.True(
+                dayChanged,
+                $"Server-only day did not advance past {before.Season} {before.Day} Y{before.Year}."
+            );
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+    }
+
+    private async Task AssertHomesUnchangedAsync(
+        long uidA,
+        string homeA,
+        long uidB,
+        string homeB,
+        string when,
+        CancellationToken ct
+    )
+    {
+        var diag = await ServerApi.GetDiagnosticsState(ct);
+        Assert.NotNull(diag);
+        foreach (var (uid, expected, label) in new[] { (uidA, homeA, "A"), (uidB, homeB, "B") })
+        {
+            var entry = diag.FarmhandData.FirstOrDefault(f => f.UniqueMultiplayerId == uid);
+            Assert.True(entry != null, $"[{when}] Farmhand {label} missing from farmhandData.");
+            Assert.True(
+                expected == entry!.HomeLocation,
+                $"[{when}] Farmhand {label}'s homeLocation drifted from its real cabin: "
+                    + $"expected '{expected}', got '{entry.HomeLocation}'. A lobby value here is "
+                    + "the lobby-homed-spouses regression (client resend re-poisoning the home)."
+            );
+        }
+    }
+
+    /// <summary>
+    /// Polls until both spouse NPCs are physically inside their couple's real cabin — the
+    /// durable outcome marriageDuties produces from a healthy homeLocation. Pre-fix they'd be
+    /// warped to the lobby interior's (-999,-999) instead.
+    /// </summary>
+    private async Task AssertSpousesInCabinsAsync(
+        long uidA,
+        string homeA,
+        long uidB,
+        string homeB,
+        string when,
+        CancellationToken ct
+    )
+    {
+        var inCabins = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_LobbyHome_SpousesInCabins,
+            async () =>
+            {
+                var a = await ServerApi.GetWeddingState(uidA, SpouseNpcA, ct);
+                var b = await ServerApi.GetWeddingState(uidB, SpouseNpcB, ct);
+                return a?.SpouseCurrentLocation == homeA && b?.SpouseCurrentLocation == homeB;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        if (!inCabins)
+        {
+            var a = await ServerApi.GetWeddingState(uidA, SpouseNpcA, ct);
+            var b = await ServerApi.GetWeddingState(uidB, SpouseNpcB, ct);
+            Assert.Fail(
+                $"[{when}] Spouse NPCs are not inside their couples' cabins.\n"
+                    + $"  {SpouseNpcA}: at '{a?.SpouseCurrentLocation}' (expected '{homeA}')\n"
+                    + $"  {SpouseNpcB}: at '{b?.SpouseCurrentLocation}' (expected '{homeB}')\n"
+                    + "A lobby interior here is the reported bug: marriageDuties re-homing the "
+                    + "spouse into the lobby's level-0 (-999,-999) bed spot."
+            );
+        }
+    }
+}
+
+/// <summary>
+/// Covers the reconciliation layer against the reporter's actual save shape, on a PASSWORDLESS
+/// server — load-bearing, because the old join-time repair lived in PasswordProtectionService,
+/// whose constructor early-returns without a password (its patches never register), which is
+/// exactly why disabling the password permanently disabled the only heal. The sweeps live in
+/// CabinManagerService (unconditionally constructed), so they must work here.
+///
+/// <para>
+/// /test/stamp_lobby_home reproduces the poisoned state live: a shared lobby cabin (built at the
+/// lobby position; classification is position-based), a farmhand married (synthesized) to an NPC,
+/// the farmhand's homeLocation/lastSleepLocation and the NPC's DefaultMap/position all pointing
+/// at the lobby interior. One real day transition must heal everything (DayStarted sweep +
+/// marriageDuties interplay, the reporter's live scenario), and the healed state must survive a
+/// /reload (SaveLoaded sweep guards the disk path regardless of whether the nightly save was
+/// written before or after the DayStarted heal).
+/// </para>
+/// </summary>
+// Exclusive: mutates the calendar and farmhand/NPC state on the shared server.
+[TestServer(Clients = 0, Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class LobbyHomedSpouseHealTests : TestBase
+{
+    private const string SpouseNpc = "Abigail";
+
+    [Fact]
+    public async Task PoisonedLobbyHomes_HealOnDayStart_AndStayHealedAcrossReload()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The boot world becomes reachable (IsReady flips) a beat before its SaveLoaded
+        // handlers finish, so a stamp can race the boot's own SaveLoaded sweep — which would
+        // heal the poison instantly and leave the day-transition leg below testing nothing
+        // (observed live: stamp at T, boot save_loaded sweep at T+0.6s). No status field
+        // orders against SaveLoaded-handler completion, but /reload's completion contract
+        // does: it resolves only on the tick AFTER SaveLoaded, once every reconciliation
+        // handler has run. Reload first, then stamp into the quiescent world — nothing sweeps
+        // again until the next SaveLoaded/DayStarted, both of which this test drives itself.
+        var ready = await ServerApi.WaitForServerOnline(
+            TestTimings.DayChangeTimeout,
+            cancellationToken: ct,
+            requireInviteCode: false
+        );
+        Assert.True(ready?.IsReady == true, "Server must be ready before the settle reload.");
+        await ReloadServerAsync();
+
+        // Poison: lobby cabin + synthesized married couple, both homed at the lobby.
+        var stamp = await ServerApi.StampLobbyHome(SpouseNpc, ct);
+        Assert.NotNull(stamp);
+        Assert.True(stamp.Success, $"stamp_lobby_home failed: {stamp.Error}");
+        Assert.False(
+            string.IsNullOrEmpty(stamp.OriginalHome),
+            "Stamp must capture the farmhand's original real-cabin home."
+        );
+        Assert.NotEqual(stamp.OriginalHome, stamp.LobbyLocation);
+
+        // The poison must be visible through the API before the transition — otherwise a green
+        // result would prove nothing about the heal.
+        var poisoned = await ServerApi.GetDiagnosticsState(ct);
+        var poisonedEntry = poisoned?.FarmhandData.FirstOrDefault(f =>
+            f.UniqueMultiplayerId == stamp.StampedUid
+        );
+        Assert.True(
+            poisonedEntry?.HomeLocation == stamp.LobbyLocation,
+            $"Stamped farmhand must read lobby-homed pre-heal "
+                + $"(home='{poisonedEntry?.HomeLocation}', lobby='{stamp.LobbyLocation}')."
+        );
+        var poisonedNpc = await ServerApi.GetWeddingState(stamp.StampedUid, SpouseNpc, ct);
+        Assert.True(
+            poisonedNpc?.SpouseCurrentLocation == stamp.LobbyLocation,
+            $"Stamped NPC must sit in the lobby pre-heal "
+                + $"(at '{poisonedNpc?.SpouseCurrentLocation}')."
+        );
+
+        // One real day transition, server alone (host passes out at 2:00 AM).
+        var before = await ServerApi.GetStatus(ct);
+        Assert.NotNull(before);
+        await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+        await ServerApi.SetClockSpeed(20, ct);
+        try
+        {
+            var dayChanged = await DayChange.WaitAsync(before.Day, before.Season, before.Year, ct);
+            Assert.True(dayChanged, "Day did not advance for the heal transition.");
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+
+        // The DayStarted sweep must restore the farmhand to their OWN cabin (ownership-first
+        // reassignment via the cabin's farmhandReference), scrub the lobby sleep hint, and pull
+        // the NPC into that cabin.
+        var healed = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_LobbyHome_PoisonHealed,
+            async () => await ReadCoupleHealedAsync(stamp, ct),
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        if (!healed)
+        {
+            await FailWithCoupleStateAsync("after the day transition", stamp, ct);
+        }
+
+        // The heal must survive a reload. /reload completion is gated on SaveLoaded (all
+        // CabinManagerService handlers done), so the first post-reload read is authoritative.
+        // The nightly save is written BEFORE the DayStarted sweep runs (log-verified: the
+        // reloaded world re-heals with context=save_loaded), so this leg loads a genuinely
+        // poisoned disk save and exercises the SaveLoaded migration — the reporter's
+        // restore-a-poisoned-save scenario.
+        await ReloadServerAsync();
+        if (!await ReadCoupleHealedAsync(stamp, ct))
+        {
+            await FailWithCoupleStateAsync("after /reload", stamp, ct);
+        }
+
+        LogSuccess(
+            $"Lobby-poisoned couple healed: farmhand {stamp.StampedUid} restored to its own "
+                + $"cabin '{stamp.OriginalHome}' (from lobby '{stamp.LobbyLocation}'), "
+                + $"{SpouseNpc} re-homed into that cabin, and the heal survived a /reload."
+        );
+    }
+
+    private async Task<bool> ReadCoupleHealedAsync(
+        TestStampLobbyHomeResponse stamp,
+        CancellationToken ct
+    )
+    {
+        var diag = await ServerApi.GetDiagnosticsState(ct);
+        var entry = diag?.FarmhandData.FirstOrDefault(f =>
+            f.UniqueMultiplayerId == stamp.StampedUid
+        );
+        if (entry == null)
+        {
+            return false;
+        }
+
+        var npcState = await ServerApi.GetWeddingState(stamp.StampedUid, SpouseNpc, ct);
+        return entry.HomeLocation == stamp.OriginalHome
+            && entry.LastSleepLocation == stamp.OriginalHome
+            && npcState?.SpouseCurrentLocation == stamp.OriginalHome;
+    }
+
+    private async Task FailWithCoupleStateAsync(
+        string when,
+        TestStampLobbyHomeResponse stamp,
+        CancellationToken ct
+    )
+    {
+        var diag = await ServerApi.GetDiagnosticsState(ct);
+        var entry = diag?.FarmhandData.FirstOrDefault(f =>
+            f.UniqueMultiplayerId == stamp.StampedUid
+        );
+        var npcState = await ServerApi.GetWeddingState(stamp.StampedUid, SpouseNpc, ct);
+        Assert.Fail(
+            $"Lobby-poisoned couple not healed {when}.\n"
+                + $"  farmhand home: '{entry?.HomeLocation}' (expected '{stamp.OriginalHome}', "
+                + $"poison was '{stamp.LobbyLocation}')\n"
+                + $"  farmhand lastSleep: '{entry?.LastSleepLocation}' (expected "
+                + $"'{stamp.OriginalHome}')\n"
+                + $"  {SpouseNpc} location: '{npcState?.SpouseCurrentLocation}' (expected "
+                + $"'{stamp.OriginalHome}')"
+        );
+    }
+}

--- a/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
+++ b/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
@@ -169,6 +169,11 @@ public class LobbyHomedSpouseSteadyStateTests : TestBase
         // the persisted farmhandData homes — which must stay the real cabins.
         await farmhandB.DisconnectAsync();
         await DisconnectAsync();
+        Assert.True(
+            await ServerApi.WaitForPlayersRemovedByIdAsync(new[] { uidA, uidB }, ct: ct),
+            "Both farmhands must be removed server-side before the server-only nights — "
+                + "otherwise marriageDuties still reads their live roots, not farmhandData."
+        );
 
         for (var night = 4; night <= 5; night++)
         {


### PR DESCRIPTION
Fixes #464 — NPC spouses (and farmhand homes) stranded in the password lobby's cabin interior at `(-999,-999)`.

**Root cause**: with `SERVER_PASSWORD` set, the lobby redirect wrote the lobby cabin into each joining farmhand's durable `homeLocation`. The client is authoritative for its own Farmer root, so its nightly full-root resend cloned the lobby home back into `farmhandData`; `NPC.marriageDuties` reads the spouse-farmer's `homeLocation` raw at every day-start — for offline farmhands too — and warped NPC spouses into the ownerless lobby interior, whose level-0 bed-spot fallback renders as the reported `(-999,-999)`. Disabling the password permanently disabled the only join-time repair, since `PasswordProtectionService` no-ops without a password.

## Changes

- **Prevention**: `ApplyLobbyRedirectToFarmhand` no longer writes `homeLocation`; the transient spawn hints (`disconnect*`, `lastSleep*`) alone land the joining client in the lobby. The lobby containment path is unchanged.
- **Reconciliation** in `CabinManagerService` (unconditionally constructed, so it works with the password off):
  - `EnsureFarmhandRealHome`: ownership-first reassignment (farmhand's own cabin via owner/`farmhandReference` → vanilla `TryAssignFarmhandHome` → build-and-retry), plus scrubbing of lobby-poisoned `lastSleepLocation`/`disconnectLocation` spawn hints. Heals both the persisted `farmhandData` entry and the live `otherFarmers` root per UID. Married farmhands are never left home-less (`marriageDuties` crash guard).
  - `ReHomeNpc` / `HealLobbyHomedResidents`: re-homes married NPCs into the healed spouse home (`DefaultMap` + `DefaultPosition` together), unmarried villagers to their village home, children to the parent's home, pets to the Farm. Also covers NPCs left with a dangling `DefaultMap` by lobbies destroyed on older builds. Unified with the cabin-destroy reset path.
  - Wired at **SaveLoaded** (one-shot migration for already-poisoned saves, e.g. the reporter's) and **DayStarted** (tripwire, Warn-level — steady state is zero heals; any heal there signals an unknown ingress route).
- `PasswordProtectionService.EnsureRealCabinAssignment` delegates to the shared core instead of duplicating detection/reassignment.
- **Tests**:
  - `LobbyHomedSpouseSteadyStateTests`: password server, two farmhands join through the lobby, marry NPCs, homes + spouse locations asserted every morning across two connected nights (nightly client resends, the old poison generator) and two server-only nights (the reporter's 24/7 offline-couple scenario). Zero heal events in the server log confirms prevention rather than daily re-healing.
  - `LobbyHomedSpouseHealTests`: new `/test/stamp_lobby_home` endpoint reproduces the poisoned save shape on a passwordless server; one day transition heals farmhand + NPC (DayStarted), and the heal survives `/reload`, which loads the genuinely poisoned disk save (SaveLoaded migration).
  - The second concurrent test farmer now inherits the server password for auto-login (`FarmerTestHelper`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented married farmhands and their spouses from being assigned to shared-lobby cabins.
  * Added automatic “lobby-homed” recovery to repair farmhand homes, sleep locations, and spouse residence locations during joins and save/day-start healing.
  * Improved consistency for both connected and offline scenarios across multiple in-game days and reloads.
* **Tests**
  * Added end-to-end coverage validating persistent spouse housing and ensuring corrupted lobby-home assignments heal and remain fixed after reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->