### PR TITLE
fix(test-ui): honor test_enrichment outcome so reclassified tests render canceled

### DIFF
--- a/tests/test-ui/src/composables/useTestStore.ts
+++ b/tests/test-ui/src/composables/useTestStore.ts
@@ -501,10 +501,9 @@ export function useTestStore(): TestStore {
     }
 
     // Apply a terminal outcome to a test: transition counts, set status, mark the
-    // tree dirty, and hand off auto-selection if a failure was demoted off the
-    // selected slot. Works from any current status (transitionStatus rebalances
-    // whatever was there) and no-ops when status already matches, so it is safe to
-    // call from both producers in either order.
+    // tree dirty, and reconcile auto-selection. Works from any current status
+    // (transitionStatus rebalances whatever was there) and no-ops when status
+    // already matches, so it is safe to call from both producers in either order.
     function setTerminalOutcome(test: TestSnapshot, outcome: "passed" | "failed" | "canceled") {
         if (test.status === outcome) {
             return;
@@ -512,11 +511,17 @@ export function useTestStore(): TestStore {
         transitionStatus(test.status, outcome);
         test.status = outcome;
         markTreeDirty();
-        // A failure demoted off the selected slot (e.g. failed→canceled) hands the
-        // headline back to the freshest remaining real failure; if none remain the
-        // selection stays put (a canceled test never auto-selects, but we don't
-        // proactively deselect either — matching the pre-fix test_failed behavior).
-        if (outcome !== "failed" && selectedTest.value?.displayName === test.displayName) {
+        if (outcome === "failed") {
+            // A genuine failure — including one enrichment upgraded from canceled after
+            // test_failed's OCE guess already skipped selection — jumps to the headline,
+            // matching test_failed's own auto-select. The status===outcome early-return
+            // above keeps an already-failed re-apply from re-selecting.
+            autoSelect(test);
+        } else if (selectedTest.value?.displayName === test.displayName) {
+            // A failure demoted off the selected slot (e.g. failed→canceled) hands the
+            // headline back to the freshest remaining real failure; if none remain the
+            // selection stays put (a canceled test never auto-selects, but we don't
+            // proactively deselect either — matching the pre-fix test_failed behavior).
             const next = findMostRecentFailure();
             if (next) {
                 autoSelect(next);

--- a/tests/test-ui/src/composables/useTestStore.ts
+++ b/tests/test-ui/src/composables/useTestStore.ts
@@ -500,6 +500,30 @@ export function useTestStore(): TestStore {
         return collection ? `${collection}:${category}:${phase}` : `${category}:${phase}`;
     }
 
+    // Apply a terminal outcome to a test: transition counts, set status, mark the
+    // tree dirty, and hand off auto-selection if a failure was demoted off the
+    // selected slot. Works from any current status (transitionStatus rebalances
+    // whatever was there) and no-ops when status already matches, so it is safe to
+    // call from both producers in either order.
+    function setTerminalOutcome(test: TestSnapshot, outcome: "passed" | "failed" | "canceled") {
+        if (test.status === outcome) {
+            return;
+        }
+        transitionStatus(test.status, outcome);
+        test.status = outcome;
+        markTreeDirty();
+        // A failure demoted off the selected slot (e.g. failed→canceled) hands the
+        // headline back to the freshest remaining real failure; if none remain the
+        // selection stays put (a canceled test never auto-selects, but we don't
+        // proactively deselect either — matching the pre-fix test_failed behavior).
+        if (outcome !== "failed" && selectedTest.value?.displayName === test.displayName) {
+            const next = findMostRecentFailure();
+            if (next) {
+                autoSelect(next);
+            }
+        }
+    }
+
     function applyEvent(event: TestEvent) {
         switch (event.event) {
             case "populate_tests":
@@ -739,7 +763,9 @@ export function useTestStore(): TestStore {
                     event.exceptionType === "System.Threading.Tasks.TaskCanceledException";
                 if (test) {
                     const oldStatus = test.status;
-                    const newStatus = isCanceled ? "canceled" : "failed";
+                    // Enrichment (test-process verdict) may have arrived first; honor it over the
+                    // exception-type guess, mirroring the runner's SetOutcome source policy.
+                    const newStatus = test.enrichmentOutcome ?? (isCanceled ? "canceled" : "failed");
                     test.status = newStatus;
                     test.durationMs = event.durationMs;
                     test.queueDurationMs = event.queueDurationMs ?? null;
@@ -762,8 +788,8 @@ export function useTestStore(): TestStore {
                     transitionStatus(oldStatus, newStatus);
                     markTreeDirty();
                     markSelectedContentDirty(test);
-                    // Auto-select failed test (but not canceled ones)
-                    if (!isCanceled) {
+                    // Auto-select only a genuine failure (canceled never auto-selects).
+                    if (newStatus === "failed") {
                         autoSelect(test);
                     }
                 }
@@ -997,6 +1023,13 @@ export function useTestStore(): TestStore {
                         lastKeepDisposeMs: event.lastKeepDisposeMs,
                         leaseReleaseMs: event.leaseReleaseMs,
                     };
+                    // The enrichment outcome is the runner's authoritative verdict (it has
+                    // already run SetOutcome). Apply it and cache it for a possibly-later
+                    // test_failed, whose exception-type guess must defer to the cache.
+                    if (event.outcome === "passed" || event.outcome === "failed" || event.outcome === "canceled") {
+                        test.enrichmentOutcome = event.outcome;
+                        setTerminalOutcome(test, event.outcome);
+                    }
                     markSelectedContentDirty(test);
                 }
                 break;

--- a/tests/test-ui/src/types/state.ts
+++ b/tests/test-ui/src/types/state.ts
@@ -180,6 +180,11 @@ export interface TestSnapshot {
     serverInstanceId: string | null;
     /** Latest FailureContext.DumpAsync result, or null if no dump captured. */
     failureContext: Record<string, unknown> | null;
+    /** Test-process enrichment verdict, cached so test_failed (which the runner
+     *  emits AFTER enrichment — TestLifecycle.cs:509,523-525) honors it instead
+     *  of re-deriving from the exception type. Mirrors runner
+     *  TestState.EnrichmentOutcome (TestRunState.cs:935). */
+    enrichmentOutcome?: "passed" | "failed" | "canceled";
 }
 
 export interface SetupPhaseSnapshot {


### PR DESCRIPTION
## Problem

The test-ui store folds every `test_enrichment` field **except `outcome`**, so a test the runner reclassifies (e.g. a StopOnFail cascade victim flipped `failed`→`canceled`) keeps the stale status derived from `test_failed`'s exception-type guess. The web UI rendered it as **failed** while its sibling cascade victims rendered as **canceled**.

The JSON artifacts (`summary.json` / `ctrf-report.json`) were already correct — they count from the runner's reconciled `t.Status`. Only the live web UI diverged, because its store dropped the authoritative verdict.

## Ordering constraint

Enrichment is emitted by the child inside `DisposeAsync`, *before* xUnit's pipeline emits `test_failed`, but both cross the same broadcast action and the store applies batched events in receive order — so at the UI, enrichment can arrive **before or after** `test_failed`. A fix that only patched one handler would no-op on one of the two orders. The fix caches the verdict and has `test_failed` honor it, mirroring the runner's `SetOutcome` policy + `EnrichmentOutcome` cache so both orders converge.

## Changes

- Add `TestSnapshot.enrichmentOutcome` cache field (optional; a UI-only live-reconciliation aid — not on the wire, so hydrated/finished tests carry `undefined` and never consult it).
- Add a shared `setTerminalOutcome` helper: transitions counts, sets status, marks the tree dirty, and hands selection back to the freshest remaining failure when one is demoted off the selected slot. No-ops when status already matches, so it is safe from both producers in either order.
- `test_enrichment` caches the verdict and applies it via the helper.
- `test_failed` defers to the cached verdict over its exception-type classification, and auto-selects only a genuine failure.

## Scope

UI-only. No runner change — the snapshot/hydrate path already carries the reconciled status, and the artifacts already count both directions. Downstream `test.status` consumers (tree aggregation, status color/icon mappers, filter pills) already distinguish `canceled` from `failed` and need no change.

## Verification

- `make build-test-ui` (`vue-tsc --noEmit` + `vite build`) — green.
- Traced all four event orderings for count-balance and terminal-status convergence.
- Runtime gate (rerun a StopOnFail suite with an enrichment-reclassified victim and confirm the live tree/pills match `summary.json`) is timing-dependent and not part of this static check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of test outcomes when enrichment results arrive before failure events, ensuring enrichment verdicts drive the final terminal state.
  * Added consistent terminal status transitions for passed, failed, and canceled outcomes.
  * Tightened auto-selection behavior so selection only advances when the resolved terminal status is actually `"failed"`.
  * When a selected failure is demoted away from `"failed"`, selection now moves to the most recent remaining failure.
  * Persisted enrichment verdicts on the test snapshot to honor them later during failure processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->