### PR TITLE
fix(docker): clear SMAPI crash/update markers before launch to prevent startup hang

### DIFF
--- a/docker/rootfs-test-client/startapp.sh
+++ b/docker/rootfs-test-client/startapp.sh
@@ -73,6 +73,14 @@ init_smapi() {
     fi
 }
 
+clear_smapi_marker_prompts() {
+    # SMAPI's crash/update marker checks block startup on a raw Console.ReadKey() that a
+    # headless container's stdin can't answer — a marker left in the shared game volume by
+    # a crashed run would hang every later boot. Prevent the prompts instead.
+    rm -f "${GAME_DEST_DIR}/smapi-internal/StardewModdingAPI.crash.marker" \
+        "${GAME_DEST_DIR}/smapi-internal/StardewModdingAPI.update.marker"
+}
+
 init_mods() {
     # Copy default SMAPI mods (ErrorHandler, ConsoleCommands)
     mkdir -p "${MODS_DEST_DIR}/smapi"
@@ -127,6 +135,7 @@ init_display_settings
 wait_for_game_files
 init_steam_sdk
 init_smapi
+clear_smapi_marker_prompts
 init_mods
 init_permissions
 

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -182,6 +182,14 @@ init_smapi() {
     cp -rf /data/smapi-config.json ${GAME_DEST_DIR}/smapi-internal/config.user.json
 }
 
+clear_smapi_marker_prompts() {
+    # SMAPI's crash/update marker checks block startup on a raw Console.ReadKey() that our
+    # piped, non-interactive stdin can't answer, hanging the server on the first start after
+    # any crash. Prevent the prompts instead; crash details survive in ErrorLogs/SMAPI-crash.txt.
+    rm -f "${GAME_DEST_DIR}/smapi-internal/StardewModdingAPI.crash.marker" \
+        "${GAME_DEST_DIR}/smapi-internal/StardewModdingAPI.update.marker"
+}
+
 init_mods() {
     rm -rf ${MODS_DEST_DIR}/smapi/
     mkdir -p ${MODS_DEST_DIR}/smapi/
@@ -238,6 +246,7 @@ init_display_settings
 init_stardew
 init_steam_sdk
 init_smapi
+clear_smapi_marker_prompts
 # init_patch_dll # This seems to strip debug symbols from SDV, so currently disabled to avoid issues in Space Core mod
 init_mods
 init_permissions
@@ -257,6 +266,9 @@ mkfifo "${INPUT_FIFO}"
 # Using `script` to create a PTY so SMAPI prints colored output (make it think it's a terminal)
 # Using `tail -f` on the FIFO to keep it open and avoid blocking
 # Note: `script` writes to both stdout (for docker logs) and the typescript file simultaneously
+# Caveat: the PTY covers stdout only, and the FIFO only ever delivers \n-terminated lines — SMAPI
+# prompts that read a raw keystroke (Console.ReadKey: crash/update markers, PressAnyKeyToExit)
+# can't be answered through this channel; prevent them upstream (see clear_smapi_marker_prompts)
 echo "Starting SMAPI..."
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!


### PR DESCRIPTION
## Problem

After any fatal crash, SMAPI writes a crash marker file and — on the next launch — blocks on a raw `Console.ReadKey()` prompt ("Press any key to delete the crash data and continue playing") before doing anything else. `HandleMarkerFiles()` runs unconditionally at startup (verified against SMAPI 4.5.2 source); no SMAPI setting disables it. Our containers feed SMAPI a piped, non-interactive stdin (line-oriented FIFO on the server, headless stdin on the test client), which can never satisfy a raw single-keystroke read — so the server sits hung indefinitely on the first start after any crash.

## Changes

- `docker/rootfs/startapp.sh`: delete `smapi-internal/StardewModdingAPI.crash.marker` and `StardewModdingAPI.update.marker` (same blocking-prompt shape, prerelease-only) before launching SMAPI, so the prompt is prevented rather than answered. Crash details remain on disk in `ErrorLogs/SMAPI-crash.txt`.
- `docker/rootfs/startapp.sh`: document at the FIFO piping site why `Console.ReadKey()`-shaped SMAPI prompts can't be answered through this channel, so future prompts of that shape get prevented upstream instead.
- `docker/rootfs-test-client/startapp.sh`: same marker cleanup — the test client launches SMAPI headlessly from the shared game volume, so a marker left by a crashed run would hang every later boot.

## Verification

- Both scripts pass `bash -n`; the cleanup runs in the init sequence before the SMAPI launch and is a no-op (`rm -f`) on fresh volumes.
- SMAPI-side behavior (`HandleMarkerFiles()`, marker paths, absence of a gating setting) verified against the `4.5.2` tag of Pathoschild/SMAPI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless startup reliability by automatically clearing stale crash and update prompts before launching.
  * Prevented startup hangs caused by interactive prompts that cannot be answered in non-interactive environments.
  * Applied the fix consistently across standard and test startup configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->