### PR TITLE
ci(e2e): surface E2E runs as a check run on the PR Checks tab

### DIFF
--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -230,6 +230,95 @@ function renderBody(state) {
     return lines.join("\n");
 }
 
+// --- check run (PR Checks tab) -------------------------------------------------------
+//
+// issue_comment and workflow_dispatch(+pr) runs execute at the DEFAULT branch's SHA
+// (github.sha), never the PR's head SHA, so GitHub Actions' own auto-registered check
+// run for this workflow job lands on master — invisible on the PR's Checks tab. A
+// same-named CodeRabbit-style check requires an explicit Checks API call keyed on the
+// PR's real head SHA (`checks: write`), independent of the job's own auto-check.
+const CHECK_RUN_NAME = "E2E Tests";
+
+/** Map a sticky `status` (queued|passed|failed|aborted) to a Checks API `conclusion`. */
+function statusToConclusion(status) {
+    switch (status) {
+        case "passed":
+            return "success";
+        case "failed":
+            return "failure";
+        case "aborted":
+            return "cancelled";
+        default:
+            return undefined; // 'queued' has no conclusion (still in_progress/queued)
+    }
+}
+
+/**
+ * Create-or-reuse the `E2E Tests` check run on the PR's head SHA (queued/in_progress
+ * state). Only this workflow creates runs with this name (job auto-checks use job names),
+ * so a same-named check run still `in_progress`/`queued` on this SHA is this PR's own:
+ * either a prior attempt that never reached `completed` (a Checks API failure mid-run, a
+ * job that died before its cleanup step) or — the gate runs outside the e2e concurrency
+ * singleton — a run that is still live. Reuse it rather than creating a new row, so
+ * re-running (the sticky's checkbox / repeated `/run-tests-e2e`) doesn't accumulate
+ * stale check-run entries on the PR's "Show all checks" list.
+ * Returns the check_run id to thread through job outputs for the later update call.
+ * @returns {Promise<number>} The reused or newly created check run's id.
+ */
+async function createCheckRun({ github, owner, repo, head_sha, status, detailsUrl }) {
+    // The API's `status` filter is a flat 3-value enum (queued|in_progress|completed —
+    // no combined "not completed" value), so predicate client-side. `filter: "all"`:
+    // the default `latest` collapses to the newest row per name+suite and could hide a
+    // stuck older row from the reuse scan.
+    const { data: existing } = await github.rest.checks.listForRef({
+        owner,
+        repo,
+        ref: head_sha,
+        check_name: CHECK_RUN_NAME,
+        filter: "all",
+    });
+    const reusable = existing.check_runs.find((r) => r.status !== "completed");
+    if (reusable) {
+        // Refresh the row, but never regress a live `in_progress` run back to `queued`
+        // (a re-trigger's gate can land while the previous e2e job still owns the row).
+        // PATCH semantics: an omitted status leaves the current one in place.
+        await github.rest.checks.update({
+            owner,
+            repo,
+            check_run_id: reusable.id,
+            ...(reusable.status === "in_progress" ? {} : { status }),
+            details_url: detailsUrl,
+        });
+        return reusable.id;
+    }
+
+    const { data } = await github.rest.checks.create({
+        owner,
+        repo,
+        name: CHECK_RUN_NAME,
+        head_sha,
+        status, // 'queued' | 'in_progress'
+        details_url: detailsUrl,
+    });
+    return data.id;
+}
+
+/**
+ * Update the `E2E Tests` check run to its final state. `status: 'completed'` requires
+ * `conclusion`; an in-progress transition (no conclusion) just flips status.
+ */
+async function updateCheckRun({ github, owner, repo, check_run_id, status, conclusion, detailsUrl, summary }) {
+    await github.rest.checks.update({
+        owner,
+        repo,
+        check_run_id,
+        status, // 'in_progress' | 'completed'
+        ...(conclusion ? { conclusion } : {}),
+        details_url: detailsUrl,
+        ...(summary ? { output: { title: CHECK_RUN_NAME, summary } } : {}),
+    });
+}
+
 // --- comment upsert -----------------------------------------------------------------
 
 /**
@@ -366,4 +455,7 @@ module.exports = {
     parseCommand,
     isValidFilter,
     shouldFireRerun,
+    statusToConclusion,
+    createCheckRun,
+    updateCheckRun,
 };

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -13,10 +13,13 @@ const helper = require("./e2e-pr-sticky.js");
 
 // A minimal fake of the Octokit surface the helper touches, recording the calls made so
 // tests can assert "found once, wrote to that exact id" without a network.
-function fakeGithub(existingComment) {
+// `existingCheckRuns` seeds what `checks.listForRef` returns (for createCheckRun reuse tests).
+function fakeGithub(existingComment, existingCheckRuns = []) {
     const calls = [];
+    const checkUpdates = []; // raw checks.update args, for key-presence assertions
     return {
         calls,
+        checkUpdates,
         paginate: async () => {
             calls.push("list");
             return existingComment ? [existingComment] : [];
@@ -30,6 +33,24 @@ function fakeGithub(existingComment) {
                 createComment: async () => {
                     calls.push("create");
                     return { data: { id: 999 } };
+                },
+            },
+            checks: {
+                listForRef: async (args) => {
+                    calls.push(`checks.listForRef:${args.filter || "latest"}`);
+                    return { data: { check_runs: existingCheckRuns } };
+                },
+                create: async (args) => {
+                    calls.push(`checks.create#${args.head_sha}`);
+                    return { data: { id: 555 } };
+                },
+                update: async (args) => {
+                    checkUpdates.push(args);
+                    calls.push(
+                        `checks.update#${args.check_run_id}` +
+                            (args.status ? `:${args.status}` : "") +
+                            (args.conclusion ? `:${args.conclusion}` : ""),
+                    );
                 },
             },
         },
@@ -336,6 +357,102 @@ test("deriveResult: a reportUrl is appended to the headline; absent leaves it un
     assert.match(withUrl.headline, /\[▶ Open interactive report\]\(http:\/\/x\/1\)/);
     const noUrl = helper.deriveResult({ summary: { passed: 1, failed: 0 }, jobStatus: "success", sha: "sha" });
     assert.doesNotMatch(noUrl.headline, /Open interactive report/);
+});
+
+// --- check run (PR Checks tab) -------------------------------------------------------
+
+test("statusToConclusion maps sticky status to a Checks API conclusion", () => {
+    assert.equal(helper.statusToConclusion("passed"), "success");
+    assert.equal(helper.statusToConclusion("failed"), "failure");
+    assert.equal(helper.statusToConclusion("aborted"), "cancelled");
+    assert.equal(helper.statusToConclusion("queued"), undefined);
+});
+
+test("createCheckRun creates against the given head_sha when no check run exists yet", async () => {
+    const gh = fakeGithub(null, []);
+    const id = await helper.createCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        head_sha: "deadbee",
+        status: "queued",
+        detailsUrl: "http://x",
+    });
+    assert.equal(id, 555);
+    assert.deepEqual(gh.calls, ["checks.listForRef:all", "checks.create#deadbee"]);
+});
+
+test("createCheckRun reuses a stuck queued check run, re-queuing it", async () => {
+    const gh = fakeGithub(null, [{ id: 222, status: "queued" }]);
+    const id = await helper.createCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        head_sha: "deadbee",
+        status: "queued",
+        detailsUrl: "http://x",
+    });
+    assert.equal(id, 222, "reuses the existing run's id rather than creating a new one");
+    assert.deepEqual(gh.calls, ["checks.listForRef:all", "checks.update#222:queued"]);
+});
+
+test("createCheckRun reuses an in_progress check run WITHOUT regressing it to queued", async () => {
+    const gh = fakeGithub(null, [{ id: 111, status: "in_progress" }]);
+    const id = await helper.createCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        head_sha: "deadbee",
+        status: "queued",
+        detailsUrl: "http://x",
+    });
+    assert.equal(id, 111, "reuses the live run's id rather than creating a new one");
+    assert.deepEqual(gh.calls, ["checks.listForRef:all", "checks.update#111"]);
+    assert.ok(!("status" in gh.checkUpdates[0]), "a live run's status must be left untouched");
+});
+
+test("createCheckRun ignores a completed check run and creates a fresh one", async () => {
+    const gh = fakeGithub(null, [{ id: 111, status: "completed" }]);
+    const id = await helper.createCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        head_sha: "deadbee",
+        status: "queued",
+        detailsUrl: "http://x",
+    });
+    assert.equal(id, 555, "a completed prior run is a finished history row, not reusable");
+    assert.deepEqual(gh.calls, ["checks.listForRef:all", "checks.create#deadbee"]);
+});
+
+test("updateCheckRun: in_progress carries no conclusion; completed carries the mapped conclusion", async () => {
+    const gh = fakeGithub(null);
+    await helper.updateCheckRun({ github: gh, owner: "o", repo: "r", check_run_id: 555, status: "in_progress" });
+    await helper.updateCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        check_run_id: 555,
+        status: "completed",
+        conclusion: "success",
+    });
+    assert.deepEqual(gh.calls, ["checks.update#555:in_progress", "checks.update#555:completed:success"]);
+});
+
+test("updateCheckRun sends `output` only when a summary is given (never an undefined key)", async () => {
+    const gh = fakeGithub(null);
+    await helper.updateCheckRun({ github: gh, owner: "o", repo: "r", check_run_id: 555, status: "in_progress" });
+    assert.ok(!("output" in gh.checkUpdates[0]), "no summary -> no output key at all");
+    await helper.updateCheckRun({
+        github: gh,
+        owner: "o",
+        repo: "r",
+        check_run_id: 555,
+        status: "completed",
+        conclusion: "success",
+        summary: "12 passed",
+    });
+    assert.deepEqual(gh.checkUpdates[1].output, { title: "E2E Tests", summary: "12 passed" });
 });
 
 // --- find-once upsert contract (no lost-update re-fetch) ----------------------------

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,6 +38,17 @@
 #     merge-coupled trigger (push / pull_request_target / merge_group) or mark any job a
 #     required check.
 #
+# PR visibility: issue_comment and dispatch+pr runs execute at github.sha (the default
+# branch's HEAD), not the PR's head SHA, so GitHub Actions' own auto-registered check for
+# this job lands on master and never appears on the PR's Checks tab. The `gate` job
+# explicitly creates an "E2E Tests" check run keyed on the PR's real head SHA via the
+# Checks API (createCheckRun in e2e-pr-sticky.js, checks: write), the `e2e` job
+# transitions it in_progress -> completed alongside the sticky comment, and the
+# `check-cleanup` job closes it as cancelled when the e2e job never ran (fork approval
+# rejected, or cancelled/replaced while queued). This is a visibility convenience ONLY
+# (continue-on-error / caught Checks API errors throughout) — it is never registered as
+# a required status check; see the invariant above.
+#
 # All secrets resolve from the `test-vps` GitHub Environment (the same per-environment
 # mechanism deploy-server.yml uses), not loose repo-level secrets. R2_BUCKET /
 # R2_PUBLIC_BASE_URL are test-vps *variables* (public by design; see the R2 step).
@@ -90,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write   # post/update the sticky + reactions
+      checks: write          # create the PR-visible "E2E Tests" check run
       contents: read
     # NB: use github.event.sender (the actor who triggered the event), NOT
     # github.event.comment.user. On an `edited` checkbox toggle, comment.user is the
@@ -114,6 +126,7 @@ jobs:
       filter: ${{ steps.gate.outputs.filter }}
       pr_number: ${{ steps.gate.outputs.pr_number }}
       is_fork: ${{ steps.gate.outputs.is_fork }}
+      check_run_id: ${{ steps.gate.outputs.check_run_id }}
     steps:
       # Check out ONLY the shared helper script from the (trusted) default branch, so
       # the github-script step can require() it. issue_comment already runs the default-
@@ -169,12 +182,33 @@ jobs:
                 }),
               });
 
+              // This run executes at github.sha (the default branch's HEAD on issue_comment,
+              // or master on a plain dispatch+pr) — never the PR's head SHA — so the job's own
+              // auto-registered check lands on the wrong commit and never shows on the PR.
+              // Create an explicit check run keyed on the PR's real head SHA (helper header
+              // comment has the full rationale); its id threads through to the e2e job so that
+              // job can transition it in_progress -> completed instead of creating a duplicate.
+              // The sticky above already posted "queued", so a Checks API failure here (perms,
+              // rate-limit, transient error) must not fail the whole gate and strand the run —
+              // catch and proceed with an empty check_run_id (every downstream consumer already
+              // guards on it being non-empty).
+              let checkRunId = '';
+              try {
+                checkRunId = await helper.createCheckRun({
+                  github, owner, repo, head_sha: pr.head.sha, status: 'queued',
+                  detailsUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+                });
+              } catch (err) {
+                core.warning(`Failed to create PR check run: ${err.message}`);
+              }
+
               core.setOutput('proceed', 'true');
               core.setOutput('head_sha', pr.head.sha);
               core.setOutput('head_ref', pr.head.ref);
               core.setOutput('filter', filter);
               core.setOutput('pr_number', String(issueNumber));
               core.setOutput('is_fork', String(isFork));
+              core.setOutput('check_run_id', String(checkRunId));
               return true;
             }
 
@@ -323,6 +357,7 @@ jobs:
     environment: test-vps
     permissions:
       pull-requests: write   # the "Update PR sticky" step posts results back to the PR
+      checks: write          # transition the "E2E Tests" check run in_progress -> completed
       contents: read
     # The runner's own per-test and broker timeouts catch real hangs; this job cap is only
     # a coarse backstop for a wedged process (e.g. a stuck SSH master) that those miss. It
@@ -430,6 +465,27 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
           path: trusted-helper
+
+      # Flip the PR's "E2E Tests" check run from queued -> in_progress now that the VPS
+      # job has actually started (the gate job only creates it queued). continue-on-error:
+      # a Checks API hiccup here must not fail the run — the sticky comment is the source
+      # of truth either way, this check run is a visibility convenience.
+      - name: Start PR check run
+        if: needs.gate.outputs.pr_number != '' && needs.gate.outputs.check_run_id != ''
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_RUN_ID: ${{ needs.gate.outputs.check_run_id }}
+        with:
+          script: |
+            const helper = require(`${process.env.GITHUB_WORKSPACE}/trusted-helper/.github/scripts/e2e-pr-sticky.js`);
+            const { owner, repo } = context.repo;
+            await helper.updateCheckRun({
+              github, owner, repo,
+              check_run_id: Number(process.env.CHECK_RUN_ID),
+              status: 'in_progress',
+              detailsUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+            });
 
       # The coordinator is a net10.0 app that runs HERE on the runner (the mod
       # builds inside Docker; the runner does not). .NET 10 is GA, so the default
@@ -801,14 +857,16 @@ jobs:
           if-no-files-found: warn
 
       # Replace the PR sticky with the final result (any run that resolved a PR — comment,
-      # checkbox, or dispatch+pr; the `if:` keys on pr_number). Reads the runner's
-      # summary.json for counts/status, resets the re-run checkbox to its idle
-      # label, and APPENDS a row to the retained run-history table (older rows kept) so
-      # the PR keeps a full per-run trail for debugging. if: always() fires on pass, fail,
-      # AND cancel (a maintainer preempting the run from the Actions tab) — a sibling status
-      # check picks the headline so a cancelled run reports "⚪ aborted" instead of stranding
-      # on "🟡 queued". The GITHUB_TOKEN edit does not retrigger the workflow (recursion guard).
-      - name: Update PR sticky
+      # checkbox, or dispatch+pr; the `if:` keys on pr_number), and complete the matching
+      # "E2E Tests" check run created by the gate job. Reads the runner's summary.json for
+      # counts/status, resets the re-run checkbox to its idle label, and APPENDS a row to
+      # the retained run-history table (older rows kept) so the PR keeps a full per-run
+      # trail for debugging. if: always() fires on pass, fail, AND cancel (a maintainer
+      # preempting the run from the Actions tab) — a sibling status check picks the
+      # headline so a cancelled run reports "⚪ aborted" instead of stranding on "🟡 queued"
+      # (both the sticky AND the check run reflect that same aborted state). The
+      # GITHUB_TOKEN edit does not retrigger the workflow (recursion guard).
+      - name: Update PR sticky and check run
         if: always() && needs.gate.outputs.pr_number != ''
         continue-on-error: true
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -817,6 +875,7 @@ jobs:
           FILTER: ${{ needs.gate.outputs.filter }}
           PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
           HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+          CHECK_RUN_ID: ${{ needs.gate.outputs.check_run_id }}
           # job.status is success | failure | cancelled at always()-eval time.
           JOB_STATUS: ${{ job.status }}
         with:
@@ -845,6 +904,28 @@ jobs:
             const { status, statusEmoji, resultEmoji, resultWord, headline } =
               helper.deriveResult({ summary, jobStatus, sha, reportUrl });
 
+            // Complete the check run the gate job created (queued -> in_progress in the
+            // "Start PR check run" step -> completed here). Skipped when check_run_id is
+            // empty (creation failed/was skipped) AND wrapped in try/catch, so the sticky
+            // update below runs either way — the sticky is the source of truth, the check
+            // run a convenience; an unguarded Checks API throw here would strand the
+            // sticky on its pre-run state.
+            const checkRunId = process.env.CHECK_RUN_ID;
+            if (checkRunId) {
+              try {
+                await helper.updateCheckRun({
+                  github, owner, repo,
+                  check_run_id: Number(checkRunId),
+                  status: 'completed',
+                  conclusion: helper.statusToConclusion(status),
+                  detailsUrl: reportUrl || `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+                  summary: headline,
+                });
+              } catch (err) {
+                core.warning(`Failed to complete PR check run: ${err.message}`);
+              }
+            }
+
             // Append a history row. renderBody caps the retained rows, so derive the run
             // number from the highest existing n (NOT array length, which is bounded).
             const existing = await helper.findSticky({ github, owner, repo, issue_number });
@@ -863,3 +944,53 @@ jobs:
             // Pass `existing` so the write targets the exact comment we read history from
             // (one find per update; no lost-update race against a concurrent edit).
             await helper.upsertSticky({ github, owner, repo, issue_number, body, existing });
+
+  # ── Close an orphaned "E2E Tests" check run. The gate creates it `queued`, but on the
+  # paths where the e2e job never runs (fork-pr approval rejected, a queued run cancelled
+  # or replaced via `queue: max`) no always() step exists to complete it — the PR's Checks
+  # tab would show a pending spinner until a later run reuses the row. Fires only when the
+  # e2e job was skipped or cancelled: on success/failure its own final step completed the
+  # run (and a `cancelled` conclusion here must never overwrite a real one). The
+  # checks.get guard covers cancel-MID-run, where e2e's always() step did reach completed
+  # before this job fires. Residual: a runner that dies before e2e's final step leaves the
+  # row pending (job result `failure`, deliberately not matched here) — the next run's
+  # createCheckRun reuses it. Not in the e2e concurrency singleton: it makes one API call
+  # and must run while the replacing run occupies the group.
+  check-cleanup:
+    name: Close orphaned check run
+    needs: [gate, e2e]
+    if: >
+      always() && needs.gate.outputs.check_run_id != ''
+      && (needs.e2e.result == 'skipped' || needs.e2e.result == 'cancelled')
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    timeout-minutes: 5
+    steps:
+      # Same trusted default-ref helper checkout as the gate job (never the PR head).
+      - name: Checkout sticky helper
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts/e2e-pr-sticky.js
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Complete check run as cancelled
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CHECK_RUN_ID: ${{ needs.gate.outputs.check_run_id }}
+        with:
+          script: |
+            const helper = require('./.github/scripts/e2e-pr-sticky.js');
+            const { owner, repo } = context.repo;
+            const check_run_id = Number(process.env.CHECK_RUN_ID);
+            const { data: run } = await github.rest.checks.get({ owner, repo, check_run_id });
+            if (run.status === 'completed') return; // e2e's final step got there first
+            await helper.updateCheckRun({
+              github, owner, repo, check_run_id,
+              status: 'completed',
+              conclusion: 'cancelled',
+              detailsUrl: `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+              summary: 'The E2E job never ran (cancelled while queued, or fork approval rejected).',
+            });


### PR DESCRIPTION
## Changes

- The `gate` job creates an "E2E Tests" check run keyed on the PR's real head SHA via the Checks API — issue_comment and dispatch+pr runs execute at the default branch's HEAD, so the workflow's auto-registered check lands on master and never appears on the PR's Checks tab.
- The `e2e` job flips the check run to `in_progress` when the VPS job actually starts and completes it with the derived result (`success`/`failure`/`cancelled`) alongside the sticky-comment update.
- New `check-cleanup` job closes an orphaned check run as `cancelled` when the `e2e` job never ran (fork approval rejected, or the run was cancelled/replaced while queued), so the PR never shows a permanent pending spinner. A `checks.get` guard prevents it from overwriting a conclusion the `e2e` job already wrote.
- `createCheckRun` reuses a non-completed check run on the same SHA (`filter: "all"` so a stuck row can't hide behind a newer one) instead of accumulating rows across re-runs, and never regresses a live `in_progress` row back to `queued` when a re-trigger's gate lands mid-run.
- Every Checks API call is guarded (try/catch + `continue-on-error`) so a Checks failure can never strand the sticky comment update — the sticky stays the source of truth; the check run is a visibility convenience and is never registered as a required status check (the workflow's no-required-check invariant is unchanged).
- Unit tests cover the conclusion mapping, create/reuse/ignore-completed paths, the no-regress rule, and that `output`/`status` keys are only sent when meaningful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
