### PR TITLE
test: propagate setup-abort errors, persist build logs, honest run-output

### DIFF
--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -127,6 +127,19 @@ var ChildStallTimeout = TimeSpan.FromSeconds(
         : 720
 );
 
+// Assemble the offline test-web bundle (SPA + run snapshot + copied media)
+// inside the run dir so it rides along in the uploaded artifact tree and opens
+// over file://. Driven by --report or CI; no-ops with a warning when the SPA
+// hasn't been built; never throws. Abort paths call this directly because they
+// return (or force-kill) before the outer finally.
+void TryGenerateReport()
+{
+    if (generateReport || IsCIEnvironment())
+    {
+        ReportGenerator.TryGenerate(recorder.State, TestArtifacts.RunDir, CollectKnownSecrets());
+    }
+}
+
 // Shared abort body. `cause` becomes the run_aborted event cause and the
 // summary.json abortReason. Re-entrant: the first call starts the graceful
 // teardown + 15s force-kill safety net; subsequent calls go straight to
@@ -169,6 +182,10 @@ void BeginAbort(string cause)
         {
             Console.Error.WriteLine($"[ArtifactWriter] abort-path write failed: {ex.Message}");
         }
+
+        // The force-kill can preempt the outer finally; the graceful path's
+        // duplicate call just overwrites the bundle.
+        TryGenerateReport();
 
         // Push a run_aborted event over the WebSocket so the browser UI flips
         // to the aborted state immediately. Without this, the UI only notices
@@ -387,6 +404,9 @@ void ForceExitNow(string cause)
         {
             Console.Error.WriteLine($"[ArtifactWriter] force-exit write failed: {ex.Message}");
         }
+
+        // Snapshot bundle for the aborted run — same rationale as BeginAbort.
+        TryGenerateReport();
     }
     finally
     {
@@ -437,9 +457,14 @@ async Task RunChildStallWatchdogAsync(Action<string> abort, CancellationToken ct
                 continue;
             }
 
-            Console.Error.WriteLine(
-                $"[stall-watchdog] no test progress for {idle.TotalSeconds:F0}s "
-                    + $"(threshold {ChildStallTimeout.TotalSeconds:F0}s) — aborting wedged run."
+            // OnError (not bare stderr) so the wedge is annotated in CI and lands
+            // in state/artifacts; the renderer is still alive here — BeginAbort
+            // owns artifacts + disposal from this point on.
+            renderer.OnError(
+                new ErrorEvent(
+                    $"[stall-watchdog] no test progress for {idle.TotalSeconds:F0}s "
+                        + $"(threshold {ChildStallTimeout.TotalSeconds:F0}s) — aborting wedged run."
+                )
             );
             try
             {
@@ -594,8 +619,58 @@ if (UnwrapRenderer(renderer) is WebRenderer webRendererReady)
 // (The parent process bypasses SetupEventBus's pipe channel — it owns the
 // renderer in-process; SetupEventBus is for the child where IPC is needed.
 // Existing pattern at RunnerCallbacks.cs:142-144.) The same events surface in
-// the WebUI tree; the existing Console.Error lines stay for terminal users.
+// the WebUI tree; abort failures route through renderer.OnError, which reaches
+// every mode (stderr + ::error:: in CI, error JSONL in LLM, state + web UI via
+// the dispatch guard).
 const string SetupCategory = "Runner";
+
+// Shared epilogue for the parent-side setup-abort seams (preflight, image
+// build, image/game-data distribution). Callers emit their PhaseCompleted(false)
+// first — the ERROR line lands after CIRenderer's ::endgroup:: so it can't be
+// swallowed into the collapsed setup group in the GitHub log.
+async Task<int> AbortRunAsync(string abortReason, string message, object runAbortedPayload)
+{
+    renderer.OnError(new ErrorEvent(message));
+    InfrastructureEventLog.Emit("run_aborted", runAbortedPayload);
+    recorder.SetAbortReason(abortReason);
+    recorder.WriteRunArtifacts();
+    TryGenerateReport();
+    await renderer.DisposeAsync();
+    return 2;
+}
+
+// Distribution-failure abort: one scrubbed OnError per seam (not per host) —
+// transfer errors embed SSH stderr with the VPS user@host, and the run_aborted
+// payload is persisted to infrastructure.parent.jsonl in the public artifact.
+async Task<int> AbortDistributionAsync(
+    string phaseName,
+    string tag,
+    string cause,
+    List<(string HostId, string? Error)> failures
+)
+{
+    var failureLines = failures
+        .Select(f => ScrubForLog($"host '{f.HostId}': {f.Error ?? "unknown"}"))
+        .ToList();
+    renderer.OnSetupPhaseCompleted(
+        new SetupPhaseCompletedEvent(
+            SetupCategory,
+            phaseName,
+            false,
+            $"{failures.Count} host(s) failed"
+        )
+    );
+    return await AbortRunAsync(
+        cause,
+        $"[{tag}] aborted:{Environment.NewLine}" + string.Join(Environment.NewLine, failureLines),
+        new
+        {
+            cause,
+            failures = failures.Count,
+            messages = failureLines,
+        }
+    );
+}
 
 renderer.OnSetupPhaseStarted(new SetupPhaseStartedEvent(SetupCategory, "Preflight"));
 try
@@ -626,18 +701,14 @@ try
 catch (Exception ex)
 {
     var preflightMsg = ScrubForLog(ex.Message);
-    Console.Error.WriteLine($"[HostPool] Preflight failed: {preflightMsg}");
-    InfrastructureEventLog.Emit(
-        "run_aborted",
-        new { cause = "host_preflight", message = preflightMsg }
-    );
     renderer.OnSetupPhaseCompleted(
         new SetupPhaseCompletedEvent(SetupCategory, "Preflight", false, preflightMsg)
     );
-    recorder.SetAbortReason("preflight");
-    recorder.WriteRunArtifacts();
-    await renderer.DisposeAsync();
-    return 2;
+    return await AbortRunAsync(
+        "preflight",
+        $"[HostPool] Preflight failed: {preflightMsg}",
+        new { cause = "preflight", message = preflightMsg }
+    );
 }
 
 // Self-heal stray containers/networks/volumes from prior aborted runs across
@@ -735,13 +806,12 @@ try
 catch (Exception ex)
 {
     var buildMsg = ScrubForLog(ex.Message);
-    Console.Error.WriteLine($"[ImageBuild] Parent-side build failed: {buildMsg}");
-    InfrastructureEventLog.Emit("run_aborted", new { cause = "image_build", message = buildMsg });
     parentBuildProgress.PhaseCompleted("Docker Images", false, buildMsg);
-    recorder.SetAbortReason("image_build");
-    recorder.WriteRunArtifacts();
-    await renderer.DisposeAsync();
-    return 2;
+    return await AbortRunAsync(
+        "image_build",
+        $"[ImageBuild] Parent-side build failed: {buildMsg}",
+        new { cause = "image_build", message = buildMsg }
+    );
 }
 
 // Distribute test images to remote hosts (no-op for local-only fleets).
@@ -759,29 +829,12 @@ try
     var transferFailures = transferResults.Where(r => !r.Success).ToList();
     if (transferFailures.Count > 0)
     {
-        foreach (var f in transferFailures)
-        {
-            Console.Error.WriteLine(
-                $"[ImageTransfer] host '{f.HostId}' failed: {f.Error ?? "unknown"}"
-            );
-        }
-
-        InfrastructureEventLog.Emit(
-            "run_aborted",
-            new { cause = "image_transfer", failures = transferFailures.Count }
+        return await AbortDistributionAsync(
+            "Image distribution",
+            "ImageTransfer",
+            "image_transfer",
+            transferFailures.Select(f => (f.HostId, f.Error)).ToList()
         );
-        renderer.OnSetupPhaseCompleted(
-            new SetupPhaseCompletedEvent(
-                SetupCategory,
-                "Image distribution",
-                false,
-                $"{transferFailures.Count} host(s) failed"
-            )
-        );
-        recorder.SetAbortReason("image_transfer");
-        recorder.WriteRunArtifacts();
-        await renderer.DisposeAsync();
-        return 2;
     }
     renderer.OnSetupPhaseCompleted(
         new SetupPhaseCompletedEvent(SetupCategory, "Image distribution", true)
@@ -790,18 +843,14 @@ try
 catch (Exception ex)
 {
     var transferMsg = ScrubForLog(ex.Message);
-    Console.Error.WriteLine($"[ImageTransfer] aborted: {transferMsg}");
-    InfrastructureEventLog.Emit(
-        "run_aborted",
-        new { cause = "image_transfer_exception", message = transferMsg }
-    );
     renderer.OnSetupPhaseCompleted(
         new SetupPhaseCompletedEvent(SetupCategory, "Image distribution", false, transferMsg)
     );
-    recorder.SetAbortReason("image_transfer_exception");
-    recorder.WriteRunArtifacts();
-    await renderer.DisposeAsync();
-    return 2;
+    return await AbortRunAsync(
+        "image_transfer_exception",
+        $"[ImageTransfer] aborted: {transferMsg}",
+        new { cause = "image_transfer_exception", message = transferMsg }
+    );
 }
 
 // Distribute the Stardew Valley game-data volume from the coordinator to each
@@ -819,27 +868,12 @@ try
     var gdFailures = gdResults.Where(r => !r.Success).ToList();
     if (gdFailures.Count > 0)
     {
-        foreach (var f in gdFailures)
-        {
-            Console.Error.WriteLine($"[GameData] host '{f.HostId}' failed: {f.Error ?? "unknown"}");
-        }
-
-        InfrastructureEventLog.Emit(
-            "run_aborted",
-            new { cause = "game_data_transfer", failures = gdFailures.Count }
+        return await AbortDistributionAsync(
+            "Game data distribution",
+            "GameData",
+            "game_data_transfer",
+            gdFailures.Select(f => (f.HostId, f.Error)).ToList()
         );
-        renderer.OnSetupPhaseCompleted(
-            new SetupPhaseCompletedEvent(
-                SetupCategory,
-                "Game data distribution",
-                false,
-                $"{gdFailures.Count} host(s) failed"
-            )
-        );
-        recorder.SetAbortReason("game_data_transfer");
-        recorder.WriteRunArtifacts();
-        await renderer.DisposeAsync();
-        return 2;
     }
     renderer.OnSetupPhaseCompleted(
         new SetupPhaseCompletedEvent(SetupCategory, "Game data distribution", true)
@@ -848,18 +882,14 @@ try
 catch (Exception ex)
 {
     var gameDataMsg = ScrubForLog(ex.Message);
-    Console.Error.WriteLine($"[GameData] aborted: {gameDataMsg}");
-    InfrastructureEventLog.Emit(
-        "run_aborted",
-        new { cause = "game_data_transfer_exception", message = gameDataMsg }
-    );
     renderer.OnSetupPhaseCompleted(
         new SetupPhaseCompletedEvent(SetupCategory, "Game data distribution", false, gameDataMsg)
     );
-    recorder.SetAbortReason("game_data_transfer_exception");
-    recorder.WriteRunArtifacts();
-    await renderer.DisposeAsync();
-    return 2;
+    return await AbortRunAsync(
+        "game_data_transfer_exception",
+        $"[GameData] aborted: {gameDataMsg}",
+        new { cause = "game_data_transfer_exception", message = gameDataMsg }
+    );
 }
 
 // Now that the parent-side build + distribution are complete, expose the
@@ -1010,7 +1040,12 @@ catch (Exception ex)
         }
     );
     recorder.SetAbortReason("exception");
-    throw;
+    // OnError carries the scrubbed message + stack to every mode (renderers
+    // sanitize the stack; a raw exception dump must not reach the public CI
+    // log). Exit code 2 is the abort convention; the outer finally owns
+    // artifacts + report + dispose on this path.
+    renderer.OnError(new ErrorEvent($"Run aborted — {runMsg}", ex.StackTrace));
+    exitCode = 2;
 }
 finally
 {
@@ -1052,15 +1087,8 @@ finally
         Console.Error.WriteLine($"[ArtifactWriter] finally-path write failed: {ex.Message}");
     }
 
-    // Assemble the offline test-web bundle (SPA + run snapshot + copied media)
-    // inside the run dir, so it rides along in the uploaded artifact tree and
-    // opens over file://. One site, every renderer mode — driven by --report or
-    // CI. No-ops with a warning when the SPA hasn't been built. Requires the
-    // final state, so it runs after WriteRunArtifacts.
-    if (generateReport || IsCIEnvironment())
-    {
-        ReportGenerator.TryGenerate(recorder.State, TestArtifacts.RunDir, CollectKnownSecrets());
-    }
+    // Requires the final state, so it runs after WriteRunArtifacts.
+    TryGenerateReport();
 
     // Dev-mode Web runs that completed normally: hold the browser open
     // until the operator presses a key (or signals shutdown). Skipped on
@@ -1144,19 +1172,11 @@ static IReadOnlyCollection<string> CollectKnownSecrets()
     try
     {
         var accountsJson = Environment.GetEnvironmentVariable("STEAM_ACCOUNTS");
-        foreach (
-            var account in JunimoServer.Tests.Schema.Json.UserConfigJson.ParseArrayStrict(
-                "STEAM_ACCOUNTS",
-                accountsJson
-            )
-        )
+        foreach (var account in SteamAccount.ParseList(accountsJson))
         {
-            foreach (var field in new[] { "user", "pass", "refreshToken" })
+            foreach (var value in account.SecretValues)
             {
-                if (account?[field]?.GetValue<string>() is { Length: > 0 } v)
-                {
-                    secrets.Add(v);
-                }
+                secrets.Add(value);
             }
         }
     }

--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -518,11 +518,9 @@ public sealed class CIRenderer : RendererBase
             // so it streams live in both modes (the result line itself may be buffered).
             if (_isGitHubActions)
             {
-                var escapedMsg = e
-                    .Message.Replace("%", "%25")
-                    .Replace("\r", "%0D")
-                    .Replace("\n", "%0A");
-                _err.WriteLine($"::error title={e.TestClass}.{e.TestMethod}::{escapedMsg}");
+                _err.WriteLine(
+                    $"::error title={e.TestClass}.{e.TestMethod}::{EscapeAnnotation(e.Message)}"
+                );
                 _err.Flush();
             }
 
@@ -688,27 +686,42 @@ public sealed class CIRenderer : RendererBase
 
     public override void OnError(ErrorEvent e)
     {
-        _err.WriteLine(RedBold($" ERROR: {e.Message}"));
-        if (!string.IsNullOrEmpty(e.StackTrace))
+        lock (_writeLock)
         {
-            var sanitized = SanitizeStackTrace(e.StackTrace);
-            foreach (var line in sanitized.Split('\n').Take(10))
+            // Same clear/redraw dance as OnTestAnnotation — errors can arrive
+            // while a spinner is active (e.g. the stall watchdog mid-run).
+            if (_isTTY && _spinnerLabel != null)
             {
-                _err.WriteLine(Dim($"   {line.TrimEnd()}"));
+                _err.Write("\r\x1b[2K");
             }
-        }
 
-        if (_isGitHubActions)
-        {
-            var escapedMsg = e
-                .Message.Replace("%", "%25")
-                .Replace("\r", "%0D")
-                .Replace("\n", "%0A");
-            _err.WriteLine($"::error::{escapedMsg}");
-        }
+            _err.WriteLine(RedBold($" ERROR: {e.Message}"));
+            if (!string.IsNullOrEmpty(e.StackTrace))
+            {
+                var sanitized = SanitizeStackTrace(e.StackTrace);
+                foreach (var line in sanitized.Split('\n').Take(10))
+                {
+                    _err.WriteLine(Dim($"   {line.TrimEnd()}"));
+                }
+            }
 
-        _err.Flush();
+            if (_isGitHubActions)
+            {
+                _err.WriteLine($"::error::{EscapeAnnotation(e.Message)}");
+            }
+
+            if (_isTTY && _spinnerLabel != null)
+            {
+                _out.Write(BuildSpinnerLine(_spinnerFrame));
+            }
+
+            _err.Flush();
+        }
     }
+
+    /// <summary>Escape a message for a GitHub Actions annotation body.</summary>
+    private static string EscapeAnnotation(string message) =>
+        message.Replace("%", "%25").Replace("\r", "%0D").Replace("\n", "%0A");
 
     // ── Dispose ──
 

--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -35,6 +35,12 @@ public sealed class CIRenderer : RendererBase
     // Failure collection for bottom summary (event + accumulated pipe output)
     private readonly List<(TestFailedEvent Failure, string? Output)> _failures = new();
 
+    // Display caps for failure detail blocks: stack traces carry their signal
+    // in the top frames, and unbounded output would drown the summary.
+    private const int StackTraceDisplayLines = 10;
+    private const int FailureMessageDisplayLines = 5;
+    private const int TestOutputDisplayLines = 20;
+
     // Spinner animation (TTY only)
     private static readonly string[] SpinnerFrames =
     [
@@ -142,7 +148,7 @@ public sealed class CIRenderer : RendererBase
 
                 // Additional message lines (e.g. inner exception details)
                 var messageLines = f.Message.Split('\n');
-                for (var i = 1; i < messageLines.Length && i < 5; i++)
+                for (var i = 1; i < messageLines.Length && i < FailureMessageDisplayLines; i++)
                 {
                     _out.WriteLine($"   {Red(messageLines[i].TrimEnd())}");
                 }
@@ -153,7 +159,7 @@ public sealed class CIRenderer : RendererBase
                 if (!string.IsNullOrEmpty(f.StackTrace))
                 {
                     var sanitized = SanitizeStackTrace(f.StackTrace);
-                    foreach (var line in sanitized.Split('\n').Take(10))
+                    foreach (var line in sanitized.Split('\n').Take(StackTraceDisplayLines))
                     {
                         _out.WriteLine($"   {Dim(line.TrimEnd())}");
                     }
@@ -171,7 +177,7 @@ public sealed class CIRenderer : RendererBase
                 if (!string.IsNullOrWhiteSpace(fOutput))
                 {
                     _out.WriteLine($"   {Dim("\u2500\u2500 Output \u2500\u2500")}");
-                    foreach (var line in fOutput.Split('\n').Take(20))
+                    foreach (var line in fOutput.Split('\n').Take(TestOutputDisplayLines))
                     {
                         _out.WriteLine($"   {Dim(line.TrimEnd())}");
                     }
@@ -699,7 +705,7 @@ public sealed class CIRenderer : RendererBase
             if (!string.IsNullOrEmpty(e.StackTrace))
             {
                 var sanitized = SanitizeStackTrace(e.StackTrace);
-                foreach (var line in sanitized.Split('\n').Take(10))
+                foreach (var line in sanitized.Split('\n').Take(StackTraceDisplayLines))
                 {
                     _err.WriteLine(Dim($"   {line.TrimEnd()}"));
                 }

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
@@ -403,10 +403,17 @@ public sealed class TestRunArtifactWriter
     /// needs without parsing summary.json: status, counters, paths, degradation
     /// flag. Always written (in both local and coordinator modes). The same
     /// shape is also echoed to stdout as a single JSON line for log scrapers.
+    /// <para>
+    /// <c>status</c> ranks <c>aborted &gt; failed &gt; canceled &gt; passed</c>
+    /// (matching the PR sticky's <c>deriveResult</c>), so an aborted 0-test run
+    /// says <c>"aborted"</c> here. summary.json's <c>result</c> keeps its
+    /// documented orthogonal semantics (see <see cref="ResultStatus"/>); that
+    /// contract and its consumers are untouched.
+    /// </para>
     /// </summary>
     private void WriteRunOutput(RunArtifactView v)
     {
-        var status = ResultStatus(v);
+        var status = v.Aborted ? "aborted" : ResultStatus(v);
         var degradation = BuildDegradation(v);
         var degradationStatus = degradation is null
             ? "clean"
@@ -417,6 +424,8 @@ public sealed class TestRunArtifactWriter
             ["runId"] = _runId,
             ["runDir"] = _runDir,
             ["status"] = status,
+            ["aborted"] = v.Aborted,
+            ["abortReason"] = v.AbortReason,
             ["passed"] = v.Passed,
             ["failed"] = v.Failed,
             ["skipped"] = v.Skipped,

--- a/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/WebRenderer.cs
@@ -480,7 +480,9 @@ public sealed class WebRenderer : RendererBase
         ExtractAndEmitVncUrl(e.Message);
     }
 
-    public override void OnError(ErrorEvent e) { }
+    // Stderr echo: abort paths dispose the web server immediately, so the UI
+    // alone would lose the error.
+    public override void OnError(ErrorEvent e) => Console.Error.WriteLine($"ERROR: {e.Message}");
 
     public override void OnSetupPhaseStarted(SetupPhaseStartedEvent e) { }
 

--- a/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
+++ b/tests/JunimoServer.Tests/Containers/SharedSteamAuth.cs
@@ -485,17 +485,11 @@ public class SharedSteamAuth : IAsyncDisposable
     private static HashSet<string> ExtractUsernames(string? steamAccountsJson)
     {
         var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (string.IsNullOrWhiteSpace(steamAccountsJson))
+        foreach (var account in SteamAccount.ParseList(steamAccountsJson))
         {
-            return set;
-        }
-
-        foreach (var node in UserConfigJson.ParseArrayStrict("STEAM_ACCOUNTS", steamAccountsJson))
-        {
-            var user = node["user"]?.GetValue<string>();
-            if (!string.IsNullOrWhiteSpace(user))
+            if (!string.IsNullOrWhiteSpace(account.User))
             {
-                set.Add(user);
+                set.Add(account.User);
             }
         }
         return set;
@@ -542,14 +536,11 @@ public class SharedSteamAuth : IAsyncDisposable
         {
             try
             {
-                foreach (
-                    var node in UserConfigJson.ParseArrayStrict("STEAM_ACCOUNTS", steamAccounts)
-                )
+                foreach (var account in SteamAccount.ParseList(steamAccounts))
                 {
-                    var user = node["user"]?.GetValue<string>();
-                    if (!string.IsNullOrWhiteSpace(user))
+                    if (!string.IsNullOrWhiteSpace(account.User))
                     {
-                        set.Add(user);
+                        set.Add(account.User);
                     }
                 }
                 return set;

--- a/tests/JunimoServer.Tests/Helpers/DockerImageBuilder.cs
+++ b/tests/JunimoServer.Tests/Helpers/DockerImageBuilder.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using JunimoServer.Tests.Schema.Json;
 
@@ -31,8 +30,11 @@ public static class DockerImageBuilder
     private const int FileLockMaxRetries = 5;
     private static readonly TimeSpan FileLockRetryDelay = TimeSpan.FromSeconds(2);
 
-    // Recent-output tail kept for build-failure messages.
-    private const int FailureTailLines = 30;
+    // Recent-output tail attached to build-failure messages. The tail is only the
+    // console/annotation excerpt (the full log is on disk); 50 ≈ one terminal
+    // screen, and `buildx --progress=plain` emits the failing step's output and
+    // its ERROR: block in the final lines.
+    private const int FailureTailLines = 50;
 
     // make's "*** [target] Error N" recipe trailer — restates the exit code
     // without adding signal; filtered out of the failure tail.
@@ -65,33 +67,24 @@ public static class DockerImageBuilder
     /// </summary>
     private static Dictionary<string, string> GetSteamCredentials(IBuildProgressSink progress)
     {
-        var steamAccounts = Environment.GetEnvironmentVariable("STEAM_ACCOUNTS");
-        if (string.IsNullOrEmpty(steamAccounts))
-        {
-            return new Dictionary<string, string>();
-        }
-
         try
         {
-            using var doc = JsonDocument.Parse(steamAccounts, UserConfigJson.Document);
-            var first = doc.RootElement[0];
-            var user = first.GetProperty("user").GetString() ?? "";
-            var pass = first.TryGetProperty("pass", out var p) ? p.GetString() ?? "" : "";
-            var token = first.TryGetProperty("token", out var t) ? t.GetString() ?? "" : "";
+            var accounts = SteamAccount.ParseList(
+                Environment.GetEnvironmentVariable("STEAM_ACCOUNTS")
+            );
+            if (accounts.Count == 0)
+            {
+                return new Dictionary<string, string>();
+            }
+
             return new Dictionary<string, string>
             {
-                ["STEAM_USERNAME"] = user,
-                ["STEAM_PASSWORD"] = pass,
-                ["STEAM_REFRESH_TOKEN"] = token,
+                ["STEAM_USERNAME"] = accounts[0].User,
+                ["STEAM_PASSWORD"] = accounts[0].Pass,
+                ["STEAM_REFRESH_TOKEN"] = accounts[0].Token,
             };
         }
-        catch (Exception ex)
-            when (ex
-                    is JsonException
-                        or IndexOutOfRangeException
-                        or InvalidOperationException
-                        or KeyNotFoundException
-            )
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException)
         {
             progress.Step($"STEAM_ACCOUNTS JSON malformed: {ex.Message}", SetupStepStatus.Warning);
             return new Dictionary<string, string>();
@@ -372,58 +365,115 @@ public static class DockerImageBuilder
             }
         }
 
-        using var process =
-            Process.Start(startInfo)
-            ?? throw new InvalidOperationException($"Failed to start '{command} {arguments}'");
-
-        // Bounded tail of recent output for the failure message: the CI renderer
-        // shows InProgress lines only as a transient spinner label, so without
-        // this the operator sees the exit code but never the underlying error.
-        var outputTail = new Queue<string>(FailureTailLines);
-        var outputTailLock = new object();
-
-        void CaptureTail(string line)
+        Process StartBuildProcess()
         {
-            if (string.IsNullOrWhiteSpace(line))
+            try
             {
-                return;
+                // Process.Start's own failure (Win32Exception when the executable is
+                // missing) carries no command context — rethrow with it attached.
+                return Process.Start(startInfo)
+                    ?? throw new InvalidOperationException(
+                        $"Failed to start '{command} {arguments}'"
+                    );
+            }
+            catch (Exception ex) when (ex is not InvalidOperationException)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to start '{command} {arguments}': {ex.Message}"
+                );
+            }
+        }
+
+        using var process = StartBuildProcess();
+
+        // Injected credential values (Steam user / pass / refresh token) are masked
+        // out of every line before it is streamed or buffered — the raw form never
+        // exists outside the process pipe, so the log file, infrastructure*.jsonl,
+        // consoles, and both UIs all inherit masked lines. The ≥3-length guard
+        // mirrors the report redactor's (and string.Replace throws on an empty
+        // needle).
+        var secretValues =
+            environmentVars?.Values.Where(v => !string.IsNullOrEmpty(v) && v.Length >= 3).ToArray()
+            ?? Array.Empty<string>();
+
+        string MaskSecrets(string line)
+        {
+            foreach (var secret in secretValues)
+            {
+                line = line.Replace(secret, "***");
             }
 
-            lock (outputTailLock)
+            return line;
+        }
+
+        // Full masked output, buffered for the diagnostics log file; the failure
+        // tail is sliced from the same buffer. The two reader loops run concurrently.
+        var outputLines = new List<string>();
+        var outputLock = new object();
+        var logFileName = $"image-build-{description.Replace(' ', '-')}.log";
+
+        // Diagnostics must never fail a build.
+        void WriteBuildLog()
+        {
+            try
             {
-                if (outputTail.Count == FailureTailLines)
+                string[] lines;
+                lock (outputLock)
                 {
-                    outputTail.Dequeue();
+                    lines = outputLines.ToArray();
                 }
 
-                outputTail.Enqueue(line);
+                File.WriteAllLines(
+                    Path.Combine(TestArtifacts.GetDiagnosticsDir(), logFileName),
+                    lines
+                );
             }
+            catch
+            { /* never fail the build over a log write */
+            }
+        }
+
+        // Bounded failure excerpt for exception messages: the CI renderer shows
+        // InProgress lines only as a transient spinner label, so without this the
+        // operator sees the exit code but never the underlying error.
+        string BuildFailureTail()
+        {
+            string[] tailLines;
+            lock (outputLock)
+            {
+                tailLines = outputLines
+                    .Where(l => !string.IsNullOrWhiteSpace(l) && !MakeErrorTrailer.IsMatch(l))
+                    .TakeLast(FailureTailLines)
+                    .ToArray();
+            }
+
+            var tailBlock =
+                tailLines.Length > 0
+                    ? $" Last output:{Environment.NewLine}  "
+                        + string.Join($"{Environment.NewLine}  ", tailLines)
+                    : " (no output captured)";
+            return $"{tailBlock}{Environment.NewLine}Full log: {RunArtifactNames.DiagnosticsDir}/{logFileName}";
         }
 
         // Read stdout / stderr in parallel via local async functions. ReadLineAsync
         // is fully async on .NET 6+; wrapping in Task.Run added thread-pool overhead
-        // without any concurrency benefit. Each line streams through the progress
-        // sink; the renderer surfaces them in real time.
-        async Task ReadStdoutAsync()
+        // without any concurrency benefit. Each masked line streams through the
+        // progress sink; the renderer surfaces them in real time.
+        async Task ReadLinesAsync(StreamReader reader)
         {
-            while (await process.StandardOutput.ReadLineAsync().ConfigureAwait(false) is { } line)
+            while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
             {
-                progress.Step(stepName, SetupStepStatus.InProgress, line);
-                CaptureTail(line);
+                var masked = MaskSecrets(line);
+                progress.Step(stepName, SetupStepStatus.InProgress, masked);
+                lock (outputLock)
+                {
+                    outputLines.Add(masked);
+                }
             }
         }
 
-        async Task ReadStderrAsync()
-        {
-            while (await process.StandardError.ReadLineAsync().ConfigureAwait(false) is { } line)
-            {
-                progress.Step(stepName, SetupStepStatus.InProgress, line);
-                CaptureTail(line);
-            }
-        }
-
-        var stdoutTask = ReadStdoutAsync();
-        var stderrTask = ReadStderrAsync();
+        var stdoutTask = ReadLinesAsync(process.StandardOutput);
+        var stderrTask = ReadLinesAsync(process.StandardError);
 
         using var cts = new CancellationTokenSource(timeout);
         try
@@ -432,29 +482,43 @@ public static class DockerImageBuilder
         }
         catch (OperationCanceledException)
         {
-            process.Kill(entireProcessTree: true);
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch
+            {
+                // The process (or a descendant) exited in the window between the
+                // timeout firing and the kill — the TimeoutException below is the
+                // real signal and must not be masked.
+            }
+
+            // The kill closes the pipes so reader EOF is imminent; bounded drain
+            // per drain-before-consume-disposal. Swallow drain failures for the
+            // same reason as the kill above.
+            try
+            {
+                await Task.WhenAll(stdoutTask, stderrTask).WaitAsync(TimeSpan.FromSeconds(5));
+            }
+            catch
+            { /* drain best-effort */
+            }
+
+            WriteBuildLog();
             throw new TimeoutException(
-                $"Building {description} timed out after {timeout.TotalMinutes:0} minutes"
+                $"Building {description} timed out after {timeout.TotalMinutes:0} minutes.{BuildFailureTail()}"
             );
         }
 
         await Task.WhenAll(stdoutTask, stderrTask);
 
+        // Success logs are kept too — a good/bad build diff needs both sides.
+        WriteBuildLog();
+
         if (process.ExitCode != 0)
         {
-            string[] tailLines;
-            lock (outputTailLock)
-            {
-                tailLines = outputTail.Where(l => !MakeErrorTrailer.IsMatch(l)).ToArray();
-            }
-
-            var tailBlock =
-                tailLines.Length > 0
-                    ? $" Last output:{Environment.NewLine}  "
-                        + string.Join($"{Environment.NewLine}  ", tailLines)
-                    : "";
             throw new InvalidOperationException(
-                $"Building {description} failed with exit code {process.ExitCode}.{tailBlock}"
+                $"Building {description} failed with exit code {process.ExitCode}.{BuildFailureTail()}"
             );
         }
     }

--- a/tests/JunimoServer.Tests/Infrastructure/SteamAccountSlicer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/SteamAccountSlicer.cs
@@ -59,10 +59,12 @@ public static class SteamAccountSlicer
         IReadOnlyList<DockerHost> hostsInDeclaredOrder
     )
     {
+        // Node-based (not SteamAccount.ParseList) on purpose: slice entries are
+        // re-serialized verbatim for the host's steam-auth container.
         var globalAccounts = UserConfigJson.ParseArrayStrict(
             "STEAM_ACCOUNTS",
             steamAccountsJson,
-            "{user, pass[, refreshToken]}"
+            SteamAccount.ShapeHint
         );
         var n = globalAccounts.Count;
 

--- a/tests/JunimoServer.Tests/Schema/Json/SteamAccount.cs
+++ b/tests/JunimoServer.Tests/Schema/Json/SteamAccount.cs
@@ -1,0 +1,54 @@
+namespace JunimoServer.Tests.Schema.Json;
+
+/// <summary>
+/// One entry of the <c>STEAM_ACCOUNTS</c> env JSON — the canonical field names
+/// for every test-side consumer. They mirror the consuming sidecar's
+/// deserialization contract (<c>tools/steam-service/Program.cs</c>,
+/// <c>SteamAccountConfig</c>): <c>"user"</c> plus either <c>"pass"</c> or
+/// <c>"token"</c>. The sidecar binds case-sensitively and ignores unknown keys,
+/// so names outside this record never reach Steam — keep in sync.
+/// </summary>
+public sealed record SteamAccount(string User, string Pass, string Token)
+{
+    /// <summary>Element-shape hint for <see cref="UserConfigJson.ParseArrayStrict"/> error messages.</summary>
+    public const string ShapeHint = "{user, pass[, token]}";
+
+    /// <summary>The entry's non-empty secret values, for masking/redaction consumers.</summary>
+    public IEnumerable<string> SecretValues
+    {
+        get
+        {
+            foreach (var value in new[] { User, Pass, Token })
+            {
+                if (!string.IsNullOrEmpty(value))
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Parses <c>STEAM_ACCOUNTS</c> JSON into entries; missing fields become
+    /// <c>""</c>. Empty for null/whitespace input; throws
+    /// <see cref="InvalidOperationException"/> on malformed JSON
+    /// (<see cref="UserConfigJson.ParseArrayStrict"/> semantics).
+    /// </summary>
+    public static IReadOnlyList<SteamAccount> ParseList(string? steamAccountsJson)
+    {
+        var nodes = UserConfigJson.ParseArrayStrict("STEAM_ACCOUNTS", steamAccountsJson, ShapeHint);
+        var accounts = new List<SteamAccount>(nodes.Count);
+        foreach (var node in nodes)
+        {
+            accounts.Add(
+                new SteamAccount(
+                    node["user"]?.GetValue<string>() ?? "",
+                    node["pass"]?.GetValue<string>() ?? "",
+                    node["token"]?.GetValue<string>() ?? ""
+                )
+            );
+        }
+
+        return accounts;
+    }
+}

--- a/tests/JunimoServer.Tests/Schema/Json/UserConfigJson.cs
+++ b/tests/JunimoServer.Tests/Schema/Json/UserConfigJson.cs
@@ -15,13 +15,7 @@ namespace JunimoServer.Tests.Schema.Json;
 /// </summary>
 public static class UserConfigJson
 {
-    /// <summary>
-    /// Raw options for the rare site that needs its own projection
-    /// (DockerImageBuilder's tolerant index-0 user/pass/token read). Prefer
-    /// the named methods below; reach for this only when the projection
-    /// doesn't fit one of them.
-    /// </summary>
-    public static readonly JsonDocumentOptions Document = new()
+    private static readonly JsonDocumentOptions Document = new()
     {
         AllowTrailingCommas = true,
         CommentHandling = JsonCommentHandling.Skip,


### PR DESCRIPTION
The nightly E2E run has failed since 2026-06-26 with only an exit code in the log — the actual \`docker buildx\` error is unrecoverable from any artifact, and the stdout summary claims \`"passed"\` for a 0-test run. This makes every parent-side abort observable; the root-cause fix follows once the first run with visible output identifies it.

- **DockerImageBuilder**: buffer the full build output and always write it to \`diagnostics/image-build-<slug>.log\` (success logs kept for good/bad diffs); attach a 50-line failure tail + the log path to build failures and timeouts; drain reader pipes after a timeout kill; give \`Process.Start\` failures command context; mask injected Steam credential values in every line before it is streamed or buffered, so every downstream artifact and console inherits masked lines.
- **Program.cs**: setup-abort seams (preflight, image build, image/game-data distribution) collapse into a shared \`AbortRunAsync\` epilogue — error via \`renderer.OnError\` (stderr + \`::error::\` annotation in CI, error JSONL in LLM mode, state/web UI via the dispatch guard), \`run_aborted\` event, run artifacts + report bundle, exit 2. Distribution failures carry scrubbed per-host messages. The stall watchdog annotates via \`OnError\`; the mid-run exception seam exits 2 with a scrubbed message instead of rethrowing an unscrubbed dump into the public CI log. Aborted runs now produce the \`report/\` bundle (BeginAbort/ForceExitNow included).
- **run-output.json**: \`status\` ranks \`aborted\` above test-outcome statuses and carries \`aborted\`/\`abortReason\` (matching the PR sticky's precedence); \`summary.json\`'s orthogonal \`result\` contract is unchanged.
- **Renderers**: \`WebRenderer.OnError\` echoes to stderr so web-mode aborts keep a terminal line; \`CIRenderer.OnError\` clears/redraws the spinner under the write lock and shares the annotation escaping with test failures.
- **SteamAccount** record + \`ParseList\` is now the canonical \`STEAM_ACCOUNTS\` entry shape (field names mirror the steam-service sidecar's \`SteamAccountConfig\`). Replaces four hand-rolled parsers and fixes \`CollectKnownSecrets\` reading \`refreshToken\` — a key the sidecar never accepted — so configured refresh tokens are masked by \`ScrubForLog\`/\`ReportRedactor\`.

**Verification**: local failure drill with a sabotaged Dockerfile — CI output shows the ERROR line with the real buildx parse error tail, \`diagnostics/image-build-server-image.log\` holds the full output, \`run-output.json\` says \`"status":"aborted","abortReason":"image_build"\`, the report bundle embeds the failed Docker Images phase, exit code 2, and a grep of the entire run dir finds zero configured credential values. Build, csharpier, and \`dotnet format style\` clean.

**Follow-up**: dispatch \`e2e-tests.yml\` on this branch — the nightly failure is deterministic, so the run will fail at the same point but now with the actual error in the job log and the \`e2e-test-results\` artifact; the root-cause fix lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)