### PR TITLE
fix(mod): make EndOfDay/festival timeouts wall-clock and TPS-independent

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -35,8 +35,8 @@ public class AlwaysOnServer : ModService
 
     private bool _warpingSleep;
 
-    // Shipping menu timeout reset, causes menu to be closed when bigger than `Config.EndOfDayTimeOut`
-    private int shippingMenuTimeoutTicks;
+    // Wall-clock start of the stuck-ShippingMenu window (seconds-based, so TPS-independent).
+    private DateTime? _shippingMenuTimeoutStartTime;
 
     private AlwaysOnServerFestivals alwaysOnServerFestivals;
 
@@ -194,7 +194,7 @@ public class AlwaysOnServer : ModService
         clientPaused = false;
         _isShippingMenuActive = false;
         _warpingSleep = false;
-        shippingMenuTimeoutTicks = 0;
+        _shippingMenuTimeoutStartTime = null;
         _weddingStartTime = null;
         _handledWeddingGate = null;
         ServerOptimizerOverrides.SetAutomationInputSuppression(false);
@@ -383,7 +383,7 @@ public class AlwaysOnServer : ModService
             return;
         }
 
-        // Starts a timeout counter in OnUnvalidatedUpdateTick.
+        // Marks the ShippingMenu window active; OnUnvalidatedUpdateTick then times it out.
         // Note: The actual ShippingMenu clicking is handled by HandleShippingMenu()
         // in OnOneSecondUpdateTicked, which properly waits for the intro animation.
         _isShippingMenuActive = true;
@@ -392,11 +392,14 @@ public class AlwaysOnServer : ModService
     private void OnUnvalidatedUpdateTick(object sender, UnvalidatedUpdateTickedEventArgs e)
     {
         // Waiting for ShippingMenu/Save/EndOfDay to timeout
-        if (_isShippingMenuActive && Config.EndOfDayTimeOut != 0)
+        if (_isShippingMenuActive && Config.EndOfDayTimeOutSeconds != 0)
         {
-            shippingMenuTimeoutTicks += 1;
+            _shippingMenuTimeoutStartTime ??= DateTime.UtcNow;
 
-            if (shippingMenuTimeoutTicks >= Config.EndOfDayTimeOut * Env.ServerTps)
+            var elapsedSeconds = (
+                DateTime.UtcNow - _shippingMenuTimeoutStartTime.Value
+            ).TotalSeconds;
+            if (elapsedSeconds >= Config.EndOfDayTimeOutSeconds)
             {
                 // Prevent others from joining after timeout
                 Game1.options.setServerMode("offline");
@@ -407,7 +410,7 @@ public class AlwaysOnServer : ModService
         {
             // Reset the ShippingMenu timeout since the game obviously progressed
             _isShippingMenuActive = false;
-            shippingMenuTimeoutTicks = 0;
+            _shippingMenuTimeoutStartTime = null;
 
             // Set online again in case the game kept going after timing out prematurely
             Game1.options.setServerMode("online");

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnConfig.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnConfig.cs
@@ -35,14 +35,14 @@ public class AlwaysOnConfig
 
     public int FestivalExitWarningSeconds { get; set; } = 120;
 
-    public int EndOfDayTimeOut { get; set; } = 120000;
-    public int FairTimeOut { get; set; } = 120000;
-    public int SpiritsEveTimeOut { get; set; } = 120000;
-    public int WinterStarTimeOut { get; set; } = 120000;
+    public int EndOfDayTimeOutSeconds { get; set; } = 2000;
+    public int FairTimeOutSeconds { get; set; } = 2000;
+    public int SpiritsEveTimeOutSeconds { get; set; } = 2000;
+    public int WinterStarTimeOutSeconds { get; set; } = 2000;
 
-    public int EggFestivalTimeOut { get; set; } = 120000;
-    public int FlowerDanceTimeOut { get; set; } = 120000;
-    public int LuauTimeOut { get; set; } = 120000;
-    public int DanceOfJelliesTimeOut { get; set; } = 120000;
-    public int FestivalOfIceTimeOut { get; set; } = 120000;
+    public int EggFestivalTimeOutSeconds { get; set; } = 2000;
+    public int FlowerDanceTimeOutSeconds { get; set; } = 2000;
+    public int LuauTimeOutSeconds { get; set; } = 2000;
+    public int DanceOfJelliesTimeOutSeconds { get; set; } = 2000;
+    public int FestivalOfIceTimeOutSeconds { get; set; } = 2000;
 }

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -101,7 +101,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.EggHuntCountdownSeconds,
                 AnnounceText = "The Egg Hunt will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => TicksToSeconds(Config.EggFestivalTimeOut + 180),
+                TimeoutSeconds = () => Config.EggFestivalTimeOutSeconds + 3,
             },
             new FestivalSpec
             {
@@ -111,7 +111,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.FlowerDanceCountdownSeconds,
                 AnnounceText = "The Flower Dance will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => TicksToSeconds(Config.FlowerDanceTimeOut + 90),
+                TimeoutSeconds = () => Config.FlowerDanceTimeOutSeconds + 1.5,
             },
             new FestivalSpec
             {
@@ -122,7 +122,7 @@ public class AlwaysOnServerFestivals
                 AnnounceText = "The Soup Tasting will begin in {0:0.#} minutes.",
                 OnAnnounce = AddIridiumStarfruitToSoup,
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => TicksToSeconds(Config.LuauTimeOut + 80),
+                TimeoutSeconds = () => Config.LuauTimeOutSeconds + 1.33,
             },
             new FestivalSpec
             {
@@ -132,7 +132,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.JellyDanceCountdownSeconds,
                 AnnounceText = "The Dance of the Moonlight Jellies will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => TicksToSeconds(Config.DanceOfJelliesTimeOut + 180),
+                TimeoutSeconds = () => Config.DanceOfJelliesTimeOutSeconds + 3,
             },
             new FestivalSpec
             {
@@ -144,7 +144,7 @@ public class AlwaysOnServerFestivals
                 AnnounceText = "The Grange Judging will begin in {0:0.#} minutes.",
                 AutoEndAfterCountdown = true,
                 TimeoutStart = TimeoutStart.OnEntry,
-                TimeoutSeconds = () => TicksToSeconds(Config.FairTimeOut),
+                TimeoutSeconds = () => Config.FairTimeOutSeconds,
                 EndLogText = "Grange display finished, triggering festival end",
             },
             new FestivalSpec
@@ -153,7 +153,7 @@ public class AlwaysOnServerFestivals
                 ResetCutoff = 2400,
                 RestoreHudOnReset = true,
                 HasMainEvent = false,
-                TimeoutSeconds = () => TicksToSeconds(Config.SpiritsEveTimeOut),
+                TimeoutSeconds = () => Config.SpiritsEveTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -163,22 +163,17 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.IceFishingCountdownSeconds,
                 AnnounceText = "The Ice Fishing Contest will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => TicksToSeconds(Config.FestivalOfIceTimeOut + 180),
+                TimeoutSeconds = () => Config.FestivalOfIceTimeOutSeconds + 3,
             },
             new FestivalSpec
             {
                 IsToday = SDateHelper.IsFeastOfWinterStarToday,
                 ResetCutoff = 1410,
                 HasMainEvent = false,
-                TimeoutSeconds = () => TicksToSeconds(Config.WinterStarTimeOut),
+                TimeoutSeconds = () => Config.WinterStarTimeOutSeconds,
             },
         };
     }
-
-    /// <summary>
-    /// Convert a config value (in ticks at 60 TPS) to seconds.
-    /// </summary>
-    private static double TicksToSeconds(int ticks) => ticks / 60.0;
 
     /// <summary>
     /// Get elapsed seconds since a start time, or 0 if not started.
@@ -496,7 +491,6 @@ public class AlwaysOnServerFestivals
         double resetElapsed = ElapsedSeconds(_timeoutStartTime);
         double timeoutSeconds = spec.TimeoutSeconds();
 
-        // FestivalExitWarningSeconds is already seconds (unlike the *TimeOut configs, which are ticks)
         if (!_timeoutWarned && resetElapsed >= timeoutSeconds - Config.FestivalExitWarningSeconds)
         {
             _helper.SendPublicMessage(

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -101,7 +101,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.EggHuntCountdownSeconds,
                 AnnounceText = "The Egg Hunt will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => Config.EggFestivalTimeOutSeconds + 3,
+                TimeoutSeconds = () => Config.EggFestivalTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -111,7 +111,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.FlowerDanceCountdownSeconds,
                 AnnounceText = "The Flower Dance will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => Config.FlowerDanceTimeOutSeconds + 1.5,
+                TimeoutSeconds = () => Config.FlowerDanceTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -122,7 +122,7 @@ public class AlwaysOnServerFestivals
                 AnnounceText = "The Soup Tasting will begin in {0:0.#} minutes.",
                 OnAnnounce = AddIridiumStarfruitToSoup,
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => Config.LuauTimeOutSeconds + 1.33,
+                TimeoutSeconds = () => Config.LuauTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -132,7 +132,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.JellyDanceCountdownSeconds,
                 AnnounceText = "The Dance of the Moonlight Jellies will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => Config.DanceOfJelliesTimeOutSeconds + 3,
+                TimeoutSeconds = () => Config.DanceOfJelliesTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -163,7 +163,7 @@ public class AlwaysOnServerFestivals
                 CountdownSeconds = () => Config.IceFishingCountdownSeconds,
                 AnnounceText = "The Ice Fishing Contest will begin in {0:0.#} minutes.",
                 TimeoutStart = TimeoutStart.AfterMainEvent,
-                TimeoutSeconds = () => Config.FestivalOfIceTimeOutSeconds + 3,
+                TimeoutSeconds = () => Config.FestivalOfIceTimeOutSeconds,
             },
             new FestivalSpec
             {
@@ -450,8 +450,9 @@ public class AlwaysOnServerFestivals
             _started = true;
         }
 
-        // +5 ticks of slack so the main event has been kicked off before we start its timeout / auto-end
-        if (elapsed >= countdownSeconds + 5.0 / 60.0)
+        // Small slack so the main event has been kicked off on an earlier tick before we start
+        // its timeout / auto-end.
+        if (elapsed >= countdownSeconds + 0.1)
         {
             if (spec.TimeoutStart == TimeoutStart.AfterMainEvent)
             {

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -440,20 +440,20 @@ public class AlwaysOnServerFestivals
             _announced = true;
         }
 
-        if (!_started && elapsed >= countdownSeconds)
+        if (elapsed >= countdownSeconds)
         {
-            var festivalHost = GetFestivalHost();
-            if (festivalHost != null)
+            // Kick off the main event first, then start its timeout / auto-end — the ordering
+            // here is what guarantees the event is triggered before the backstop begins.
+            if (!_started)
             {
-                Game1.CurrentEvent.answerDialogueQuestion(festivalHost, "yes");
+                var festivalHost = GetFestivalHost();
+                if (festivalHost != null)
+                {
+                    Game1.CurrentEvent.answerDialogueQuestion(festivalHost, "yes");
+                }
+                _started = true;
             }
-            _started = true;
-        }
 
-        // Small slack so the main event has been kicked off on an earlier tick before we start
-        // its timeout / auto-end.
-        if (elapsed >= countdownSeconds + 0.1)
-        {
             if (spec.TimeoutStart == TimeoutStart.AfterMainEvent)
             {
                 RunFestivalTimeout(spec);

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -80,7 +80,7 @@ public class FestivalTests : TestBase
     private static readonly (int X, int Y) ForestEntryTile = (34, 13);
 
     // How long a festival must stay active to prove the 0.17s auto-end is gone. Comfortably
-    // larger than the old window, far below the ~33-min (SpiritsEveTimeOutSeconds) wall-clock backstop.
+    // larger than the old window, far below the SpiritsEveTimeOutSeconds wall-clock backstop.
     private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
 
     /// <summary>

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -10,8 +10,8 @@ namespace JunimoServer.Tests;
 ///
 /// <para>
 /// The headline test is the regression gate for the leave-only auto-end bug: the two
-/// no-main-event festivals (Spirit's Eve, Feast of Winter Star) used to host-end ~0.17 s
-/// after loading (<c>RunLeaveOnly</c> firing <c>TicksToSeconds(10)</c>). The fix removed
+/// no-main-event festivals (Spirit's Eve, Feast of Winter Star) used to host-end almost
+/// immediately after loading (<c>RunLeaveOnly</c> firing its end dialogue). The fix removed
 /// that auto-end so the festival only ends when players leave or the wall-clock timeout
 /// elapses. Nothing automated caught the bug before; these tests are that gate.
 /// </para>
@@ -79,15 +79,15 @@ public class FestivalTests : TestBase
     private static readonly (int X, int Y) TownEntryTile = (35, 35);
     private static readonly (int X, int Y) ForestEntryTile = (34, 13);
 
-    // How long a festival must stay active to prove the 0.17s auto-end is gone. Comfortably
+    // How long a festival must stay active to prove the immediate auto-end is gone. Comfortably
     // larger than the old window, far below the SpiritsEveTimeOutSeconds wall-clock backstop.
     private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
 
     /// <summary>
     /// Test 1 (the regression gate): Spirit's Eve does NOT auto-end immediately.
     ///
-    /// Pre-fix, <c>RunLeaveOnly</c> fired <c>TryStartEndFestivalDialogue</c> ~0.17 s after
-    /// the festival loaded, ending it before the player could do anything. With the fix the
+    /// Pre-fix, <c>RunLeaveOnly</c> fired <c>TryStartEndFestivalDialogue</c> almost immediately
+    /// after the festival loaded, ending it before the player could do anything. With the fix the
     /// festival stays active until a player leaves or the wall-clock timeout elapses, so it
     /// must still be active several seconds after entry.
     /// </summary>
@@ -108,7 +108,7 @@ public class FestivalTests : TestBase
         );
 
         // The fix is the only thing keeping the festival alive here: pre-fix it would have
-        // ended within ~0.17s. Poll for the whole settle window and fail the moment the
+        // ended almost immediately. Poll for the whole settle window and fail the moment the
         // festival is observed inactive.
         var endedEarly = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_Festival_StillActiveAfterSettle,
@@ -124,7 +124,7 @@ public class FestivalTests : TestBase
         Assert.False(
             endedEarly,
             $"Spirit's Eve ended within {FestivalSettleWindow.TotalSeconds:0}s of entry. "
-                + "Pre-fix, RunLeaveOnly's TicksToSeconds(10) ≈ 0.17s auto-end did exactly this; "
+                + "Pre-fix, RunLeaveOnly's immediate auto-end did exactly this; "
                 + "the leave-only fix removed it so the festival must stay active until players leave."
         );
 

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -80,7 +80,7 @@ public class FestivalTests : TestBase
     private static readonly (int X, int Y) ForestEntryTile = (34, 13);
 
     // How long a festival must stay active to prove the 0.17s auto-end is gone. Comfortably
-    // larger than the old window, far below the ~33-min (SpiritsEveTimeOut) wall-clock backstop.
+    // larger than the old window, far below the ~33-min (SpiritsEveTimeOutSeconds) wall-clock backstop.
     private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
 
     /// <summary>


### PR DESCRIPTION
## Problem

The shipping-menu / EndOfDay timeout (closes a stuck `ShippingMenu` and flips the server `offline` if a save hangs) never fired. `OnUnvalidatedUpdateTick` counted ticks and compared against `EndOfDayTimeOut * Env.ServerTps` — a double conversion, since the config value was already a tick count. The effective window was ~33h at 60 TPS and ~16.7 days at `SERVER_TPS=5`, so an in-game day always ended first and the timeout was dead code. A server stuck with a dangling `ShippingMenu` stayed stuck indefinitely.

## Changes

- Replace the tick counter with a wall-clock `DateTime.UtcNow` start-time + elapsed-seconds comparison, so the EndOfDay timeout tracks real elapsed time and is independent of the configured (and fluctuating) tick rate.
- Unify the timeout config unit: all nine `*TimeOut` fields were "ticks at 60 TPS" decoded through a `TicksToSeconds` helper. Rename them to `*TimeOutSeconds` with plain-seconds defaults (`120000` ticks / 60 = `2000` s) and delete both `TicksToSeconds` helpers, so every timeout config is unambiguously seconds.
- Fold the festival tick offsets into seconds at the call sites (`+180`→`+3`, `+90`→`+1.5`, `+80`→`+1.33`).
- Remove/refresh the now-stale comments that described the old tick encoding.

The festival timeouts are behaviorally unchanged — their effective window was already `2000` s via `TicksToSeconds`. Only the EndOfDay path changes behavior (from never-fires to a ~33-minute wall-clock backstop). `0` still means "no timeout"; the `timeOfDay == 610` reset still clears the window and flips the server back `online` on a normal day.

## Verification

- Mod and test assemblies build clean (0 warnings/0 errors).
- Not yet exercised at runtime: driving the host into a stuck `ShippingMenu` and observing `setServerMode("offline")` fire within the wall-clock window is an E2E-level check that has not been run.
