### PR TITLE
fix(mod): pause the empty server at 6:00 instead of 6:10

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -406,14 +406,23 @@ public class AlwaysOnServer : ModService
             }
         }
 
-        if (Game1.timeOfDay == 610)
+        // Day start: the game progressed past the end-of-day save, so reset the timeout.
+        // Keyed on 600 not 610 so it still fires when the empty-server auto-pause freezes
+        // the clock at day start. The empty server then sits frozen at 600 all day, so the
+        // guards keep the body a no-op once settled instead of re-running setServerMode.
+        if (Game1.timeOfDay == 600)
         {
-            // Reset the ShippingMenu timeout since the game obviously progressed
-            _isShippingMenuActive = false;
-            _shippingMenuTimeoutStartTime = null;
+            if (_isShippingMenuActive)
+            {
+                _isShippingMenuActive = false;
+                _shippingMenuTimeoutStartTime = null;
+            }
 
-            // Set online again in case the game kept going after timing out prematurely
-            Game1.options.setServerMode("online");
+            // Set online again in case the game kept going after timing out prematurely.
+            if (!Game1.options.enableServer)
+            {
+                Game1.options.setServerMode("online");
+            }
         }
     }
 
@@ -1010,9 +1019,8 @@ public class AlwaysOnServer : ModService
         }
         else if (numPlayers == 0 && !isFestivalDay)
         {
-            // Pause during normal hours (610-2500), but unpause after 2500 to allow
-            // the forced pass-out sequence at 2600 (2:00 AM) to proceed.
-            Game1.netWorldState.Value.IsPaused = Game1.timeOfDay is >= 610 and <= 2500;
+            // The 600 floor pauses at day start (6:00), not after the first 10-minute tick.
+            Game1.netWorldState.Value.IsPaused = Game1.timeOfDay is >= 600 and <= 2500;
         }
     }
 

--- a/tests/JunimoServer.Tests/Helpers/TestTimings.cs
+++ b/tests/JunimoServer.Tests/Helpers/TestTimings.cs
@@ -159,8 +159,8 @@ public static class TestTimings
     /// <summary>2:00 AM. Game forces performPassoutWarp() at this time.</summary>
     public const int PassOutTime = 2600;
 
-    /// <summary>Start of the auto-pause window (6:10 AM). AlwaysOn pauses when no players connected.</summary>
-    public const int PauseWindowStart = 610;
+    /// <summary>Start of the auto-pause window (6:00 AM). AlwaysOn pauses when no players connected.</summary>
+    public const int PauseWindowStart = 600;
 
     /// <summary>End of the auto-pause window (1:00 AM). After this, game unpauses for pass-out sequence.</summary>
     public const int PauseWindowEnd = 2500;

--- a/tests/JunimoServer.Tests/HostAutomationTests.cs
+++ b/tests/JunimoServer.Tests/HostAutomationTests.cs
@@ -17,7 +17,7 @@ public class HostAutomationTests : TestBase
     /// <summary>
     /// Verifies that game time does NOT advance when no other player is connected.
     /// The server's AlwaysOn service pauses the game when otherFarmers.Count == 0
-    /// and timeOfDay is between 610 and 2500.
+    /// and timeOfDay is between 600 and 2500.
     ///
     /// Uses Exclusive=true to prevent other tests from acquiring this server
     /// during the verification window.
@@ -57,7 +57,7 @@ public class HostAutomationTests : TestBase
         );
         Assert.True(noPlayers, "Server should have no players connected before testing time pause");
 
-        // Set time to a known mid-day value so we're firmly inside the pause window (610-2500)
+        // Set time to a known mid-day value so we're firmly inside the pause window (600-2500)
         var setTimeResult = await ServerApi.SetTime(TestTimings.Noon, ct);
         Assert.NotNull(setTimeResult);
         Assert.True(setTimeResult.Success, $"SetTime failed: {setTimeResult.Error}");

--- a/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
+++ b/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
@@ -26,7 +26,7 @@ namespace JunimoServer.Tests;
 // Exclusive: mutates global calendar state (SetDate/SetClockSpeed) and breaks/heals a
 // villager on the shared server (SharedClass does not serialize methods on its own).
 // Clients = 1: with zero clients AlwaysOn.HandleAutoPause pauses the clock for the whole
-// 610–2500 window, so daytime schedule-departure boundaries — the exact code path under
+// 600–2500 window, so daytime schedule-departure boundaries — the exact code path under
 // test — only ever fire with a player connected.
 [TestServer(Clients = 1, Isolation = IsolationMode.SharedClass, Exclusive = true)]
 public class NpcSpriteIntegrityTests : TestBase
@@ -62,7 +62,7 @@ public class NpcSpriteIntegrityTests : TestBase
         Assert.True(ready?.IsReady == true, "Server must be ready before the settle reload.");
         await ReloadServerAsync();
 
-        // A connected player keeps the clock running (HandleAutoPause pauses 610–2500 when
+        // A connected player keeps the clock running (HandleAutoPause pauses 600–2500 when
         // the server is alone) and receives the world-state time broadcasts the frozen-clock
         // bug starves.
         var farmer = await Farmers.ConnectNewAsync(namePrefix: "SpriteHeal", ct: ct);


### PR DESCRIPTION
Closes #33.

The empty-server auto-pause floor was `610`, so the in-game clock ticked one 10-minute step (to 6:10) before pausing. This lowers it to `600` so an empty server pauses at day start (6:00), as the issue requests.

## Changes

- `HandleAutoPause`: lower the empty-server pause floor from `>= 610` to `>= 600` so the clock freezes at 6:00 rather than after the first 10-minute tick. The `<= 2500` upper bound (unpause for the pass-out sequence) is unchanged.
- `OnUnvalidatedUpdateTick`: re-key the shipping-menu timeout reset from `timeOfDay == 610` to `== 600`. With the clock now frozen at 600 on an empty server, the old `610` check would never fire, so the timeout flag would never reset and a prior end-of-day timeout couldn't restore online mode. Day start (600) is the correct anchor and `OnUnvalidatedUpdateTick` observes it every tick.
- Guard the reset body so it stays a no-op while the server sits frozen at 600 all day, instead of re-running `setServerMode` every tick.
- Update the test comments and `TestTimings.PauseWindowStart` that documented the old 610 floor.

## Notes

- The **movement freeze** symptom from the issue was already handled: `OnSaveLoaded` calls `EnableAutoMode()` → `Game1.player.Halt()` before the first update tick, so no window remains for the host farmer to wander. This PR addresses the remaining 6:00-vs-6:10 pause behavior.
- Overnight farm events are unaffected: they only follow sleep, and an empty server never sleeps, so the time-gated pause branch never runs during an event.

## Verification

- E2E `HostAutomationTests` (pause / sleep / pass-out / QiPlaneEvent matrix): 6/6 pass.
- A temporary probe confirmed the empty server freezes at exactly `TimeOfDay=600`, `IsPaused=True`, and does not advance off 600 with the clock sped 10×.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - End-of-day shipping menu state now resets at the start of the in-game day.
  - Automatic server pausing now begins at 6:00 AM instead of 6:10 AM.
  - Server mode is restored to online when appropriate at the start of a new day.

- **Tests**
  - Updated timing references and documentation to reflect the revised pause window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->