### PR TITLE
fix(mod): heal sprite-less NPCs so a failed sprite load can't freeze the world clock

### DIFF
--- a/.claude/plans/bugs/npc-sprite-nre-tenminute-update-final.md
+++ b/.claude/plans/bugs/npc-sprite-nre-tenminute-update-final.md
@@ -1,0 +1,281 @@
+# Fix plan: Sprite-null NPC freezes the world clock (`NPC.routeEndAnimationFinished` NRE)
+
+Investigation input: [`npc-sprite-nre-tenminute-update.md`](npc-sprite-nre-tenminute-update.md). This plan supersedes
+it: the mechanism is now fully verified against decompiled sources, two of its hypotheses are corrected
+(see "Corrections"), and the SkiaSharp errors it declared out-of-scope turn out to be the trigger.
+
+## Summary
+
+An NPC whose spritesheet **exists per `DoesAssetExist` but throws on load** survives save-load with
+`Sprite == null`. On this render-suppressed server nothing touches the sprite until the NPC's first
+scheduled departure, where vanilla dereferences `Sprite` unconditionally inside the ten-minute clock
+update. The queued schedule entry is never dequeued, so **every subsequent ten-minute boundary
+re-throws**, and each throw aborts the clock update before `netWorldState.UpdateFromGame1()` — the only
+path that pushes `timeOfDay` to clients — so every client's clock freezes permanently ("stuck at 6:40").
+
+Two independent root causes stack:
+
+1. **Image regression (trigger).** #473 (`d0d059b`) removed the GUI apt packages whose transitive deps
+   included `libfontconfig1`; SMAPI's SkiaSharp-based image decoding fails without it, so content-pack
+   image loads (custom NPC spritesheets from SVE etc.) throw. Data edits (JSON) still succeed, so the
+   NPCs keep their data and schedules — only the sprite is missing. The working tree already re-adds
+   `libfontconfig1` (uncommitted, `docker/Dockerfile:161-162`).
+2. **Vanilla load fragility (the class of bug to harden against).** `NPC.TryLoadSprites` swallows the
+   load exception and leaves `Sprite` null; `ChooseAppearance` downgrades that to a log warning;
+   `fixProblems` only removes villagers whose *data* is missing. Any broken content pack — not just
+   this SkiaSharp incident — reproduces the frozen-clock disaster on a headless server.
+
+Fix = commit the image dependency (layer 1) + a mod-side sprite-integrity heal at the load boundary
+(layer 2), with diagnostics that name the broken NPC, plus E2E coverage.
+
+## Verified mechanism (all cites: `decompiled/sdv-1.6.15-24356/` unless noted)
+
+### Shell creation at save-load
+
+- Save deserialization constructs NPCs via the parameterless ctor (XmlSerializer); only the
+  `Character(AnimatedSprite, ...)` ctor assigns `Sprite` (`Character.cs:571-582`). `Character.Sprite`
+  is `[XmlIgnore]` (`Character.cs:442-453`), so sprites never round-trip — they are always
+  reconstructed at load.
+- Reconstruction happens once, in `SaveGame.loadDataToLocations`: for every NPC in every location,
+  `initializeCharacter(obj, location)` (sets `currentLocation`) then `obj.reloadSprite()`
+  (`SaveGame.cs:1567-1579`) → `ChooseAppearance()` (`NPC.cs:1171-1196`).
+- `TryLoadSprites` (`NPC.cs:1249-1288`): `if (Sprite == null) Sprite = new AnimatedSprite(content,
+  assetName)` sits inside a `try/catch` that returns `false` on any exception — **a throwing content
+  load leaves `Sprite` null**. `ChooseAppearance` responds with `Game1.log.Warn("NPC {name} can't load
+  sprites from '{asset}': ...")` and carries on (`NPC.cs:1071-1074`); its final size fix-up is guarded
+  by `Sprite != null` (`NPC.cs:1080`).
+- Crucially, the hole opens **only** when `DoesAssetExist == true` but the load throws (the SkiaSharp
+  case, a corrupt PNG, a crashing loader). For a *cleanly missing* asset, `AnimatedSprite`'s ctor
+  skips loading (`AnimatedSprite.cs:203-218`) and returns a valid textureless sprite — vanilla's
+  designed degradation, rendered as an error box (`NPC.draw`, `NPC.cs:5069-5074`,
+  `Utility.DrawErrorTexture`).
+- `Game1.fixProblems` (`Game1.cs:7446-7487`) removes a villager only when `GetData() == null`; its own
+  `try/catch` around `npc.Sprite.Texture` shows vanilla anticipates Sprite-null NPCs at load. An NPC
+  with intact data but a throwing spritesheet **survives as a shell**.
+
+### Why only this server hits it
+
+- Rendering is suppressed (`SERVER_FPS=0`, `Game.Draw` patched out — see
+  `.claude/rules/display-scaling.md`). A rendering game NREs instantly at `NPC.draw`
+  (`Sprite.Texture` deref, `NPC.cs:5069`), making the broken NPC loud. Headless, the shell idles
+  silently: per-tick NPC updates only run in locations with players present, and nothing else touches
+  `Sprite` until the schedule fires.
+
+### The crash and the permanent clock freeze
+
+- Every 10 game-minutes: `Game1.UpdateGameClock` (`Game1.cs:6050-6090`) →
+  `performTenMinuteClockUpdate` (`Game1.cs:5882`): resets `gameTimeInterval` (`:5887`), advances
+  `timeOfDay += 10` (`:5890`), then iterates **all** locations calling
+  `performTenMinuteUpdate`/`timeUpdate` (`:6005-6014`), and only afterwards syncs world state to
+  clients via `netWorldState.Value.UpdateFromGame1()` (`:6017-6020`).
+- `GameLocation.performTenMinuteUpdate` loops `characters` with no try/catch, only an `IsInvisible`
+  guard (`GameLocation.cs:13638-13652`), calling `checkSchedule(timeOfDay)`.
+- `checkSchedule` (`NPC.cs:4093-4159`): queues today's due entry (`:4112-4121`), then if
+  `queuedSchedulePaths[0].time` has arrived calls `prepareToDisembarkOnNewSchedulePath()` (`:4135`) —
+  the dequeue (`RemoveAt(0)`, `:4139-4141`) happens **after** it returns.
+- `prepareToDisembarkOnNewSchedulePath` → `finishEndOfRouteAnimation` (`NPC.cs:4161-4219`): when the
+  NPC is *not* mid-end-of-route-animation, the `else` branch calls **`routeEndAnimationFinished(null)`
+  unconditionally** (`:4215-4218`). So every scheduled departure of every NPC runs it — no
+  end-of-route animation state is required (correction to the input doc).
+- `routeEndAnimationFinished` (`NPC.cs:4276-4305`): first statements dereference `Sprite`
+  (`Sprite.SpriteWidth = data?.Size.X ?? 16;`, `:4281-4285`). The `who` parameter is never used, so
+  `null` is fine; `GetData()` is null-safe; every other member in the method is a non-nullable
+  NetField or plain field. **`Sprite == null` is the only NRE candidate.** Line arithmetic matches the
+  reported `NPC.cs:4786`: the two stack anchors (real 4713/4719 ↔ decompiled 4217/4223) put the first
+  `Sprite.` deref at real ≈4777 + ~9 doc-comment lines = 4786.
+- Consequences of the throw, per boundary:
+  - The queued entry is never dequeued → the same throw repeats at **every** later boundary that day.
+  - The `foreach` over locations aborts → remaining locations get no ten-minute/time updates.
+  - `UpdateFromGame1()` is skipped → clients never see `timeOfDay` change again (client time is only
+    driven by the world-state broadcast — `.claude/rules/host-automation.md` invariant 6). The
+    *server-internal* clock still advances (the increment precedes the loop), which is why the log
+    shows exactly one NRE per real ~N seconds, not a tick-storm.
+  - SMAPI catches at `SCore.OnPlayerInstanceUpdating` ("An error occurred in the base update loop")
+    so the process survives in this zombie state.
+- Overnight, `NPC.dayUpdate` clears the queue (`NPC.cs:6091`) and retries `ChooseAppearance`
+  (`:6135`) — which fails again while the content is broken, so the crash loop re-arms every morning.
+
+### Corrections to the input investigation
+
+- **Join-race hypothesis: refuted.** The master never deserializes NPC shells mid-session, and no
+  vanilla code nulls a live NPC's sprite after construction (project-wide grep for `Sprite = null` /
+  `sprite.Value = null`: only unrelated `TemporaryAnimatedSprite` locals). The second player's join is
+  incidental timing. The load boundary is the *only* shell-creation seam on the master.
+- **SkiaSharp errors are the trigger, not a separate bug.** The "9 minutes after the NRE" ordering
+  argument only covered the pasted excerpt; the load-time failures ("NPC X can't load sprites from
+  ...") happen at boot. Timeline fits: #473 merged 2026-07-12, operator pulls the new image, restarts
+  → save reloads with broken SkiaSharp → shells → first scheduled departure freezes the clock.
+- **#474 `ReHomeNpc` exonerated with mechanism**: `ClearSchedule` leaves `queuedSchedulePaths` stale,
+  but `checkSchedule` early-returns on `Schedule == null` (`NPC.cs:4107-4110`) and `dayUpdate` clears
+  the queue (`:6091`), so the stale entries are unreachable.
+
+### Answers to the input doc's open questions
+
+1. *Which NPC?* Not derivable from the excerpt; the reporter's log names it — see "Field
+   confirmation". The fix's diagnostics name it permanently.
+2. *Mid-resync at join?* Irrelevant — no server-side shell path exists via joins.
+3. *Deterministic?* Yes: with broken content it reproduces on **every load**, not a race.
+4. *Vanilla-only?* Vanilla bug (worth an upstream report), but the headless config uniquely hides the
+   visual signal and uniquely suffers the clock freeze — the hardening belongs in this mod.
+5. *Stuck clock mechanism?* Answered above: repeat-throw before dequeue + skipped `UpdateFromGame1`.
+
+## Field confirmation (cheap; do before/alongside the fix)
+
+- Reporter's full SMAPI log, grep: `can't load sprites from` (names every shell NPC at load),
+  `Removed broken NPC` (data-less removals), and the NRE recurring once per boundary after 16:00:12.
+- Confirm the server image is post-#473 without the `libfontconfig1` line, and that the server was
+  restarted (image update) before in-game day 4.
+
+## Fix design
+
+### Layer 1 — image dependency (already in working tree, commit it)
+
+`docker/Dockerfile` re-adds `libfontconfig1` with a consumer comment. Ship as its own
+`fix(docker):` commit/PR — it unbreaks all content-pack image loading (EditImage too) independently
+of the mod hardening.
+
+Verification (per `.claude/rules/image-runtime-deps-must-be-explicit.md` — same #473 incident class
+as libicu67): build, boot a server container far enough that the game files exist (they live in the
+volume, downloaded at runtime), then
+`docker exec <c> ldd /data/game/smapi-internal/libSkiaSharp.so` → no `not found` lines. A green build
+proves nothing here.
+
+### Layer 2 — mod: `NpcSpriteIntegrityService` (the durable hardening)
+
+**Principle: restore the engine invariant at the boundary that violates it.** The engine assumes
+`NPC.Sprite != null` in ~40 unguarded call sites (schedule departure, route animations, emotes, draw,
+day updates); guarding the one reported crash site would be whack-a-mole. Removal is wrong too —
+vanilla only removes *data-less* NPCs, and these NPCs have data, schedules, possibly marriages. The
+correct heal makes the "asset exists but throws" case converge onto vanilla's already-supported
+"asset missing" case: a **valid, textureless `AnimatedSprite`**, which vanilla renders as an error
+box (`NPC.cs:5069-5074`) and null-guards everywhere that matters (`AnimatedSprite.draw`
+`:563-577`, `UpdateSourceRect` via `Texture?.Width ?? 96` `:73-75`, `StopAnimation` `:244-256`).
+
+New service `mod/JunimoServer/Services/NpcIntegrity/NpcSpriteIntegrityService.cs` (auto-discovered via
+`IModService`, ctor-injected `IModHelper`/`IMonitor`, subscribes in `Entry()`):
+
+- `GameLoop.SaveLoaded` → `HealSpritelessNpcs("save_loaded")` — the seam where shells are created.
+- `GameLoop.DayStarted` → `HealSpritelessNpcs("day_started")` — tripwire sweep against unknown seams,
+  mirroring the `HealLobbyHomedResidents` precedent (`CabinManagerService.cs:214,225`). No-ops (zero
+  allocations beyond the walk) on healthy saves; runs twice per day, not per-tick.
+- `HealSpritelessNpcs(string context)`:
+  - `Utility.ForEachLocation(..., includeInteriors: true)` over `location.characters` — married
+    spouses live in cabin/farmhouse interiors. All `NPC` subtypes are eligible (a Sprite-null
+    Pet/Child/Horse breaks other engine paths the same way), not just villagers.
+  - For each `npc.Sprite == null`:
+    - `npc.Sprite = new AnimatedSprite();` (property assignment — same shape `TryLoadSprites` uses;
+      the `NetRef` replicates the healed sprite to clients, whose draw takes the error-box path
+      instead of NREing at `NPC.cs:5069`).
+    - Size from data, mirroring `routeEndAnimationFinished`'s own fallbacks: `SpriteWidth =
+      GetData()?.Size.X ?? 16`, `SpriteHeight = GetData()?.Size.Y ?? 32`, then `UpdateSourceRect()`.
+    - **Do not set `textureName`.** A broken name would throw in every client's lazy `Texture` getter
+      (`AnimatedSprite.cs:64-71,220-232` — `loadTexture` has no exists-gate and no catch); a null
+      name is exactly what vanilla produces for missing assets. Self-heal is free: the engine's daily
+      `dayUpdate → ChooseAppearance → TryLoadSprites → Sprite.LoadTexture(...)` (`NPC.cs:1278`)
+      restores the real texture the day the content is fixed.
+    - `Monitor.Log(..., LogLevel.Warn)` naming NPC, location, and `getTextureName()` (**Warn, not
+      Error** — `.claude/rules/debugging.md`: Error is test poison), and
+      `Diagnostics.ModEventLog.Emit("npc_sprite_healed", new { npcName, location, textureName,
+      context })` — mirrors `npc_rehomed` (`CabinManagerService.cs:1697-1709`).
+  - Track last-run metadata (context, healed count) in fields for the test-status endpoint.
+
+**Deliberately not doing** (with reasons, so nobody re-adds them):
+- No Harmony guard on `routeEndAnimationFinished`/`checkSchedule`/`performTenMinuteUpdate`: with no
+  mid-day Sprite writer in the engine (grep-verified) the load/day boundaries are complete coverage;
+  a guard would defend against nothing real and add a per-boundary patch to maintain.
+- No `ChooseAppearance` postfix: it's virtual with seven overrides (Pet, Horse, Child, Junimo,
+  Monster, TrashBear, JunimoHarvester), Harmony only hits the base implementation, and load-time
+  calls run off the main thread; the sweep avoids all of that and matches the in-tree heal pattern.
+- No portrait heal: `Portrait` is `[XmlIgnore]`, loaded per-machine, unused by any server-side code
+  path (the server opens no dialogue UI); clients load their own.
+- No NPC removal (breaks marriages/quests for an NPC that is otherwise fully functional).
+
+### Test surface (`ApiService.TestEndpoints.cs`, existing `/test/*` switch + `Env.IsTest` gate)
+
+- `GET /test/npc_sprite_integrity` → `{ lastRunContext, lastRunHealedCount, spritelessNpcs: [names] }`
+  (live scan + service metadata). The metadata assertion proves the SaveLoaded *wiring* fired, not
+  just that the heal logic works when invoked — closes the bypass-path gap
+  (`.claude/rules/universal/passing-test-isnt-proof-the-scenario-ran.md`).
+- `POST /test/break_npc_sprite` `{ "npcName": "..." }` → nulls that NPC's `Sprite` on the game thread
+  (`RunOnGameThreadAsync`), returning prior state. This is the same inject-synthetic-state-for-a-sweep
+  pattern as `/test/stamp_claim` / `/test/stamp_lobby_home`.
+- `POST /test/heal_npc_sprites` → invokes the same `HealSpritelessNpcs("test")` the event handlers
+  call; returns healed count. (Service exposed to ApiService via DI, like other services.)
+
+## Implementation steps
+
+1. **Commit layer 1** (`fix(docker): restore libfontconfig1 for SkiaSharp image decoding`) with the
+   boot + `ldd` verification recorded in the PR. Independent PR; ship first.
+2. **`NpcSpriteIntegrityService`** as specified above (new folder `Services/NpcIntegrity/`).
+3. **Test endpoints** (3 routes + models per existing file conventions; follow the dispatcher's
+   registration list so unknown-route behavior stays consistent).
+4. **E2E tests** — new `tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs`:
+   - `BrokenSprite_IsHealed_AndClockAdvances`: `/test/set_date` (fresh 6:00 day — no schedule entry
+     due in the first boundaries, so the break→heal window is safe), `POST /test/break_npc_sprite`
+     for a scheduled Town villager (e.g. Abigail), immediately `POST /test/heal_npc_sprites`; assert
+     healed count 1 and `spritelessNpcs` empty; then assert `timeOfDay` (existing `/status`-family
+     endpoint) advances across ≥2 ten-minute boundaries — the incident's failure mode is "frozen",
+     so time-advance is the load-bearing assertion. Time flows only with a connected player: lease a
+     pooled client (standard `KeepConnected` pattern) or use the suite's established time-advance
+     primitive.
+   - `Sweep_RunsOnReload_HealthySaveHealsNothing`: `/reload`, then assert
+     `lastRunContext == "save_loaded"` and `lastRunHealedCount == 0` — proves subscription wiring AND
+     that healthy saves are untouched (regression guard for the whole suite).
+   - Assert via HTTP API only (`.claude/rules/tests-assert-via-http-api.md`); the
+     `npc_sprite_healed` event is diagnostics.
+   - *Optional follow-up (not this PR):* full load-seam fidelity via an `Env.IsTest`-gated
+     `AssetRequested` fault (custom `TextureName` + throwing loader + `/reload`). Prerequisite to
+     verify first: SMAPI must propagate a crashing sole-loader as `ContentLoadException` rather than
+     degrade to asset-missing — if it degrades, the shell never forms and the test is unbuildable.
+     The decompile-verified `TryLoadSprites` behavior plus the two tests above already cover the
+     shipped code paths.
+5. **Docs**: one line in the events schema doc for `npc_sprite_healed` if the catalog lists mod
+   events (follow `event-catalog-no-inline-enums.md` — reference the emitting class).
+
+## Pre-implementation verification checklist (claims to re-confirm in-code before writing)
+
+- `Game1.warpCharacter` / `NPC.arriveAt*` touch nothing on `Sprite` (input doc verified this; cheap
+  re-read) — makes SaveLoaded handler ordering vs `CabinManagerService`'s NPC-warping heals
+  irrelevant (services subscribe in alphabetical `StartServices` order; CabinManager runs first).
+- `Utility.ForEachLocation(Func<GameLocation,bool>, includeInteriors)` exact signature.
+- The exact status endpoint field for `timeOfDay` used by existing tests.
+- OpenAPI generator treatment of `/test/*` routes (they're outside the `[ApiEndpoint]` attribute
+  surface — confirm new routes don't need spec entries, matching existing test endpoints).
+
+## Compatibility verification (per `plan-discipline.md`)
+
+- **Transports (LAN/Steam):** heal touches only NPC state; no transport interaction. Tests run on
+  default LAN harness.
+- **`SERVER_TPS=5` / FPS 0:** sweep is event-driven (twice per day), no per-tick work; satisfies
+  `mod-game-thread-allocation.md` (allocations only on the rare heal path).
+- **Lobby/cabin interiors:** covered by `includeInteriors: true`; lobby-homed NPC heals (#474) run
+  before or after harmlessly (no `Sprite` interaction either direction).
+- **Clients:** healed sprite replicates via the `sprite` NetRef → clients render vanilla's error box
+  instead of NREing on a null `Sprite`; a client that has the working content pack still gets its
+  texture back the day the server's content heals (textureName re-syncs from
+  `LoadTexture(assetName, IsMasterGame: true)`).
+- **`multiplayerMode = 2`:** sweep runs on the master by construction
+  (`masterplayer-is-player-on-server.md` — no host/master split to consider).
+- **Save flow / day transition:** SaveLoaded and DayStarted both run outside the overnight
+  save window; the heal never mutates during serialization.
+
+## Post-conditions (runtime gates, not static checks)
+
+1. `make test FILTER=NpcSpriteIntegrityTests` green, **and** the run artifact shows the heal Warn
+   line + `npc_sprite_healed` event exactly once in the break test and zero heals in the reload test
+   (read the server container log, per `passing-test-isnt-proof-the-scenario-ran.md`).
+2. Full suite unaffected (sweep no-ops on every healthy load — gate 1's reload test asserts it, the
+   suite confirms at scale).
+3. Layer 1: rebuilt image boots and `ldd` on `libSkiaSharp.so` resolves cleanly inside the container.
+4. Field: reporter (or a local repro with a deliberately broken content pack) confirms the server
+   now logs the heal, keeps the clock advancing, and shows error-box NPCs instead of freezing.
+
+## Out of scope / follow-ups
+
+- **Upstream report to ConcernedApe/SMAPI**: `TryLoadSprites` leaving `Sprite` null +
+  `routeEndAnimationFinished`'s unguarded deref is a vanilla bug pair worth reporting.
+- **Optional operator preflight**: a startup warning when `libSkiaSharp.so`'s dynamic deps don't
+  resolve (protects modded servers against the whole "image lib removed" class). Only if wanted —
+  layer 1's explicit dependency + comment is the primary defense.
+- The broader CP `EditImage` breakage from missing SkiaSharp is fully covered by layer 1; nothing
+  mod-side to do.

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -433,6 +433,62 @@ public class TestConsoleCommandResponse
     public string? Error { get; set; }
 }
 
+/// <summary>
+/// Response from GET /test/npc_sprite_integrity (test-only). Reports the
+/// NpcSpriteIntegrityService's sweep metadata plus a live scan for sprite-less NPCs, so E2E
+/// tests can prove both the heal outcome and the SaveLoaded/DayStarted wiring (the run
+/// counters only advance when the real event handlers fire — a direct /test/heal_npc_sprites
+/// call can't satisfy them).
+/// </summary>
+public class TestNpcSpriteIntegrityResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>Names of NPCs currently missing a sprite (live scan; empty when healthy).</summary>
+    public List<string> SpritelessNpcs { get; set; } = new();
+
+    /// <summary>Context tag of the most recent sweep ("save_loaded", "day_started", "test"), or null.</summary>
+    public string? LastRunContext { get; set; }
+
+    /// <summary>NPCs healed by the most recent sweep.</summary>
+    public int LastRunHealedCount { get; set; }
+
+    /// <summary>Sweeps triggered by the SaveLoaded handler since mod start.</summary>
+    public int SaveLoadedRuns { get; set; }
+
+    /// <summary>Sweeps triggered by the DayStarted handler since mod start.</summary>
+    public int DayStartedRuns { get; set; }
+
+    /// <summary>NPCs healed across all sweeps since mod start.</summary>
+    public int TotalHealed { get; set; }
+}
+
+/// <summary>
+/// Response from POST /test/break_npc_sprite (test-only fault injector — see the handler doc).
+/// </summary>
+public class TestBreakNpcSpriteResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>The NPC whose sprite was nulled.</summary>
+    public string NpcName { get; set; } = "";
+
+    /// <summary>True if the NPC had a sprite before the break (sanity signal for the test).</summary>
+    public bool HadSprite { get; set; }
+}
+
+/// <summary>Response from POST /test/heal_npc_sprites (test-only).</summary>
+public class TestHealNpcSpritesResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>NPCs healed by this sweep run.</summary>
+    public int HealedCount { get; set; }
+}
+
 /// <summary>Response from POST /test/import_save.</summary>
 public class TestImportSaveResponse
 {

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -73,6 +73,12 @@ public partial class ApiService
                             await HandleGetTestWeddingStateAsync(request)
                         );
                         return;
+                    case "/test/npc_sprite_integrity":
+                        await WriteJsonAsync(
+                            response,
+                            await HandleGetTestNpcSpriteIntegrityAsync()
+                        );
+                        return;
                 }
                 break;
             case "POST":
@@ -131,6 +137,15 @@ public partial class ApiService
                         return;
                     case "/test/force_save":
                         await WriteJsonAsync(response, await HandlePostTestForceSaveAsync());
+                        return;
+                    case "/test/break_npc_sprite":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestBreakNpcSpriteAsync(request)
+                        );
+                        return;
+                    case "/test/heal_npc_sprites":
+                        await WriteJsonAsync(response, await HandlePostTestHealNpcSpritesAsync());
                         return;
                 }
                 break;
@@ -1693,6 +1708,113 @@ public partial class ApiService
                     }
                 }
 
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/npc_sprite_integrity",
+        Summary = "NPC sprite-integrity sweep status + live scan for sprite-less NPCs (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestNpcSpriteIntegrityResponse), 200)]
+    private async Task<TestNpcSpriteIntegrityResponse> HandleGetTestNpcSpriteIntegrityAsync()
+    {
+        var result = new TestNpcSpriteIntegrityResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                result.SpritelessNpcs = _npcSpriteIntegrity.FindSpritelessNpcs();
+                result.LastRunContext = _npcSpriteIntegrity.LastRunContext;
+                result.LastRunHealedCount = _npcSpriteIntegrity.LastRunHealedCount;
+                result.SaveLoadedRuns = _npcSpriteIntegrity.SaveLoadedRuns;
+                result.DayStartedRuns = _npcSpriteIntegrity.DayStartedRuns;
+                result.TotalHealed = _npcSpriteIntegrity.TotalHealed;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Fault injector: reproduces the exact field state a failed load-time sprite rebuild
+    /// leaves behind (NPC.TryLoadSprites swallows a throwing asset load and the NPC survives
+    /// with Sprite == null). The state is hazardous — the engine NREs at the NPC's next
+    /// scheduled departure — so callers heal promptly (/test/heal_npc_sprites) within the
+    /// same quiet in-game window.
+    /// </summary>
+    [ApiEndpoint(
+        "POST",
+        "/test/break_npc_sprite",
+        Summary = "Null an NPC's Sprite, reproducing a failed load-time sprite rebuild (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestBreakNpcSpriteResponse), 200)]
+    private async Task<TestBreakNpcSpriteResponse> HandlePostTestBreakNpcSpriteAsync(
+        HttpListenerRequest request
+    )
+    {
+        var npcName = request.QueryString["npc"] ?? "Abigail";
+        var result = new TestBreakNpcSpriteResponse { NpcName = npcName };
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var npc = Game1.getCharacterFromName(npcName);
+                if (npc == null)
+                {
+                    result.Error = $"NPC '{npcName}' not found";
+                    return;
+                }
+
+                result.HadSprite = npc.Sprite != null;
+                npc.Sprite = null;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/heal_npc_sprites",
+        Summary = "Run the NPC sprite-integrity heal sweep immediately (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestHealNpcSpritesResponse), 200)]
+    private async Task<TestHealNpcSpritesResponse> HandlePostTestHealNpcSpritesAsync()
+    {
+        var result = new TestHealNpcSpritesResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                result.HealedCount = _npcSpriteIntegrity.HealSpritelessNpcs("test");
                 result.Success = true;
             });
         }

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -756,6 +756,7 @@ public partial class ApiService : ModService
     private readonly RoleService _roleService;
     private readonly PasswordProtectionService? _passwordProtectionService;
     private readonly SaveImport.SaveImportService _saveImportService;
+    private readonly NpcIntegrity.NpcSpriteIntegrityService _npcSpriteIntegrity;
 
     // WebSocket client management
     private readonly List<WebSocket> _wsClients = new();
@@ -1016,6 +1017,7 @@ public partial class ApiService : ModService
         CabinManagerService cabinManager,
         RoleService roleService,
         SaveImport.SaveImportService saveImportService,
+        NpcIntegrity.NpcSpriteIntegrityService npcSpriteIntegrity,
         PasswordProtectionService? passwordProtectionService = null
     )
         : base(helper, monitor)
@@ -1025,6 +1027,7 @@ public partial class ApiService : ModService
         _cabinManager = cabinManager;
         _roleService = roleService;
         _saveImportService = saveImportService;
+        _npcSpriteIntegrity = npcSpriteIntegrity;
         _passwordProtectionService = passwordProtectionService;
     }
 

--- a/mod/JunimoServer/Services/NpcIntegrity/NpcSpriteIntegrityService.cs
+++ b/mod/JunimoServer/Services/NpcIntegrity/NpcSpriteIntegrityService.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using JunimoServer.Services.Diagnostics;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley;
+
+namespace JunimoServer.Services.NpcIntegrity;
+
+/// <summary>
+/// Restores the engine invariant that every NPC in a location has a non-null
+/// <c>Sprite</c>.
+///
+/// <para>
+/// NPCs deserialize from the save via the parameterless ctor (Sprite null) and rely on
+/// <c>reloadSprite → ChooseAppearance → TryLoadSprites</c> at load to rebuild it. When the
+/// spritesheet asset exists per <c>DoesAssetExist</c> but throws on load (broken content
+/// pack, missing native image decoder, corrupt file), <c>TryLoadSprites</c> swallows the
+/// exception and the NPC survives load with <c>Sprite == null</c> — vanilla removes an NPC
+/// at load only when its <em>data</em> is missing (<c>Game1.fixProblems</c>). The engine then
+/// dereferences <c>Sprite</c> unguarded on the NPC's next scheduled departure
+/// (<c>checkSchedule → prepareToDisembarkOnNewSchedulePath → routeEndAnimationFinished</c>),
+/// inside <c>Game1.performTenMinuteClockUpdate</c>; the queued schedule entry is dequeued
+/// only after that call returns, so the NRE repeats at every ten-minute boundary and each
+/// throw aborts the clock update before <c>netWorldState.UpdateFromGame1()</c> — freezing
+/// every client's clock. On this render-suppressed server nothing surfaces the shell earlier
+/// (a rendering game crashes visibly in <c>NPC.draw</c>).
+/// </para>
+///
+/// <para>
+/// The heal gives such NPCs an empty <see cref="AnimatedSprite"/> — the exact state vanilla
+/// itself produces when a spritesheet is cleanly missing: clients render the error-box
+/// placeholder (<c>NPC.draw</c>) and every sprite path is null-texture-safe. The texture name
+/// stays unset on purpose (a broken name would throw in clients' lazy <c>Texture</c> getter);
+/// the engine's own daily retry (<c>dayUpdate → ChooseAppearance</c>) restores the real
+/// texture once the asset loads again.
+/// </para>
+/// </summary>
+public class NpcSpriteIntegrityService : ModService
+{
+    /// <summary>Sweeps triggered by SaveLoaded since mod start. Wiring proof for tests.</summary>
+    public int SaveLoadedRuns { get; private set; }
+
+    /// <summary>Sweeps triggered by DayStarted since mod start. Wiring proof for tests.</summary>
+    public int DayStartedRuns { get; private set; }
+
+    /// <summary>Context tag of the most recent sweep, or null if none ran yet.</summary>
+    public string? LastRunContext { get; private set; }
+
+    /// <summary>NPCs healed by the most recent sweep.</summary>
+    public int LastRunHealedCount { get; private set; }
+
+    /// <summary>NPCs healed across all sweeps since mod start.</summary>
+    public int TotalHealed { get; private set; }
+
+    public NpcSpriteIntegrityService(IModHelper helper, IMonitor monitor)
+        : base(helper, monitor) { }
+
+    public override void Entry()
+    {
+        // SaveLoaded is the seam where shells are created (the load-time sprite rebuild is
+        // the only Sprite writer that can fail); DayStarted is a tripwire against unknown
+        // seams, mirroring CabinManagerService's lobby-heal sweeps.
+        Helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+        Helper.Events.GameLoop.DayStarted += OnDayStarted;
+    }
+
+    private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+    {
+        SaveLoadedRuns++;
+        HealSpritelessNpcs("save_loaded");
+    }
+
+    private void OnDayStarted(object sender, DayStartedEventArgs e)
+    {
+        DayStartedRuns++;
+        HealSpritelessNpcs("day_started");
+    }
+
+    /// <summary>
+    /// Names of all NPCs currently missing a sprite, across every location (interiors
+    /// included). Empty on a healthy world. Game thread only.
+    /// </summary>
+    public List<string> FindSpritelessNpcs()
+    {
+        var broken = new List<string>();
+        Utility.ForEachLocation(
+            location =>
+            {
+                foreach (var npc in location.characters)
+                {
+                    if (npc.Sprite == null)
+                    {
+                        broken.Add(npc.Name);
+                    }
+                }
+                return true;
+            },
+            includeInteriors: true
+        );
+        return broken;
+    }
+
+    /// <summary>
+    /// Sweeps every location (interiors included — married spouses live in cabins) and heals
+    /// each sprite-less NPC. Returns the number healed. Game thread only.
+    /// </summary>
+    public int HealSpritelessNpcs(string context)
+    {
+        var healed = 0;
+        Utility.ForEachLocation(
+            location =>
+            {
+                foreach (var npc in location.characters)
+                {
+                    if (npc.Sprite == null && TryHealNpc(npc, location, context))
+                    {
+                        healed++;
+                    }
+                }
+                return true;
+            },
+            includeInteriors: true
+        );
+
+        LastRunContext = context;
+        LastRunHealedCount = healed;
+        TotalHealed += healed;
+        return healed;
+    }
+
+    /// <summary>
+    /// Never throws: a heal failure must not abort the sweep (or the SaveLoaded chain) —
+    /// one unhealable NPC is strictly better than several unhealed ones.
+    /// </summary>
+    private bool TryHealNpc(NPC npc, GameLocation location, string context)
+    {
+        try
+        {
+            var textureName = npc.getTextureName();
+
+            npc.Sprite = new AnimatedSprite();
+            var data = npc.GetData();
+            // Same size fallbacks the engine uses in routeEndAnimationFinished.
+            npc.Sprite.SpriteWidth = data?.Size.X ?? 16;
+            npc.Sprite.SpriteHeight = data?.Size.Y ?? 32;
+            npc.Sprite.UpdateSourceRect();
+
+            Monitor.Log(
+                $"Healed sprite-less NPC '{npc.Name}' in '{location.NameOrUniqueName}' "
+                    + $"({context}): its spritesheet '{textureName}' failed to load, which "
+                    + "would freeze the world clock at the NPC's next scheduled departure. "
+                    + "The NPC keeps an empty sprite (renders as an error box) until the "
+                    + "asset loads again.",
+                LogLevel.Warn
+            );
+            ModEventLog.Emit(
+                "npc_sprite_healed",
+                new
+                {
+                    npcName = npc.Name,
+                    location = location.NameOrUniqueName,
+                    textureName,
+                    context,
+                }
+            );
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Monitor.Log(
+                $"Failed to heal sprite-less NPC '{npc.Name}' in "
+                    + $"'{location.NameOrUniqueName}' ({context}): {ex}",
+                LogLevel.Warn
+            );
+            return false;
+        }
+    }
+}

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -711,6 +711,70 @@ public class TestStampLobbyHomeResponse
     public string OriginalHome { get; set; } = "";
 }
 
+/// <summary>
+/// Test-side mirror of the server's TestNpcSpriteIntegrityResponse DTO: the sprite-integrity
+/// sweep's run metadata plus a live scan for sprite-less NPCs.
+/// </summary>
+public class TestNpcSpriteIntegrityResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("spritelessNpcs")]
+    public List<string> SpritelessNpcs { get; set; } = new();
+
+    [JsonPropertyName("lastRunContext")]
+    public string? LastRunContext { get; set; }
+
+    [JsonPropertyName("lastRunHealedCount")]
+    public int LastRunHealedCount { get; set; }
+
+    [JsonPropertyName("saveLoadedRuns")]
+    public int SaveLoadedRuns { get; set; }
+
+    [JsonPropertyName("dayStartedRuns")]
+    public int DayStartedRuns { get; set; }
+
+    [JsonPropertyName("totalHealed")]
+    public int TotalHealed { get; set; }
+}
+
+/// <summary>
+/// Test-side mirror of the server's TestBreakNpcSpriteResponse DTO (sprite fault injector).
+/// </summary>
+public class TestBreakNpcSpriteResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("npcName")]
+    public string NpcName { get; set; } = "";
+
+    [JsonPropertyName("hadSprite")]
+    public bool HadSprite { get; set; }
+}
+
+/// <summary>
+/// Test-side mirror of the server's TestHealNpcSpritesResponse DTO.
+/// </summary>
+public class TestHealNpcSpritesResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("healedCount")]
+    public int HealedCount { get; set; }
+}
+
 /// <summary>Body for /test/seed_import_source (test-only). Mirrors the server-side DTO.</summary>
 public class TestSeedImportSourceRequest
 {
@@ -1867,6 +1931,50 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestStampLobbyHomeResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: sprite-integrity sweep metadata + live scan for sprite-less NPCs.
+    /// GET /test/npc_sprite_integrity
+    /// </summary>
+    public async Task<TestNpcSpriteIntegrityResponse?> GetNpcSpriteIntegrity(
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(HttpMethod.Get, "/test/npc_sprite_integrity", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestNpcSpriteIntegrityResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: null an NPC's Sprite, reproducing a failed load-time sprite rebuild.
+    /// Hazardous state — heal promptly via <see cref="HealNpcSprites"/>.
+    /// POST /test/break_npc_sprite?npc=Name
+    /// </summary>
+    public async Task<TestBreakNpcSpriteResponse?> BreakNpcSprite(
+        string npc,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            $"/test/break_npc_sprite?npc={Uri.EscapeDataString(npc)}",
+            ct
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestBreakNpcSpriteResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: run the NPC sprite-integrity heal sweep immediately (same sweep the
+    /// SaveLoaded/DayStarted handlers run).
+    /// POST /test/heal_npc_sprites
+    /// </summary>
+    public async Task<TestHealNpcSpritesResponse?> HealNpcSprites(CancellationToken ct = default)
+    {
+        var response = await SendWithRetryAsync(HttpMethod.Post, "/test/heal_npc_sprites", ct);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestHealNpcSpritesResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -191,4 +191,8 @@ public enum WaitName
     Polling_LobbyHome_CeremoniesCompleted,
     Polling_LobbyHome_SpousesInCabins,
     Polling_LobbyHome_PoisonHealed,
+
+    // NpcSpriteIntegrityTests.cs (1)
+    /// <summary>Game clock crossed the daytime schedule-departure boundaries after the heal.</summary>
+    Polling_NpcSprite_DaytimeBoundariesCrossed,
 }

--- a/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
+++ b/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
@@ -1,0 +1,237 @@
+using JunimoServer.Tests.Helpers;
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// E2E gates for the sprite-integrity heal (NpcSpriteIntegrityService): an NPC that survives
+/// save-load with <c>Sprite == null</c> (its spritesheet asset exists per DoesAssetExist but
+/// throws on load — broken content pack, missing native image decoder) NREs on its next
+/// scheduled departure inside <c>Game1.performTenMinuteClockUpdate</c>. The queued schedule
+/// entry is never dequeued, so every later ten-minute boundary re-throws, each throw aborting
+/// the clock update before <c>netWorldState.UpdateFromGame1()</c> — permanently freezing every
+/// client's clock. The service heals such NPCs with an empty sprite (vanilla's own
+/// missing-asset degradation, rendered as an error box) at SaveLoaded and DayStarted.
+///
+/// <para>
+/// Sprites are not serialized (<c>Character.Sprite</c> is [XmlIgnore]; they rebuild on every
+/// load), so a persisted-poison reload test like the lobby-home sweeps use is impossible —
+/// the broken state can only exist live. Instead: /test/break_npc_sprite reproduces the exact
+/// post-load field state, /test/heal_npc_sprites runs the same sweep the event handlers run,
+/// and the SaveLoaded/DayStarted <em>wiring</em> is proven separately via the service's run
+/// counters, which only the real event handlers advance.
+/// </para>
+/// </summary>
+// Exclusive: mutates global calendar state (SetDate/SetClockSpeed) and breaks/heals a
+// villager on the shared server (SharedClass does not serialize methods on its own).
+// Clients = 1: with zero clients AlwaysOn.HandleAutoPause pauses the clock for the whole
+// 610–2500 window, so daytime schedule-departure boundaries — the exact code path under
+// test — only ever fire with a player connected.
+[TestServer(Clients = 1, Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class NpcSpriteIntegrityTests : TestBase
+{
+    /// <summary>A vanilla Town villager with a daily schedule — the incident shape.</summary>
+    private const string BrokenNpc = "Abigail";
+
+    /// <summary>
+    /// Daytime target the clock must reach after the heal: from 6:00 this crosses ~36
+    /// ten-minute boundaries, including the healed NPC's first schedule departure (Abigail's
+    /// vanilla schedules start mid-morning) — each departure runs
+    /// checkSchedule → routeEndAnimationFinished, the exact call that NREs on a null sprite
+    /// and freezes the clock.
+    /// </summary>
+    private const int DaytimeTarget = 1200;
+
+    [Fact]
+    public async Task BrokenSprite_IsHealed_AndScheduleBoundariesDoNotFreezeClock()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The boot world becomes reachable a beat before its SaveLoaded handlers finish, so
+        // an immediate break could race the boot's own SaveLoaded sweep (which would heal it
+        // and leave the explicit-heal leg counting 0). /reload's completion contract resolves
+        // only on the tick after every SaveLoaded handler ran — break into a quiescent world.
+        // Same settle pattern as LobbyHomedSpouseHealTests. Reload precedes the connect so
+        // the world swap can't kick the farmer.
+        var ready = await ServerApi.WaitForServerOnline(
+            TestTimings.DayChangeTimeout,
+            cancellationToken: ct,
+            requireInviteCode: false
+        );
+        Assert.True(ready?.IsReady == true, "Server must be ready before the settle reload.");
+        await ReloadServerAsync();
+
+        // A connected player keeps the clock running (HandleAutoPause pauses 610–2500 when
+        // the server is alone) and receives the world-state time broadcasts the frozen-clock
+        // bug starves.
+        var farmer = await Farmers.ConnectNewAsync(namePrefix: "SpriteHeal", ct: ct);
+        var uid = farmer.JoinResult.UniqueMultiplayerId;
+        Assert.True(
+            await ServerApi.WaitForPlayerByIdAsync(uid, ct: ct),
+            $"Farmer (uid={uid}) must be present server-side after the join."
+        );
+
+        // Fresh non-festival morning (spring 2 → 3 crosses no festival): set_date resets the
+        // clock to 6:00, three game-hours before the earliest schedule departure, so no
+        // boundary can reach the broken NPC's schedule in the sub-second break→heal window.
+        var setDate = await ServerApi.SetDate("spring", 2, year: 1, ct);
+        Assert.True(setDate?.Success == true, $"SetDate(spring 2) failed: {setDate?.Error}");
+
+        var baseline = await ServerApi.GetNpcSpriteIntegrity(ct);
+        Assert.True(
+            baseline?.Success == true,
+            $"Baseline integrity read failed: {baseline?.Error}"
+        );
+        Assert.True(
+            baseline!.SpritelessNpcs.Count == 0,
+            "A healthy world must have no sprite-less NPCs before the break, got "
+                + $"[{string.Join(", ", baseline.SpritelessNpcs)}]."
+        );
+
+        // Fault-inject the post-load shape a failed sprite rebuild leaves behind.
+        var broken = await ServerApi.BreakNpcSprite(BrokenNpc, ct);
+        Assert.True(broken?.Success == true, $"break_npc_sprite failed: {broken?.Error}");
+        Assert.True(
+            broken!.HadSprite,
+            $"{BrokenNpc} must have had a sprite before the break — a false value means the "
+                + "world was already broken and this test is not injecting anything."
+        );
+
+        var poisoned = await ServerApi.GetNpcSpriteIntegrity(ct);
+        Assert.True(
+            poisoned?.SpritelessNpcs.Contains(BrokenNpc) == true,
+            $"{BrokenNpc} must read sprite-less after the break, got "
+                + $"[{string.Join(", ", poisoned?.SpritelessNpcs ?? new())}]."
+        );
+
+        // Heal via the same sweep the SaveLoaded/DayStarted handlers run.
+        var healed = await ServerApi.HealNpcSprites(ct);
+        Assert.True(healed?.Success == true, $"heal_npc_sprites failed: {healed?.Error}");
+        Assert.True(
+            healed!.HealedCount == 1,
+            $"The sweep must heal exactly the one broken NPC, healed {healed.HealedCount}."
+        );
+
+        var afterHeal = await ServerApi.GetNpcSpriteIntegrity(ct);
+        Assert.True(
+            afterHeal?.Success == true && afterHeal.SpritelessNpcs.Count == 0,
+            "No sprite-less NPCs may remain after the heal, got "
+                + $"[{string.Join(", ", afterHeal?.SpritelessNpcs ?? new())}]."
+        );
+
+        try
+        {
+            // The load-bearing gate: cross the morning schedule-departure boundaries with the
+            // healed NPC. Pre-fix (unhealed), the first departure NREs, the clock never
+            // advances again (and the ERROR log-scan poisons the server); healed, the clock
+            // sails past. ~36 boundaries at clock speed 20 ≈ 15s.
+            await ServerApi.SetClockSpeed(20, ct);
+            var crossed = await PollingHelper.WaitUntilAsync(
+                WaitName.Polling_NpcSprite_DaytimeBoundariesCrossed,
+                async () => (await ServerApi.GetStatus(ct))?.TimeOfDay >= DaytimeTarget,
+                timeout: TestTimings.DayChangeTimeout,
+                cancellationToken: ct
+            );
+            if (!crossed)
+            {
+                var status = await ServerApi.GetStatus(ct);
+                Assert.Fail(
+                    $"Clock did not reach {DaytimeTarget} (stuck at {status?.TimeOfDay}) with "
+                        + $"the healed {BrokenNpc} in the world — a frozen clock across "
+                        + "schedule departures is the incident this fix exists for."
+                );
+            }
+
+            // Finish the day the proven way (client sleeps, clock runs to pass-out): the
+            // overnight dayUpdate re-runs ChooseAppearance (restoring the real sprite where
+            // content is healthy) and the DayStarted sweep runs.
+            var before = await ServerApi.GetStatus(ct);
+            Assert.NotNull(before);
+            var sleep = await GameClient.Actions.Sleep();
+            Assert.True(sleep?.Success == true, $"Farmer sleep failed: {sleep?.Error}");
+            await ServerApi.SetTime(TestTimings.PrePassOutTime, ct);
+            var (dayChanged, disconnected) = await DayChange.WaitAsync(
+                before.Day,
+                before.Season,
+                before.Year,
+                checkConnection: true,
+                ct
+            );
+            Assert.False(disconnected, "The farmer disconnected during the sleep-through.");
+            Assert.True(
+                dayChanged,
+                $"Day did not advance past {before.Season} {before.Day} Y{before.Year}."
+            );
+        }
+        finally
+        {
+            await ServerApi.SetClockSpeed(1, ct);
+        }
+
+        var nextMorning = await ServerApi.GetNpcSpriteIntegrity(ct);
+        Assert.True(
+            nextMorning?.Success == true && nextMorning.SpritelessNpcs.Count == 0,
+            "No sprite-less NPCs may exist the morning after the heal, got "
+                + $"[{string.Join(", ", nextMorning?.SpritelessNpcs ?? new())}]."
+        );
+
+        LogSuccess(
+            $"Sprite-less {BrokenNpc} was healed by the sweep (count=1), the clock crossed "
+                + $"the morning departure boundaries to {DaytimeTarget}+ without freezing, "
+                + "and the day completed normally."
+        );
+    }
+
+    [Fact]
+    public async Task Sweeps_AreWiredToSaveLoadedAndDayStarted_HealthyWorldHealsNothing()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var ready = await ServerApi.WaitForServerOnline(
+            TestTimings.DayChangeTimeout,
+            cancellationToken: ct,
+            requireInviteCode: false
+        );
+        Assert.True(ready?.IsReady == true, "Server must be ready before the wiring reload.");
+
+        // /reload completes only after every SaveLoaded handler ran, so the first read below
+        // observes this reload's own sweep — proving the subscription fired, not just that
+        // the sweep logic works when invoked directly (the bypass path a green
+        // /test/heal_npc_sprites call can't distinguish).
+        await ReloadServerAsync();
+
+        var integrity = await ServerApi.GetNpcSpriteIntegrity(ct);
+        Assert.True(
+            integrity?.Success == true,
+            $"Integrity read after reload failed: {integrity?.Error}"
+        );
+        Assert.True(
+            integrity!.SaveLoadedRuns >= 1,
+            "The SaveLoaded sweep must have run at least once after a /reload — zero means "
+                + "the subscription wiring is broken and shells from a failed load would "
+                + "never be healed."
+        );
+        Assert.True(
+            integrity.DayStartedRuns >= 1,
+            "The DayStarted tripwire sweep must have run at least once — zero means its "
+                + "subscription wiring is broken."
+        );
+        Assert.True(
+            integrity.LastRunHealedCount == 0,
+            $"A healthy world must heal nothing on load, healed {integrity.LastRunHealedCount} "
+                + "— a nonzero count means the load path is producing sprite-less NPCs."
+        );
+        Assert.True(
+            integrity.SpritelessNpcs.Count == 0,
+            "A freshly reloaded healthy world must have no sprite-less NPCs, got "
+                + $"[{string.Join(", ", integrity.SpritelessNpcs)}]."
+        );
+
+        LogSuccess(
+            "Sprite-integrity sweeps are wired: SaveLoadedRuns="
+                + $"{integrity.SaveLoadedRuns}, DayStartedRuns={integrity.DayStartedRuns}, "
+                + "and the healthy reload healed nothing."
+        );
+    }
+}


### PR DESCRIPTION
## Problem

An NPC whose spritesheet asset exists per `DoesAssetExist` but throws on load (broken content pack, missing native image decoder, corrupt file) survives save-load with `Sprite == null`: `NPC.TryLoadSprites` swallows the exception, `ChooseAppearance` downgrades it to a log warning, and `Game1.fixProblems` only removes villagers whose *data* is missing. The engine then dereferences `Sprite` unguarded on the NPC's next scheduled departure (`checkSchedule` → `prepareToDisembarkOnNewSchedulePath` → `routeEndAnimationFinished`) inside `Game1.performTenMinuteClockUpdate`. The queued schedule entry is only dequeued after that call returns, so every subsequent ten-minute boundary re-throws — and each throw aborts the clock update before `netWorldState.UpdateFromGame1()`, the only path that pushes `timeOfDay` to clients. Every client's clock freezes permanently ("server stuck at 6:40"). A headless server hides the broken NPC until then because no draw path ever touches it.

Full verified mechanism, field-confirmation steps, and design rationale: `.claude/plans/bugs/npc-sprite-nre-tenminute-update-final.md`. The incident's trigger (a native image-decoding dependency missing from the server image) is fixed separately in `docker/Dockerfile`; this PR is the durable hardening against the whole class.

## Changes

- **`NpcSpriteIntegrityService`** (new): sweeps every location (interiors included) on `SaveLoaded` — the seam where shells are created — and `DayStarted` (tripwire), healing each sprite-less NPC with an empty `AnimatedSprite` sized from its character data. This converges the "asset throws on load" case onto vanilla's own supported "asset cleanly missing" state: clients render the error-box placeholder (`NPC.draw`), every sprite path is null-texture-safe, and the engine's daily `ChooseAppearance` retry restores the real texture once the asset loads again. `textureName` stays unset on purpose so clients' lazy `Texture` getter can't throw on a broken asset name.
- **Diagnostics**: each heal logs a Warn line and emits an `npc_sprite_healed` event naming the NPC, location, and texture asset — so the operator sees exactly which content is broken instead of a frozen world.
- **Test endpoints** (`Env.IsTest`-gated): `GET /test/npc_sprite_integrity` (live sprite-less scan + sweep run counters), `POST /test/break_npc_sprite` (fault injector reproducing the post-load field state), `POST /test/heal_npc_sprites` (runs the same sweep the event handlers run).
- **E2E** (`NpcSpriteIntegrityTests`): break/heal round-trip, then a fast-clock run across the healed NPC's schedule departures — the exact path that NREs unhealed — followed by a full day transition; plus a reload-based wiring test proving the `SaveLoaded`/`DayStarted` subscriptions fire (via run counters a direct heal call can't satisfy) and that a healthy load heals nothing.

## Verification

- Both E2E tests green; the run's server log shows exactly one heal Warn + `npc_sprite_healed` event in the break test, zero heals in the reload test, and no NRE.
- Sweep is event-driven (twice per game day), no per-tick cost; no behavior change on healthy worlds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented NPC sprite-loading issues from freezing the in-game clock during scheduled departures.
  - NPCs with missing sprites are now automatically repaired when a save loads and when a new day begins.
  - Improved resilience when character image assets fail to load, allowing gameplay and time progression to continue normally.

- **Reliability**
  - Added safeguards and monitoring to detect and recover from damaged NPC sprite state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->