### PR TITLE
test(cabin): fix AnotherPlayerInFootprint flake with per-poll !cabin resend + reply asserts

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -70,6 +70,19 @@ public class TestFarmersResponse
 }
 
 /// <summary>
+/// Response from /test/object_at_tile (test-only). Whether a placed Object sits on a
+/// (location, tile) server-side, via the same getObjectAtTile lookup CabinPlacementValidator
+/// reaches — so a test can gate a placement command on the obstacle being server-visible,
+/// which the periodic snapshots don't carry.
+/// </summary>
+public class TestObjectAtTileResponse
+{
+    public bool Success { get; set; }
+    public bool Present { get; set; }
+    public string? Error { get; set; }
+}
+
+/// <summary>
 /// Response from /test/set_date (test-only date jump).
 /// </summary>
 public class TestSetDateResponse

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -64,6 +64,12 @@ public partial class ApiService
                     case "/test/farmers":
                         await WriteJsonAsync(response, await HandleGetTestFarmersAsync(request));
                         return;
+                    case "/test/object_at_tile":
+                        await WriteJsonAsync(
+                            response,
+                            await HandleGetTestObjectAtTileAsync(request)
+                        );
+                        return;
                     case "/test/save_tmp_exists":
                         await WriteJsonAsync(response, HandleGetTestSaveTmpExists(request));
                         return;
@@ -321,6 +327,59 @@ public partial class ApiService
                     );
                 }
 
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/object_at_tile",
+        Summary = "Whether an Object sits on a (location, tile), by the same lookup CabinPlacementValidator reads (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestObjectAtTileResponse), 200)]
+    private async Task<TestObjectAtTileResponse> HandleGetTestObjectAtTileAsync(
+        HttpListenerRequest request
+    )
+    {
+        // ?location=<name> (default "Farm")&x=&y=. Reads getObjectAtTile — the same lookup
+        // CabinPlacementValidator.IsTileBuildable reaches (CabinPlacementValidator.cs:138) — so a
+        // test can gate its !cabin on the obstacle being server-visible, which the periodic
+        // snapshots don't carry (mirrors /test/farmers + WaitForFarmerServerTile for a farmer).
+        var locationName = request.QueryString["location"] ?? "Farm";
+        var result = new TestObjectAtTileResponse();
+
+        if (
+            !int.TryParse(request.QueryString["x"], out var x)
+            || !int.TryParse(request.QueryString["y"], out var y)
+        )
+        {
+            result.Success = false;
+            result.Error = "x and y query parameters are required integers";
+            return result;
+        }
+
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var location = Game1.getLocationFromName(locationName);
+                if (location == null)
+                {
+                    result.Success = true;
+                    return;
+                }
+
+                result.Present = location.getObjectAtTile(x, y) != null;
                 result.Success = true;
             });
         }

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -107,16 +107,30 @@ public class CabinPlacementValidationTests : TestBase
         );
         Assert.True(pot?.Success == true, $"PlacePot failed: {pot?.Error}");
 
-        var rejected = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinPlacement_Rejected,
-            // "Can't move cabin" (validator reply), not "Must be on Farm" (off-Farm
-            // bail); resends absorb server-location lag.
-            () => Chat.AssertResponseAsync("!cabin", "Can't move cabin"),
-            TestTimings.CabinAssignmentTimeout,
-            cancellationToken: ct
+        // Gate the !cabin on the pot being server-visible: it replicates from the client's Game1
+        // over several ticks, and this site must stay single-shot (a resent-then-accepted move
+        // masks the pot forever — see SendOnceAndCaptureAsync), so an early send would wrongly pass.
+        var potVisible = await ServerApi.WaitForObjectAtServerTileAsync(
+            CabinPlacementHelper.ExpectedCabinTile.X + 1,
+            CabinPlacementHelper.ExpectedCabinTile.Y,
+            ct: ct
+        );
+        Assert.True(
+            potVisible,
+            "Garden Pot did not replicate to the server before the rejection check"
         );
 
-        Assert.True(rejected, "Expected a 'Can't move cabin' rejection reply");
+        // "Can't move cabin" (validator reply), not "Must be on Farm" (off-Farm bail).
+        var rejection = await Chat.SendOnceAndCaptureAsync(
+            "!cabin",
+            "Can't move cabin",
+            replyFamilyPrefix: "Can't move cabin",
+            timeout: TestTimings.CabinAssignmentTimeout
+        );
+        Assert.True(
+            rejection.Matched,
+            $"Expected a 'Can't move cabin' rejection reply; {rejection.Describe()}"
+        );
 
         // Reply alone only proves a message; confirm the move was actually blocked.
         var after = await GetOurCabinAsync(ownerId, ct);
@@ -141,13 +155,18 @@ public class CabinPlacementValidationTests : TestBase
         var ownerId = client.JoinResult.UniqueMultiplayerId;
         var baseline = await GetOurCabinAsync(ownerId, ct);
 
-        var rejected = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinPlacement_Rejected,
-            () => Chat.AssertResponseAsync("!cabin", "Must be on Farm"),
-            TestTimings.CabinAssignmentTimeout,
-            cancellationToken: ct
+        // Static gate (fresh farmhand spawns off-Farm), no race — resend is harmless here, used for
+        // the self-identifying reply and one consistent pattern across the rejection sites.
+        var rejection = await Chat.ResendUntilResponseAsync(
+            "!cabin",
+            "Must be on Farm",
+            replyFamilyPrefix: "Must be on Farm",
+            timeout: TestTimings.CabinAssignmentTimeout
         );
-        Assert.True(rejected, "Expected a 'Must be on Farm' rejection reply");
+        Assert.True(
+            rejection.Matched,
+            $"Expected a 'Must be on Farm' rejection reply; {rejection.Describe()}"
+        );
 
         var after = await GetOurCabinAsync(ownerId, ct);
         Assert.True(after.IsHidden, "Cabin should still be hidden after an off-Farm reject");
@@ -203,13 +222,19 @@ public class CabinPlacementValidationTests : TestBase
             "Farmer B's position did not replicate to the server before the rejection check"
         );
 
-        var rejected = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinPlacement_Rejected,
-            () => Chat.AssertResponseAsync("!cabin", "another player is standing there"),
-            TestTimings.CabinAssignmentTimeout,
-            cancellationToken: ct
+        // Resend recovers a send that hit a one-tick-lagged server view. Safe (unlike the pot)
+        // because the gate above pins B in farm.farmers and a stationary farmer doesn't leave it,
+        // so no accepted-then-masked window opens — the gate, not the resend, is what makes it safe.
+        var rejection = await Chat.ResendUntilResponseAsync(
+            "!cabin",
+            "another player is standing there",
+            replyFamilyPrefix: "Can't move cabin",
+            timeout: TestTimings.CabinAssignmentTimeout
         );
-        Assert.True(rejected, "Expected an 'another player is standing there' rejection");
+        Assert.True(
+            rejection.Matched,
+            $"Expected an 'another player is standing there' rejection; {rejection.Describe()}"
+        );
 
         var after = await GetOurCabinAsync(ownerIdA, ct);
         Assert.True(after.IsHidden, "A's cabin should still be hidden after rejection");

--- a/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
@@ -59,16 +59,19 @@ public class CabinStrategyFarmhouseStackTests : TestBase
         await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
         var baseline = await GetOurCabinAsync(ownerId, ct);
 
-        // "keep all cabins" is unique to the FarmhouseStack gate. Match only this fragment,
-        // not the full phrase: the delivered chat message has a double space ("cabins  in")
-        // that a longer substring would straddle.
-        var rejected = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinPlacement_Rejected,
-            () => Chat.AssertResponseAsync("!cabin", "keep all cabins"),
-            TestTimings.CabinAssignmentTimeout,
-            cancellationToken: ct
+        // Static strategy gate, no race — resend is harmless here (self-identifying reply + one
+        // consistent pattern). Match only "keep all cabins" (unique to this gate), not a longer
+        // phrase: the delivered message has a double space ("cabins  in") a substring would straddle.
+        var rejection = await Chat.ResendUntilResponseAsync(
+            "!cabin",
+            "keep all cabins",
+            replyFamilyPrefix: "Can't move cabin",
+            timeout: TestTimings.CabinAssignmentTimeout
         );
-        Assert.True(rejected, "Expected a FarmhouseStack rejection reply");
+        Assert.True(
+            rejection.Matched,
+            $"Expected a FarmhouseStack rejection reply; {rejection.Describe()}"
+        );
 
         // No move, and no intent written on rejection.
         var after = await GetOurCabinAsync(ownerId, ct);

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -529,6 +529,19 @@ public class TestFarmersResponse
     public string? Error { get; set; }
 }
 
+/// <summary>Response from /test/object_at_tile GET endpoint (test-only). Mirrors the server-side DTO.</summary>
+public class TestObjectAtTileResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("present")]
+    public bool Present { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 /// <summary>
 /// Response from /test/festival_state GET endpoint (test-only). Mirrors the server-side
 /// TestFestivalStateResponse DTO — a direct read of the host's festival state.
@@ -1813,6 +1826,58 @@ public class ServerApiClient : IDisposable
                     );
                     var f = farmers?.Farmers.FirstOrDefault(x => x.Id == farmerId);
                     return f != null && f.TileX == tileX && f.TileY == tileY;
+                }
+                catch (Exception ex)
+                    when (ex
+                            is HttpRequestException
+                                or TaskCanceledException
+                                or OperationCanceledException
+                        && !ct.IsCancellationRequested
+                    )
+                {
+                    // Per-request timeout or connection error, retry.
+                    return false;
+                }
+            },
+            timeout ?? Helpers.TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+    }
+
+    /// <summary>
+    /// Test-only: poll until an Object is present at (<paramref name="tileX"/>,<paramref name="tileY"/>)
+    /// in <paramref name="location"/>, via the same <c>getObjectAtTile</c> lookup CabinPlacementValidator
+    /// reads. A placed Object replicates from the placing client's Game1 to the server over several
+    /// ticks (the cross-process gap <see cref="WaitForFarmerServerTileAsync"/> covers for a farmer); a
+    /// test forcing a rejection must await THIS before the placement command, else the validator sees a
+    /// clear footprint and wrongly ACCEPTS the move. GET /test/object_at_tile.
+    /// </summary>
+    public async Task<bool> WaitForObjectAtServerTileAsync(
+        int tileX,
+        int tileY,
+        string location = "Farm",
+        TimeSpan? timeout = null,
+        CancellationToken ct = default
+    )
+    {
+        var url =
+            $"/test/object_at_tile?location={Uri.EscapeDataString(location)}&x={tileX}&y={tileY}";
+        return await Helpers.PollingHelper.WaitUntilAsync(
+            Helpers.WaitName.Polling_ServerApi_WaitForObjectAtServerTile,
+            async () =>
+            {
+                try
+                {
+                    // Bound each request well under the outer budget: _httpClient.Timeout is 5
+                    // min, so an unbounded request could outlive the poll and hang.
+                    using var reqCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    reqCts.CancelAfter(Helpers.TestTimings.PollingRequestTimeout);
+                    var response = await _httpClient.GetAsync(url, reqCts.Token);
+                    response.EnsureSuccessStatusCode();
+                    var body = await response.Content.ReadFromJsonAsync<TestObjectAtTileResponse>(
+                        reqCts.Token
+                    );
+                    return body?.Present == true;
                 }
                 catch (Exception ex)
                     when (ex

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -79,7 +79,7 @@ public enum WaitName
     Polling_GameTestClient_WaitForLocation,
     Polling_GameTestClient_WaitForAuthWarp,
 
-    // ServerApiClient.cs (7)
+    // ServerApiClient.cs (8)
     Polling_ServerApi_WaitForPlayerByName,
     Polling_ServerApi_WaitForPlayerById,
     Polling_ServerApi_WaitForPlayersRemovedByName,
@@ -87,6 +87,7 @@ public enum WaitName
     Polling_ServerApi_WaitForFarmhandByName,
     Polling_ServerApi_WaitForFarmhandDeletedByName,
     Polling_ServerApi_WaitForFarmerServerTile,
+    Polling_ServerApi_WaitForObjectAtServerTile,
 
     // SharedSteamAuth.cs (1)
     Polling_SharedSteamAuth_AccountsReady,

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/ChatTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/ChatTestHelper.cs
@@ -16,20 +16,30 @@ internal sealed class ChatTestHelper
     }
 
     /// <summary>
-    /// Polls chat history until all keywords appear in messages with Seq > seqBefore.
+    /// Polls chat history until all keywords appear in messages with Seq > the active cursor.
     /// Uses sequence-based tracking to correctly handle duplicate response texts.
+    ///
+    /// <para>
+    /// <paramref name="prepareIteration"/>, when set, runs at the start of each iteration and
+    /// returns the cursor that iteration matches against (the resend path uses it to re-fire and
+    /// re-cursor per poll, so a reply from an earlier send can't satisfy a later poll). Null keeps
+    /// the fixed <paramref name="seqBefore"/>.
+    /// </para>
     /// </summary>
     public async Task<bool> PollForKeywordsAsync(
         long seqBefore,
         string[] keywords,
         TimeSpan? timeout = null,
-        Action<ChatHistoryResult>? onPoll = null
+        Action<ChatHistoryResult>? onPoll = null,
+        Func<Task<long>>? prepareIteration = null
     )
     {
         return await PollingHelper.WaitUntilAsync(
             WaitName.Polling_TestBase_WaitForChatMessageAfter,
             async () =>
             {
+                var cursor = prepareIteration is null ? seqBefore : await prepareIteration();
+
                 var chat = await _testBase.GameClient.GetChatHistory(20);
                 if (chat?.Messages == null)
                 {
@@ -37,7 +47,7 @@ internal sealed class ChatTestHelper
                 }
 
                 onPoll?.Invoke(chat);
-                var newMessages = chat.Messages.Where(m => m.Seq > seqBefore).ToList();
+                var newMessages = chat.Messages.Where(m => m.Seq > cursor).ToList();
                 return keywords.All(k =>
                     newMessages.Any(m => m.Message.Contains(k, StringComparison.OrdinalIgnoreCase))
                 );
@@ -111,6 +121,144 @@ internal sealed class ChatTestHelper
             }
         }
         return allFound;
+    }
+
+    /// <summary>
+    /// Outcome of a capture read (<see cref="ResendUntilResponseAsync"/> /
+    /// <see cref="SendOnceAndCaptureAsync"/>). <see cref="ObservedReply"/> is the latest reply seen
+    /// in the command's family (or the matching reply on success), or null if none appeared — which
+    /// distinguishes an accepted command from a wrong-reason reply.
+    /// </summary>
+    public readonly record struct CommandResponse(bool Matched, string? ObservedReply)
+    {
+        public string Describe() =>
+            ObservedReply is null
+                ? "no reply observed (command accepted or no response sent)"
+                : $"got reply \"{ObservedReply}\"";
+    }
+
+    /// <summary>
+    /// Resends <paramref name="command"/> each poll until <paramref name="expectedContains"/>
+    /// appears, capturing the latest reply in the command's family
+    /// (<paramref name="replyFamilyPrefix"/>, e.g. "Can't move cabin") so a wrong-reason failure
+    /// names the actual reply instead of recurring as an opaque miss.
+    ///
+    /// <para>
+    /// IDEMPOTENT commands ONLY — resending a mutating command double-applies it. Used for
+    /// <c>!cabin</c> rejection reads whose "obstacle" is a live, replicated farmer/state that can
+    /// lag the client warp by a tick: a single send landing on a lagged tick sees no collision and
+    /// the move is silently accepted, and there's no re-fire to recover. Single-shot mutating
+    /// commands stay on <see cref="AssertResponseAsync"/>; a single-shot self-identifying read
+    /// (where an early resend would be UNSAFE) uses <see cref="SendOnceAndCaptureAsync"/>.
+    /// </para>
+    /// </summary>
+    public Task<CommandResponse> ResendUntilResponseAsync(
+        string command,
+        string expectedContains,
+        string? replyFamilyPrefix = null,
+        TimeSpan? timeout = null
+    ) =>
+        CaptureResponseAsync(
+            command,
+            () => SendAndSnapshotCursorAsync(command),
+            expectedContains,
+            replyFamilyPrefix,
+            timeout
+        );
+
+    /// <summary>
+    /// Sends <paramref name="command"/> ONCE, then polls until <paramref name="expectedContains"/>
+    /// appears — same self-identifying <see cref="CommandResponse"/> as
+    /// <see cref="ResendUntilResponseAsync"/>, but WITHOUT resending. Use when an early resend would
+    /// permanently mask the rejection (e.g. an accepted <c>!cabin</c> relocates the cabin over its
+    /// own footprint, so the validator's self-overlap guard skips the obstacle forever); such a site
+    /// must gate the single send on the obstacle being server-visible beforehand.
+    /// </summary>
+    public Task<CommandResponse> SendOnceAndCaptureAsync(
+        string command,
+        string expectedContains,
+        string? replyFamilyPrefix = null,
+        TimeSpan? timeout = null
+    )
+    {
+        // Memoize the cursor so the prepare hook sends only on the first poll and returns that same
+        // cursor thereafter — the reply stays matchable without re-firing the command.
+        long? fixedCursor = null;
+        return CaptureResponseAsync(
+            command,
+            async () => fixedCursor ??= await SendAndSnapshotCursorAsync(command),
+            expectedContains,
+            replyFamilyPrefix,
+            timeout
+        );
+    }
+
+    /// <summary>Snapshots the pre-send seq cursor, sends <paramref name="command"/>, and returns the
+    /// cursor — so a reply to this send reads as Seq &gt; cursor.</summary>
+    private async Task<long> SendAndSnapshotCursorAsync(string command)
+    {
+        var chatBefore = await _testBase.GameClient.GetChatHistory(20);
+        var cursor = chatBefore?.TotalReceived ?? 0;
+        await _testBase.GameClient.SendChat(command);
+        return cursor;
+    }
+
+    private async Task<CommandResponse> CaptureResponseAsync(
+        string command,
+        Func<Task<long>> sendAndSnapshotCursor,
+        string expectedContains,
+        string? replyFamilyPrefix,
+        TimeSpan? timeout
+    )
+    {
+        // Advanced by the prepare hook each poll to that send's cursor, so a captured reply
+        // attributes to the current send, not a stale reply from a prior one.
+        long cursor = 0;
+        string? observedReply = null;
+
+        var matched = await PollForKeywordsAsync(
+            seqBefore: 0,
+            keywords: new[] { expectedContains },
+            timeout: timeout,
+            onPoll: chat =>
+            {
+                var hit = chat
+                    .Messages.Where(m => m.Seq > cursor)
+                    .FirstOrDefault(m =>
+                        m.Message.Contains(expectedContains, StringComparison.OrdinalIgnoreCase)
+                    );
+                if (hit != null)
+                {
+                    observedReply = hit.Message;
+                    return;
+                }
+
+                // No expected match this poll: remember the latest family reply so a wrong-reason
+                // failure (e.g. "blocked by terrain or object") names what actually came back.
+                if (replyFamilyPrefix != null)
+                {
+                    var family = chat
+                        .Messages.Where(m =>
+                            m.Seq > cursor
+                            && m.Message.Contains(
+                                replyFamilyPrefix,
+                                StringComparison.OrdinalIgnoreCase
+                            )
+                        )
+                        .LastOrDefault();
+                    if (family != null)
+                    {
+                        observedReply = family.Message;
+                    }
+                }
+            },
+            prepareIteration: async () => cursor = await sendAndSnapshotCursor()
+        );
+
+        var result = new CommandResponse(matched, observedReply);
+        Log($"{command} → expected \"{expectedContains}\": {result.Describe()}");
+
+        return result;
     }
 
     private static bool AllChatKeywordsPresent(ChatHistoryResult? chat, string[] keywords)


### PR DESCRIPTION
## Problem

`AnotherPlayerInFootprint_RejectsAndDoesNotMove` flakes with an opaque "Expected an 'another player is standing there' rejection — No trace available". The keyword can be absent for two indistinguishable reasons: the move was accepted (server's farmer view lagged a tick, no reply sent), or a wrong-reason reply fired (`"blocked by terrain or object"`). The bare `Assert.True` can't tell them apart.

Root cause: the rejection sites sent `!cabin` once inside an outer poll that barely iterated (`AssertResponseAsync` burns the full timeout in its own loop), so a single send landing on a one-tick-lagged server farmer view was silently accepted with no re-fire to recover.

## Changes

- **`ChatTestHelper`**: extend `PollForKeywordsAsync` with an optional per-iteration prepare hook (default null = unchanged; existing callers untouched). Add two wrappers sharing one core:
  - `ResendUntilResponseAsync` — resends the command each poll (idempotent commands only). Recovers a send that hit a lagged server view.
  - `SendOnceAndCaptureAsync` — sends once, memoized cursor (for sites where a resent-then-accepted command would mask the rejection).
  - Both return a `CommandResponse` that names the actual reply, so a future miss self-identifies (accepted vs wrong-reason) instead of recurring as an opaque no-trace.
- Move the `AnotherPlayer` / `OffFarm` / `FarmhouseStack` rejection reads onto `ResendUntilResponseAsync`; each assert now prints the observed reply on failure.
- `ObstacleInFootprint` stays **single-shot** — an accepted move relocates the cabin over the pot tile, after which the validator's self-overlap guard skips it forever. It now gates the send on a new `GET /test/object_at_tile` probe (mirrors `/test/farmers` + `WaitForFarmerServerTileAsync`) confirming the pot has replicated to the server before `!cabin`.
- New endpoint reads `getObjectAtTile` — the same lookup `CabinPlacementValidator.IsTileBuildable` uses; new `WaitForObjectAtServerTileAsync` client wait + `WaitName` variant.

## Verification

- All 5 affected tests pass (`CabinPlacementValidationTests` ×4, `CabinStrategyFarmhouseStackTests` ×1).
- Run JSONL confirms the scenarios ran: `ObstacleInFootprint`'s pot-wait matched (~7 polls) before the reject and stayed single-shot; the resend path fired and matched.
- No production mod/server logic changes — the new endpoint is gated to the test API surface and reads game state read-only on the game thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a test-only API endpoint to check whether an object is present at a specified tile and location.
  * Added test client support for waiting until an object appears at a server tile.
  * Added structured command-response capture helpers for more reliable chat command validation.

* **Tests**
  * Improved cabin-placement rejection checks by retrying commands and capturing matching responses.
  * Enhanced diagnostics when expected rejection messages are not received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->