### PR TITLE
fix(docker): restore libfontconfig1 dropped by GUI-package cleanup

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,6 +158,8 @@ RUN apt-get update && apt-get install -y \
     curl \
     # .NET globalization (SMAPI FailFasts at startup without it)
     libicu67 \
+    # SkiaSharp's native image decoder (Content Patcher EditImage) needs fontconfig to load
+    libfontconfig1 \
     locales \
     procps \
     unzip \


### PR DESCRIPTION
## Summary
- Content packs that edit images (Stardew Valley Expanded, Immersive Farm 2 Remastered, etc.) fail to load with `DllNotFoundException: Unable to load shared library 'libSkiaSharp'`
- Root cause: #473 removed X11/GUI apt packages (`x11-utils`, `polybar`, `rofi`, `xwallpaper`, etc.) which transitively pulled in `libfontconfig1`; SMAPI's bundled SkiaSharp image decoder links against `libfontconfig.so.1` and fails to initialize without it
- Fix: add `libfontconfig1` back to the explicit package list, following the same pattern already used for `libicu67` in the same commit

## Verification
- Extracted the exact SkiaSharp native binary version pinned by the game itself (`Stardew Valley.deps.json` / `StardewModdingAPI.deps.json`: `2.80.3-preview.93`)
- `readelf -d` on that binary confirms its only non-libc runtime dependency is `libfontconfig.so.1`
- Built the runtime apt layer against the exact pinned base image (`jlesage/baseimage-gui:debian-11-v4.11.3`) with the current package list (fix included) plus the Dockerfile's own `apt-get autoremove -y` step
- `ldd` against the real pinned binary resolves every shared library with zero missing entries; `libfontconfig1` survives `autoremove` (flagged manually-installed, not orphaned)

## Test plan
- [ ] CI passes
- [ ] Manual: boot server with a content pack using Content Patcher `EditImage` (e.g. SVE) and confirm no `SContentLoadException`/`DllNotFoundException` in the log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility for features that rely on font configuration within the application container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->