### PR TITLE
test: normalize ConnectionHelper trace log wording

### DIFF
--- a/tests/JunimoServer.Tests/Helpers/ConnectionHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/ConnectionHelper.cs
@@ -241,7 +241,7 @@ public class ConnectionHelper
 
             if (attempt > 1)
             {
-                Log("[Connect] Returning to title for retry...");
+                Log("[Connect] Returning to title for retry");
                 await EnsureDisconnectedAsync();
                 await Task.Delay(TestTimings.RetryPauseDelay, cancellationToken);
 
@@ -286,7 +286,7 @@ public class ConnectionHelper
         CancellationToken cancellationToken
     )
     {
-        Log($"[Connect] Attempt {attempt}/{maxAttempts} - connecting via invite code...");
+        Log($"[Connect] Attempt {attempt}/{maxAttempts}: connecting via invite code");
 
         try
         {
@@ -377,7 +377,9 @@ public class ConnectionHelper
                 return ConnectionResult.Failed("Load farmhand slots: timeout", attempt);
             }
 
-            Log($"Connected ({farmhands.Farmhands.Count} slots, attempt {attempt}/{maxAttempts})");
+            Log(
+                $"[Connect] Connected ({farmhands.Farmhands.Count} slots, attempt {attempt}/{maxAttempts})"
+            );
             await CaptureCheckpointIfEnabled("after_connect");
             return ConnectionResult.Succeeded(attempt, farmhands);
         }
@@ -418,7 +420,7 @@ public class ConnectionHelper
 
             if (attempt > 1)
             {
-                Log("[Connect] Returning to title for retry...");
+                Log("[Connect] Returning to title for retry");
                 await EnsureDisconnectedAsync();
                 await Task.Delay(TestTimings.RetryPauseDelay, cancellationToken);
             }
@@ -456,7 +458,7 @@ public class ConnectionHelper
     )
     {
         var fullAddress = port == 24642 ? address : $"{address}:{port}";
-        Log($"[Connect] Attempt {attempt}/{maxAttempts} - connecting via LAN to {fullAddress}...");
+        Log($"[Connect] Attempt {attempt}/{maxAttempts}: connecting via LAN to {fullAddress}");
 
         try
         {
@@ -497,7 +499,7 @@ public class ConnectionHelper
             }
 
             Log(
-                $"Connected via LAN ({farmhands.Farmhands.Count} slots, attempt {attempt}/{maxAttempts})"
+                $"[Connect] Connected via LAN ({farmhands.Farmhands.Count} slots, attempt {attempt}/{maxAttempts})"
             );
             await CaptureCheckpointIfEnabled("after_connect");
             return ConnectionResult.Succeeded(attempt, farmhands);
@@ -730,7 +732,7 @@ public class ConnectionHelper
             }
             catch (Exception ex)
             {
-                Log($"[Retry] Disconnect before retry failed: {ex.Message}");
+                Log($"[Join] Disconnect before retry failed: {ex.Message}");
             }
             finally
             {
@@ -870,7 +872,7 @@ public class ConnectionHelper
                     if (loginAttempt > 1)
                     {
                         Log(
-                            $"[Auth] Retrying !login (attempt {loginAttempt}/{TestTimings.AuthLoginMaxAttempts})..."
+                            $"[Auth] Retrying !login (attempt {loginAttempt}/{TestTimings.AuthLoginMaxAttempts})"
                         );
                     }
 
@@ -884,9 +886,7 @@ public class ConnectionHelper
                         continue;
                     }
 
-                    Log(
-                        "[Auth] Waiting for post-auth warp (location change to different cabin)..."
-                    );
+                    Log("[Auth] Waiting for post-auth warp (location change to different cabin)");
                     wasAuthenticated = await _gameClient.WaitForAuthWarpAsync(
                         preAuthLocation!,
                         ct: cancellationToken
@@ -900,7 +900,7 @@ public class ConnectionHelper
                     }
 
                     Log(
-                        $"[Auth] Auth not confirmed within {TestTimings.AuthLoginAttemptTimeout.TotalSeconds}s"
+                        $"[Auth] Not confirmed within {TestTimings.AuthLoginAttemptTimeout.TotalSeconds}s"
                     );
                 }
 
@@ -991,7 +991,7 @@ public class ConnectionHelper
 
         var authStatus = wasAuthenticated ? ", authenticated" : (wasInLobby ? ", in lobby" : "");
         Log(
-            $"Joined world as '{farmerName}' (uid={uid}){authStatus} (attempt {attempt}/{_options.MaxAttempts})"
+            $"[Join] Joined world as '{farmerName}' (uid={uid}){authStatus} (attempt {attempt}/{_options.MaxAttempts})"
         );
         return (
             JoinWorldResult.Succeeded(
@@ -1061,7 +1061,7 @@ public class ConnectionHelper
             if (bounce > 0)
             {
                 Log(
-                    $"[Join] Server bounced back to farmhand selection (attempt {bounce}/{maxBounceRetries}), re-selecting slot..."
+                    $"[Join] Bounce {bounce}/{maxBounceRetries}: server bounced back to farmhand selection, re-selecting slot"
                 );
             }
 


### PR DESCRIPTION
Normalizes the `[ConnectionHelper] …` Trace lines so every message follows one shape and one wording convention. Pure log-string cleanup — no behavioral, control-flow, or diagnostic-event (`EmitDiagnostic`) changes. These lines are `Trace`-level diagnostics; no test or consumer parses them.

- Tag every message-producing line with its `[Phase]` sub-tag — the three success-summary lines that carried none now get `[Connect]` / `[Join]`.
- Fold the one-off `[Retry]` tag into `[Join]` (it fires inside the join retry-cleanup path).
- Drop trailing `...` from all lines — noise in a fire-once Trace line that isn't paired with a "done" line.
- Replace the ` - ` dash-clause join with a colon to match the dominant `label: detail` style used elsewhere in the file.
- De-duplicate the tag word: `[Auth] Auth not confirmed` → `[Auth] Not confirmed`.
- Fix the `bounce` counter mislabeled as "attempt" on one line while an adjacent line called it "Bounce".
- Render each counter consistently by position: subject-style `Counter {n}/{m}: detail` when the counter is the line's subject, trailing `(attempt {n}/{m})` when it's metadata appended to another subject.

## Verification

- `dotnet build tests/JunimoServer.Tests` — succeeds, 0 warnings / 0 errors (confirms no interpolation-token typo).
- `dotnet csharpier check` — clean.
- All 21 message strings verified to start with a `[Phase]` tag; none end in `...`.

Not yet exercised: a runtime read of the rendered lines in a real connect run's annotation stream. The change is string-literal only with no control-flow surface, so build + format + static inspection cover it; a live run would only confirm appearance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection, retry, join, authentication, and character-selection diagnostic messages.
  * Standardized log prefixes and removed inconsistent trailing ellipses to make progress easier to follow.
  * Updated failure, wait, and timeout wording for more consistent retry/disconnect behavior during world joining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->