### PR TITLE
perf(test): speed up the same-day two-wedding E2E (~23% faster testbody)

### DIFF
--- a/.claude/plans/bugs/day-transition-wedge-with-lobby-player.md
+++ b/.claude/plans/bugs/day-transition-wedge-with-lobby-player.md
@@ -1,0 +1,145 @@
+# Day transition wedges the server permanently when a lobby player is connected
+
+Status: narrowed to a blocking barrier inside the NewDay task. The barrier's **name** is the one
+remaining unknown and needs one targeted log line plus a repro. Not fixed.
+
+Intermittent (~50% of full-suite runs on 2026-08-03: `07-13-01Z` and `11-16-51Z` of four).
+Pre-existing — the identical failure occurred at `1b5ea11` (2026-07-12,
+`TestResults/runs/2026-07-12T19-48-23Z_1b5ea11` in the main checkout), which predates any of the
+wedding-speedup work.
+
+## Symptom
+
+`LobbyHomedSpouseSteadyStateTests.MarriedCouples_UnderPassword_HomesStayRealAcrossNightsAndOffline`
+fails with `503 (Service Unavailable)`, `failureCategory: "infrastructure"`. The server it ran on is
+dead for the remainder of the run — every game-thread endpoint returns 503, and under `stopOnFail`
+the whole run dies with it.
+
+## Sequence (run `2026-08-03T07-13-01Z_38d72b9`, `containers/server-3/container.log`)
+
+- `07:26:57` a client registers unauthenticated in the lobby (`lobby_unauthenticated_registered`,
+  player `-183582307287801172`) — owned by `PasswordProtectionTests.Help_Command_WorksInLobby`,
+  which parks a client in the lobby on purpose and never authenticates.
+- `07:27:00` that client confirms character creation; `07:27:02` the server logs
+  `[Auth] Player … finished character customization`. It remains unauthenticated.
+- `07:27:03` `LobbyHomedSpouseSteadyStateTests` drives its night: `DayEnding`,
+  `Synchronizing 'NewDay' task`, plus `[Auth] Blocked startNewDaySync` ×1 and
+  `Blocked newDaySync` ×4 to that player (`PasswordProtectionService.cs:456-473` blocks those two
+  message types to unauthenticated peers so their customization menu isn't closed).
+- `07:27:06` `game_thread_stall_started lastTickMs=3150`. Never recovers.
+
+**Why every endpoint then 503s.** `ApiService` drains its game-thread queue in `OnUpdateTicked`
+(`ApiService.cs:1132-1140`), deliberately on the validated tick so mutating callbacks can't corrupt
+a save. No tick → no drain → `RunOnGameThreadAsync`'s 5s guard (`:1773`) fires on every request.
+`/stats` and `/health` keep answering in 0ms because they read the cached snapshot. Not resource
+starvation: CPU 3-8%, `avgTickMs` frozen at 4.66 (no new ticks).
+
+## Verified
+
+**The lobby exclusion is working.** The `sleep` ready check reports `numberRequired: 3` at
+`07:26:57.9` — computed *after* the lobby player joined, with four farmers online (host + 2
+authenticated + 1 lobby) — and reaches `3/3 isReady:true` at `07:27:03`. A passing run corroborates
+from the other side: `2026-06-30T19-28-04Z_864566d` server-2 ran a full transition with a lobby
+player connected and 27 blocked `newDaySync` sends at `sleep numberRequired: 1`, and completed fine.
+So `LobbyService`'s `IsFarmerRequired` postfix (`LobbyService.cs:273-298`, body `:580-599`) applies
+and is not being inlined away.
+
+**`ready_for_save` never ran.** `GameEventTracer` emits `ready_check_transition` on every state
+change and demonstrably works for this check on this server (`07:17:27`, and the *previous* night at
+`07:25:58-59` ending `3/3 isReady:true`). During the wedge, 204 server-3 events were emitted and
+**zero `ready_for_save` transitions**. So that check's `Update` never ran during the stalled
+transition.
+
+**The host is blocked inside the NewDay task, before the save handshake.** SMAPI runs the transition
+on a background thread; the main game thread is frozen. The only hard blocking wait in that range is
+`NetSynchronizer.barrier()` (`decompiled/.../StardewValley/NetSynchronizer.cs:55-73`), whose
+`while (!barrierReady(name))` loop cannot exit on the host — `shouldAbort()` reads
+`Game1.client.timedOut` and `Game1.client` is null on the master, so a host-side barrier stall is
+permanent by construction. That puts the stall in one of the ~15 barriers from `start` through
+`saveFarmhands` (`Game1.cs:7786-8241`), and means `BarrierReady_Postfix`
+(`LobbyService.cs:500-566`) — which exists precisely to release those for excluded players — did not
+release this one.
+
+## Ruled out (do not rebuild on these)
+
+- **"The lobby player is counted as required at `ready_for_save`."** This came from the frozen
+  `SaveGameMenu` readout "waiting for other players… (3/…)" plus the reasoning "3 ready and still
+  blocked ⇒ required ≥ 4". Wrong: `ready_for_save.Update` never ran, so the displayed
+  `numReadyForSave()` = 3 is a **stale cached value from the previous night**. The readout says
+  nothing about the live gate. (The denominator is `Game1.getOnlineFarmers().Count`, unfiltered —
+  `decompiled/.../Menus/SaveGameMenu.cs:186,208`.)
+- **Harmony patch lost to JIT inlining of `IsFarmerRequired`.** Disproved by the `sleep` counts
+  above.
+
+## The one open question
+
+**Which barrier.** The barrier system emits no events, so no artifact records it — this is the only
+part that needs runtime.
+
+**Next step (small, in existing code):** `BarrierReady_Postfix` already runs on the blocked thread
+and already has the barrier `name` and `___barriers` in scope. Log the name and the unsatisfied ids
+once a barrier has been unsatisfied for more than N seconds. Do not build a general stall-diagnostic
+service — this is a handful of lines in a method that already exists.
+
+Weigh these once the name is known: the postfix returns early when `__result` is already true, when
+`_instance` is null, and when `HasPlayersToExclude()` is false (`:511-525`); it also reads
+`Game1.otherFarmers.Keys` from the background task thread while the main thread can mutate it.
+
+## Repro
+
+Today this needs the broker to schedule two classes onto one server, which is why it is ~50% and not
+reproducible on demand. A test that parks a client unauthenticated in the lobby and then drives a
+night on the same server makes it deterministic, and is the gate for any fix.
+
+Per `.claude/rules/universal/passing-test-isnt-proof-the-scenario-ran.md`, assert the transition
+completes **and** confirm from the artifact that the lobby player was connected throughout — a green
+assertion would also pass if the lobby client happened to disconnect first.
+
+## Fix
+
+Not proposed. Every candidate depends on which barrier stalls and why the postfix did not release
+it; writing one now would be a guess. Whatever it turns out to be, do not add a retry or a re-apply
+loop (`.claude/rules/universal/retry-is-evidence-of-root-cause.md`).
+
+## Secondary finding — the stuck-barrier recovery cannot run during the stall
+
+`DesyncKicker` detects the stall at +20s and *enqueues* its kick onto `_pendingGameThreadActions`
+(`DesyncKicker.cs:168`), drained in `GameLoop.UpdateTicked` (`:48-50`). The game thread is frozen,
+so the enqueued action can never execute — matching the log (kick announced at `07:27:23`, no
+`Kicking …` line follows).
+
+Real latent defect: the recovery path is inert in exactly the situation it exists for. It is **not**
+the fix for this bug. If repaired, the seam is something that runs while the thread is blocked
+(`NetSynchronizer.processMessages`, called every spin iteration) or an off-thread
+`Game1.server.kick`. Open decision.
+
+## Relationship to PR #494
+
+Not caused by it — the mechanism is entirely server-side and reproduced at `1b5ea11` on master.
+But not cleanly independent either: `SessionJoinMode.Unauthenticated` routes through
+`Connect.JoinWithoutAuthAsync` (`PersistentSessionCoordinator.cs:258-259`), one of the two methods
+#494 rewired (`ConnectionRetryHelper.cs:139-181`), so the lobby join that creates the precondition
+is resequenced by that PR. An exposure-rate shift cannot be excluded from four runs. The wedge
+itself predates it.
+
+## Evidence notes
+
+Run artifacts under `TestResults/runs/` are local and get pruned. The decisive frame came from the
+server's own recording — the host's screen names the menu it is stuck in, and the on-screen TICK
+counter across two frames says whether the game thread is alive:
+
+```bash
+ffmpeg -ss <seconds-from-start> -i containers/server-N/full_recording.mp4 -frames:v 1 out.png
+```
+
+For `2026-08-03T07-13-01Z_38d72b9` server-3 (686s long), t≈650 shows the frozen `SaveGameMenu`.
+Reach for this before writing instrumentation.
+
+## Related
+
+- `tests-password-config-shared-with-exclusive-class.md` — the test-side collision that creates the
+  precondition in CI. Fixing it reduces exposure but not the bug.
+- `newgame-day-transition-never-completes.md` — same symptom family (transition never completes),
+  different mechanism (game thread healthy, zero players).
+- `tests-flake-cropsaver-day-advance.md` Mode 1 — also "day doesn't happen", but the clock freezes
+  *before* any transition starts. Distinct.

--- a/.claude/plans/bugs/newgame-day-transition-never-completes.md
+++ b/.claude/plans/bugs/newgame-day-transition-never-completes.md
@@ -1,0 +1,73 @@
+# `/newgame` never completes — 504 after 120s with a healthy game thread and zero players
+
+Status: narrowed, not root-caused. Next read identified.
+
+Seen once in four full-suite runs on 2026-08-03 (`09-31-27Z`). Not new — PR #496's plan records the
+same failure on a different test (`CabinPositionPersistenceTests.DummyCabin_AfterMoveAndReconnect_…`,
+run `2026-07-13T21-24-09Z`).
+
+## Symptom
+
+`SaveImportTests.Import_AsIs_PreservesOwnerAsHost` fails with `504 (Gateway Timeout)`,
+`failureCategory: "infrastructure"`, on `POST /newgame` after `durationMs: 120406`.
+
+## Evidence (run `2026-08-03T09-31-27Z_38d72b9`, `containers/server-4`)
+
+- `09:42:11-13` the save-import reload succeeds cleanly (`Loading Save`, `SaveLoaded`,
+  `save_import_finalized`, cabins synced).
+- `09:42:36` `[API] New game requested` → `[GameCreator] After NewDay(0f): newDay=True,
+  fadeToBlack=True` → `setGameMode(playingGameMode (3))` → `Warping to Farm`.
+- `09:42:37` onward: `snapshot_skipped_newday` repeats — and keeps repeating **past** the timeout
+  (still firing at `09:44:39`, after the 504 at `09:44:36`).
+- `09:44:36` `http_served {"path":"/newgame","status":504,"durationMs":120406}`.
+
+So the transition was genuinely unfinished; this is not a lost or mis-routed response. The 504 is
+emitted by the mod itself (`ApiService.cs:4814/4949`), and `snapshot_skipped_newday` only fires while
+`Game1.newDay` is true (`:1238`).
+
+## What separates it from the lobby wedge
+
+The server's own recording settles it. Two frames 50s apart show the on-screen counter at
+TICK 3319 → 3569 — exactly 250 ticks in 50s, i.e. 5/sec, matching `SERVER_TPS`. The game thread is
+**healthy and ticking**, the overlay reads "0 Players Online", and the world is black.
+
+```bash
+ffmpeg -ss <seconds> -i containers/server-4/full_recording.mp4 -frames:v 1 out.png
+```
+
+(Recording is 719s; t≈659 and t≈709 were the two frames used. Run artifacts under `TestResults/runs/`
+are local and get pruned.)
+
+That rules out the mechanism of `day-transition-wedge-with-lobby-player.md`, where the thread is
+frozen and a peer is being waited on. Here there is nobody to wait for and the loop is running.
+
+## Next read
+
+`/newgame` completion is gated on `ComputeDayTransitionComplete()`, which returns false while
+`Game1.newDaySync != null && hasInstance() && !hasFinished()` (`ApiService.cs:1664-1672`). With zero
+other players, establish which of these holds:
+
+1. the transition is genuinely stalled mid-flight, or
+2. it completed but a `newDaySync` instance is left un-finished / un-destroyed, so the completion
+   contract never resolves.
+
+`NewDaySynchronizer.finish()` only sends `finished` when `Game1.IsServer`
+(`decompiled/.../StardewValley/NewDaySynchronizer.cs:114-121`), and `hasFinished()` reads that var
+(`:123-126`) — start there. Also check `newDaySync.destroy()` (`Game1.cs:4294`) on the
+return-to-title path that `/newgame` takes, since this run reloaded a save immediately before.
+
+Relevant context: `.claude/rules/tests-assert-via-http-api.md` documents that `/newgame`'s
+completion was deliberately gated on **both** `SaveLoaded` and `ComputeDayTransitionComplete()` to
+fix an earlier flake — so this gate is load-bearing and must not simply be loosened.
+
+## Note on the prior explanation
+
+PR #496's plan closes its occurrence as "stalled ~120s at the host's reverse proxy under end-of-run
+saturation", with an isolated re-run passing. Three observations contradict that reading for this
+occurrence: the 504 was emitted by the server itself (it appears in the server's own
+`http_served` event), `snapshot_skipped_newday` continues past the timeout, and the game thread was
+ticking at full rate throughout. Re-confirm before accepting either explanation.
+
+## Relationship to PR #494
+
+None. Server-side, zero players connected, no join involved. Also observed on PR #496's branch.

--- a/.claude/plans/bugs/tests-cabin-placement-rejection-resend-flake.md
+++ b/.claude/plans/bugs/tests-cabin-placement-rejection-resend-flake.md
@@ -224,3 +224,71 @@ every existing caller unchanged). Change 3 adds a new test-only endpoint + clien
 established pair (`/test/farmers` + `WaitForFarmerServerTileAsync`); the endpoint is gated to the
 test API surface and reads game state read-only on the game thread. No production mod/server logic
 changes.
+
+---
+
+# Update 2026-08-03 — the fix shipped and `ObstacleInFootprint` still failed
+
+Status: all three changes above are **in the tree** — `ChatTestHelper.ResendUntilResponseAsync` /
+`SendOnceAndCaptureAsync` + `CommandResponse.Describe()` (`ChatTestHelper.cs:127-172`), and the
+pot-visibility gate `ServerApi.WaitForObjectAtServerTileAsync` at
+`CabinPlacementValidationTests.cs:113-121`. The flake recurred anyway, on the *other* method.
+
+## The occurrence
+
+Run `2026-08-03T10-36-17Z_38d72b9`,
+`CabinPlacementValidationTests.ObstacleInFootprint_RejectsAndDoesNotMove`:
+
+```
+Expected a 'Can't move cabin' rejection reply; no reply observed (command accepted or no response sent)
+```
+
+The `Describe()` channel worked as designed — the failure self-identifies as **scenario 1** (no
+reply in the `"Can't move cabin"` family at all), not scenario 2.
+
+## What this rules out
+
+The plan's root cause for this method — the Garden Pot not yet replicated server-side when `!cabin`
+runs — **is excluded**. The pot gate (`:113-121`) asserts `potVisible` *before* the command is sent,
+and it passed; had it failed, the reported message would have been "Garden Pot did not replicate to
+the server before the rejection check". The site also correctly stayed single-shot
+(`SendOnceAndCaptureAsync`), so the self-overlap masking path is not in play either.
+
+## What the server shows (`containers/server-1/container.log`)
+
+```
+[10:44:04 TRACE JunimoServer] [ChatCommands] OnChatMessage: !cabin
+[10:44:04 TRACE JunimoServer] [ChatCommands] Found command: cabin
+```
+
+…and then **nothing**: no `"Can't move cabin"` reply, no cabin move/relocate, no `cabin_*` event, no
+error, through to the test's 35s timeout and client disconnect at `10:44:40`. The handler was
+entered and produced no observable outcome.
+
+That does not fit either scenario in the original framing (both assumed the validator *ran* and
+either accepted or rejected for a different reason).
+
+## Next read
+
+`CabinCommand.cs:24-85` — every branch either sends a reply or moves the cabin, so "entered, nothing
+happened" needs explaining. In order:
+
+1. **Did the cabin actually move?** A silent accept is the benign reading, but the success path's
+   logging needs checking — nothing in the 10:44 window mentions a relocate, and the test failed
+   before its own "confirm the move was blocked" assertion could run.
+2. **Did the handler throw?** `ChatCommands.cs:171-172` calls `command.Action(...)` with **no
+   try/catch**, so an exception would propagate to the SMAPI event and surface as an `ERROR` line —
+   none is present, which argues against it. `Game1.GetPlayer(msg.SourceFarmer)` returning null
+   (`CabinCommand.cs:44`) would NRE on the next line, so this is worth confirming rather than
+   assuming.
+3. **Did the reply get sent but not captured?** `SendPrivateMessage` → client chat history is the
+   assertion's channel; the client recording for that test would show whether the text ever
+   rendered.
+
+Do (1) and (3) from artifacts before adding instrumentation — the client recording is already on
+disk (run artifacts under `TestResults/runs/` are local and get pruned).
+
+## Relationship to PR #494
+
+None. The precedent for this failure family predates it (`e8f9535`, 2026-06-22), and the
+`!cabin` path involves no join sequencing.

--- a/.claude/plans/bugs/tests-password-config-shared-with-exclusive-class.md
+++ b/.claude/plans/bugs/tests-password-config-shared-with-exclusive-class.md
@@ -27,6 +27,15 @@ it, and the password config violates it today.
 `KeepConnected` session already connected to that instance. So a lobby client can sit inside another
 class's night.
 
+**The cross-class sharing itself is by design, not the defect.** `test-broker-invariants.md:45`:
+"same config produces the same server key, regardless of `SharedAssembly` vs `SharedClass`
+lifetime — the broker reuses an existing matching server." Isolation governs server *lifetime and
+reuse*, not exclusivity, and pooling by config is what keeps the run inside its per-host
+`serverSlots`. Do not "fix" this by adding the test class to the `SharedClass` key: 14 of 33 test
+classes are `SharedClass` (some explicitly, some by default), so that would split their pooling into
+per-class servers at ~41s boot apiece. The defect is narrower — an *unauthenticated* session held on
+a server where another class drives day transitions.
+
 ## Consequence
 
 This is the CI trigger for `day-transition-wedge-with-lobby-player.md` — two of four full-suite runs

--- a/.claude/plans/bugs/tests-password-config-shared-with-exclusive-class.md
+++ b/.claude/plans/bugs/tests-password-config-shared-with-exclusive-class.md
@@ -1,0 +1,73 @@
+# Password test classes share one server: three `KeepConnected` classes alongside an `Exclusive` one
+
+Status: root-caused, fix is one attribute. Not applied.
+
+`.claude/rules/test-broker-invariants.md` already forbids this pairing ("DO NOT use
+`[TestServer(Exclusive = true)]` on classes sharing a server with KeepConnected"). Nothing enforces
+it, and the password config violates it today.
+
+## Root cause
+
+`ComputeConfigHash` deliberately excludes `Clients` (`ResourceRequirements.cs:63-72`) and
+`Isolation` defaults to `SharedClass` (`TestServerAttribute.cs:103-105`), which keys as
+`config-{hash}` — the same form `SharedAssembly` produces. So every class with
+`Password = "test-password-123"` and default farm/cabins/strategy lands on **one** server instance
+(`config-21937f75bcf8`, label `lan+pw-farm0-CabinStack-c30`, 33 tests in the 2026-08-03 runs):
+
+| Class | Attribute |
+|---|---|
+| `PasswordProtectionTests` | `KeepConnected` — parks an **unauthenticated** lobby session |
+| `LobbyCommandsCRUDTests` | `KeepConnected` |
+| `LobbyCommandsEditingTests` | `KeepConnected` |
+| `LobbyCommandsPermissionsTests` | plain |
+| `PasswordProtectionDisruptiveTests` | plain |
+| `LobbyHomedSpouseSteadyStateTests` | **`Exclusive`**, drives day transitions |
+
+`Exclusive` serializes a class's own methods and holds the server between them; it does not evict a
+`KeepConnected` session already connected to that instance. So a lobby client can sit inside another
+class's night.
+
+## Consequence
+
+This is the CI trigger for `day-transition-wedge-with-lobby-player.md` — two of four full-suite runs
+on 2026-08-03 died this way. Fixing it removes the collision in the suite; it does **not** fix the
+underlying server bug (a real player sitting at the password prompt at 2am hits the same wedge).
+
+## Fix
+
+Give `LobbyHomedSpouseSteadyStateTests` its own instance. At
+`tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs:38-43`:
+
+```csharp
+[TestServer(
+    Clients = 2,
+    Password = "test-password-123",
+    Isolation = IsolationMode.SharedGroup,
+    SharedGroup = "lobby-homed-spouse",
+    Exclusive = true
+)]
+```
+
+`SharedGroup` keys as `group-{SharedGroup}-{hash}` (`ResourceRequirements.cs:38-45`), so the class
+gets its own server while keeping its password semantics. One attribute added.
+
+Cost: one more server instance for the run. Check it against host `serverSlots` before landing —
+`.claude/rules/provision-up-front-when-startup-exceeds-serviceable-tail.md` covers the capacity
+trade-off.
+
+## Do NOT add a broker-level throw for `Exclusive` + `KeepConnected`
+
+The same pairing exists on the 90-test non-password config: `NoPasswordTests` is `KeepConnected`
+while `CabinPlacementValidationTests`, `CabinStrategyFarmhouseStackTests`, `CabinStrategyNoneTests`,
+`FarmMapTypeTests` and `RenderingTests` are `Exclusive`. Those held sessions are **authenticated**,
+so they participate in barriers normally and the pairing is harmless there. A fail-fast would reject
+the committed config on its first run — see
+`.claude/rules/universal/preflight-check-vs-committed-config.md`.
+
+A `Warn`-level prestart diagnostic naming the sharing classes is acceptable and cheap. The
+hazardous combination to name is narrower than the rule's blanket wording: **an unauthenticated
+session held on a server where another class drives day transitions.**
+
+## Relationship to PR #494
+
+None. Pure test configuration, unchanged by that PR, and independently landable.

--- a/.claude/rules/test-broker-invariants.md
+++ b/.claude/rules/test-broker-invariants.md
@@ -46,7 +46,7 @@ Load-bearing invariants for the test resource broker, capacity gating, and sessi
 
 - **`config-{hash}` keys identify reusable servers.** Same config produces the same server key, regardless of `SharedAssembly` vs `SharedClass` lifetime — the broker reuses an existing matching server.
 - **Config hash inputs**: password, starting cabins, farm type, max players, allow IP connections, Steam authentication, cabin strategy. Changing any of these splits the cache.
-- **Different `clientsNeeded` test demand produces different config hashes.** `StartingCabins` is derived from a test's `[TestServer(Clients = N)]` value, so two tests requesting different N split the cache even with otherwise identical config.
+- **`Clients` does NOT split the cache.** It is excluded from the hash, and `StartingCabins` — which is in the hash — defaults to `Math.Max(4, hosts.Max(h => h.ClientCapacity.Capacity) * 3)` (`TestServerAttribute.cs:71-77`), i.e. host client capacity, *not* the test's `Clients` value. So two classes requesting different `Clients` share one server unless something else in the hash differs. Only an explicit `StartingCabins = N` splits it.
 
 ## Diagnostic Snapshots
 

--- a/tests/JunimoServer.Tests/Helpers/ConnectionHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/ConnectionHelper.cs
@@ -164,6 +164,26 @@ public class ConnectionHelper
     /// </summary>
     public Func<string, Task>? OnCheckpointScreenshot { get; set; }
 
+    /// <summary>
+    /// Optional per-server join gate, set by the caller from <c>ManagedServer</c>.
+    /// <see cref="JoinWorldCoreAsync"/> holds it from just before each connect attempt until the server
+    /// APPROVES the join, then releases so the creation/world-ready tail overlaps the next queued join
+    /// instead of serializing the whole join. The gate exists to serialize the pre-approval same-slot /
+    /// farmhand-deletion races; those are resolved by approval, which is signalled per slot type:
+    /// <list type="bullet">
+    /// <item>uncustomized — the character-customization menu, which the client opens only from
+    /// receiveServerIntroduction → setUpGame (Client.cs:280,226-228), sent only after
+    /// checkFarmhandRequest assigned the home and added the player (GameServer.cs:567,577,602 — both
+    /// strictly precede the send), so the slot is committed out of a concurrent joiner's pool by then;</item>
+    /// <item>already-customized — world-ready.</item>
+    /// </list>
+    /// Both null (the connect-only paths) means no gating.
+    /// </summary>
+    public Func<CancellationToken, Task>? AcquireJoinGate { get; set; }
+
+    /// <summary>Releases the gate acquired by <see cref="AcquireJoinGate"/>.</summary>
+    public Action? ReleaseJoinGate { get; set; }
+
     public ConnectionHelper(
         GameTestClient gameClient,
         ConnectionOptions? options = null,
@@ -588,6 +608,44 @@ public class ConnectionHelper
     }
 
     /// <summary>
+    /// Holds at most one per-server join-gate token, releasing it exactly once. Makes the early
+    /// (approval) release and the safety-net (finally) release idempotent, so no path double-releases
+    /// the gate or leaks a token across a retry.
+    /// </summary>
+    private sealed class JoinGateHolder
+    {
+        private readonly Func<CancellationToken, Task>? _acquire;
+        private readonly Action? _release;
+        private bool _held;
+
+        public JoinGateHolder(Func<CancellationToken, Task>? acquire, Action? release)
+        {
+            _acquire = acquire;
+            _release = release;
+        }
+
+        public async Task AcquireAsync(CancellationToken ct)
+        {
+            if (_acquire == null || _held)
+            {
+                return;
+            }
+            await _acquire(ct);
+            _held = true;
+        }
+
+        public void Release()
+        {
+            if (!_held)
+            {
+                return;
+            }
+            _held = false;
+            _release?.Invoke();
+        }
+    }
+
+    /// <summary>
     /// Shared implementation for JoinWorldAsync and JoinWorldViaLanAsync.
     /// Owns the single retry loop. connectOnceAsync performs one attempt with no internal retries.
     /// </summary>
@@ -614,8 +672,14 @@ public class ConnectionHelper
                 new { attempt, maxAttempts = _options.MaxAttempts }
             );
 
+            // One hold per attempt, released early at approval; the finally is the safety net. See
+            // AcquireJoinGate.
+            var gate = new JoinGateHolder(AcquireJoinGate, ReleaseJoinGate);
+
             try
             {
+                await gate.AcquireAsync(cancellationToken);
+
                 // Connect to server (single attempt; this method owns the retry loop)
                 var connectResult = await connectOnceAsync(
                     attempt,
@@ -658,7 +722,8 @@ public class ConnectionHelper
                 }
                 else
                 {
-                    // Complete the join (slot selection, character creation, auto-login)
+                    // Complete the join (slot selection, character creation, auto-login). gate.Release
+                    // fires at the approval point (see AcquireJoinGate).
                     var (joinResult, completeError) = await CompleteJoinAsync(
                         connectResult.Farmhands,
                         farmerName,
@@ -666,6 +731,7 @@ public class ConnectionHelper
                         preferExistingFarmer,
                         skipAutoLogin,
                         attempt,
+                        gate.Release,
                         cancellationToken
                     );
 
@@ -713,6 +779,11 @@ public class ConnectionHelper
                     );
                 }
             }
+            finally
+            {
+                // Safety net: releases on any path that didn't reach the approval point. Idempotent.
+                gate.Release();
+            }
 
             // Return to title before retry
             EmitDiagnostic("join_retry_cleanup_started", new { attempt });
@@ -756,6 +827,8 @@ public class ConnectionHelper
     /// <summary>
     /// Handles the post-connection join flow: slot selection, character creation, and auto-login.
     /// Returns (result, null) on success, or (null, error) if the attempt should be retried.
+    /// <paramref name="releaseGate"/> is the idempotent join-gate release, called at the approval point
+    /// (see <see cref="AcquireJoinGate"/>).
     /// </summary>
     private async Task<(JoinWorldResult? Result, string? Error)> CompleteJoinAsync(
         FarmhandsResponse farmhands,
@@ -764,6 +837,7 @@ public class ConnectionHelper
         bool preferExistingFarmer,
         bool skipAutoLogin,
         int attempt,
+        Action releaseGate,
         CancellationToken cancellationToken
     )
     {
@@ -791,11 +865,13 @@ public class ConnectionHelper
         // We detect this and re-select the slot.
         if (!targetSlot.IsCustomized)
         {
+            // Releases the gate at the character-menu approval point; holds it across bounce re-selects.
             var (characterCreated, charError) = await SelectSlotAndCreateCharacterAsync(
                 targetSlot,
                 farmerName,
                 favoriteThing,
                 preferExistingFarmer,
+                releaseGate,
                 cancellationToken
             );
             if (!characterCreated)
@@ -818,6 +894,10 @@ public class ConnectionHelper
         {
             return (null, $"Wait for world ready: {worldWait?.Error ?? "timeout"}");
         }
+
+        // Customized slots have no character-menu signal — release at world-ready instead. Idempotent
+        // no-op for the uncustomized path (already released at the menu).
+        releaseGate();
 
         await CaptureCheckpointIfEnabled("after_join");
 
@@ -1046,6 +1126,7 @@ public class ConnectionHelper
         string farmerName,
         string favoriteThing,
         bool preferExistingFarmer,
+        Action releaseGate,
         CancellationToken cancellationToken
     )
     {
@@ -1163,6 +1244,9 @@ public class ConnectionHelper
                                     bounce,
                                 }
                             );
+                            // Uncustomized approval point — slot is committed, safe to release (see
+                            // AcquireJoinGate). Only this terminal branch releases; the bounce path doesn't.
+                            releaseGate();
                         }
                         else if (result.Condition == "farmhand-menu")
                         {

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/ConnectionRetryHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/ConnectionRetryHelper.cs
@@ -78,8 +78,8 @@ internal sealed class ConnectionRetryHelper
         using var _phase = TestIdentityContext.PushPhase("connect");
         var joinSw = System.Diagnostics.Stopwatch.StartNew();
 
+        // Join gate is acquired/released inside JoinWorldCoreAsync (wired in TestBase.GetClientAsync).
         var lease = _testBase.LeaseInternal!;
-        await lease.Managed.AcquireJoinGateAsync(ct);
         try
         {
             var result = lease.RequiresSteamConnection
@@ -125,10 +125,6 @@ internal sealed class ConnectionRetryHelper
             _testBase.ThrowIfServerErrorInternal(ex, "joining world");
             throw;
         }
-        finally
-        {
-            lease.Managed.ReleaseJoinGate();
-        }
     }
 
     /// <summary>
@@ -143,8 +139,8 @@ internal sealed class ConnectionRetryHelper
     {
         await _testBase.GetClientAsyncInternal(ct);
         var joinSw = System.Diagnostics.Stopwatch.StartNew();
+        // The per-server join gate is acquired/released inside JoinWorldCoreAsync (see JoinWithRetryAsync).
         var lease = _testBase.LeaseInternal!;
-        await lease.Managed.AcquireJoinGateAsync(ct);
         try
         {
             var result = lease.RequiresSteamConnection
@@ -184,10 +180,6 @@ internal sealed class ConnectionRetryHelper
         {
             _testBase.ThrowIfServerErrorInternal(ex, "joining world");
             throw;
-        }
-        finally
-        {
-            lease.Managed.ReleaseJoinGate();
         }
     }
 

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/FarmerTestHelper.cs
@@ -131,15 +131,10 @@ internal sealed class FarmerTestHelper
     /// start), then both join sequences run together via <see cref="Task.WhenAll(Task[])"/>.
     ///
     /// <para>
-    /// The server's game loop processes one farmhand join at a time, so the two joins can't
-    /// land at the literal same instant — both go through the per-server join gate
-    /// (<c>ManagedServer.AcquireJoinGateAsync</c>), which serializes the game-thread join and
-    /// is what stops a concurrent join bouncing back to farmhand selection
-    /// (<c>isGameAvailable() == false</c>). What overlaps is everything else: the second
-    /// client's lease/cold-start and both clients' menu navigation and character creation. So
-    /// instead of farmhand B's whole sequence starting only after A's fully completes, the two
-    /// are present together within seconds of each other — the scenario weddings/multiplayer
-    /// tests want.
+    /// The join gate serializes only each join's pre-approval phase and releases at approval (see
+    /// <c>ConnectionHelper.AcquireJoinGate</c>), so each join's creation/world-ready/auth tail overlaps
+    /// the other's pre-approval — plus the second client's cold-start and both clients' menu navigation.
+    /// So B is present within seconds of A, not only after A's whole sequence completes.
     /// </para>
     ///
     /// <para>
@@ -205,10 +200,9 @@ internal sealed class FarmerTestHelper
 
     /// <summary>
     /// Joins a second farmer over an already-leased client and wraps it as a
-    /// <see cref="SecondFarmer"/>. The join goes through the server's join gate so it
-    /// serializes correctly against the primary join (the game loop processes one farmhand
-    /// join at a time). Disposes the supplied lease if the join throws; on success the
-    /// returned <see cref="SecondFarmer"/> owns disposal.
+    /// <see cref="SecondFarmer"/>, gated (via its own <see cref="ConnectionHelper"/>) against the primary
+    /// join's pre-approval phase. Disposes the supplied lease if the join throws; on success the returned
+    /// <see cref="SecondFarmer"/> owns disposal.
     /// </summary>
     private async Task<SecondFarmer> JoinSecondFarmerAsync(
         ResourceLease lease,
@@ -225,22 +219,19 @@ internal sealed class FarmerTestHelper
                 clientLease.Client,
                 new ConnectionOptions { ServerPassword = lease.Password },
                 serverApi: _testBase.ServerApi
+            )
+            {
+                // Same gate as the primary path, so two concurrent joins serialize their pre-approval
+                // phase against each other (see ConnectionHelper.AcquireJoinGate).
+                AcquireJoinGate = lease.Managed.AcquireJoinGateAsync,
+                ReleaseJoinGate = lease.Managed.ReleaseJoinGate,
+            };
+            var join = await conn.JoinWorldViaLanAsync(
+                lease.ServerLanAddress,
+                lease.ServerLanPort,
+                name,
+                cancellationToken: ct
             );
-            await lease.Managed.AcquireJoinGateAsync(ct);
-            JoinWorldResult join;
-            try
-            {
-                join = await conn.JoinWorldViaLanAsync(
-                    lease.ServerLanAddress,
-                    lease.ServerLanPort,
-                    name,
-                    cancellationToken: ct
-                );
-            }
-            finally
-            {
-                lease.Managed.ReleaseJoinGate();
-            }
             Assert.True(
                 join.Success,
                 $"Second farmer '{name}' failed to join via LAN: {join.Error}"

--- a/tests/JunimoServer.Tests/Infrastructure/IsolationMode.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/IsolationMode.cs
@@ -5,7 +5,11 @@ namespace JunimoServer.Tests.Infrastructure;
 /// </summary>
 public enum IsolationMode
 {
-    /// <summary>Server shared across all tests in the same class. Default.</summary>
+    /// <summary>
+    /// Server shared across all tests in the same class. Default. Governs lifetime and reuse, NOT
+    /// exclusivity: the key is <c>config-{hash}</c> with no class identity, so other classes with a
+    /// matching config share the same instance (see <c>.claude/rules/test-broker-invariants.md</c>).
+    /// </summary>
     SharedClass,
 
     /// <summary>Server shared across all classes with matching SharedGroup name.</summary>

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -252,7 +252,8 @@ internal sealed class ManagedServer : IAsyncDisposable
             snapshot: () => new { server = Key }
         );
 
-    /// <summary>Releases the join gate after a farmer join completes or fails.</summary>
+    /// <summary>Releases the per-server join gate at the join's approval point (or via the safety-net
+    /// finally on a pre-approval failure); see <see cref="ConnectionHelper.AcquireJoinGate"/>.</summary>
     public void ReleaseJoinGate() => _joinGate.Release();
 
     /// <summary>True if an exclusive test currently holds the gate on this instance.</summary>

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -237,16 +237,13 @@ internal sealed class ManagedServer : IAsyncDisposable
     private readonly SemaphoreSlim _exclusiveClassTurn = new(0); // serializes same-class inheritance
     private readonly object _exclusiveLock = new();
 
-    // Join serialization: the game loop is single-threaded and can only process one
-    // farmhand join at a time. Without this gate, concurrent KeepConnected classes on
-    // the same server all call Connect.JoinWithRetryAsync simultaneously, causing the
-    // server to bounce clients back to farmhand selection (isGameAvailable() == false).
+    // Serializes each join's pre-approval phase per server. Without it, concurrent joins (KeepConnected
+    // classes, or two farmers via ConnectBothConcurrentlyAsync) race the same-slot / farmhand-deletion
+    // window and bounce back to farmhand selection. ConnectionHelper owns the acquire/release timing.
     private readonly SemaphoreSlim _joinGate = new(1, 1);
 
-    /// <summary>
-    /// Serializes farmer join operations on this server instance.
-    /// The game loop can only process one farmhand join at a time.
-    /// </summary>
+    /// <summary>Acquires the per-server join gate. Held only across a join's pre-approval phase
+    /// (see <see cref="ConnectionHelper.AcquireJoinGate"/>), not the whole join.</summary>
     public Task AcquireJoinGateAsync(CancellationToken ct) =>
         WaitTrace.RunAsync(
             WaitName.ManagedServer_JoinGate,

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -437,6 +437,14 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
 
         _connection = new ConnectionHelper(lease.Client, connectionOptions, ServerApi);
 
+        // Wire the per-server join gate onto the join core (see ConnectionHelper.AcquireJoinGate).
+        var managed = serverLease.Managed;
+        if (managed != null)
+        {
+            _connection.AcquireJoinGate = managed.AcquireJoinGateAsync;
+            _connection.ReleaseJoinGate = managed.ReleaseJoinGate;
+        }
+
         _connection.OnCheckpointScreenshot = async (label) =>
         {
             if (ScreenshotMode == TestScreenshotMode.All)

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -417,7 +417,7 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
             SetupEventBus.EmitInstanceLeased(
                 lease.InstanceId,
                 _testDisplayName,
-                serverLease.Managed?.InstanceId
+                serverLease.Managed.InstanceId
             );
         }
 
@@ -438,12 +438,8 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
         _connection = new ConnectionHelper(lease.Client, connectionOptions, ServerApi);
 
         // Wire the per-server join gate onto the join core (see ConnectionHelper.AcquireJoinGate).
-        var managed = serverLease.Managed;
-        if (managed != null)
-        {
-            _connection.AcquireJoinGate = managed.AcquireJoinGateAsync;
-            _connection.ReleaseJoinGate = managed.ReleaseJoinGate;
-        }
+        _connection.AcquireJoinGate = serverLease.Managed.AcquireJoinGateAsync;
+        _connection.ReleaseJoinGate = serverLease.Managed.ReleaseJoinGate;
 
         _connection.OnCheckpointScreenshot = async (label) =>
         {

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -2773,15 +2773,14 @@ public sealed class TestResourceBroker : IAsyncDisposable
         // its join lane drained — every joining test queues on that instance's
         // single join gate (ManagedServer._joinGate, one pre-approval lane per
         // instance), producing the end-of-run join convoy. Reactive expansion
-        // can't rescue it: a server
-        // boots in ~41s, so an instance spun up at the tail serves ~0 tests before
-        // the run ends. Front-load instead — give the dominant config a 2nd
-        // prestart instance (its own join gate = a real second lane) by demoting
-        // the smallest single-slot config to on-demand. Total stays ≤ slots, so
-        // no slot over-subscription and no churn (the 2nd instance has the whole
-        // backlog to chew through). Guarded on slots >= 2 so single-slot hosts
-        // (CI) are untouched. See .claude/rules/provision-up-front-when-startup-
-        // exceeds-serviceable-tail.md and PLAN-suite-speedup.md §3.
+        // can't rescue it: a server boots in ~41s, so an instance spun up at the
+        // tail serves ~0 tests before the run ends. Front-load instead — give the
+        // dominant config a 2nd prestart instance (its own join gate = a real
+        // second lane) by demoting the smallest single-slot config to on-demand.
+        // Total stays ≤ slots, so no slot over-subscription and no churn (the 2nd
+        // instance has the whole backlog to chew through). Guarded on slots >= 2
+        // so single-slot hosts (CI) are untouched. See PLAN-suite-speedup.md §3 and
+        // .claude/rules/provision-up-front-when-startup-exceeds-serviceable-tail.md.
         // Scope: only fires when demands.Count > slots. At demands.Count == slots
         // (e.g. a narrow --filter run) the Hamilton path below caps every config at
         // 1, so no promotion — the convoy fix targets the saturated full-suite case.

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -2771,8 +2771,9 @@ public sealed class TestResourceBroker : IAsyncDisposable
         // the rest create on-demand. With one slot apiece, a config whose
         // non-exclusive demand needs ≥2 instances (InstancesNeeded) cannot keep
         // its join lane drained — every joining test queues on that instance's
-        // single per-game-loop join gate (ManagedServer._joinGate), producing the
-        // end-of-run join convoy. Reactive expansion can't rescue it: a server
+        // single join gate (ManagedServer._joinGate, one pre-approval lane per
+        // instance), producing the end-of-run join convoy. Reactive expansion
+        // can't rescue it: a server
         // boots in ~41s, so an instance spun up at the tail serves ~0 tests before
         // the run ends. Front-load instead — give the dominant config a 2nd
         // prestart instance (its own join gate = a real second lane) by demoting

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -116,13 +116,9 @@ public class WeddingTests : TestBase
             $"SetDate({WeddingSeason} {EngageDay}) failed: {setDate.Error}"
         );
 
-        // Connect BOTH farmhands CONCURRENTLY — both players present together from the start, not A
-        // then B. The two client containers are leased up front (overlapping their cold start) and both
-        // join sequences run together; the per-server join gate serializes only the game-thread join
-        // (the loop processes one farmhand at a time), so B lands right behind A instead of waiting on
-        // A's whole lease+join. The primary is held as the shared GameClient, the second wrapped as a
-        // SecondFarmer; neither is privileged. await using → farmhandB disconnects before the class's
-        // /newgame reset.
+        // Connect BOTH farmhands CONCURRENTLY — both present from the start, not A then B (the scenario
+        // under test). Neither is privileged: the primary is the shared GameClient, the second a
+        // SecondFarmer. await using → farmhandB disconnects before the class's /newgame reset.
         var (farmhandA, farmhandBConn) = await Farmers.ConnectBothConcurrentlyAsync(
             primaryPrefix: "WeddingA",
             secondaryPrefix: "WeddingB",

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -56,7 +56,7 @@ namespace JunimoServer.Tests;
 /// video shows them). The test client drives each ceremony through the honest player path — the
 /// <c>WeddingCutscenePlayer</c> tweak clicks each <c>speak</c> dialogue box per tick, so the cutscene
 /// advances and renders frame-by-frame to its <c>waitForOtherPlayers</c> gate (which auto-readies on
-/// arrival), with deliberate ~2.5s pauses at the "couple assembled" and "marriage pronounced" beats so
+/// arrival), with deliberate ~1.5s pauses at the "couple assembled" and "marriage pronounced" beats so
 /// it's obvious in the video. Each distinct ceremony a client renders is recorded in
 /// <c>/status.weddingsRendered</c> (one entry per <c>weddingEnd&lt;farmerId&gt;</c> gate) — a client
 /// that force-skipped the ceremony would render nothing, so this is the proof the cutscene actually ran.
@@ -90,10 +90,10 @@ public class WeddingTests : TestBase
     private const string SpouseNpcB = "Penny";
 
     // How long for both clients to fully RENDER both ceremonies before we consider the server hung.
-    // Each client plays each cutscene through at CLIENT_TPS=5 — every speak box costs ~750ms safetyTimer
-    // (~4 ticks) plus typing, and WeddingCutscenePlayer adds two ~2.5s "make it visible" beats per
-    // ceremony — so two ceremonies × two clients runs minutes, not seconds. Sized well above that; a
-    // genuine hang (a ceremony that never starts/renders, or a host stall) still blows past it.
+    // Each client plays each cutscene through at CLIENT_TPS=5 (scripted pauses, dialogue clicks, and two
+    // 1.5s "make it visible" beats per ceremony), so two ceremonies × two clients takes tens of seconds
+    // even with the pace speedups. Deliberately oversized headroom: a genuine hang (a ceremony that never
+    // starts/renders, or a host stall) still blows past it.
     private static readonly TimeSpan CeremoniesResolveTimeout = TimeSpan.FromSeconds(240);
 
     /// <summary>

--- a/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
+++ b/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
@@ -233,10 +233,10 @@ public class WeddingCutscenePlayer
             return;
         }
 
-        // Click the box the way a player does. The box's own gating handles timing: a first click
-        // completes the typed text, a later click (once its safetyTimer elapses) advances/closes it —
-        // so calling this each tick walks the dialogue forward without us re-implementing the timers
-        // (DialogueBox.receiveLeftClick, decompiled DialogueBox.cs).
+        // Click the box the way a player does. A first click completes the typed text, a later one
+        // advances/closes it — so calling this each tick walks the dialogue forward. During a wedding
+        // WeddingDialogueSpeedup zeroes the box's safetyTimer, so the advance click lands the very next
+        // tick instead of after the vanilla 750ms guard (DialogueBox.receiveLeftClick, decompiled).
         box.receiveLeftClick(0, 0, playSound: false);
     }
 
@@ -248,6 +248,15 @@ public class WeddingCutscenePlayer
     public void PauseAfterWeddingWarp()
     {
         if ((DateTime.UtcNow - _lastCeremonyEndedUtc).TotalMilliseconds > CeremonyEndWarpWindowMs)
+        {
+            return;
+        }
+        // Linger only after the day's LAST ceremony. Game1.pauseTime is the SAME global the script's
+        // `pause` reads, so a linger still active when the next ceremony's first `pause` runs swallows
+        // it (its expiry advances the event early). getAvailableWeddingEvent pops the running ceremony's
+        // farmer before the event runs, so Count > 0 means another wedding is queued — same guard as
+        // AlwaysOn.WarpHostHomeAfterWeddings.
+        if (Game1.weddingsToday is { Count: > 0 })
         {
             return;
         }
@@ -263,8 +272,10 @@ public class WeddingCutscenePlayer
         );
     }
 
-    /// <summary>True once the event has reached its final command — the <c>waitForOtherPlayers</c> gate
-    /// is the last thing left, so the dialogue currently up is the ceremony's closing line.</summary>
+    /// <summary>True when the box currently up belongs to the ceremony's last <c>speak</c> (the "marriage
+    /// pronounced" line). Keys off the last <c>speak</c> index: the terminal <c>waitForOtherPlayers</c> +
+    /// <c>end</c> commands run only after every box has closed, so a box being up means we're at (or past)
+    /// the last speak.</summary>
     private static bool IsAtFinalDialogue(Event ev)
     {
         var commands = ev.eventCommands;
@@ -272,9 +283,32 @@ public class WeddingCutscenePlayer
         {
             return false;
         }
-        // The wait gate is the terminal command in the vanilla wedding script; if we're on (or past)
-        // the second-to-last command with a dialogue up, this is the closing line.
-        return ev.CurrentCommand >= commands.Length - 2;
+
+        int lastSpeakIndex = -1;
+        for (int i = commands.Length - 1; i >= 0; i--)
+        {
+            if (IsCommand(commands[i], "speak"))
+            {
+                lastSpeakIndex = i;
+                break;
+            }
+        }
+
+        return lastSpeakIndex >= 0 && ev.CurrentCommand >= lastSpeakIndex;
+    }
+
+    /// <summary>True if an event-command line's command name (its first space-delimited token) equals
+    /// <paramref name="name"/>. Prefix-checks the raw line rather than splitting it, so scanning the
+    /// command list each tick allocates nothing (a command line is "<c>name</c>" or "<c>name </c>…").</summary>
+    private static bool IsCommand(string? line, string name)
+    {
+        if (line == null || !line.StartsWith(name, System.StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+        // Exact command (no args) or the next char is the token separator — not a longer word
+        // that merely starts with `name`.
+        return line.Length == name.Length || line[name.Length] == ' ';
     }
 
     /// <summary>Capture the just-started ceremony into <see cref="_activeCeremony"/>. Not yet added to

--- a/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
+++ b/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
@@ -251,11 +251,11 @@ public class WeddingCutscenePlayer
         {
             return;
         }
-        // Linger only after the day's LAST ceremony. Game1.pauseTime is the SAME global the script's
-        // `pause` reads, so a linger still active when the next ceremony's first `pause` runs swallows
-        // it (its expiry advances the event early). getAvailableWeddingEvent pops the running ceremony's
-        // farmer before the event runs, so Count > 0 means another wedding is queued — same guard as
-        // AlwaysOn.WarpHostHomeAfterWeddings.
+        // Don't linger while another ceremony is still queued. Game1.pauseTime is the SAME global the
+        // script's `pause` reads, so a linger still active when the next ceremony's first `pause` runs
+        // swallows it (its expiry advances the event early). getAvailableWeddingEvent pops the running
+        // ceremony's farmer before the event runs, so Count > 0 means another wedding is queued — same
+        // guard as AlwaysOn.WarpHostHomeAfterWeddings.
         if (Game1.weddingsToday is { Count: > 0 })
         {
             return;

--- a/tests/test-client/GameTweaks/WeddingDialogueSpeedup.cs
+++ b/tests/test-client/GameTweaks/WeddingDialogueSpeedup.cs
@@ -1,0 +1,59 @@
+using HarmonyLib;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Menus;
+
+namespace JunimoTestClient.GameTweaks;
+
+/// <summary>
+/// Zeroes <see cref="DialogueBox.safetyTimer"/> while a wedding plays, so the auto-clicker
+/// (<see cref="WeddingCutscenePlayer"/>) advances each box without waiting out the timer's per-box input
+/// guard. Vanilla itself zeroes it for automated participants — <c>(!Game1.IsDedicatedHost) ? 750 : 0</c>
+/// (DialogueBox.cs:462) — and the headless test client is exactly one; we mirror that, scoped to
+/// weddings, rather than invent new timing. A prefix on <see cref="DialogueBox.update"/> re-zeroes it
+/// every tick, covering every path that sets it. <c>Event.Speak</c>'s separate 500ms throttle is left
+/// alone (event-machinery pacing with no vanilla automation exemption to mirror).
+///
+/// <para>
+/// Accepted cost: boxes then live ~2 ticks, so at CLIENT_FPS=1 the dialogue text mostly won't land in a
+/// recorded frame — the beats (WeddingCutscenePlayer's visible pauses), not the text, are the anchor.
+/// </para>
+/// </summary>
+public class WeddingDialogueSpeedup
+{
+    private readonly IMonitor _monitor;
+    private readonly Harmony _harmony;
+
+    public WeddingDialogueSpeedup(IMonitor monitor, Harmony harmony)
+    {
+        _monitor = monitor;
+        _harmony = harmony;
+    }
+
+    public void Apply()
+    {
+        try
+        {
+            _harmony.Patch(
+                AccessTools.Method(typeof(DialogueBox), nameof(DialogueBox.update)),
+                prefix: new HarmonyMethod(typeof(WeddingDialogueSpeedup), nameof(Update_Prefix))
+            );
+            _monitor.Log("WeddingDialogueSpeedup applied.", LogLevel.Info);
+        }
+        catch (System.Exception ex)
+        {
+            _monitor.Log(
+                $"Failed to apply WeddingDialogueSpeedup patch: {ex.Message}",
+                LogLevel.Error
+            );
+        }
+    }
+
+    private static void Update_Prefix(DialogueBox __instance)
+    {
+        if (Game1.CurrentEvent?.isWedding == true)
+        {
+            __instance.safetyTimer = 0;
+        }
+    }
+}

--- a/tests/test-client/GameTweaks/WeddingPaceCompressor.cs
+++ b/tests/test-client/GameTweaks/WeddingPaceCompressor.cs
@@ -1,0 +1,105 @@
+using System.Text.RegularExpressions;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewValley.GameData.Weddings;
+
+namespace JunimoTestClient.GameTweaks;
+
+/// <summary>
+/// Caps the wedding script's scripted <c>pause</c> holds so a rendered ceremony plays faster. Every
+/// command still executes (the test guards against SKIPPING commands, which this doesn't do). The
+/// vanilla <c>Data/Weddings</c> "default" script holds ~20.5s across eleven pauses; these are
+/// millisecond-based (<c>Game1.pauseTime</c>), so no TPS change shortens them — only this data edit
+/// does, bringing them to ~7.9s. Ceremony parts that ARE tick-inflated (globalFade, NPC walk) belong to
+/// the TPS-agnostic patches, not here.
+///
+/// <para>
+/// Client-side only, <c>EventScript</c> values only (never <c>Attendees</c>); the server mod's copy is
+/// untouched (the host force-ends its copy on the wait gate). Only exact <c>pause &lt;int&gt;</c>
+/// segments are rewritten, so a future script reshape degrades to vanilla pacing, never a broken test.
+/// </para>
+/// </summary>
+public class WeddingPaceCompressor
+{
+    private readonly IModHelper _helper;
+    private readonly IMonitor _monitor;
+
+    // Long enough to still read on the recording, short enough to shed most of the vanilla holds.
+    private const int MaxPauseMs = 800;
+
+    private const string WeddingsAsset = "Data/Weddings";
+
+    // Anchored on the '/' command delimiter (or script start/end) so it only matches a standalone
+    // `pause` command, never a "pause" inside a quoted dialogue string — letting us edit the raw asset
+    // without the quote-aware split/rejoin the engine's own parser needs.
+    private static readonly Regex PauseSegment = new(
+        @"(?<=^|/)pause (\d+)(?=/|$)",
+        RegexOptions.Compiled
+    );
+
+    public WeddingPaceCompressor(IModHelper helper, IMonitor monitor)
+    {
+        _helper = helper;
+        _monitor = monitor;
+    }
+
+    public void Apply()
+    {
+        _helper.Events.Content.AssetRequested += OnAssetRequested;
+    }
+
+    private void OnAssetRequested(object? sender, AssetRequestedEventArgs e)
+    {
+        if (!e.NameWithoutLocale.IsEquivalentTo(WeddingsAsset))
+        {
+            return;
+        }
+
+        e.Edit(asset =>
+        {
+            var data = asset.GetData<WeddingData>();
+            if (data.EventScript == null)
+            {
+                return;
+            }
+
+            int rewritten = 0;
+            // Snapshot keys so we can reassign values while iterating.
+            foreach (var key in data.EventScript.Keys.ToList())
+            {
+                (data.EventScript[key], var n) = CompressPauses(data.EventScript[key]);
+                rewritten += n;
+            }
+
+            _monitor.Log(
+                $"[WeddingPace] Capped scripted pauses to {MaxPauseMs}ms — rewrote {rewritten} segment(s).",
+                LogLevel.Trace
+            );
+        });
+    }
+
+    /// <summary>Caps every whole <c>pause &lt;int&gt;</c> command to <see cref="MaxPauseMs"/>, leaving the
+    /// rest of the raw script byte-identical. Returns the rewritten script and how many were capped.</summary>
+    private static (string Script, int Rewritten) CompressPauses(string script)
+    {
+        if (string.IsNullOrEmpty(script))
+        {
+            return (script, 0);
+        }
+
+        int rewritten = 0;
+        var result = PauseSegment.Replace(
+            script,
+            match =>
+            {
+                if (!int.TryParse(match.Groups[1].Value, out var ms) || ms <= MaxPauseMs)
+                {
+                    return match.Value;
+                }
+                rewritten++;
+                return $"pause {MaxPauseMs}";
+            }
+        );
+        return (result, rewritten);
+    }
+}

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -33,6 +33,8 @@ public class ModEntry : Mod
     private GodTool? _godTool;
     private QiPlaneSkip? _qiPlaneSkip;
     private WeddingCutscenePlayer? _weddingPlayer;
+    private WeddingPaceCompressor? _weddingPaceCompressor;
+    private WeddingDialogueSpeedup? _weddingDialogueSpeedup;
 
     // Diagnostics
     private HealthWatchdog? _healthWatchdog;
@@ -89,6 +91,12 @@ public class ModEntry : Mod
         // from OnUpdateTicked; render record reset per session from OnSaveLoaded (not per day — a
         // day-boundary reset would race the ceremonies, see WeddingCutscenePlayer.ResetForNewSession).
         _weddingPlayer = new WeddingCutscenePlayer(Monitor);
+
+        _weddingPaceCompressor = new WeddingPaceCompressor(helper, Monitor);
+        _weddingPaceCompressor.Apply();
+
+        _weddingDialogueSpeedup = new WeddingDialogueSpeedup(Monitor, _harmony);
+        _weddingDialogueSpeedup.Apply();
 
         // Apply Steam/Galaxy auth patches (must be before Steam diagnostics)
         var authService = new ClientAuthService(helper, Monitor, _harmony);


### PR DESCRIPTION
Speeds up `TwoFarmhandNpcWeddings_SameDay_BothCompleteWithoutHangingHost` without weakening what it proves — every event command still executes through the vanilla `Event` machinery (nothing is skipped, which is the line the original deadlock bug was about).

## Changes

**Test-client — faster rendered ceremonies (Parts A/C/D)**
- `WeddingPaceCompressor` (new): caps the `Data/Weddings` script's millisecond-based `pause` holds to 800ms via `AssetRequested`. `EventScript` values only, never `Attendees`; only exact `pause <int>` segments rewritten, so a future script reshape degrades to vanilla pacing rather than breaking. Logs the rewritten-segment count.
- `WeddingDialogueSpeedup` (new): Harmony prefix zeroing `DialogueBox.safetyTimer` while a wedding plays, mirroring vanilla's own automated-participant exemption (`(!Game1.IsDedicatedHost) ? 750 : 0`), scoped to `isWedding`.
- `WeddingCutscenePlayer`: fixed the "marriage pronounced" final beat that never fired (predicate now keys off the last `speak` index instead of the terminal command, which had no box up by then); the between-ceremony linger no longer swallows the next ceremony's first scripted `pause`.

**Test infra — narrow the join gate (Part B)**
- The per-server join gate now serializes only each join's pre-approval phase and releases at server approval (character-customization for uncustomized slots, world-ready for customized), instead of holding across the whole join. The creation/world-ready/auth tail overlaps the next queued join. Release is at the approval point because the slot is committed by then (`checkFarmhandRequest` assigns the home and adds the player strictly before `sendServerIntroduction`); the bounce-retry loop stays under the gate. Idempotent acquire/release via a per-attempt holder, wired onto both the primary and second-farmer connection paths.

## Verification

- Controlled same-config A/B at `SERVER_TPS=5` (baseline `d98e3b9` vs branch): WeddingTests body **112.3s → 86.8s (−23%)**; both ceremonies **81s → 55s (−32%)**.
- `WeddingTests` **1/1** on HEAD @ TPS=5, scenario confirmed from artifacts: two distinct wait-gate readies via the honest "other players ready" path, both clients render both ceremonies (`renderedSoFar=2`), final beat fires twice per client, no pause-swallow (ceremony 2 not shorter than ceremony 1).
- Touches only `tests/` — nothing under `mod/`. Both projects build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved wedding cutscene pacing by compressing long pauses and speeding dialogue advancement.
  * Enhanced detection of the final wedding dialogue so ceremonies complete more reliably.
* **Bug Fixes**
  * Reduced unnecessary waiting after queued weddings by skipping the “teleported home” linger when another ceremony is pending.
  * Improved reliability when multiple players join servers concurrently, including safer recovery from failed or retried joins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->