### PR TITLE
fix(tests): recreate the only Steam client after an outage kills it, so later Steam tests run

### DIFF
--- a/tests/JunimoServer.Tests/AbandonedClaimTests.cs
+++ b/tests/JunimoServer.Tests/AbandonedClaimTests.cs
@@ -49,7 +49,7 @@ public class AbandonedClaimTests : TestBase
     [TestServer(WithSteam = true)]
     public async Task AbandonedClaim_OnDisconnect_IsClearedDurably()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // Connect to the FarmhandMenu without customizing. WithRetryAsync is transport-aware
         // (Steam invite code vs LAN address) and uses the primary client; it stops at the menu.
@@ -160,7 +160,7 @@ public class AbandonedClaimTests : TestBase
     [TestServer(StartingCabins = 2)]
     public async Task AbandonedClaim_SweptOnReload()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(
             farmType: 0,
             cabinStrategy: "CabinStack",

--- a/tests/JunimoServer.Tests/CabinConcurrencyTests.cs
+++ b/tests/JunimoServer.Tests/CabinConcurrencyTests.cs
@@ -41,7 +41,7 @@ public class CabinConcurrencyTests : TestBase
     [Fact]
     public async Task Join_DoesNotAccumulatePhantomFarmhandEntries()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
         await ServerApi.WaitForFarmhandByNameAsync(
@@ -102,7 +102,7 @@ public class CabinConcurrencyTests : TestBase
     [Fact]
     public async Task SecondFarmerDisconnectAndDelete_DoesNotBreakGrantAdminForFirst()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // First farmer joins and customizes.
         var clientA = await Farmers.ConnectNewAsync(ct: ct);

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -51,7 +51,7 @@ public class CabinPlacementValidationTests : TestBase
     [Fact]
     public async Task ValidPlacement_MovesCabinToFarmerTilePlusOne()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -88,7 +88,7 @@ public class CabinPlacementValidationTests : TestBase
     [Fact]
     public async Task ObstacleInFootprint_RejectsAndDoesNotMove()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -148,7 +148,7 @@ public class CabinPlacementValidationTests : TestBase
     [Fact]
     public async Task OffFarm_RejectsAndDoesNotMove()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -191,7 +191,7 @@ public class CabinPlacementValidationTests : TestBase
     [Fact]
     public async Task AnotherPlayerInFootprint_RejectsAndDoesNotMove()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var clientA = await Farmers.ConnectNewAsync(ct: ct);

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -62,7 +62,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task MoveToStack_PlacedCabinSurvivesReload()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -93,7 +93,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task MoveToStack_UnclaimedCabinSweptOnReload()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // None strategy starts cabins at real, visible map positions. After switching
         // to CabinStack + MoveToStack and reloading, those unclaimed cabins (no /cabin
         // intent) must be pulled into the hidden stack.
@@ -129,7 +129,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task StrategySwitch_NoneToCabinStack_PlacedCabinSurvives()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -162,7 +162,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task Deletion_ClearsSavedPositionIntent()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -215,7 +215,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task ResetCabin_ReturnsCabinToStackAndClearsIntent()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -273,7 +273,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task SameSweep_KeepsPlacedCabin_SweepsUntouchedCabin()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None", startingCabins: 2);
 
         var clientA = await Farmers.ConnectNewAsync(ct: ct);
@@ -353,7 +353,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task TwoPlayers_PlaceCabinsToDistinctTiles()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var clientA = await Farmers.ConnectNewAsync(ct: ct);
@@ -421,7 +421,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task DummyCabin_ReconnectAfterMove_JoinSucceedsAndMasterUnchanged()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);
@@ -455,7 +455,7 @@ public class CabinPositionPersistenceTests : TestBase
     [Fact]
     public async Task DummyCabin_AfterMoveAndReconnect_ClientSeesDoorDeadDummyAtStack()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);

--- a/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyFarmhouseStackTests.cs
@@ -49,7 +49,7 @@ public class CabinStrategyFarmhouseStackTests : TestBase
     [Fact]
     public async Task FarmhouseStack_RejectsCabinMove()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "FarmhouseStack");
 
         var client = await Farmers.ConnectNewAsync(ct: ct);

--- a/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyNoneTests.cs
@@ -64,7 +64,7 @@ public class CabinStrategyNoneTests : TestBase
 
         Log($"Server ready: {Server.BaseUrl}");
 
-        var cabinsResponse = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabinsResponse = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabinsResponse);
         Assert.Equal("None", cabinsResponse.Strategy);
@@ -85,7 +85,7 @@ public class CabinStrategyNoneTests : TestBase
 
         Log($"Server ready: {Server.BaseUrl}");
 
-        var cabinsResponse = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabinsResponse = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabinsResponse);
         Assert.Equal("None", cabinsResponse.Strategy);
@@ -113,7 +113,7 @@ public class CabinStrategyNoneTests : TestBase
         _needsServerReset = true;
         await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "None", startingCabins: 1);
 
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var client = await Farmers.ConnectNewAsync(ct: ct);
         var ownerId = client.JoinResult.UniqueMultiplayerId;
 

--- a/tests/JunimoServer.Tests/CabinStrategyTests.cs
+++ b/tests/JunimoServer.Tests/CabinStrategyTests.cs
@@ -29,8 +29,8 @@ public class CabinStrategyTests : TestBase
     [TestServer(Clients = 0)]
     public async Task Cabins_StrategyMatchesSettings()
     {
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
-        var settings = await ServerApi.GetSettings(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
+        var settings = await ServerApi.GetSettings(TestCt);
 
         Assert.NotNull(cabins);
         Assert.NotNull(settings);
@@ -46,7 +46,7 @@ public class CabinStrategyTests : TestBase
     [TestServer(Clients = 0)]
     public async Task DefaultCabinStack_HasAtLeastOneAvailableCabin()
     {
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabins);
         Assert.True(
@@ -63,7 +63,7 @@ public class CabinStrategyTests : TestBase
     [TestServer(Clients = 0)]
     public async Task Cabins_CountsAreConsistent()
     {
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabins);
         Assert.Equal(cabins.TotalCount, cabins.AssignedCount + cabins.AvailableCount);
@@ -81,7 +81,7 @@ public class CabinStrategyTests : TestBase
     [TestServer(Clients = 0)]
     public async Task CabinStack_AllCabinsAreHidden()
     {
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabins);
         Assert.Equal("CabinStack", cabins.Strategy);
@@ -137,25 +137,25 @@ public class CabinStrategyTests : TestBase
     public async Task CabinStack_AfterPlayerJoins_CabinReplenished()
     {
         // Record state before join
-        var cabinsBefore = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabinsBefore = await ServerApi.GetCabins(TestCt);
         Assert.NotNull(cabinsBefore);
         var availableBefore = cabinsBefore.AvailableCount;
         Log($"Before join: total={cabinsBefore.TotalCount}, available={availableBefore}");
 
         // Join and enter world (consumes one cabin slot via customization)
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Disconnect and wait for the server to release the farmhand slot
         await Farmers.DisconnectAndWaitForSlotAsync(
             client.JoinResult.UniqueMultiplayerId,
             client.FarmerName,
-            TestContext.Current.CancellationToken
+            TestCt
         );
 
         // Rejoin world to trigger cabin replenishment. sendServerIntroduction (and thus
         // OnServerJoined -> EnsureAtLeastXCabins) only fires after farmhand slot selection,
         // not when merely reaching the farmhand screen. A full rejoin is required.
-        await Farmers.ReconnectAsync(client.FarmerName, ct: TestContext.Current.CancellationToken);
+        await Farmers.ReconnectAsync(client.FarmerName, ct: TestCt);
 
         // Poll until our farmer's cabin appears as assigned AND at least 1 available
         // (replenishment). Must check for our specific farmer; other tests on a shared
@@ -166,7 +166,7 @@ public class CabinStrategyTests : TestBase
             WaitName.Polling_CabinStrategy_OurCabinAssigned,
             async () =>
             {
-                cabinsAfter = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+                cabinsAfter = await ServerApi.GetCabins(TestCt);
                 ourCabin = cabinsAfter?.Cabins.FirstOrDefault(c =>
                     c.OwnerName.Equals(client.FarmerName, StringComparison.OrdinalIgnoreCase)
                     && c.IsAssigned
@@ -177,7 +177,7 @@ public class CabinStrategyTests : TestBase
                 return ourCabin != null && cabinsAfter?.AvailableCount >= 1;
             },
             TestTimings.CabinAssignmentTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(
@@ -197,17 +197,14 @@ public class CabinStrategyTests : TestBase
     [Fact]
     public async Task CabinStack_PlayerJoin_CabinAssignedToPlayer()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Poll until cabin ownership appears (server needs time to sync farmhand
         // isCustomized flag and Name after character creation)
-        var ownedCabin = await WaitForCabinAssignedAsync(
-            client.FarmerName,
-            TestContext.Current.CancellationToken
-        );
+        var ownedCabin = await WaitForCabinAssignedAsync(client.FarmerName, TestCt);
 
         // Log all cabins for diagnostics
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
         Log($"Cabins after join ({cabins!.Cabins.Count} total):");
         foreach (var c in cabins.Cabins)
         {
@@ -230,7 +227,7 @@ public class CabinStrategyTests : TestBase
     [Fact]
     public async Task Cabins_OurFarmerAppearsInBothEndpoints()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Poll until our farmer appears in both /cabins and /farmhands
         CabinInfoResponse? ourCabin = null;
@@ -239,7 +236,7 @@ public class CabinStrategyTests : TestBase
             WaitName.Polling_CabinStrategy_FarmerSyncedCabinAndFarmhand,
             async () =>
             {
-                var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+                var cabins = await ServerApi.GetCabins(TestCt);
                 var farmhands = await ServerApi.GetFarmhands();
                 ourCabin = cabins?.Cabins.FirstOrDefault(c =>
                     c.OwnerName.Equals(client.FarmerName, StringComparison.OrdinalIgnoreCase)
@@ -252,7 +249,7 @@ public class CabinStrategyTests : TestBase
                 return ourCabin != null && ourFarmhand != null;
             },
             TestTimings.CabinAssignmentTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(
@@ -271,17 +268,14 @@ public class CabinStrategyTests : TestBase
     public async Task Cabins_AfterDeletion_SlotIsFreed()
     {
         // Create, join, disconnect, and wait for persistence
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
-        await Farmers.DisconnectAndWaitForPersistenceAsync(
-            client.FarmerName,
-            TestContext.Current.CancellationToken
-        );
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, TestCt);
 
         // Delete the farmhand
         Log($"Deleting farmhand '{client.FarmerName}'...");
         var deleteResult = await ServerApi.WaitForFarmhandDeletedByNameAsync(
             client.FarmerName,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Assert.True(
             deleteResult?.Success,
@@ -300,7 +294,7 @@ public class CabinStrategyTests : TestBase
             WaitName.Polling_CabinStrategy_FarmerDeletionReflected,
             async () =>
             {
-                cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+                cabins = await ServerApi.GetCabins(TestCt);
                 farmhands = await ServerApi.GetFarmhands();
                 if (cabins == null || farmhands == null)
                 {
@@ -314,7 +308,7 @@ public class CabinStrategyTests : TestBase
                 return ourFarmerGone && cabins.AvailableCount >= 1;
             },
             TestTimings.NetworkSyncTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         var customizedCount = farmhands!.Farmhands.Count(f => f.IsCustomized);

--- a/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
@@ -93,6 +93,13 @@ public class GameClientContainer : IAsyncDisposable
     public int SteamAccountIndex { get; internal set; } = -1;
 
     /// <summary>
+    /// True once <see cref="Infrastructure.ClientPool.MarkClientDead"/> has retired this
+    /// container: it stays in the pool's roster only for recording extraction at dispose
+    /// and must not count toward the live container cap.
+    /// </summary>
+    public bool IsMarkedDead { get; internal set; }
+
+    /// <summary>
     /// Final Galaxy auth state captured from <c>/health</c> when readiness was reached.
     /// Only populated when the container was created with <c>requireGalaxyResolved=true</c>
     /// (i.e. it bears a Steam account). Values mirror the test-client side:

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -85,7 +85,7 @@ public class CropSaverTests : TestBase
     [Fact]
     public async Task GardenPotCrop_IsRegisteredWithCropSaverWatcher()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await PlacePotAndPlantCauliflowerAsync(TileA_X, TileA_Y, ct);
         await AssertWatcherRegistersPotAsync("Farm", TileA_X, TileA_Y, ct);
     }
@@ -93,7 +93,7 @@ public class CropSaverTests : TestBase
     [Fact]
     public async Task GardenPotCrop_KillSuppressedOnSeasonTransition_WhileOwnerOffline()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var farmhand = await PlacePotAndPlantCauliflowerAsync(TileB_X, TileB_Y, ct);
         await AssertWatcherRegistersPotAsync("Farm", TileB_X, TileB_Y, ct);
@@ -200,7 +200,7 @@ public class CropSaverTests : TestBase
     [Fact]
     public async Task PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // Plant a Pumpkin in a Garden Pot inside the farmhand's own cabin
         // interior — an indoor (season-immune) location, exercising the same fix

--- a/tests/JunimoServer.Tests/FarmMapTypeTests.cs
+++ b/tests/JunimoServer.Tests/FarmMapTypeTests.cs
@@ -59,7 +59,7 @@ public class FarmMapTypeTests : TestBase
 
         // Verify cabins were created via API
         // CabinStack maintains at least 1 available cabin automatically
-        var cabinsResponse = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabinsResponse = await ServerApi.GetCabins(TestCt);
 
         Assert.NotNull(cabinsResponse);
         Assert.True(
@@ -69,16 +69,13 @@ public class FarmMapTypeTests : TestBase
         Log($"Cabins created: {cabinsResponse.TotalCount} (strategy: {cabinsResponse.Strategy})");
 
         // Verify actual loaded farm type via GetFarmTypeKey()
-        var statusResponse = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusResponse = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusResponse);
         Assert.Equal(expectedFarmTypeKey, statusResponse.FarmTypeKey);
         Log($"Farm type key verified: {statusResponse.FarmTypeKey}");
 
         // Join the server with a test farmer
-        await Farmers.ConnectNewAsync(
-            farmerName: $"Test_{expectedFarmTypeKey}",
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(farmerName: $"Test_{expectedFarmTypeKey}", ct: TestCt);
 
         Log($"Successfully joined {expectedFarmTypeKey} farm!");
     }

--- a/tests/JunimoServer.Tests/FarmerCreationTests.cs
+++ b/tests/JunimoServer.Tests/FarmerCreationTests.cs
@@ -28,10 +28,7 @@ public class FarmerCreationTests : TestBase
     public async Task CreateFarmer_ExitAndReconnect_FarmerPersists()
     {
         // Join with a new farmer (forces new slot, handles auth automatically)
-        var client = await Farmers.ConnectNewAsync(
-            preferExistingFarmer: false,
-            ct: TestContext.Current.CancellationToken
-        );
+        var client = await Farmers.ConnectNewAsync(preferExistingFarmer: false, ct: TestCt);
         await Exceptions.AssertNoExceptionsAsync("initial connect");
 
         Log($"Created farmer '{client.FarmerName}'");
@@ -51,7 +48,7 @@ public class FarmerCreationTests : TestBase
         // Don't wait for PlayerCount==0; other tests may have clients connected.
         await ServerApi.WaitForPlayerRemovedByIdAsync(
             client.JoinResult.UniqueMultiplayerId,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         // Wait for the server's farmhandData to reflect the customized farmer.
@@ -60,9 +57,9 @@ public class FarmerCreationTests : TestBase
         var farmerPersisted = await ServerApi.WaitForFarmhandByNameAsync(
             client.FarmerName,
             requireCustomized: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
-        var serverFarmhands = await ServerApi.GetFarmhands(TestContext.Current.CancellationToken);
+        var serverFarmhands = await ServerApi.GetFarmhands(TestCt);
 
         // Log server-side state for diagnostics
         if (serverFarmhands?.Farmhands != null)
@@ -93,7 +90,7 @@ public class FarmerCreationTests : TestBase
         await Exceptions.AssertNoExceptionsAsync("after disconnecting");
 
         // Reconnect with retry
-        var reconnectResult = await Connect.WithRetryAsync(TestContext.Current.CancellationToken);
+        var reconnectResult = await Connect.WithRetryAsync(TestCt);
         Connect.AssertConnectionSuccess(reconnectResult);
 
         // Verify the farmer we created exists
@@ -139,7 +136,7 @@ public class FarmerCreationTests : TestBase
         await Connect.EnsureDisconnectedAsync();
 
         // Connect with retry
-        var connectResult = await Connect.WithRetryAsync(TestContext.Current.CancellationToken);
+        var connectResult = await Connect.WithRetryAsync(TestCt);
         Connect.AssertConnectionSuccess(connectResult);
 
         // Verify we have farmhand slots
@@ -163,7 +160,7 @@ public class FarmerCreationTests : TestBase
         await Farmers.ConnectNewAsync(
             favoriteThing: "RetryTesting",
             preferExistingFarmer: false,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         await Exceptions.AssertNoExceptionsAsync("after joining world");

--- a/tests/JunimoServer.Tests/FarmhandManagementTests.cs
+++ b/tests/JunimoServer.Tests/FarmhandManagementTests.cs
@@ -28,20 +28,20 @@ public class FarmhandManagementTests : TestBase
     )]
     public async Task ServerFarmhands_ReflectCustomizationState()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Check server-side farmhand list (poll until name syncs and customized flag is set)
         var found = await ServerApi.WaitForFarmhandByNameAsync(
             client.FarmerName,
             requireCustomized: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         Assert.True(
             found,
             $"Farmhand '{client.FarmerName}' should appear in /farmhands within timeout"
         );
-        var farmhands = await ServerApi.GetFarmhands(TestContext.Current.CancellationToken);
+        var farmhands = await ServerApi.GetFarmhands(TestCt);
         Assert.NotNull(farmhands);
         Assert.NotEmpty(farmhands.Farmhands);
 
@@ -74,19 +74,16 @@ public class FarmhandManagementTests : TestBase
     [Fact]
     public async Task DeleteFarmhand_WhenOffline_Succeeds()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Disconnect and wait for persistence
-        await Farmers.DisconnectAndWaitForPersistenceAsync(
-            client.FarmerName,
-            TestContext.Current.CancellationToken
-        );
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, TestCt);
 
         // Delete the farmhand
         Log($"Deleting offline farmhand '{client.FarmerName}'...");
         var deleteResult = await ServerApi.WaitForFarmhandDeletedByNameAsync(
             client.FarmerName,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         Assert.True(
@@ -107,7 +104,7 @@ public class FarmhandManagementTests : TestBase
                     ) == true;
             },
             TestTimings.FarmerDeleteTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
         Assert.True(
             isGone,
@@ -128,18 +125,15 @@ public class FarmhandManagementTests : TestBase
     public async Task DeleteFarmhand_SlotBecomesReusable()
     {
         // Create first farmer, disconnect, and wait for persistence
-        var client1 = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
-        await Farmers.DisconnectAndWaitForPersistenceAsync(
-            client1.FarmerName,
-            TestContext.Current.CancellationToken
-        );
+        var client1 = await Farmers.ConnectNewAsync(ct: TestCt);
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client1.FarmerName, TestCt);
         Log($"After first join: farmer '{client1.FarmerName}' exists");
 
         // Delete farmer1 (poll until server processes disconnect)
         Log($"Deleting farmhand '{client1.FarmerName}'...");
         var deleteResult = await ServerApi.WaitForFarmhandDeletedByNameAsync(
             client1.FarmerName,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Assert.True(
             deleteResult?.Success,
@@ -148,7 +142,7 @@ public class FarmhandManagementTests : TestBase
         Farmers.CreatedFarmers.RemoveAll(f => f.Uid == client1.JoinResult.UniqueMultiplayerId);
 
         // Verify slot is available (uncustomized)
-        var afterDelete = await ServerApi.GetFarmhands(TestContext.Current.CancellationToken);
+        var afterDelete = await ServerApi.GetFarmhands(TestCt);
         Assert.NotNull(afterDelete);
         var uncustomizedSlots = afterDelete.Farmhands.Count(f => !f.IsCustomized);
         Assert.True(
@@ -158,13 +152,13 @@ public class FarmhandManagementTests : TestBase
         Log($"After delete: {uncustomizedSlots} uncustomized slot(s) available");
 
         // Create second farmer using the freed slot
-        var client2 = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client2 = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Verify farmer2 exists (poll until name syncs)
         var farmer2Found = await ServerApi.WaitForFarmhandByNameAsync(
             client2.FarmerName,
             requireCustomized: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         Assert.True(farmer2Found, $"Farmer '{client2.FarmerName}' should exist after reusing slot");
@@ -178,7 +172,7 @@ public class FarmhandManagementTests : TestBase
     [Fact]
     public async Task DeleteFarmhand_WhenOnline_Fails()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Try to delete while still connected - should fail. Use the UID overload
         // because fresh joiners may not have name-synced yet.
@@ -187,7 +181,7 @@ public class FarmhandManagementTests : TestBase
         );
         var deleteResult = await ServerApi.DeleteFarmhandById(
             client.JoinResult.UniqueMultiplayerId,
-            TestContext.Current.CancellationToken
+            TestCt
         );
         Assert.NotNull(deleteResult);
         Assert.False(deleteResult.Success, "Delete should fail for an online farmhand");
@@ -196,10 +190,7 @@ public class FarmhandManagementTests : TestBase
         Log($"Delete correctly refused: {deleteResult.Error}");
 
         // Verify the farmhand still exists (poll until name syncs)
-        var stillFound = await ServerApi.WaitForFarmhandByNameAsync(
-            client.FarmerName,
-            ct: TestContext.Current.CancellationToken
-        );
+        var stillFound = await ServerApi.WaitForFarmhandByNameAsync(client.FarmerName, ct: TestCt);
 
         Assert.True(
             stillFound,

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -94,7 +94,7 @@ public class FestivalTests : TestBase
     [Fact]
     public async Task SpiritsEve_DoesNotAutoEndImmediately()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         await EnterFestivalAsync(
             SpiritsEveSeason,
@@ -150,7 +150,7 @@ public class FestivalTests : TestBase
     [Fact]
     public async Task SpiritsEve_EndsWhenPlayerLeaves()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         await EnterFestivalAsync(
             SpiritsEveSeason,
@@ -202,7 +202,7 @@ public class FestivalTests : TestBase
     [Fact]
     public async Task EmptyFestivalEnds_AndNextFestivalIsLeavable()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var farmhand = await EnterFestivalAsync(
             SpiritsEveSeason,
@@ -296,7 +296,7 @@ public class FestivalTests : TestBase
     [Fact]
     public async Task EggFestival_MainEventStartsWithCountdownSkip()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         await EnterFestivalAsync(
             EggSeason,

--- a/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
+++ b/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
@@ -71,7 +71,7 @@ public class GalaxyOutageReproTests : TestBase
     [Fact]
     public async Task TotalConnectivityLoss_RecordsGalaxyReauthSignal()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // ── Configurable outage dwell. This is timing margin held AFTER steam_session_lost is
         // already gate-confirmed below — it lets the Galaxy lobby genuinely drop before restore,
@@ -259,7 +259,7 @@ public class GalaxyOutageReproTests : TestBase
     [Fact]
     public async Task GalaxyReloginGate_WhileHealthy_SkipsAndKeepsClientConnected()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var serverSlug = $"server-{Lease!.Managed.Server.ServerIndex}";
 
         // Fully join a client (with auth), so there's a live Galaxy lobby the gate must protect.

--- a/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
+++ b/tests/JunimoServer.Tests/Helpers/InfrastructureEventLog.cs
@@ -157,7 +157,10 @@ namespace JunimoServer.Tests.Helpers;
 /// <c>steam_account_allocated</c> / <c>steam_account_released</c> /
 /// <c>steam_account_pool_insufficient</c> (<c>kind:"server"|"client", index?,
 /// remaining?, available?, totalSize?, inUse?</c>) ·
-/// <c>steam_account_release_error</c> (ClientPool release path).</item>
+/// <c>steam_account_release_error</c> (ClientPool release path) ·
+/// <c>steam_account_allocation_timeout</c> (<c>clientIndex, boundSec</c>; a client
+/// Steam-account allocation exceeded <see cref="TestTimings.SteamAccountAllocationBound"/>
+/// — no account released within the bound, so the lease fails fast as infrastructure).</item>
 ///
 /// <item><b>Docker / container lifecycle</b>:
 /// <c>docker_preflight</c> (ContainerStatsCollector.InitializeAsync:
@@ -307,8 +310,11 @@ namespace JunimoServer.Tests.Helpers;
 /// <c>cancellation_detected</c> · <c>farmer_removal_waited</c>.</item>
 ///
 /// <item><b>Client pool</b>:
-/// <c>client_created</c> (<c>clientIndex, durationMs, reason:"prewarm"|"lease_demand"</c>) ·
-/// <c>client_create_failed</c> ·
+/// <c>client_created</c> (<c>clientIndex, durationMs, reason:"prewarm"|"lease_demand"|
+/// "steam_selfheal"|"blip_retry"</c>) · <c>client_create_failed</c> ·
+/// <c>steam_client_selfheal</c> (<c>availableInBag</c>; the last Steam-bearing client died
+/// via <c>client_marked_dead</c>, so the next Steam lease creates a replacement rather than
+/// waiting on a return that can never come) ·
 /// <c>client_acquired</c> (<c>clientIndex, instanceId, serverInstanceId?,
 /// serverKey, steamAccountIndex</c>) ·
 /// <c>client_returned</c> (<c>clientIndex, serverKey, poolAvailable</c>) ·

--- a/tests/JunimoServer.Tests/Helpers/TestTimings.cs
+++ b/tests/JunimoServer.Tests/Helpers/TestTimings.cs
@@ -38,6 +38,17 @@ public static class TestTimings
     public static readonly TimeSpan SteamAccountReadyTimeout = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    /// Bound on a single client Steam-account allocation in ClientPool.CreateClientAsync.
+    /// Worst legitimate case is ~0s semaphore wait (accounts release eagerly on
+    /// death/discard/dispose) plus the ≤90s readiness-probe phase inside
+    /// SteamAccountAllocator.AllocateAsync (AllocationReadinessBudget), so 120s cannot
+    /// false-trip. Expiry means no account will ever be released (an account leak), so
+    /// the lease fails fast as infrastructure (InfrastructureSkipException) instead of
+    /// blocking to the run-stall watchdog.
+    /// </summary>
+    public static readonly TimeSpan SteamAccountAllocationBound = TimeSpan.FromSeconds(120);
+
+    /// <summary>
     /// Timeout for stopping Docker containers during cleanup.
     /// </summary>
     public static readonly TimeSpan ContainerStopTimeout = TimeSpan.FromSeconds(10);

--- a/tests/JunimoServer.Tests/HostAutomationTests.cs
+++ b/tests/JunimoServer.Tests/HostAutomationTests.cs
@@ -28,7 +28,7 @@ public class HostAutomationTests : TestBase
     {
         await Connect.EnsureDisconnectedAsync();
 
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         Log($"Exclusive access granted, refs={Lease!.RefCount}");
 
         // Wait until no other players are connected (previous test may still be cleaning up).
@@ -148,9 +148,9 @@ public class HostAutomationTests : TestBase
     [TestServer(Exclusive = true)]
     public async Task TimeAdvances_WhenPlayerConnected()
     {
-        await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        await Farmers.ConnectNewAsync(ct: TestCt);
 
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // Set time to a known value so the measurement is clean
         var setTimeResult = await ServerApi.SetTime(TestTimings.Noon, ct);
@@ -253,10 +253,10 @@ public class HostAutomationTests : TestBase
     [TestServer(Exclusive = true)]
     public async Task HostAutoSleeps_WhenPlayerSleeps()
     {
-        await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Record the current day
-        var statusBefore = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusBefore = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusBefore);
         var dayBefore = statusBefore.Day;
         var seasonBefore = statusBefore.Season;
@@ -292,7 +292,7 @@ public class HostAutomationTests : TestBase
             seasonBefore,
             yearBefore,
             checkConnection: true,
-            TestContext.Current.CancellationToken
+            TestCt
         );
 
         Assert.False(
@@ -306,7 +306,7 @@ public class HostAutomationTests : TestBase
             "Day should have advanced after farmhand slept and host auto-slept"
         );
 
-        var statusAfter = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusAfter = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusAfter);
         Log(
             $"After sleep: {statusAfter.Season} {statusAfter.Day}, Year {statusAfter.Year}, Time {statusAfter.TimeOfDay}"
@@ -332,10 +332,10 @@ public class HostAutomationTests : TestBase
     [TestServer(Exclusive = true)]
     public async Task HostPassesOut_WhenTimeReaches2AM()
     {
-        await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Record the current day
-        var statusBefore = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusBefore = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusBefore);
         var dayBefore = statusBefore.Day;
         var seasonBefore = statusBefore.Season;
@@ -345,16 +345,13 @@ public class HostAutomationTests : TestBase
         );
 
         // Set time to 2550, just one 10-minute tick before 2:00 AM (2600).
-        var setTimeResult = await ServerApi.SetTime(
-            TestTimings.PrePassOutTime,
-            TestContext.Current.CancellationToken
-        );
+        var setTimeResult = await ServerApi.SetTime(TestTimings.PrePassOutTime, TestCt);
         Assert.NotNull(setTimeResult);
         Assert.True(setTimeResult.Success, $"SetTime failed: {setTimeResult.Error}");
         Log($"Set time to {setTimeResult.TimeOfDay}, waiting for 2:00 AM pass-out...");
 
         // Speed up clock 10x so the tick from 2550→2600 takes ~0.7s instead of ~7s
-        var speedResult = await ServerApi.SetClockSpeed(10, TestContext.Current.CancellationToken);
+        var speedResult = await ServerApi.SetClockSpeed(10, TestCt);
         Assert.True(speedResult?.Success, $"SetClockSpeed failed: {speedResult?.Error}");
 
         bool dayChanged;
@@ -362,21 +359,16 @@ public class HostAutomationTests : TestBase
         {
             // Wait for the day to transition.
             // At 2600, the game forces pass-out → sleep ready check → day transition.
-            dayChanged = await DayChange.WaitAsync(
-                dayBefore,
-                seasonBefore,
-                yearBefore,
-                TestContext.Current.CancellationToken
-            );
+            dayChanged = await DayChange.WaitAsync(dayBefore, seasonBefore, yearBefore, TestCt);
         }
         finally
         {
             // Always restore clock speed
-            await ServerApi.SetClockSpeed(1, TestContext.Current.CancellationToken);
+            await ServerApi.SetClockSpeed(1, TestCt);
         }
         Assert.True(dayChanged, "Day should have advanced after 2:00 AM pass-out");
 
-        var statusAfter = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusAfter = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusAfter);
         Log(
             $"After pass-out: {statusAfter.Season} {statusAfter.Day}, Year {statusAfter.Year}, Time {statusAfter.TimeOfDay}"
@@ -407,7 +399,7 @@ public class HostAutomationTests : TestBase
     [TestServer(Exclusive = true)]
     public async Task HostCompletesQiPlaneEvent_AcrossFpsMatrix(int fps)
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await Farmers.ConnectNewAsync(ct: ct);
 
         var initialRendering = await ServerApi.GetRendering(ct);

--- a/tests/JunimoServer.Tests/HostFarmhouseUpgradeGuardTests.cs
+++ b/tests/JunimoServer.Tests/HostFarmhouseUpgradeGuardTests.cs
@@ -20,7 +20,7 @@ public class HostFarmhouseUpgradeGuardTests : TestBase
     [TestServer(Clients = 0, Exclusive = true)]
     public async Task DebugHouseUpgradeCommand_OnHost_IsBlocked(string command)
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var response = await ServerApi.RunDebugHouseUpgrade(command, ct);
         Assert.NotNull(response);

--- a/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
@@ -229,13 +229,48 @@ internal sealed class ClientPool : IAsyncDisposable
             }
         }
 
+        // Self-heal: a Steam-required lease with NO Steam-bearing client anywhere in the
+        // pool (bag, leased, or in flight — the last one died via MarkClientDead) can never
+        // be satisfied by a returning client, so the cap and patience waits below would
+        // park it until the run-stall watchdog. Go straight to cold-start create; the
+        // account freed by the death is re-allocated to the fresh container. May exceed
+        // _maxContainers by one transiently when live non-Steam clients hold the cap —
+        // bounded by the allocator slice (a concurrent second Steam lease routes to the
+        // steam-wait branch via _inFlightSteamCreations) and preferable to a wedged run.
+        // The _steamAuthUrl gate mirrors CreateClientAsync's allocation predicate exactly:
+        // without it, an allocator-but-no-auth-url host would create a NON-Steam client here
+        // (no allocation), leave PoolHasAnySteamBearingClient false, and self-heal on every
+        // subsequent lease forever. Such a lease falls through to the cold-start path instead.
+        if (
+            requireSteam
+            && _accountAllocator != null
+            && _steamAuthUrl != null
+            && !PoolHasAnySteamBearingClient()
+        )
+        {
+            TestLog.Client("No Steam-bearing client left in pool; creating a replacement");
+            InfrastructureEventLog.Emit(
+                "steam_client_selfheal",
+                new { availableInBag = _available.Count }
+            );
+            client = await CreateClientGuardedAsync(
+                requireSteam: true,
+                reason: "steam_selfheal",
+                StartPriority.Normal,
+                ct
+            );
+            return new ClientLease(this, client, serverKey);
+        }
+
         // Check container cap: if at limit, wait for a return or discard.
         // Include in-flight creations (from pre-warm or concurrent on-demand)
-        // that haven't registered in _allClients yet.
+        // that haven't registered in _allClients yet. Marked-dead carcasses are
+        // excluded via CountLiveClientsLocked — they hold no leasable client, only
+        // a recording to extract at dispose, so they must not consume a cap slot.
         int currentCount;
         lock (_allClientsLock)
         {
-            currentCount = _allClients.Count + _inFlightCreations;
+            currentCount = CountLiveClientsLocked() + _inFlightCreations;
         }
 
         while (currentCount >= _maxContainers)
@@ -269,7 +304,7 @@ internal sealed class ClientPool : IAsyncDisposable
             // Discard freed a slot; break to create a new one
             lock (_allClientsLock)
             {
-                currentCount = _allClients.Count + _inFlightCreations;
+                currentCount = CountLiveClientsLocked() + _inFlightCreations;
             }
         }
 
@@ -285,7 +320,7 @@ internal sealed class ClientPool : IAsyncDisposable
             int outstandingClients;
             lock (_allClientsLock)
             {
-                outstandingClients = _allClients.Count - _available.Count;
+                outstandingClients = CountLiveClientsLocked() - _available.Count;
             }
             if (outstandingClients > 0)
             {
@@ -329,11 +364,14 @@ internal sealed class ClientPool : IAsyncDisposable
             }
         }
 
-        // Cold-start path: no Steam-bearing client has ever been created on this host
-        // (Steam case), or no client of any kind exists yet (non-Steam case). Create
-        // a new one under the global Docker creation limiter. Steam allocation happens
-        // inside CreateClientAsync via _accountAllocator and binds the account to this
-        // new container for its lifetime — the lease-availability gate above
+        // Cold-start path: no client of any kind exists yet (non-Steam case), or
+        // requireSteam with a null allocator (Steam demanded, no accounts configured —
+        // allocates nothing). A requireSteam lease with an allocator no longer reaches
+        // here: it is served either by the steam-wait branch (a Steam-bearing client
+        // exists) or by the self-heal route above (none does). Create a new container
+        // under the global Docker creation limiter. Steam allocation, when it happens,
+        // is inside CreateClientAsync via _accountAllocator and binds the account to
+        // this new container for its lifetime — the lease-availability gate above
         // (_steamAvailable) is the source of truth thereafter.
         client = await CreateClientGuardedAsync(
             requireSteam,
@@ -441,13 +479,34 @@ internal sealed class ClientPool : IAsyncDisposable
     }
 
     /// <summary>
+    /// Counts clients that still hold a leasable container — everything in
+    /// <c>_allClients</c> except carcasses retired by <see cref="MarkClientDead"/>
+    /// (which linger only for recording extraction at dispose). This is the count
+    /// that gates the container cap; a dead carcass must not consume a cap slot.
+    /// Requires <see cref="_allClientsLock"/> held.
+    /// </summary>
+    private int CountLiveClientsLocked()
+    {
+        int live = 0;
+        foreach (var c in _allClients)
+        {
+            if (!c.IsMarkedDead)
+            {
+                live++;
+            }
+        }
+        return live;
+    }
+
+    /// <summary>
     /// True iff at least one Steam-bearing client exists in this pool — either
     /// already in <c>_allClients</c> (returned to the bag, currently leased, or
     /// pending teardown) or in flight in <see cref="CreateClientAsync"/> after
     /// the allocator handed out an index. When false, a Steam lease must take
-    /// the cold-start cap-and-create path; when true, it must wait on
-    /// <c>_steamAvailable</c> so two concurrent Steam leases never both race
-    /// into cold-start and block on the now-empty allocator.
+    /// the self-heal route in <see cref="LeaseClientAsync"/> (straight to a
+    /// cold-start create); when true, it must wait on <c>_steamAvailable</c> so
+    /// two concurrent Steam leases never both race into cold-start and block on
+    /// the now-empty allocator.
     /// </summary>
     private bool PoolHasAnySteamBearingClient()
     {
@@ -493,8 +552,8 @@ internal sealed class ClientPool : IAsyncDisposable
         // Tracks whether the in-flight counters have been decremented yet, so the
         // catch/outer-finally don't double-decrement. Decremented on the success path
         // right after _allClients.Add (so the client is never double-counted in the
-        // capacity check `_allClients.Count + _inFlightCreations` while recording starts),
-        // and on the failure path in the outer finally.
+        // capacity check `CountLiveClientsLocked() + _inFlightCreations` while recording
+        // starts), and on the failure path in the outer finally.
         var inFlightDecremented = false;
         try
         {
@@ -623,7 +682,34 @@ internal sealed class ClientPool : IAsyncDisposable
         var allocateSteam = requireSteam && _steamAuthUrl != null && _accountAllocator != null;
         if (allocateSteam)
         {
-            steamAccountIndex = await _accountAllocator!.AllocateClientAsync(ct);
+            // Bound the allocation: the semaphore wait is normally ~0s (accounts release
+            // eagerly), so exceeding SteamAccountAllocationBound means no account will be
+            // released (an account leak). Fail fast as infrastructure rather than block to
+            // the run-stall watchdog. The readiness-probe phase swallows cancellation and
+            // dequeues anyway, so this bound only converts the semaphore-starvation case.
+            using var allocCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            allocCts.CancelAfter(TestTimings.SteamAccountAllocationBound);
+            try
+            {
+                steamAccountIndex = await _accountAllocator!.AllocateClientAsync(allocCts.Token);
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                InfrastructureEventLog.Emit(
+                    "steam_account_allocation_timeout",
+                    new
+                    {
+                        clientIndex,
+                        boundSec = (int)TestTimings.SteamAccountAllocationBound.TotalSeconds,
+                    }
+                );
+                throw new InfrastructureSkipException(
+                    $"No Steam client account became available within "
+                        + $"{TestTimings.SteamAccountAllocationBound.TotalSeconds:0}s — all accounts are "
+                        + "held and none released (likely an account leak after a client death). "
+                        + "Skipped — infrastructure, not a test defect."
+                );
+            }
             options.SteamAuthUrl = _steamAuthUrl;
             options.SteamAccountIndex = steamAccountIndex;
             TestLog.Client($"client-{clientIndex} assigned Steam account {steamAccountIndex}");
@@ -823,8 +909,12 @@ internal sealed class ClientPool : IAsyncDisposable
     /// <summary>
     /// Marks a client as dead (won't be reused) but keeps it in <c>_allClients</c>
     /// so <see cref="DisposeAsync"/> can still retrieve the full recording from it.
-    /// Releases the Steam account index back to <see cref="_accountAllocator"/>;
-    /// <see cref="_steamAvailable"/> is not signaled (see <see cref="DiscardClient"/>).
+    /// Sets <see cref="GameClientContainer.IsMarkedDead"/> so the carcass no longer
+    /// counts toward the live container cap. Releases the Steam account index back to
+    /// <see cref="_accountAllocator"/>; <see cref="_steamAvailable"/> is not signaled
+    /// (see <see cref="DiscardClient"/>). When this retires the last Steam-bearing
+    /// client, the next <c>requireSteam</c> lease self-heals via the <c>steam_selfheal</c>
+    /// route in <see cref="LeaseClientAsync"/>.
     /// </summary>
     internal void MarkClientDead(GameClientContainer client)
     {
@@ -842,7 +932,13 @@ internal sealed class ClientPool : IAsyncDisposable
                 new { clientIndex = client.ClientIndex, error = ex.Message }
             );
         }
-        // Keep in _allClients; DisposeAsync will handle cleanup + recording extraction
+        // Retire from the live-count while keeping the carcass in _allClients for
+        // recording extraction at dispose. The lock write-side fences the counting
+        // reads that run under the same lock in LeaseClientAsync.
+        lock (_allClientsLock)
+        {
+            client.IsMarkedDead = true;
+        }
         TestLog.Client($"client-{client.ClientIndex} marked dead (kept for recording extraction)");
         InfrastructureEventLog.Emit("client_marked_dead", new { clientIndex = client.ClientIndex });
         _returnSignal.Release();

--- a/tests/JunimoServer.Tests/LobbyCommandsTestBase.cs
+++ b/tests/JunimoServer.Tests/LobbyCommandsTestBase.cs
@@ -63,7 +63,7 @@ public abstract class LobbyCommandsTestBase : TestBase
     {
         await EnsureConnectedAsync("LobbyAdmin");
 
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var uid =
             PersistentSession.ConnectedFarmerUid
             ?? throw new InvalidOperationException(
@@ -95,11 +95,7 @@ public abstract class LobbyCommandsTestBase : TestBase
     /// </summary>
     protected async Task SetupAsNonAdmin()
     {
-        await Farmers.ConnectNewAsync(
-            breakSession: true,
-            assertAuthenticated: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(breakSession: true, assertAuthenticated: true, ct: TestCt);
 
         var welcome = await GameClient.Chat.WaitForMessageContainingAsync(
             "Welcome",

--- a/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
+++ b/tests/JunimoServer.Tests/LobbyHomedSpouseTests.cs
@@ -58,7 +58,7 @@ public class LobbyHomedSpouseSteadyStateTests : TestBase
     [Fact]
     public async Task MarriedCouples_UnderPassword_HomesStayRealAcrossNightsAndOffline()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var setDate = await ServerApi.SetDate(Season, EngageDay, year: 1, ct);
         Assert.NotNull(setDate);
@@ -394,7 +394,7 @@ public class LobbyHomedSpouseHealTests : TestBase
     [Fact]
     public async Task PoisonedLobbyHomes_HealOnDayStart_AndStayHealedAcrossReload()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // The boot world becomes reachable (IsReady flips) a beat before its SaveLoaded
         // handlers finish, so a stamp can race the boot's own SaveLoaded sweep — which would

--- a/tests/JunimoServer.Tests/ModFarmDisambiguationTests.cs
+++ b/tests/JunimoServer.Tests/ModFarmDisambiguationTests.cs
@@ -38,13 +38,13 @@ public class ModFarmDisambiguationTests : TestBase
 
         // The fixture's entry is the SECOND AdditionalFarms entry (after base MeadowlandsFarm);
         // getting its Id back proves resolution matched on Id, not array position.
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var status = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(status);
         Assert.Equal(FixtureFarmId, status.FarmTypeKey);
         Log($"Farm type key verified: {status.FarmTypeKey}");
 
         // Verify the modded farm map built cabins (server-side proof the farm loaded).
-        var cabins = await ServerApi.GetCabins(TestContext.Current.CancellationToken);
+        var cabins = await ServerApi.GetCabins(TestCt);
         Assert.NotNull(cabins);
         Assert.True(cabins.TotalCount >= 1, $"Expected at least 1 cabin, got {cabins.TotalCount}");
 
@@ -65,7 +65,7 @@ public class ModFarmDisambiguationTests : TestBase
 
         // "modded" picks the first non-Meadowlands AdditionalFarms entry; the fixture mod adds
         // exactly one (JunimoTest.SecondFarm), so the keyword must land on it.
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var status = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(status);
         Assert.Equal(FixtureFarmId, status.FarmTypeKey);
         Log($"\"modded\" resolved to: {status.FarmTypeKey}");

--- a/tests/JunimoServer.Tests/NavigationTests.cs
+++ b/tests/JunimoServer.Tests/NavigationTests.cs
@@ -27,7 +27,7 @@ public class NavigationTests : TestBase
         Assert.NotNull(ServerStatus);
         Assert.True(ServerStatus.IsOnline, "Server should be online");
 
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // InviteCode is read from a file, not from the snapshot — long-poll for
         // any newer snapshot via `since`, then check IsOnline + InviteCode in
         // the response body.
@@ -65,7 +65,7 @@ public class NavigationTests : TestBase
     [TestServer(Clients = 0)]
     public async Task ServerApi_GetStatus_ShouldReturnValidResponse()
     {
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var status = await ServerApi.GetStatus(TestCt);
 
         Assert.NotNull(status);
         Assert.NotNull(status.ServerVersion);
@@ -84,7 +84,7 @@ public class NavigationTests : TestBase
     public async Task ServerApi_GetInviteCode_ShouldReturnValidCode()
     {
         // Galaxy invite code may arrive asynchronously; poll briefly
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var hasCode = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_Navigation_HasGalaxyInviteCode,
             async () =>
@@ -115,7 +115,7 @@ public class NavigationTests : TestBase
         // (no `since` cursor — the server's health bit is "is the game thread
         // ticking now"), so each iteration returns immediately on a healthy
         // server or after up to WaitMaxTimeout (10s) on a stalled one.
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         HealthResponse? health = null;
         var healthy = await PollingHelper.LongPollAsync(
             WaitName.Polling_Navigation_HealthyOk,

--- a/tests/JunimoServer.Tests/NoPasswordTests.cs
+++ b/tests/JunimoServer.Tests/NoPasswordTests.cs
@@ -24,7 +24,7 @@ public class NoPasswordTests : TestBase
     [Fact]
     public async Task NewPlayer_JoinsDirectly_WhenNoPasswordConfigured()
     {
-        await EnsureConnectedAsync("NoPwd", ct: TestContext.Current.CancellationToken);
+        await EnsureConnectedAsync("NoPwd", ct: TestCt);
 
         // Get current location
         var state = await GameClient.GetState();
@@ -48,10 +48,7 @@ public class NoPasswordTests : TestBase
     {
         // This test needs a fresh connection; we're asserting about messages
         // received on join, so we can't reuse an existing session.
-        await Farmers.ConnectNewAsync(
-            breakSession: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(breakSession: true, ct: TestCt);
 
         // Poll for the delivery window. If auth messages appear at any point,
         // the test fails immediately instead of waiting the full duration.
@@ -71,7 +68,7 @@ public class NoPasswordTests : TestBase
                     ) == true;
             },
             TestTimings.ChatDeliveryDelay,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         // Should NOT have received any auth messages
@@ -98,7 +95,7 @@ public class NoPasswordTests : TestBase
     [Fact]
     public async Task Player_CanInteract_WithoutAuthentication()
     {
-        await EnsureConnectedAsync("NoPwd", ct: TestContext.Current.CancellationToken);
+        await EnsureConnectedAsync("NoPwd", ct: TestCt);
 
         // Verify we're connected and in-game
         var state = await GameClient.GetState();
@@ -132,7 +129,7 @@ public class NoPasswordTests : TestBase
                 return countAfter > countBefore;
             },
             TestTimings.ChatCommandTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         // Should see the message in chat history (not blocked)

--- a/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
+++ b/tests/JunimoServer.Tests/NpcSpriteIntegrityTests.cs
@@ -46,7 +46,7 @@ public class NpcSpriteIntegrityTests : TestBase
     [Fact]
     public async Task BrokenSprite_IsHealed_AndScheduleBoundariesDoNotFreezeClock()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // The boot world becomes reachable a beat before its SaveLoaded handlers finish, so
         // an immediate break could race the boot's own SaveLoaded sweep (which would heal it
@@ -186,7 +186,7 @@ public class NpcSpriteIntegrityTests : TestBase
     [Fact]
     public async Task Sweeps_AreWiredToSaveLoadedAndDayStarted_HealthyWorldHealsNothing()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         var ready = await ServerApi.WaitForServerOnline(
             TestTimings.DayChangeTimeout,

--- a/tests/JunimoServer.Tests/PasswordProtectionDisruptiveTests.cs
+++ b/tests/JunimoServer.Tests/PasswordProtectionDisruptiveTests.cs
@@ -37,10 +37,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
     public async Task Login_WithWrongPassword_Fails()
     {
         // Join the server WITHOUT auto-login (to test wrong password manually)
-        await Farmers.ConnectNewAsync(
-            skipAutoLogin: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(skipAutoLogin: true, ct: TestCt);
 
         // Get initial location (should be lobby)
         var stateBefore = await GameClient.GetState();
@@ -86,7 +83,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
     public async Task Login_ExceedsMaxAttempts_KicksPlayer()
     {
         // Query the server's configured max attempts instead of hardcoding
-        var authStatus = await ServerApi.GetAuthStatus(TestContext.Current.CancellationToken);
+        var authStatus = await ServerApi.GetAuthStatus(TestCt);
         Assert.NotNull(authStatus);
         Assert.True(authStatus.Enabled, "Password protection should be enabled");
         var maxAttempts = authStatus.MaxAttempts;
@@ -94,10 +91,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
         Log($"Server max login attempts: {maxAttempts}");
 
         // Join the server WITHOUT auto-login (to test manual wrong passwords)
-        var client = await Farmers.ConnectNewAsync(
-            skipAutoLogin: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        var client = await Farmers.ConnectNewAsync(skipAutoLogin: true, ct: TestCt);
 
         // Wait for welcome message first
         await GameClient.Chat.WaitForMessageContainingAsync(
@@ -115,7 +109,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
                 var gotResponse = await GameClient.Chat.SendAndWaitForResponseAsync(
                     $"!login wrongpassword{i}",
                     FailureKeywords,
-                    ct: TestContext.Current.CancellationToken
+                    ct: TestCt
                 );
                 Log($"Attempt {i} server response received: {gotResponse}");
             }
@@ -124,9 +118,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
                 // Final attempt. Server kicks without sending a chat response,
                 // so we can't wait for one. Instead, verify the server saw our
                 // player BEFORE sending, then send and poll for disconnect.
-                var playersBefore = await ServerApi.GetPlayers(
-                    TestContext.Current.CancellationToken
-                );
+                var playersBefore = await ServerApi.GetPlayers(TestCt);
                 var ourPlayer = playersBefore?.Players?.FirstOrDefault(p =>
                     p.Name?.Contains(client.FarmerName, StringComparison.OrdinalIgnoreCase) == true
                 );
@@ -159,7 +151,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
                 return s?.IsConnected != true;
             },
             TestTimings.DisconnectedTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         if (!kicked)
@@ -170,7 +162,7 @@ public class PasswordProtectionDisruptiveTests : TestBase
                     + $"Location={finalState?.Location}, IsInGame={finalState?.IsInGame}"
             );
 
-            var serverPlayers = await ServerApi.GetPlayers(TestContext.Current.CancellationToken);
+            var serverPlayers = await ServerApi.GetPlayers(TestCt);
             Log(
                 $"KICK FAILED: server players: {serverPlayers?.Players?.Count ?? -1} "
                     + $"[{string.Join(", ", serverPlayers?.Players?.Select(p => p.Name) ?? Array.Empty<string>())}]"

--- a/tests/JunimoServer.Tests/PasswordProtectionTests.cs
+++ b/tests/JunimoServer.Tests/PasswordProtectionTests.cs
@@ -40,11 +40,7 @@ public class PasswordProtectionTests : TestBase
     [Fact]
     public async Task NewPlayer_InLobby_HasCorrectStateAndWelcome()
     {
-        await EnsureConnectedAsync(
-            "Lobby",
-            SessionJoinMode.Unauthenticated,
-            TestContext.Current.CancellationToken
-        );
+        await EnsureConnectedAsync("Lobby", SessionJoinMode.Unauthenticated, TestCt);
 
         // Wait for welcome message
         await GameClient.Chat.WaitForMessageContainingAsync(
@@ -55,7 +51,7 @@ public class PasswordProtectionTests : TestBase
         // Verify placement: should be in a lobby cabin
         var state = await GameClient.WaitForLocationAsync(
             "^" + GameTestClient.CabinLocationPrefix,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Log($"Player location: {state?.Location}");
         Assert.NotNull(state);
@@ -84,11 +80,7 @@ public class PasswordProtectionTests : TestBase
     [Fact]
     public async Task Help_Command_WorksInLobby()
     {
-        await EnsureConnectedAsync(
-            "Lobby",
-            SessionJoinMode.Unauthenticated,
-            TestContext.Current.CancellationToken
-        );
+        await EnsureConnectedAsync("Lobby", SessionJoinMode.Unauthenticated, TestCt);
 
         // Wait for welcome message first
         await GameClient.Chat.WaitForMessageContainingAsync(
@@ -104,7 +96,7 @@ public class PasswordProtectionTests : TestBase
         await GameClient.Chat.SendAndWaitForResponseAsync(
             "!help",
             helpResponseKeywords,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         var chatHistory = await GameClient.Chat.GetHistory(20);
@@ -130,11 +122,7 @@ public class PasswordProtectionTests : TestBase
     [Fact]
     public async Task UnauthenticatedPlayer_RegularChat_IsBlocked()
     {
-        await EnsureConnectedAsync(
-            "Lobby",
-            SessionJoinMode.Unauthenticated,
-            TestContext.Current.CancellationToken
-        );
+        await EnsureConnectedAsync("Lobby", SessionJoinMode.Unauthenticated, TestCt);
 
         // Wait for welcome message first
         await GameClient.Chat.WaitForMessageContainingAsync(
@@ -150,7 +138,7 @@ public class PasswordProtectionTests : TestBase
             "hello everyone",
             blockedKeywords,
             matchAll: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         var chatHistory = await GameClient.Chat.GetHistory(20);
@@ -181,7 +169,7 @@ public class PasswordProtectionTests : TestBase
         await PersistentSession.BreakSessionAsync();
 
         // Query the server's configured auth timeout
-        var authStatus = await ServerApi.GetAuthStatus(TestContext.Current.CancellationToken);
+        var authStatus = await ServerApi.GetAuthStatus(TestCt);
         Assert.NotNull(authStatus);
         Assert.True(authStatus.Enabled, "Password protection should be enabled");
 
@@ -194,10 +182,7 @@ public class PasswordProtectionTests : TestBase
 
         // Temporarily lower the timeout so we don't wait 2+ minutes
         const int testTimeout = 5;
-        var setResult = await ServerApi.SetAuthTimeout(
-            testTimeout,
-            TestContext.Current.CancellationToken
-        );
+        var setResult = await ServerApi.SetAuthTimeout(testTimeout, TestCt);
         Assert.NotNull(setResult);
         Assert.True(setResult.Success, $"Failed to set auth timeout: {setResult.Error}");
         Log($"Auth timeout lowered: {originalTimeout}s → {testTimeout}s");
@@ -205,10 +190,7 @@ public class PasswordProtectionTests : TestBase
         try
         {
             // Join the server WITHOUT auto-login (to sit in lobby)
-            await Farmers.ConnectNewAsync(
-                skipAutoLogin: true,
-                ct: TestContext.Current.CancellationToken
-            );
+            await Farmers.ConnectNewAsync(skipAutoLogin: true, ct: TestCt);
 
             // Wait for welcome message to confirm we're in the lobby
             await GameClient.Chat.WaitForMessageContainingAsync(
@@ -227,7 +209,7 @@ public class PasswordProtectionTests : TestBase
                     return s?.IsConnected != true;
                 },
                 kickTimeout,
-                cancellationToken: TestContext.Current.CancellationToken
+                cancellationToken: TestCt
             );
 
             Assert.True(kicked, $"Player should be disconnected after {testTimeout}s auth timeout");
@@ -237,7 +219,7 @@ public class PasswordProtectionTests : TestBase
         finally
         {
             // Restore original timeout for other tests sharing this server
-            await ServerApi.SetAuthTimeout(originalTimeout, TestContext.Current.CancellationToken);
+            await ServerApi.SetAuthTimeout(originalTimeout, TestCt);
             Log($"Auth timeout restored to {originalTimeout}s");
         }
     }
@@ -254,24 +236,21 @@ public class PasswordProtectionTests : TestBase
         var client = await Farmers.ConnectNewAsync(
             breakSession: true,
             assertAuthenticated: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         var stateAfterAuth = await GameClient.GetState();
         Log($"Location after first auth: {stateAfterAuth?.Location}");
 
         // Reconnect-to-same-farmer needs customized farmhand persisted, not just slot released.
-        await Farmers.DisconnectAndWaitForPersistenceAsync(
-            client.FarmerName,
-            TestContext.Current.CancellationToken
-        );
+        await Farmers.DisconnectAndWaitForPersistenceAsync(client.FarmerName, TestCt);
         Log("Disconnected from first session");
 
         // Second session: Reconnect and authenticate
         var reconnect = await Farmers.ReconnectAsync(
             client.FarmerName,
             assertAuthenticated: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Assert.True(reconnect.JoinResult.WasInLobby, "Should start in lobby on reconnect");
 
@@ -280,7 +259,7 @@ public class PasswordProtectionTests : TestBase
         // (passout message type 29) may still be in flight when join returns.
         var stateAfterReconnect = await GameClient.WaitForLocationAsync(
             "^" + GameTestClient.CabinLocationPrefix,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Log($"Location after reconnect and auth: {stateAfterReconnect?.Location}");
 
@@ -289,7 +268,7 @@ public class PasswordProtectionTests : TestBase
         // Verify this is the player's OWN cabin via the server API.
         var ownedCabin = await WaitForCabinAssignedAsync(
             client.JoinResult.UniqueMultiplayerId,
-            TestContext.Current.CancellationToken
+            TestCt
         );
 
         Assert.NotNull(ownedCabin);
@@ -310,11 +289,7 @@ public class PasswordProtectionTests : TestBase
     public async Task LobbyPlayer_SurvivesDayTransition_CanAuthenticateAfter()
     {
         // Join the server WITHOUT auto-login (sit in lobby)
-        await Farmers.ConnectNewAsync(
-            breakSession: true,
-            skipAutoLogin: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(breakSession: true, skipAutoLogin: true, ct: TestCt);
 
         // Wait for welcome message to confirm we're in the lobby
         await GameClient.Chat.WaitForMessageContainingAsync(
@@ -323,7 +298,7 @@ public class PasswordProtectionTests : TestBase
         );
 
         // Record current day
-        var statusBefore = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusBefore = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(statusBefore);
         var dayBefore = statusBefore.Day;
         var seasonBefore = statusBefore.Season;
@@ -335,24 +310,16 @@ public class PasswordProtectionTests : TestBase
         // Trigger a day transition by setting time to pass-out which forces the day to advance.
         // The server's host bot auto-sleeps when no authenticated players are connected,
         // and the lobby player is excluded from sleep checks.
-        var setTimeResult = await ServerApi.SetTime(
-            TestTimings.PassOutTime,
-            TestContext.Current.CancellationToken
-        );
+        var setTimeResult = await ServerApi.SetTime(TestTimings.PassOutTime, TestCt);
         Assert.NotNull(setTimeResult);
         Assert.True(setTimeResult.Success, $"SetTime failed: {setTimeResult.Error}");
         Log("Set time to 2600, waiting for day transition...");
 
         // Wait for day to change and server to finish the transition
-        var dayChanged = await DayChange.WaitAsync(
-            dayBefore,
-            seasonBefore,
-            yearBefore,
-            TestContext.Current.CancellationToken
-        );
+        var dayChanged = await DayChange.WaitAsync(dayBefore, seasonBefore, yearBefore, TestCt);
         Assert.True(dayChanged, "Day should have advanced");
 
-        var statusAfter = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var statusAfter = await ServerApi.GetStatus(TestCt);
         Log(
             $"After day transition: {statusAfter?.Season} {statusAfter?.Day}, Time {statusAfter?.TimeOfDay}"
         );
@@ -376,7 +343,7 @@ public class PasswordProtectionTests : TestBase
         var authenticated = await GameClient.WaitForAuthWarpAsync(
             preAuthLocation!,
             TimeSpan.FromSeconds(15),
-            TestContext.Current.CancellationToken
+            TestCt
         );
 
         Assert.True(
@@ -408,7 +375,7 @@ public class PasswordProtectionTests : TestBase
         var first = await Farmers.ConnectNewAsync(
             breakSession: true,
             assertAuthenticated: true,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
 
         // Disconnect and delete via API — this is the path that calls DestroyCabin,
@@ -416,11 +383,11 @@ public class PasswordProtectionTests : TestBase
         await Farmers.DisconnectAndWaitForSlotAsync(
             first.JoinResult.UniqueMultiplayerId,
             first.FarmerName,
-            TestContext.Current.CancellationToken
+            TestCt
         );
         var deleteResult = await ServerApi.WaitForFarmhandDeletedByNameAsync(
             first.FarmerName,
-            ct: TestContext.Current.CancellationToken
+            ct: TestCt
         );
         Assert.True(
             deleteResult?.Success,
@@ -433,11 +400,7 @@ public class PasswordProtectionTests : TestBase
         // cabin's name as homeLocation, causing FindPlayerCabin to return null
         // at !login time and kick the player. assertAuthenticated throws if the
         // post-auth warp doesn't complete, so its success here proves the fix.
-        await Farmers.ConnectNewAsync(
-            breakSession: true,
-            assertAuthenticated: true,
-            ct: TestContext.Current.CancellationToken
-        );
+        await Farmers.ConnectNewAsync(breakSession: true, assertAuthenticated: true, ct: TestCt);
 
         await Exceptions.AssertNoExceptionsAsync("after deleted-cabin re-join cycle");
     }

--- a/tests/JunimoServer.Tests/PlayerTrackingTests.cs
+++ b/tests/JunimoServer.Tests/PlayerTrackingTests.cs
@@ -21,7 +21,7 @@ public class PlayerTrackingTests : TestBase
     [TestServer(Clients = 0, Artifacts = false)]
     public async Task ServerStatus_HasValidGameWorldData()
     {
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var status = await ServerApi.GetStatus(TestCt);
 
         Assert.NotNull(status);
         Assert.True(status.IsOnline, "Server should be online");
@@ -45,10 +45,10 @@ public class PlayerTrackingTests : TestBase
     public async Task ConnectedClient_TrackedInPlayersAndStatus()
     {
         // Get the client (lazy)
-        await GetClientAsync(TestContext.Current.CancellationToken);
+        await GetClientAsync(TestCt);
 
         // Verify our farmer is not already in the player list
-        var initialPlayers = await ServerApi.GetPlayers(TestContext.Current.CancellationToken);
+        var initialPlayers = await ServerApi.GetPlayers(TestCt);
         var farmerName = Farmers.GenerateName();
         Assert.True(
             initialPlayers?.Players?.All(p =>
@@ -58,20 +58,14 @@ public class PlayerTrackingTests : TestBase
         );
 
         // Join the server and enter the game world
-        var client = await Farmers.ConnectNewAsync(
-            farmerName: farmerName,
-            ct: TestContext.Current.CancellationToken
-        );
+        var client = await Farmers.ConnectNewAsync(farmerName: farmerName, ct: TestCt);
 
         // Verify the client appears in /players (poll until name syncs — this test
         // specifically verifies name-sync behavior, so name-based match is intentional).
-        var playerFound = await ServerApi.WaitForPlayerByNameAsync(
-            farmerName,
-            ct: TestContext.Current.CancellationToken
-        );
+        var playerFound = await ServerApi.WaitForPlayerByNameAsync(farmerName, ct: TestCt);
 
         Assert.True(playerFound, $"Player '{farmerName}' should appear in /players within timeout");
-        var connectedPlayers = await ServerApi.GetPlayers(TestContext.Current.CancellationToken);
+        var connectedPlayers = await ServerApi.GetPlayers(TestCt);
         Assert.NotNull(connectedPlayers);
         Assert.NotEmpty(connectedPlayers.Players);
 
@@ -85,7 +79,7 @@ public class PlayerTrackingTests : TestBase
         // Verify /status reflects a connected player (at least our client is counted).
         // NOTE: We don't snapshot a baseline count because other tests on the shared
         // server may connect/disconnect concurrently, making any baseline unstable.
-        var connectedStatus = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var connectedStatus = await ServerApi.GetStatus(TestCt);
         Assert.NotNull(connectedStatus);
         Assert.True(
             connectedStatus.PlayerCount >= 1,
@@ -97,7 +91,7 @@ public class PlayerTrackingTests : TestBase
         await Farmers.DisconnectAndWaitForSlotAsync(
             client.JoinResult.UniqueMultiplayerId,
             farmerName,
-            TestContext.Current.CancellationToken
+            TestCt
         );
         Log("Verified: player removed from /players after disconnect");
     }

--- a/tests/JunimoServer.Tests/RenderingTests.cs
+++ b/tests/JunimoServer.Tests/RenderingTests.cs
@@ -57,11 +57,8 @@ public class RenderingTests : TestBase
         // failed mid-change and left rendering in an unknown state.
         try
         {
-            await ServerApi.SetServerFps(0, TestContext.Current.CancellationToken);
-            await Task.Delay(
-                TestTimings.RenderingToggleDelay,
-                TestContext.Current.CancellationToken
-            );
+            await ServerApi.SetServerFps(0, TestCt);
+            await Task.Delay(TestTimings.RenderingToggleDelay, TestCt);
         }
         catch (Exception ex)
         {
@@ -73,37 +70,31 @@ public class RenderingTests : TestBase
     public async Task ServerApi_SetServerFps_EnableAndDisable_ShouldUpdateState()
     {
         // Initial state: rendering disabled (set by InitializeAsync)
-        var initialStatus = await ServerApi.GetRendering(TestContext.Current.CancellationToken);
+        var initialStatus = await ServerApi.GetRendering(TestCt);
         Assert.NotNull(initialStatus);
         Assert.Equal(0, initialStatus.Fps);
 
         // Enable at a positive rate
-        var enableResponse = await ServerApi.SetServerFps(
-            EnabledFps,
-            TestContext.Current.CancellationToken
-        );
+        var enableResponse = await ServerApi.SetServerFps(EnabledFps, TestCt);
         Assert.NotNull(enableResponse);
         Assert.True(enableResponse.Success, enableResponse.Error ?? "Enable failed");
         Assert.Equal(EnabledFps, enableResponse.Fps);
         Assert.Equal(0, enableResponse.PreviousFps);
 
         // Verify GET reflects the change
-        var enabledStatus = await ServerApi.GetRendering(TestContext.Current.CancellationToken);
+        var enabledStatus = await ServerApi.GetRendering(TestCt);
         Assert.NotNull(enabledStatus);
         Assert.Equal(EnabledFps, enabledStatus.Fps);
 
         // Disable again (fps 0)
-        var disableResponse = await ServerApi.SetServerFps(
-            0,
-            TestContext.Current.CancellationToken
-        );
+        var disableResponse = await ServerApi.SetServerFps(0, TestCt);
         Assert.NotNull(disableResponse);
         Assert.True(disableResponse.Success, disableResponse.Error ?? "Disable failed");
         Assert.Equal(0, disableResponse.Fps);
         Assert.Equal(EnabledFps, disableResponse.PreviousFps);
 
         // Verify GET reflects the change
-        var disabledStatus = await ServerApi.GetRendering(TestContext.Current.CancellationToken);
+        var disabledStatus = await ServerApi.GetRendering(TestCt);
         Assert.NotNull(disabledStatus);
         Assert.Equal(0, disabledStatus.Fps);
     }
@@ -117,7 +108,7 @@ public class RenderingTests : TestBase
         // brightness (nighttime, day-transition fade, etc.).
 
         // Step 1: Ensure rendering is OFF, poll until the test overlay disappears.
-        await ServerApi.SetServerFps(0, TestContext.Current.CancellationToken);
+        await ServerApi.SetServerFps(0, TestCt);
 
         int disabledBrightness = 0;
         var isDark = await PollingHelper.WaitUntilAsync(
@@ -141,7 +132,7 @@ public class RenderingTests : TestBase
             },
             TimeSpan.FromSeconds(5),
             pollInterval: TimeSpan.FromMilliseconds(500),
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(
@@ -150,7 +141,7 @@ public class RenderingTests : TestBase
         );
 
         // Step 2: Enable rendering, poll until the test overlay appears.
-        await ServerApi.SetServerFps(EnabledFps, TestContext.Current.CancellationToken);
+        await ServerApi.SetServerFps(EnabledFps, TestCt);
 
         int enabledBrightness = 0;
         var overlayVisible = await PollingHelper.WaitUntilAsync(
@@ -174,7 +165,7 @@ public class RenderingTests : TestBase
             },
             TimeSpan.FromSeconds(10),
             pollInterval: TimeSpan.FromMilliseconds(500),
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(
@@ -183,7 +174,7 @@ public class RenderingTests : TestBase
         );
 
         // Step 3: Disable rendering again and poll until the test overlay disappears.
-        await ServerApi.SetServerFps(0, TestContext.Current.CancellationToken);
+        await ServerApi.SetServerFps(0, TestCt);
 
         int reDisabledBrightness = 0;
         var wentDark = await PollingHelper.WaitUntilAsync(
@@ -207,7 +198,7 @@ public class RenderingTests : TestBase
             },
             TimeSpan.FromSeconds(5),
             pollInterval: TimeSpan.FromMilliseconds(500),
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(
@@ -239,7 +230,7 @@ public class RenderingTests : TestBase
     /// </summary>
     private async Task<(int brightness, byte[]? pngBytes)> CaptureTestOverlayBrightnessAsync()
     {
-        var result = await ServerApi.GetScreenshot(TestContext.Current.CancellationToken);
+        var result = await ServerApi.GetScreenshot(TestCt);
         if (result?.Success != true || result.Base64Png == null)
         {
             return (0, null);

--- a/tests/JunimoServer.Tests/SaveImportTests.cs
+++ b/tests/JunimoServer.Tests/SaveImportTests.cs
@@ -95,7 +95,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_DemotesOwnerAndBindsUserId()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest { OwnerName = "Alice" },
             ct
@@ -161,7 +161,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_MovesFarmhouseContentsToCabin()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest
             {
@@ -226,7 +226,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_UpgradedHouse_BuildPath_MovesContents()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // startingCabins:1 → no spare assignable cabin → TryAssignFarmhandHome fails → build path.
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest
@@ -291,7 +291,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_RelocatesPetToCabin()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest { OwnerName = "Dave", SpawnPet = true },
             ct
@@ -348,7 +348,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_MovesCellarContentsToOwnerCellar()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest { OwnerName = "Liam", PlaceCellarItem = true },
             ct
@@ -399,7 +399,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_AsIs_PreservesOwnerAsHost()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // Seed the master as a real owner so the source isn't a clone-blank Server master; as-is
         // keeps that owner AS the host (the headline trap, which this test pins as intended for a
         // single-player-style import).
@@ -455,7 +455,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_MalformedSave_LeavesFileByteUnchanged()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         await GenerateSourceSaveAsync(new TestSeedImportSourceRequest { OwnerName = "Frank" }, ct);
 
         // Clone the valid active save to a fresh folder, then corrupt the clone's <player> — one
@@ -526,7 +526,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_CarriesMasterGatedState()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         const string mailFlag = "ccDoorUnlock";
         const string eventSeen = "191393";
         var seed = await GenerateSourceSaveAsync(
@@ -625,7 +625,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_FinalizeIsSingleShot_AcrossReloads()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest { OwnerName = "Judy", PlaceChest = true },
             ct
@@ -708,7 +708,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_SwapHost_RejectsUserIdCollision()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // Seed a spare uncustomized farmhand slot with SyntheticBindId (before the save, so the clone
         // carries it). A swap binding the SAME id must then be rejected by the cross-farmhand
         // userID-collision walk (LAN won't stamp a userID on its own).
@@ -760,7 +760,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_Reload_RefusesWhenClientConnected()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         // Master is "Nina"; a finalized swap would flip it to "Server", so "Nina" persisting proves no reload.
         await GenerateSourceSaveAsync(new TestSeedImportSourceRequest { OwnerName = "Nina" }, ct);
 
@@ -807,7 +807,7 @@ public class SaveImportTests : TestBase
     [Fact]
     public async Task Import_ForceReload_KicksThenFinalizes()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var seed = await GenerateSourceSaveAsync(
             new TestSeedImportSourceRequest { OwnerName = "Omar" },
             ct

--- a/tests/JunimoServer.Tests/ServerApiTests.cs
+++ b/tests/JunimoServer.Tests/ServerApiTests.cs
@@ -32,11 +32,11 @@ public class ServerApiTests : TestBase
             WaitName.Polling_ServerApi_NoPlayersConnected,
             async () =>
             {
-                var players = await ServerApi.GetPlayers(TestContext.Current.CancellationToken);
+                var players = await ServerApi.GetPlayers(TestCt);
                 return players?.Players?.Count == 0;
             },
             TestTimings.FarmerDeleteTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
         Assert.True(noPlayers, "Server should have no players connected");
         Log("Verified: no players connected");
@@ -49,15 +49,12 @@ public class ServerApiTests : TestBase
     [TestServer(Artifacts = true)]
     public async Task GetPlayers_WhenPlayerConnected_ShowsPlayer()
     {
-        var client = await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        var client = await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Poll until player appears in the /players API
         PlayersResponse? response = null;
-        await ServerApi.WaitForPlayerByNameAsync(
-            client.FarmerName,
-            ct: TestContext.Current.CancellationToken
-        );
-        response = await ServerApi.GetPlayers(TestContext.Current.CancellationToken);
+        await ServerApi.WaitForPlayerByNameAsync(client.FarmerName, ct: TestCt);
+        response = await ServerApi.GetPlayers(TestCt);
 
         Assert.NotNull(response);
         Assert.NotNull(response.Players);
@@ -84,10 +81,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task SetTime_WithValidValue_Succeeds()
     {
-        var response = await ServerApi.SetTime(
-            TestTimings.Noon,
-            TestContext.Current.CancellationToken
-        );
+        var response = await ServerApi.SetTime(TestTimings.Noon, TestCt);
 
         Assert.NotNull(response);
         Assert.True(response.Success, response.Error ?? "SetTime failed");
@@ -104,7 +98,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task SetTime_OutOfRange_ReturnsError(int timeValue, string description)
     {
-        var response = await ServerApi.SetTime(timeValue, TestContext.Current.CancellationToken);
+        var response = await ServerApi.SetTime(timeValue, TestCt);
 
         Assert.NotNull(response);
         Assert.False(response.Success, $"Expected failure for {description} ({timeValue})");
@@ -124,10 +118,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task DeleteFarmhandByName_WhenNotExists_ReturnsNotFoundError()
     {
-        var response = await ServerApi.DeleteFarmhandByName(
-            "NonExistentFarmer12345",
-            TestContext.Current.CancellationToken
-        );
+        var response = await ServerApi.DeleteFarmhandByName("NonExistentFarmer12345", TestCt);
 
         Assert.NotNull(response);
         Assert.False(response.Success);
@@ -143,10 +134,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task DeleteFarmhandById_WhenNotExists_ReturnsNotFoundError()
     {
-        var response = await ServerApi.DeleteFarmhandById(
-            999999999L,
-            TestContext.Current.CancellationToken
-        );
+        var response = await ServerApi.DeleteFarmhandById(999999999L, TestCt);
 
         Assert.NotNull(response);
         Assert.False(response.Success);
@@ -162,10 +150,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task GrantAdminByName_WhenNotExists_ReturnsNotFoundError()
     {
-        var response = await ServerApi.GrantAdminByName(
-            "NonExistentAdmin12345",
-            TestContext.Current.CancellationToken
-        );
+        var response = await ServerApi.GrantAdminByName("NonExistentAdmin12345", TestCt);
 
         Assert.NotNull(response);
         Assert.False(response.Success);
@@ -181,10 +166,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task GrantAdminById_WhenNotExists_ReturnsNotFoundError()
     {
-        var response = await ServerApi.GrantAdminById(
-            999999999L,
-            TestContext.Current.CancellationToken
-        );
+        var response = await ServerApi.GrantAdminById(999999999L, TestCt);
 
         Assert.NotNull(response);
         Assert.False(response.Success);
@@ -204,7 +186,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task GetOpenApiSpec_ReturnsValidJson()
     {
-        var spec = await ServerApi.GetOpenApiSpec(TestContext.Current.CancellationToken);
+        var spec = await ServerApi.GetOpenApiSpec(TestCt);
 
         Assert.NotNull(spec);
         Assert.NotEmpty(spec);
@@ -236,7 +218,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task Api_HandlesConcurrentRequests()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         var tasks = new List<Task<ServerStatus?>>
         {
             ServerApi.GetStatus(ct),
@@ -271,7 +253,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task WebSocket_CanConnect()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         using var ws = new ClientWebSocket();
         var wsUrl = ServerApi.GetWebSocketUrl();
         Log($"Connecting to WebSocket: {wsUrl}");
@@ -291,7 +273,7 @@ public class ServerApiTests : TestBase
     [TestServer(Clients = 0)]
     public async Task WebSocket_PingPong()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         using var ws = new ClientWebSocket();
         var wsUrl = ServerApi.GetWebSocketUrl();
 
@@ -324,10 +306,10 @@ public class ServerApiTests : TestBase
     public async Task WebSocket_ChatSend_MessageAppearsInGame()
     {
         // Connect a player to receive the chat message
-        await Farmers.ConnectNewAsync(ct: TestContext.Current.CancellationToken);
+        await Farmers.ConnectNewAsync(ct: TestCt);
 
         // Send message via WebSocket API
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
         using var ws = new ClientWebSocket();
         var wsUrl = ServerApi.GetWebSocketUrl();
         await ws.ConnectAsync(new Uri(wsUrl), ct);
@@ -354,7 +336,7 @@ public class ServerApiTests : TestBase
                     ) == true;
             },
             TestTimings.ChatCommandTimeout,
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.NotNull(chatHistory);

--- a/tests/JunimoServer.Tests/ServerSettingsTests.cs
+++ b/tests/JunimoServer.Tests/ServerSettingsTests.cs
@@ -26,7 +26,7 @@ public class ServerSettingsTests : TestBase
     [Fact]
     public async Task Settings_ReturnsValidResponse()
     {
-        var settings = await ServerApi.GetSettings(TestContext.Current.CancellationToken);
+        var settings = await ServerApi.GetSettings(TestCt);
 
         Assert.NotNull(settings);
         Assert.NotNull(settings.Game);
@@ -76,7 +76,7 @@ public class ServerSettingsTests : TestBase
     [MemberData(nameof(DefaultSettingsData))]
     public async Task DefaultSettings_HaveExpectedValues(string settingPath, object expectedValue)
     {
-        var settings = await ServerApi.GetSettings(TestContext.Current.CancellationToken);
+        var settings = await ServerApi.GetSettings(TestCt);
         Assert.NotNull(settings);
 
         var actualValue = GetSettingValue(settings, settingPath);
@@ -114,8 +114,8 @@ public class ServerSettingsTests : TestBase
     [Fact]
     public async Task Settings_FarmNameMatchesStatus()
     {
-        var settings = await ServerApi.GetSettings(TestContext.Current.CancellationToken);
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var settings = await ServerApi.GetSettings(TestCt);
+        var status = await ServerApi.GetStatus(TestCt);
 
         Assert.NotNull(settings);
         Assert.NotNull(status);
@@ -130,8 +130,8 @@ public class ServerSettingsTests : TestBase
     [Fact]
     public async Task Settings_MaxPlayersMatchesStatus()
     {
-        var settings = await ServerApi.GetSettings(TestContext.Current.CancellationToken);
-        var status = await ServerApi.GetStatus(TestContext.Current.CancellationToken);
+        var settings = await ServerApi.GetSettings(TestCt);
+        var status = await ServerApi.GetStatus(TestCt);
 
         Assert.NotNull(settings);
         Assert.NotNull(status);

--- a/tests/JunimoServer.Tests/SteamAppIdTests.cs
+++ b/tests/JunimoServer.Tests/SteamAppIdTests.cs
@@ -41,9 +41,7 @@ public class SteamAppIdTests : TestBase
     public async Task Server_HasCorrectSteamAppId()
     {
         // Get container logs. Use a timeout since GetLogsAsync can hang on disposed containers.
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.Current.CancellationToken
-        );
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCt);
         cts.CancelAfter(TimeSpan.FromSeconds(30));
         var logs = await Server.Container.GetLogsAsync(ct: cts.Token);
         var combinedLogs = (logs.Stdout ?? "") + (logs.Stderr ?? "");
@@ -114,9 +112,7 @@ public class SteamAppIdTests : TestBase
             WaitName.Polling_SteamAppId_SdrStatusLine,
             async () =>
             {
-                using var cts = CancellationTokenSource.CreateLinkedTokenSource(
-                    TestContext.Current.CancellationToken
-                );
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(TestCt);
                 cts.CancelAfter(TimeSpan.FromSeconds(10));
                 var logs = await Server.Container.GetLogsAsync(ct: cts.Token);
                 var combinedLogs = (logs.Stdout ?? "") + (logs.Stderr ?? "");
@@ -132,7 +128,7 @@ public class SteamAppIdTests : TestBase
                 return false;
             },
             TimeSpan.FromSeconds(30),
-            cancellationToken: TestContext.Current.CancellationToken
+            cancellationToken: TestCt
         );
 
         Assert.True(found, "SDR relay status line should appear in server logs");

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -106,7 +106,7 @@ public class WeddingTests : TestBase
     [Fact]
     public async Task TwoFarmhandNpcWeddings_SameDay_BothCompleteWithoutHangingHost()
     {
-        var ct = TestContext.Current.CancellationToken;
+        var ct = TestCt;
 
         // Land on the day before the weddings.
         var setDate = await ServerApi.SetDate(WeddingSeason, EngageDay, year: 1, ct);


### PR DESCRIPTION
## Problem

`TotalConnectivityLoss_RecordsGalaxyReauthSignal` severs the single Steam-bearing test client. At lease dispose the client can't cleanly disconnect, so `MarkClientDead` retires it and frees its Steam account — but no path recreated a Steam client. When the pool was at the container cap (live non-Steam clients from other configs holding every slot), the next `requireSteam` lease parked in the cap-wait loop forever — no Steam client would ever return to satisfy it — blocking until the run-stall watchdog aborted the whole run (~630s idle, 1–2 leases outstanding). The hung test was always `GalaxyReloginGate_WhileHealthy_SkipsAndKeepsClientConnected` (dispatched, never recorded).

## Fix — three layers

**Layer 1 — the lease path self-heals:**
- `GameClientContainer.IsMarkedDead` retires a dead carcass; it stays in the roster only for recording extraction and no longer counts toward the live container cap.
- `CountLiveClientsLocked` excludes marked-dead carcasses at all three cap/patience sites.
- A `requireSteam` lease with no Steam-bearing client anywhere (bag, leased, in flight) routes straight to a cold-start create (`steam_selfheal`) instead of parking on a return that can never come; the freed account is re-allocated to the fresh container. Gated on `_steamAuthUrl != null` to mirror the allocation predicate exactly.

**Layer 2 — per-test timeout reaches a stuck acquire:**
- Switch test-body reads of `TestContext.Current.CancellationToken` to `TestCt` across 29 test classes so the 300s per-test budget can cancel a blocked lease. `TestBase`'s own doc already prescribes `TestCt` for this reason; no test runs near 300s, so the switch is inert unless a test genuinely hangs.

**Layer 3 — fail fast on a provable account leak:**
- Bound the client Steam-account allocation (`SteamAccountAllocationBound` 120s). The semaphore wait is normally ~0s plus a ≤90s readiness probe, so this only trips on semaphore starvation (an account leak), throwing `InfrastructureSkipException` (dynamic skip, no StopOnFail cascade) instead of blocking to the watchdog.

**Event catalog:** added `steam_client_selfheal` and `steam_account_allocation_timeout`, and extended `client_created`'s `reason` enum (`steam_selfheal`, plus the previously-undocumented `blip_retry`).

## Verification

All runtime gates passed, verified from `infrastructure.jsonl` (not just the green result):

- **Repro** (`GalaxyOutageRepro|AbandonedClaim|NavigationTests`): 8/8 passed, `aborted:false`. Self-heal chain fired once in order — `client_marked_dead` → `steam_client_selfheal` → `client_created{reason:"steam_selfheal"}` → `steam_account_allocated{kind:"client"}`. `GalaxyReloginGate` (the pre-fix hang victim) passed.
- **Full suite**: `aborted:false`, self-heal fired once. The single failure was an unrelated transient 504 on a LAN test (`FarmMapType`, 1 of 10 theory variants, not budget-cancelled, server not poisoned) — characterized as infrastructure flake, not a regression.
- **Layer-2 deterministic proof**: a focused test reconstructed the exact wedge and confirmed the stuck `requireSteam` lease is cancelled by its caller token after exactly 15s (`ClientPool_LeaseAtCap` `cancelled`, `durationMs:14999`), not the 600s watchdog. In production this token is `TestCt` (300s budget). The test and its scaffolding were removed after the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved client-pool recovery when no Steam-enabled clients remain by enabling automatic replacement.
  - Excluded retired clients from capacity calculations to prevent unnecessary leasing delays.
  - Added a timeout for Steam account allocation, with clearer failure reporting.

- **Tests**
  - Standardized cancellation handling across integration tests for more reliable execution.
  - Expanded rendering-state verification coverage.

- **Documentation**
  - Updated infrastructure event documentation and test timing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->