### PR TITLE
test: surface image-build errors in the CLI, clean up rules/docs

### DIFF
--- a/.claude/archive/plans/bugs/polybar-rosetta-fork-crash.md
+++ b/.claude/archive/plans/bugs/polybar-rosetta-fork-crash.md
@@ -1,0 +1,132 @@
+# Server container aborts on ARM hosts: polybar dies on any fork under Rosetta → supervisor tears the container down
+
+Status: root-caused + fix planned (this plan). Not implemented yet.
+
+## Incident
+
+First run against a remote Apple-Silicon host (`.env.test` fleet = single `mac` entry,
+OrbStack daemon, `docker_preflight` reports `architecture: aarch64`, amd64 images run
+under Rosetta). Every server container exited with code 1 before the game ever started;
+all tests failed/canceled as infrastructure (run `2026-07-12T00-22-07Z_3d5be35`:
+0 passed / 32 failed / 118 canceled, `failure.json` on server-0..5).
+
+Container log (identical on every server-N):
+
+```
+[supervisor    ] starting service 'polybar'...
+[supervisor    ] service 'polybar' failed to be started: not ready after 10000 msec, giving up.
+[supervisor    ] stopping service 'polybar'...        ← teardown of everything follows
+```
+
+The `gpu` host flag is unrelated (tried both). client-0 was unaffected (test-client
+image has no polybar service).
+
+## Root cause chain
+
+1. `services.d/gui/polybar.dep` gates the `gui` service (game startup) on polybar
+   readiness; a not-ready service makes the jlesage supervisor abort the container.
+   (This also disproves `.claude/rules/startup-cold-start-measurement.md:18` —
+   "polybar + resize-handler … don't gate startup". They do gate it, fatally.)
+2. `services.d/polybar/is_ready` = `pgrep polybar`. It stayed false for the whole 10s
+   window because polybar dies ~instantly after launch, every respawn.
+3. **polybar 3.5.5 crashes with a spurious "Termination signal received, shutting
+   down..." the moment it forks any child process under Rosetta** (multithreaded
+   translated process + fork → stray SIGINT/TERM/QUIT to the parent). Our bar config
+   includes `module/taskbar` (`custom/script` → `taskbar.sh`), which forks at startup.
+
+Bisection evidence (all reproduced directly on the mac, `sdvd/server:local`,
+Xvnc up, with and without openbox):
+
+| Variant | Result |
+|---|---|
+| Full config (taskbar module) | DEAD < 3s, "Termination signal received" |
+| Minimal config, `internal/date` only | ALIVE |
+| Full config minus taskbar (launcher / rendering-toggle / date) | ALIVE |
+| Full config, taskbar → trivial `custom/script` `exec = echo hi` | DEAD — **any fork kills it** |
+| `taskbar.sh` standalone (no polybar) | fine — the script is innocent |
+
+Click actions also fork, so even a "fixed" bar would crash on every button press
+under Rosetta. Combined with the bar being pure eyecandy, the decision is to
+**remove polybar and the surrounding GUI garnish entirely** rather than patch around it.
+
+## Pixel-safety evidence
+
+Frames extracted from a healthy local recording
+(`runs/2026-06-30T19-28-04Z_864566d/containers/server-0/full_recording.mp4`, frame 5
+and last-3s) show the game window at 0,0 filling the entire 640×360 display. Polybar,
+wallpaper, and openbox margins are never visible in recordings — no test, recorder,
+or validator can depend on them (`grep` of tests/tools: zero hits). Removal only
+uncovers game pixels.
+
+## Fix inventory
+
+### Delete
+
+- `docker/rootfs/etc/services.d/polybar/` (run, is_ready, respawn, disabled)
+- `docker/rootfs/etc/services.d/resize-handler/` + `opt/base/bin/resize-handler.sh` —
+  it never performed the VNC resize itself (TigerVNC/xrandr handles that natively);
+  its only jobs were "restart polybar" and "re-apply wallpaper" on resize, both dead
+  after this cleanup
+- `docker/rootfs/etc/services.d/gui/` — our overlay dir only holds `polybar.dep` +
+  `resize-handler.dep`; the base image's own `gui` service is untouched
+- `docker/rootfs/root/.config/polybar/` (config.ini, user_modules.ini)
+- `docker/rootfs/opt/base/bin/taskbar.sh`
+- `docker/rootfs/opt/base/bin/toggle-rendering.sh` — only caller was the bar's click
+  button; function survives via `POST /rendering?fps=N` or
+  `echo "rendering 10" > /tmp/smapi-input`
+- `docker/rootfs/data/images/wallpaper-junimo-server.png`, `wallpaper-sdv.png`
+  (`junimo.png` stays — WebVNC icon)
+- `docker/rootfs/opt/base/etc/openbox/keybinds.xml` (contains only commented-out rofi
+  binds) + its `xi:include` in `rc.xml.template:564`
+
+### Edit
+
+- `docker/Dockerfile`
+  - apt line: drop `polybar`, `rofi`, `slop`, `wmctrl`, `xwallpaper`, `exa`, `scrot`,
+    `x11-utils` (only consumers were taskbar.sh/resize-handler.sh xprop/xev/xrandr;
+    smoke test confirms the base image doesn't need it)
+  - drop the whole "Install polybar theme" section (adi1090x clone, shades configs,
+    fantasque/iosevka fonts — all polybar-only)
+- `docker/rootfs/startapp.sh` — delete `init_gui()` (polybar comment block,
+  `colors-dark.sh` theme call, wallpaper) and its call site
+- `docker/rootfs/opt/base/etc/openbox/rc.xml.template` — remove the reserved-margins
+  block (17px bottom/left/right + "Top is controlled by polybar" comment); margins are
+  inert for the fullscreen game window
+- `.claude/rules/startup-cold-start-measurement.md:18` — the "polybar +
+  resize-handler … don't gate startup" claim is wrong and becomes moot; fix the line
+
+### Keep (verified consumers)
+
+| Package | Consumer |
+|---|---|
+| `curl` | image `HEALTHCHECK`, startapp.sh |
+| `tcpdump` | in-image `netdebug` tool spawns it |
+| `htop`, `nano` | operator-shell utilities (explicitly retained; cheap) |
+| `procps` | `pgrep` in base scripts |
+| locales + CJK cont-init font | game fonts (`chat-font-language-tag.md`) |
+| tmux, ffmpeg, mesa-utils, TigerVNC | CLI attach / recording / rendering |
+
+## Verification
+
+1. `make build-server` locally; then artifact check per
+   `verify-edit-landed-in-artifact.md`: `docker create` + `docker cp` — confirm
+   `/etc/services.d/polybar` is absent from the image (rootfs COPY is server-image only).
+2. Smoke on the mac: run the image; supervisor must reach `app`/`gui` with no 10s
+   polybar abort; xvnc/openbox up.
+3. Full loop: `make test FILTER=<one small class>` against the mac fleet.
+
+## Expectation
+
+This removes the container-fatal blocker on ARM hosts. Whether Stardew + SMAPI itself
+runs correctly under Rosetta is the next unknown — step 3 above is where it surfaces.
+
+## Related, not in this plan
+
+Image-build failures surface poorly in the CLI: build output streams as
+`SetupStepStatus.InProgress` (spinner-only in `CIRenderer`), and the thrown
+`InvalidOperationException` carries only the exit code, so the operator sees
+`Building server image failed with exit code 2.` without the underlying
+`docker buildx` error line (and `make`'s `*** Error` trailer is noise when it does
+appear). Fix separately in `DockerImageBuilder.RunBuildCommand`: keep a bounded tail
+of build output, filter `^make(\[\d+\])?: \*\*\*` lines, include the tail in the
+exception message.

--- a/.claude/plans/bugs/issue-157-xvnc-host-networking.md
+++ b/.claude/plans/bugs/issue-157-xvnc-host-networking.md
@@ -19,8 +19,7 @@ evidence-backed reply, not two.
   check, and the 10 000 ms timeout all come from the base image
   `jlesage/baseimage-gui:debian-11-v4.11.3` (`docker/Dockerfile:129`) and its
   `cinit` supervisor — not this repo. There is no `is_ready` override for xvnc
-  here (repo-managed `polybar` and `resize-handler` have `is_ready` scripts;
-  xvnc has only `run`), so nothing in this repo can change the readiness
+  here (xvnc has only `run`), so nothing in this repo can change the readiness
   behavior without a base-image-level override.
 - The repo's `docker-compose.yml` uses default bridge networking (no
   `network_mode` anywhere); the failure is reported only under the non-default

--- a/.claude/plans/features/docker-arm64.md
+++ b/.claude/plans/features/docker-arm64.md
@@ -16,7 +16,7 @@
 
 | Native arm64 | Emulated x86-64 under box64 |
 |---|---|
-| Base image, supervisor/services, Xvfb/Xvnc, polybar | `StardewModdingAPI` → game process, incl. its bundled .NET 6 runtime |
+| Base image, supervisor/services, Xvfb/Xvnc | `StardewModdingAPI` → game process, incl. its bundled .NET 6 runtime |
 | ffmpeg (BtbN publishes `linuxarm64` builds), go2rtc (`arm64` asset), tmux | All game-side native libs: SDL2, OpenAL, `libGalaxy64.so`, `libGalaxyCSharpGlue.so`, `steamclient.so`, SkiaSharp, lz4 |
 | `steam-service` sidecar (SteamKit2, pure managed — runs unchanged) | — |
 

--- a/.claude/rules/debugging.md
+++ b/.claude/rules/debugging.md
@@ -6,7 +6,7 @@ paths:
 
 # LogLevel.Error in mod code is test poison
 
-Logging at `LogLevel.Error` (or any line matching `\b(ERROR|FATAL)\b`) from mod code triggers `ServerContainer`'s error cancellation. Use `LogLevel.Warn` or `LogLevel.Trace` for benign-but-noteworthy conditions.
+Logging at `LogLevel.Error` (or any line matching `\b(ERROR|FATAL)\b`) from mod code triggers `ServerContainer`'s error cancellation. Use `LogLevel.Warn` or `LogLevel.Trace` for benign-but-noteworthy conditions. The scan also treats an unprefixed `Process terminated.` line (.NET FailFast, e.g. missing libicu) as fatal, so a runtime hard-crash fails startup instead of masquerading as a transport timeout.
 
 **Why:** `tests/JunimoServer.Tests/Containers/ServerContainer.cs` regex-matches SMAPI log-line headers against `\b(ERROR|FATAL)\b`. A match cancels `_errorCancellation`, which `ManagedServer` ties into test cancellation. The mod has no in-band signal that a log line poisoned a test; the failure surfaces as a downstream timeout or assertion. Multiple times mod code has logged at Error for recoverable conditions and silently failed unrelated tests.
 

--- a/.claude/rules/startup-cold-start-measurement.md
+++ b/.claude/rules/startup-cold-start-measurement.md
@@ -15,7 +15,6 @@ paths:
 **Already-verified dead ends — do NOT re-investigate as boot-band perf wins:**
 - **Xvnc/X cannot be removed.** A live `GraphicsDevice` is needed even at `SERVER_FPS=0` (`RenderingController.ShouldGameDraw` does `GraphicsDevice.Clear`, `RenderingController.cs:108`; MapUtil/ApiService need it).
 - **OpenAPI DLLs are load-bearing** — the spec is generated live at runtime (`ApiService.cs:1580`, `OpenApiGenerator.Generate`).
-- **polybar + resize-handler boot in parallel** with `app` and don't gate startup.
 - **`ntpdate` is absent**, so `init_time_sync` is a few ms, not a stall.
 - A large fraction of the local boot band is **intrinsic Mono + SMAPI Cecil assembly-rewrite bootstrap** — not addressable in the Docker/rootfs layer.
 

--- a/.env.test.example
+++ b/.env.test.example
@@ -37,8 +37,8 @@
 #                `-i {key} -o IdentitiesOnly=yes` to every ssh invocation for
 #                this host. Omit to fall back to ~/.ssh/config + ssh-agent.
 #   socketPath   optional, remote hosts only. Daemon Unix socket on the remote
-#                (default: /var/run/docker.sock). Override e.g.
-#                ~/.docker/run/docker.sock for macOS Docker Desktop.
+#                (default: /var/run/docker.sock). Set only for daemons
+#                listening elsewhere, e.g. rootless Docker.
 #
 # Each test's server and clients run on the same host. Reuse-on-host
 # scheduling: the runner picks a host first, then prefers a matching

--- a/docs/developers/testing/remote-host-setup.md
+++ b/docs/developers/testing/remote-host-setup.md
@@ -13,7 +13,7 @@ How to configure `SDVD_DOCKER_HOSTS` for multi-host runs and how `STEAM_ACCOUNTS
 | `clientSlots` | yes | Concurrent client containers this host can run. Sets the upper bound on how many clients a server on this host can serve concurrently. |
 | `endpoint` | no | `ssh://user@machine` for remote daemons. Omit for the local Docker daemon. |
 | `sshKey` | no | Either a path to a private key (relative paths anchor at the project root, `~` is expanded), or inline key material (a `-----BEGIN…` block, written to a 0600 temp file — used in CI so the whole `SDVD_DOCKER_HOSTS` JSON, key included, can live in one secret). Omit to use `~/.ssh/config` + ssh-agent. |
-| `socketPath` | no | Remote Unix socket path. Defaults to `/var/run/docker.sock` (the standard Docker location). Override for hosts where the daemon listens elsewhere — most commonly macOS Docker Desktop's per-user `~/.docker/run/docker.sock`. Ignored for local entries. |
+| `socketPath` | no | Remote daemon Unix socket. Standard Docker installs serve the default `/var/run/docker.sock` — omit it. Set only when the daemon listens elsewhere, e.g. rootless Docker (`/run/user/<uid>/docker.sock`). Ignored for local entries. |
 | `gpu` | no | `true` if this host has an NVIDIA GPU + Container Toolkit. Defaults to `false`. Per-host so a fleet can mix GPU workstations and CPU-only VPSes. |
 | `concurrentStarts` | no | Cap on simultaneous `docker create+start` calls against this daemon. When omitted, falls back to `SDVD_MAX_CONCURRENT_STARTS` (if set) and otherwise to this host's `serverSlots + clientSlots`. Independent across hosts. |
 
@@ -24,7 +24,7 @@ Example:
   {"id": "local", "serverSlots": 3, "clientSlots": 6, "gpu": true},
   {"id": "vps",  "endpoint": "ssh://sdvd-runner@10.0.0.2", "sshKey": "~/.ssh/sdvd_runner",
                  "serverSlots": 2, "clientSlots": 4},
-  {"id": "mac",  "endpoint": "ssh://dev@mac.local", "socketPath": "~/.docker/run/docker.sock",
+  {"id": "rootless", "endpoint": "ssh://dev@rootless-vps", "socketPath": "/run/user/1000/docker.sock",
                  "serverSlots": 1, "clientSlots": 2}
 ]
 ```

--- a/tests/JunimoServer.Tests/Helpers/DockerImageBuilder.cs
+++ b/tests/JunimoServer.Tests/Helpers/DockerImageBuilder.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using JunimoServer.Tests.Schema.Json;
 
 namespace JunimoServer.Tests.Helpers;
@@ -29,6 +30,16 @@ public static class DockerImageBuilder
     private static readonly SemaphoreSlim BuildSemaphore = new(1, 1);
     private const int FileLockMaxRetries = 5;
     private static readonly TimeSpan FileLockRetryDelay = TimeSpan.FromSeconds(2);
+
+    // Recent-output tail kept for build-failure messages.
+    private const int FailureTailLines = 30;
+
+    // make's "*** [target] Error N" recipe trailer — restates the exit code
+    // without adding signal; filtered out of the failure tail.
+    private static readonly Regex MakeErrorTrailer = new(
+        @"^\s*make(\[\d+\])?: \*\*\*",
+        RegexOptions.Compiled
+    );
 
     private static readonly string ImageTag =
         Environment.GetEnvironmentVariable("SDVD_IMAGE_TAG") ?? "local";
@@ -365,6 +376,30 @@ public static class DockerImageBuilder
             Process.Start(startInfo)
             ?? throw new InvalidOperationException($"Failed to start '{command} {arguments}'");
 
+        // Bounded tail of recent output for the failure message: the CI renderer
+        // shows InProgress lines only as a transient spinner label, so without
+        // this the operator sees the exit code but never the underlying error.
+        var outputTail = new Queue<string>(FailureTailLines);
+        var outputTailLock = new object();
+
+        void CaptureTail(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            lock (outputTailLock)
+            {
+                if (outputTail.Count == FailureTailLines)
+                {
+                    outputTail.Dequeue();
+                }
+
+                outputTail.Enqueue(line);
+            }
+        }
+
         // Read stdout / stderr in parallel via local async functions. ReadLineAsync
         // is fully async on .NET 6+; wrapping in Task.Run added thread-pool overhead
         // without any concurrency benefit. Each line streams through the progress
@@ -374,6 +409,7 @@ public static class DockerImageBuilder
             while (await process.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
             {
                 progress.Step(stepName, SetupStepStatus.InProgress, line);
+                CaptureTail(line);
             }
         }
 
@@ -382,6 +418,7 @@ public static class DockerImageBuilder
             while (await process.StandardError.ReadLineAsync().ConfigureAwait(false) is { } line)
             {
                 progress.Step(stepName, SetupStepStatus.InProgress, line);
+                CaptureTail(line);
             }
         }
 
@@ -405,11 +442,19 @@ public static class DockerImageBuilder
 
         if (process.ExitCode != 0)
         {
-            // Streamed InProgress events above already carried each line through the
-            // progress sink; the InvalidOperationException then surfaces as
-            // SetupStepStatus.Failed in the calling BuildAndEmitStatus.
+            string[] tailLines;
+            lock (outputTailLock)
+            {
+                tailLines = outputTail.Where(l => !MakeErrorTrailer.IsMatch(l)).ToArray();
+            }
+
+            var tailBlock =
+                tailLines.Length > 0
+                    ? $" Last output:{Environment.NewLine}  "
+                        + string.Join($"{Environment.NewLine}  ", tailLines)
+                    : "";
             throw new InvalidOperationException(
-                $"Building {description} failed with exit code {process.ExitCode}."
+                $"Building {description} failed with exit code {process.ExitCode}.{tailBlock}"
             );
         }
     }

--- a/tests/JunimoServer.Tests/Infrastructure/HostPool.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/HostPool.cs
@@ -21,8 +21,8 @@ namespace JunimoServer.Tests.Infrastructure;
 /// <c>endpoint</c> (omit for local daemon, or <c>ssh://user@host</c>),
 /// <c>sshKey</c> (either a path to a private key — <c>~</c>-expanded — or inline
 /// <c>-----BEGIN…</c> key material, which is written to a 0600 temp file), and
-/// <c>socketPath</c> (remote Unix socket; defaults to <c>/var/run/docker.sock</c>,
-/// override e.g. <c>~/.docker/run/docker.sock</c> for macOS Docker Desktop).
+/// <c>socketPath</c> (remote Unix socket; defaults to <c>/var/run/docker.sock</c> —
+/// set only for daemons listening elsewhere, e.g. rootless Docker).
 /// </para>
 /// <example>
 /// <code>
@@ -30,7 +30,7 @@ namespace JunimoServer.Tests.Infrastructure;
 ///   {"id": "local", "serverSlots": 3, "clientSlots": 6},
 ///   {"id": "vps",   "endpoint": "ssh://sdvd-runner@10.0.0.2", "sshKey": "~/.ssh/sdvd_runner",
 ///                   "serverSlots": 2, "clientSlots": 4},
-///   {"id": "mac",   "endpoint": "ssh://dev@mac.local", "socketPath": "~/.docker/run/docker.sock",
+///   {"id": "rootless", "endpoint": "ssh://dev@rootless-vps", "socketPath": "/run/user/1000/docker.sock",
 ///                   "serverSlots": 1, "clientSlots": 2}
 /// ]'
 /// </code>
@@ -384,7 +384,7 @@ public sealed class HostPool : IAsyncDisposable
     /// (the local daemon is reached via OS default endpoint, no socket-path
     /// concept on this side). Defaults to <c>/var/run/docker.sock</c> for
     /// remote entries; override for hosts where the daemon listens elsewhere
-    /// (macOS Docker Desktop: <c>~/.docker/run/docker.sock</c>). The path is
+    /// (e.g. rootless Docker: <c>/run/user/&lt;uid&gt;/docker.sock</c>). The path is
     /// not expanded coordinator-side — it's threaded into the remote
     /// <c>ssh -L &lt;port&gt;:&lt;path&gt;</c> command and resolved by the remote shell.
     /// </summary>
@@ -441,8 +441,8 @@ public sealed class HostPool : IAsyncDisposable
         /// <summary>
         /// Remote Unix socket path for the daemon. Defaults to
         /// <c>/var/run/docker.sock</c> when omitted. Override for hosts whose
-        /// daemon listens elsewhere — most commonly macOS Docker Desktop, which
-        /// uses <c>~/.docker/run/docker.sock</c> per-user. Ignored for local
+        /// daemon listens elsewhere — e.g. rootless Docker's per-user
+        /// <c>/run/user/&lt;uid&gt;/docker.sock</c>. Ignored for local
         /// entries (no SSH endpoint).
         /// </summary>
         [JsonPropertyName("socketPath")]


### PR DESCRIPTION
## Changes

- Image-build failures now include the last 30 lines of build output in the error message
  (make's `*** Error N` trailer filtered out) — previously the CLI showed only the exit code
  while the actual docker error lived in a transient spinner label
- `debugging.md`: document the unprefixed `Process terminated.` (.NET FailFast) fatal-log
  pattern added in #473
- Archive the completed GUI-removal plan; drop stale polybar/resize-handler references from
  remaining plans and rules
- Generalize `socketPath` guidance (docs, `.env.test.example`, `HostPool.cs` comments): the
  default `/var/run/docker.sock` works for standard installs; set only for daemons listening
  elsewhere, e.g. rootless Docker
