### PR TITLE
ci(e2e): instant running transition + live progress in the PR sticky

### DIFF
--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -168,7 +168,7 @@ function deriveResult({ summary, jobStatus, sha, reportUrl }) {
  * next event to recover, a status block, the re-run checkbox, and the collapsed
  * run-history table.
  * @param {object} state
- * @param {'queued'|'passed'|'failed'|'aborted'} state.status - Run status (drives wording).
+ * @param {'queued'|'running'|'passed'|'failed'|'aborted'} state.status - Run status (drives wording).
  * @param {string} state.statusEmoji - Emoji shown in the heading.
  * @param {string} state.headline - Markdown headline line under the heading.
  * @param {string} state.filter - The run filter (empty = full suite).
@@ -239,7 +239,7 @@ function renderBody(state) {
 // PR's real head SHA (`checks: write`), independent of the job's own auto-check.
 const CHECK_RUN_NAME = "E2E Tests";
 
-/** Map a sticky `status` (queued|passed|failed|aborted) to a Checks API `conclusion`. */
+/** Map a sticky `status` (queued|running|passed|failed|aborted) to a Checks API `conclusion`. */
 function statusToConclusion(status) {
     switch (status) {
         case "passed":
@@ -249,7 +249,7 @@ function statusToConclusion(status) {
         case "aborted":
             return "cancelled";
         default:
-            return undefined; // 'queued' has no conclusion (still in_progress/queued)
+            return undefined; // 'queued'/'running' have no conclusion (still in flight)
     }
 }
 

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -299,6 +299,33 @@ test("renderBody links: run + report when present, omitted when absent", () => {
     assert.ok(b2.includes("[run](http://r/1)") && !b2.includes("report]("));
 });
 
+test("renderBody: running status renders the 🔵 heading and preserves filter/history", () => {
+    const rows = [
+        {
+            n: 3,
+            result: "passed",
+            resultEmoji: "🟢",
+            sha: "abc1234",
+            filter: "Foo",
+            when: "t",
+            runUrl: "http://r/3",
+            reportUrl: "",
+        },
+    ];
+    const body = helper.renderBody({
+        status: "running",
+        statusEmoji: "🔵",
+        headline: "Running for `abc1234`… 12/96 (11 passed, 1 failed, 0 canceled, 0 skipped)",
+        filter: "Foo",
+        history: rows,
+        requested: false,
+    });
+    assert.ok(body.includes("### 🔵 E2E Tests"));
+    assert.match(body, /Running for `abc1234`… 12\/96/);
+    assert.equal(helper.readFilter(body), "Foo");
+    assert.deepEqual(helper.readHistory(body), rows);
+});
+
 // --- result derivation -------------------------------------------------------------
 
 test("deriveResult: a cancelled job is aborted regardless of a partial summary", () => {
@@ -366,6 +393,7 @@ test("statusToConclusion maps sticky status to a Checks API conclusion", () => {
     assert.equal(helper.statusToConclusion("failed"), "failure");
     assert.equal(helper.statusToConclusion("aborted"), "cancelled");
     assert.equal(helper.statusToConclusion("queued"), undefined);
+    assert.equal(helper.statusToConclusion("running"), undefined);
 });
 
 test("createCheckRun creates against the given head_sha when no check run exists yet", async () => {

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -450,8 +450,9 @@ jobs:
           persist-credentials: false
 
       # SECURITY: the workspace above is PR HEAD — on a fork PR it is untrusted code.
-      # The "Update PR sticky" step runs with the test-vps secrets + pull-requests:write,
-      # so it must NOT require() the sticky helper from that checkout (a fork could edit it
+      # The sticky-writing steps ("Mark PR sticky running", the run step's progress poll,
+      # "Update PR sticky") run with the test-vps secrets + pull-requests:write, so they
+      # must NOT require() the sticky helper from that checkout (a fork could edit it
       # to run arbitrary JS with secrets — CodeQL "Untrusted Checkout TOCTOU"). Pull the
       # helper from the TRUSTED default branch into a separate path and require() that copy.
       # (Building/testing the PR code itself is the intended, fork-pr-gated behaviour; this
@@ -606,6 +607,42 @@ jobs:
             | { grep -v '^SDVD_EVENT ' || true; }
           exit "${PIPESTATUS[0]}"
 
+      # Flip the sticky from "queued" to "running" now that setup is done and the suite
+      # is about to start (the sibling of "Start PR check run" above, for the comment).
+      # Outputs the sticky's comment id so the run step's progress poll can PATCH the
+      # exact comment without re-finding it each tick. continue-on-error: a sticky
+      # hiccup must not fail the run — an empty comment_id just disables the poll.
+      - name: Mark PR sticky running
+        id: mark-running
+        if: needs.gate.outputs.pr_number != ''
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.gate.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
+          FILTER: ${{ needs.gate.outputs.filter }}
+        with:
+          script: |
+            // Trusted (default-branch) copy — NOT the PR-HEAD checkout (see "Checkout
+            // trusted sticky helper" above).
+            const helper = require(`${process.env.GITHUB_WORKSPACE}/trusted-helper/.github/scripts/e2e-pr-sticky.js`);
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const existing = await helper.findSticky({ github, owner, repo, issue_number });
+            const history = existing ? helper.readHistory(existing.body) : [];
+            // Keep the checkbox's "(requested)" suffix while the run is in flight — it
+            // is only cleared when fresh results post (the final sticky update).
+            const requested = !!existing && existing.body.includes(helper.RERUN_REQUESTED_LABEL);
+            const id = await helper.upsertSticky({
+              github, owner, repo, issue_number, existing,
+              body: helper.renderBody({
+                status: 'running', statusEmoji: '🔵',
+                headline: `Running for \`${helper.shortSha(process.env.HEAD_SHA)}\`…`,
+                filter: process.env.FILTER || '', history, requested,
+              }),
+            });
+            core.setOutput('comment_id', String(id));
+
       # The whole pipeline in one command. The runner builds all three images
       # in-process (reading STEAM_ACCOUNTS[0] for the Steam --secret login),
       # streams them + the game-data volume to the VPS, then runs the tests there.
@@ -613,6 +650,11 @@ jobs:
       # that class); with no filter the full suite runs. STEAM_ACCOUNTS is required
       # here from the very first run — without it the in-process image build fails
       # with a Steam-login error.
+      #
+      # On PR runs the suite is backgrounded through `tee` and this step's poll loop
+      # lifts CIRenderer's periodic PROGRESS line (stdout is non-TTY here) into the
+      # sticky comment every ~60s — GitHub Actions steps are strictly sequential, so
+      # live progress must come out of this one long-running step, not a sibling.
       - name: Run E2E suite
         env:
           SDVD_DOCKER_HOSTS: ${{ secrets.SDVD_DOCKER_HOSTS }}
@@ -623,12 +665,68 @@ jobs:
           # checkbox; empty (the default) runs the full suite — pass --filter only
           # when a non-whitespace value was provided.
           FILTER: ${{ needs.gate.outputs.filter }}
+          # For the progress poll loop (PR runs only): gh auth to PATCH the sticky
+          # located by "Mark PR sticky running". Empty comment id (no PR context, or
+          # that step failed) means a plain foreground run with no polling.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STICKY_COMMENT_ID: ${{ steps.mark-running.outputs.comment_id }}
+          HEAD_SHA: ${{ needs.gate.outputs.head_sha }}
         run: |
+          args=()
           if [ -n "${FILTER//[[:space:]]/}" ]; then
-            dotnet run --project ./tests/JunimoServer.TestRunner -- --filter "$FILTER"
-          else
-            dotnet run --project ./tests/JunimoServer.TestRunner
+            args=(-- --filter "$FILTER")
           fi
+
+          if [ -z "${STICKY_COMMENT_ID:-}" ]; then
+            exec dotnet run --project ./tests/JunimoServer.TestRunner "${args[@]}"
+          fi
+
+          # The subshell records the runner's own exit code: after `wait` $? would be
+          # tee's, and PIPESTATUS does not cover a backgrounded pipeline. `set +e` in the
+          # subshell: it inherits this step's errexit, which would otherwise abort it on a
+          # runner failure before the echo runs (leaving run.exit empty).
+          : > run.exit
+          ( set +e; dotnet run --project ./tests/JunimoServer.TestRunner "${args[@]}" 2>&1; echo "$?" > run.exit ) | tee run.log &
+          TEE_PID=$!
+
+          update_sticky() {
+            # Render with the TRUSTED helper copy (never the PR-HEAD one — see the
+            # trusted-helper checkout above). Read the live body each tick so history
+            # rows appended by other runs survive the PATCH.
+            gh api "/repos/${GITHUB_REPOSITORY}/issues/comments/${STICKY_COMMENT_ID}" --jq .body > sticky-body.txt \
+              && PROGRESS_LINE="$1" node -e '
+                const fs = require("fs");
+                const helper = require(process.env.GITHUB_WORKSPACE + "/trusted-helper/.github/scripts/e2e-pr-sticky.js");
+                const body = fs.readFileSync("sticky-body.txt", "utf8");
+                const counts = process.env.PROGRESS_LINE.replace(/^PROGRESS /, "");
+                process.stdout.write(helper.renderBody({
+                  status: "running", statusEmoji: "🔵",
+                  headline: "Running for `" + helper.shortSha(process.env.HEAD_SHA) + "`… " + counts,
+                  filter: process.env.FILTER || "",
+                  history: helper.readHistory(body),
+                  requested: body.includes(helper.RERUN_REQUESTED_LABEL),
+                }));
+              ' > sticky-new.txt \
+              && gh api --method PATCH --silent \
+                   "/repos/${GITHUB_REPOSITORY}/issues/comments/${STICKY_COMMENT_ID}" \
+                   -F "body=@sticky-new.txt"
+          }
+
+          last=""
+          while kill -0 "$TEE_PID" 2>/dev/null; do
+            sleep 60
+            progress=$(grep -ao 'PROGRESS [0-9][0-9]*/[0-9][0-9]* ([^)]*)' run.log | tail -n 1 || true)
+            if [ -n "$progress" ] && [ "$progress" != "$last" ]; then
+              # A sticky/API hiccup must never fail the run — retry on the next tick.
+              if update_sticky "$progress"; then last="$progress"; else echo "PROGRESS sticky update failed (non-fatal)"; fi
+            fi
+          done
+          wait "$TEE_PID" || true
+
+          # Propagate the runner's real exit code; a missing run.exit (the subshell was
+          # killed before writing it) counts as failure.
+          RUN_EXIT=$(cat run.exit 2>/dev/null)
+          exit "${RUN_EXIT:-1}"
 
       # Render the runner's ctrf-report.json (TestRunArtifactWriter.WriteCtrfReport,
       # one per CI invocation) into the job Summary tab. summary-report = pass/fail

--- a/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/CIRenderer.cs
@@ -12,7 +12,8 @@ namespace JunimoServer.TestRunner.Rendering;
 /// reposition the cursor — so streaming there would re-emit a class header (and its
 /// ::group::) every time execution flips back to that class, duplicating headers and
 /// breaking groups. So non-TTY buffers per-test result lines and emits them grouped by
-/// class once, at run end. Diagnostics/annotations stream live in both modes.
+/// class once, at run end. Diagnostics/annotations stream live in both modes, and
+/// non-TTY additionally emits a periodic PROGRESS line as a mid-run liveness signal.
 /// </summary>
 public sealed class CIRenderer : RendererBase
 {
@@ -63,6 +64,13 @@ public sealed class CIRenderer : RendererBase
     private bool _spinnerIsSetup; // true = setup step spinner, false = test spinner
     private int _terminalWidth;
 
+    // Periodic PROGRESS line for non-TTY sinks — the only mid-run liveness signal there
+    // (no spinner), and what the CI workflow's sticky-comment poll loop greps for.
+    // _runFinished (under _writeLock) stops a tick already in flight at dispose time.
+    private Timer? _progressTimer;
+    private bool _runFinished;
+    private static readonly TimeSpan ProgressInterval = TimeSpan.FromSeconds(30);
+
     public CIRenderer(bool verbose = false)
         : this(Console.Out, Console.Error, verbose) { }
 
@@ -103,6 +111,33 @@ public sealed class CIRenderer : RendererBase
         _out.WriteLine();
         _out.WriteLine($" {Bold("JunimoServer.Tests")}");
         _out.Flush();
+
+        if (!_isTTY)
+        {
+            _progressTimer = new Timer(ProgressTick, null, ProgressInterval, ProgressInterval);
+        }
+    }
+
+    private void ProgressTick(object? state)
+    {
+        lock (_writeLock)
+        {
+            if (_runFinished)
+            {
+                return;
+            }
+
+            // ::notice:: additionally surfaces the line as a GH Actions log annotation;
+            // omit it on a plain piped local log where the syntax is meaningless.
+            var prefix = _isGitHubActions ? "::notice::" : "";
+            var completed = PassedCount + FailedCount + CanceledCount + SkippedCount;
+            _out.WriteLine(
+                $"{prefix}PROGRESS {completed}/{TotalDiscovered} "
+                    + $"({PassedCount} passed, {FailedCount} failed, "
+                    + $"{CanceledCount} canceled, {SkippedCount} skipped)"
+            );
+            _out.Flush();
+        }
     }
 
     public override void OnDiscoveryComplete(DiscoveryCompleteEvent e)
@@ -114,6 +149,12 @@ public sealed class CIRenderer : RendererBase
     {
         lock (_writeLock)
         {
+            // Setting _runFinished under the lock turns a progress tick that is already
+            // blocked on it into a no-op — Timer.Dispose alone doesn't drain callbacks.
+            _runFinished = true;
+            _progressTimer?.Dispose();
+            _progressTimer = null;
+
             if (_isTTY)
             {
                 EndClassGroup();
@@ -735,6 +776,10 @@ public sealed class CIRenderer : RendererBase
     {
         lock (_writeLock)
         {
+            // Covers aborted runs that never reach OnRunFinished.
+            _runFinished = true;
+            _progressTimer?.Dispose();
+            _progressTimer = null;
             StopSpinnerLocked();
         }
         // Close any open GitHub Actions group


### PR DESCRIPTION
Implements `.claude/plans/features/e2e-sticky-live-progress.md`: the E2E PR sticky no longer sits on "🟡 Queued…" for the entire ~20–30 min run.

- `CIRenderer` emits a periodic `PROGRESS completed/total (passed, failed, canceled, skipped)` line every ~30s on non-TTY sinks — the only mid-run liveness signal where there is no spinner (CI logs and piped local runs alike). Prefixed `::notice::` only on GH Actions; the timer is disposed in `OnRunFinished`/`DisposeAsync` with an in-flight tick guarded under the existing `_writeLock`.
- New "Mark PR sticky running" workflow step flips the sticky to "🔵 Running for `sha`…" right before the suite starts (trusted-helper copy, `continue-on-error`, preserves the checkbox's "(requested)" suffix mid-flight) and outputs the sticky's comment id.
- The "Run E2E suite" step backgrounds the runner through `tee` on PR runs and every ~60s lifts the latest PROGRESS line into the sticky via the helper's pure `renderBody`/`readHistory` (history is re-read live each tick so rows appended by other runs survive) and a `gh api` PATCH. Non-PR runs (dispatch/schedule) `exec` the runner unchanged.
- The runner's real exit code propagates via a `run.exit` file: `PIPESTATUS` does not cover a backgrounded pipeline, and the step's inherited `errexit` would otherwise abort the subshell before recording a failure — a poll/API hiccup can never mask or fail the run.
- `renderBody` gains the `running` status in its contract docs plus unit tests; `statusToConclusion` treats it like `queued` (no conclusion).

Verification: `npm test` (40 pass, incl. the new running-body test); TestRunner builds clean; a probe harness drove the real `CIRenderer` non-TTY and the workflow's exact grep extracted the emitted line; the poll loop's render stage and the exit-code plumbing were simulated under `bash -e -o pipefail` (failing runner → step exits with the runner's code). The end-to-end sticky flow (queued → running flip, ~60s updates, final update on top) needs this PR's first real run to confirm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull request E2E test status now displays a clear “Running” state while tests are in progress.
  - E2E test runs provide periodic live progress updates, including completed, passed, failed, canceled, and skipped counts.
  - Progress updates remain available during non-interactive runs and in GitHub Actions.

- **Bug Fixes**
  - Preserved accurate final test results even when progress updates encounter temporary issues.
  - Improved handling of test status transitions and in-progress checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->