### PR TITLE
perf: make gameplay TPS-agnostic (fades, movement, projectiles, debris) + velocity-decay fix

### DIFF
--- a/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
+++ b/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
@@ -55,14 +55,46 @@ Registered on both mods (`JunimoServer/ModEntry.cs` `LoadServiceDependencies`, `
 | `Character.MovePosition` (`Character.cs:824-975`) | `position ±= speed + addedSpeed` per direction, gated by per-step `isCollidingPosition(nextPosition(dir))`; `time` used only for animation + `blockedInterval` (ms-scaled). `NPC.MovePosition` (`NPC.cs:3085-3092`) is a thin `movementPause` gate over `base.MovePosition`, so one seam covers villagers AND event actors | **Sub-step (2)** — postfix runs `floor(carry += TickScale) − 1` extra full vanilla steps under a re-entrancy guard; never scales the per-step delta (would tunnel the collision probe / overshoot the fixed-16px event NPC arrival window at `Event.cs:5259`) | All NPC walking 12× slow **server-wide** — verified: `_UpdateLocation` → `updateEvenIfFarmerIsntHere` (`Game1.cs:5871`) runs `updateCharacters` → `NPC.update` → `MovePosition` for EVERY location each tick (`Utility.ForEachLocation`), so inactive-location villagers walk (not teleport) their schedules and lag the real-time clock. Event choreography crawls (Lewis: 6.4s vs 0.5s) |
 | `Farmer.getMovementSpeed()` event branch (`Farmer.cs:8083`) | `Max(1, speed + farmerAddedSpeed…)` per tick — unscaled (the free-move branch `:8069-8081` already ms-scales by `ElapsedGameTime.Milliseconds`) | **Scaled step (1)** — postfix scales `__result *= TickScale` only on the event branch (detected by `CurrentEvent != null && !playerControlSequence`). Safe to scale (unlike NPCs): scripted event moves BYPASS the collision probe (`Farmer.MovePositionImpl:8595` `\|\| flag` where `flag = eventUp && !isFestival && !playerControlSequence`), so no collider to tunnel, and the farmer event arrival margin self-scales with the returned speed (`16f + movementSpeed`, `Event.cs:5236`), so no overshoot. *(Plan's earlier "collisions cleared at Event.cs:10879" citation was wrong — that line RE-ENABLES collisions at event end; the real mechanism is the `flag` bypass in `MovePositionImpl`.)* | Farmer event/cutscene movement 12× slow |
 
-### Tick-scaled, gameplay-relevant — audit the full body, then fix (Stage 3)
+### Stage 3 — creature MOVEMENT: IMPLEMENTED (Monster/FarmAnimal/Child sub-step)
 
-| Site | Verified so far | To audit before fixing |
+Patched with the SAME sub-step primitive as Stage 1 (`MovePosition_SubStep_Postfix`), extended for a
+correctness bug found during Stage 3 (see below). Registered in `TpsAgnosticPacing.Apply`.
+
+| Site | Mechanism (verified) | Fix | Notes |
+|---|---|---|---|
+| `Monster.MovePosition` (`Monster.cs:1011-1200`) | Own impl (not via `Character`). Walk portion is `position ± speed` per direction with per-step `isCollidingPosition` — same shape as `Character`. Knockback branch already self-substeps large velocities (`ceil(|v|/bbox)` lerp loop) and decays velocity per call | **Sub-step (2)** — postfix runs the whole method `floor(carry)-1` extra times. Whole-method sub-step reproduces vanilla 60Hz knockback decay exactly | `slideAnimationTimer`/`blockedInterval`/wall-slide-correction are ms-based — see zero-time fix below |
+| `FarmAnimal.MovePosition` (`FarmAnimal.cs:2099+`) | Own impl; `Game1.IsClient` early-return = server-simulated. `position ± speed` step + per-step `isCollidingPosition` | **Sub-step (2)** | `nextFollowDirectionChange -= ms` is ms-based — zero-time fix applies |
+| `Child.MovePosition` (`Child.cs:157+`) | Own impl gated on `Game1.IsMasterGame`; `position ± speed` + per-step collision. Festival case delegates to `base.MovePosition` (Character seam) | **Sub-step (2)** with a festival-skip guard (that path is already sub-stepped by the Character seam — avoids double-step) | — |
+
+**Zero-time sub-step correction (found + fixed during Stage 3, applies to Stage 1 too):** the original
+Stage 1 postfix re-invoked `MovePosition(time, …)` with the REAL `time`, so ms-based accumulators inside
+the body (`blockedInterval += ms` → stuck-emote/charge; Monster `slideAnimationTimer`, wall-slide
+`speed*ms/64`; FarmAnimal `nextFollowDirectionChange -= ms`) advanced once PER sub-step (~12× too fast at
+TPS 5). Fix: extra sub-steps now pass `ZeroElapsedGameTime`, so the per-tick-constant *position* step
+(which never reads `time`) still advances while every ms-based term contributes zero on the extra calls
+— only the real (first) call carries the tick's ms budget. This corrects a latent bug in the shipped
+Stage 1 Character sub-step (a stuck NPC charged after ~0.4s instead of 5s at TPS 5).
+
+*Known cosmetic limitation of zero-time:* the walk-cycle animation (`Sprite.Animate(time, …)`) does NOT
+advance on the extra zero-time steps, so at low TPS a character's *position* moves at correct wall-clock
+speed but its leg animation still cycles at the tick rate (12× slow at TPS 5). Position/arrival — the
+gameplay-relevant property — is correct; only the sprite cadence is slow. Accepted: animating on the
+extra steps would require passing real `time`, which reintroduces the ms-accumulator over-count. Position
+correctness > animation smoothness.
+
+### Stage 3 — projectiles + debris: AUDITED, DEFERRED (not built) — necessity is marginal on this server
+
+| Site | Mechanism (verified) | Why deferred |
 |---|---|---|
-| `Monster.MovePosition` (`Monster.cs:1011+`) | Own implementation, does NOT route through the `Character` seam (no `base.MovePosition` call). Knockback branch already self-substeps large velocities (`ceil(|v|/bbox)` loop, `:1030-1040`) — vanilla precedent for the technique | The walk portion's step mechanics; knockback decay factors; `behaviorAtGameTick` timers. Decided: fix to vanilla wall-clock combat pacing |
-| `FarmAnimal.MovePosition` (`FarmAnimal.cs:2099+`) | Own implementation; `Game1.IsClient` early-return proves server-side simulation | Step mechanics, grazing/follow timers |
-| `Child.MovePosition` (`Child.cs:157+`) | Own implementation, bypasses the `Character` seam (verified via override grep) | Body unread — audit then fix (farmhouse children are world NPCs like any other) |
-| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile.cs:69-80`) | `position += velocity; velocity += acceleration` per call, unscaled — a shaman fireball at TPS 5 travels at 1/12 speed (trivially dodgeable). Projectile *timers* are ms-based (`Projectile.cs:334,365,431`) | Simulation authority (host vs client-with-location); `Debris` physics same question. Fix note: sub-step the WHOLE `updatePosition` (velocity += acceleration inside each sub-step) — that reproduces vanilla's 60Hz Euler integration exactly, so trajectories match a real client bit-for-bit; scaling only the position delta would distort them |
+| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile`) | `velocity += acceleration; position += velocity` per call (all `NetField.Value`), unscaled — a fireball at TPS 5 travels 1/12 speed | (1) **Collision is checked OUTSIDE the physics step** — `Projectile.update` calls `updatePosition` then `isColliding` ONCE per tick, so sub-stepping only `updatePosition` still tunnels; a correct fix must sub-step the collision-bearing slice of `update` and avoid N-counting its `travelTime += ms` grace-period timer. (2) **All projectile-firing monsters are MINE/dungeon monsters** (Ghost, Skeleton, ShadowShaman, SquidKid…) — the dedicated farm server never simulates them; real players fight them client-side at 60 TPS. (3) **No E2E test spawns a monster/projectile and there's no `/test` combat probe**, so no runtime gate exists to validate a fix per the plan's own gate standard. Necessity on this server's actual deployment is marginal; building a combat-probe harness is a disproportionate sub-project. |
+| `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/Euler, unscaled | Physics + pickup + bounce checks are all self-contained in `updateChunks` (no external-collision tunneling, unlike projectiles — more tractable). Still DEFERRED for the same reason (3): no test exercises debris landing/pickup at low TPS, so no runtime gate. Debris settles ~12× slower at TPS 5 (item drops drift longer before resting) — a real but low-severity cosmetic-adjacent effect. |
+
+**TODO (concrete, per `holistic-or-explicit-todo`):** to close projectiles+debris, add a `/test/spawn_monster`
++ `/test/fire_projectile` + `/test/drop_debris` endpoint set and a WeddingTests-style measurement test
+(walk/fire at TPS 5 vs 60, ±10% wall-clock), then implement: Projectile = sub-step the collision-bearing
+slice of `Projectile.update` (collision checked per sub-step, `travelTime` counted once via the same
+zero-time technique); Debris = sub-step `updateChunks` (self-contained, zero-time for any ms terms). Until
+that harness exists these stay audited-not-fixed — mechanism known, fix shape known, blocked on validation.
 | `Debris` chunk physics (`Debris.cs:763-824`) | *(promoted from Stage 2 audit)* `xVelocity += 0.8f` (capped 8f), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity Euler integration, unscaled | Same as projectiles — sub-step the whole chunk update (velocity accumulation inside each sub-step). Simulation authority + whether debris landing position matters for pickup at low TPS. Gameplay-relevant (debris = collectible drops) |
 
 **Stage 3 audit progress (2026-07-13):** Verified `Monster.MovePosition` (`Monster.cs:1011-1130`) — the knockback/velocity branch's self-substep is real: `num3 = ceil(|velocity|/bbox_dim)`, then `for (i=1..num3)` lerps the bbox and runs `isCollidingPosition` per sub-step (`:1025-1050`) — vanilla's own sub-step precedent, so the technique is engine-sanctioned. The walk-portion step (the non-velocity movement, further in the body) is the part still needing the Stage 1 sub-step primitive; `slideAnimationTimer -= ElapsedGameTime.Milliseconds` (`:1073`) is already ms-based. NOT yet fixed — Stage 3 fixes need the runtime CPU gate (compat item 4) which requires a full run.

--- a/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
+++ b/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
@@ -26,10 +26,20 @@ WeddingTests green twice (both clients render both ceremonies — scenario confi
 the check); full suite 129 passed (the lone failure was an unrelated 504 infra flake that passes in
 isolation); CPU noise-level (median tick 0.22ms / 200ms budget).
 
-**OPEN (see "Remaining work to close the plan" at the bottom):**
-1. Stage 2 audit — a few sweep items still unclassified (Utility ambient spawns, world-update int-timers).
-2. Stage 3 projectiles + debris — audited, NOT built; the server DOES simulate mine monsters/projectiles (master-authority), so this is a genuine deferral needing a `/test` combat probe to validate.
-3. Two unexercised runtime gates — kill-switch A/B (not wired into container env) and the arbitrary/non-integer-TPS matrix (the fractional-carry path has never run in a test).
+**ALL CORE WORK DONE + VALIDATED (2026-07-14).** Every item closed with a runtime gate:
+1. **Non-integer-TPS gate** ✅ — WeddingTests at `SERVER_TPS=CLIENT_TPS=24` (scale 2.5, fractional carry).
+2. **Kill-switch A/B** ✅ — wired into container env; boot log confirms `DISABLED` when off (knob consumed).
+3. **Stage 2 sweep** ✅ — complete; surfaced the flyer/velocity finding (everything else ms-based/cosmetic).
+4. **Stage 3 projectile + debris** ✅ — prefix sub-step + combat probe (projectile 696-1536px, debris settles).
+5. **Velocity-decay-over-substep bug (found via the flyer investigation — a real bug in the SHIPPED Stage 1/3
+   sub-steps):** Part 1 (knockback, all monsters+NPCs) ✅ — slime knockback 400px. Part 2 (gliders/fliers) ✅
+   — Bat homing 693-766px (was ~15px unpatched). Final regression: PacingProbeTests (all 5) + WeddingTests
+   all green, no Stage-1 regression (both ceremonies rendered, zero errors) — run `2026-07-14T21-16-39Z`.
+
+Remaining: only a broader full-suite regression (catch anything outside the probe/wedding classes) is
+un-run since the velocity/glider changes landed; the targeted PacingProbeTests+WeddingTests regression is
+green. Minor known deviation: Fly/Serpent heading-tracking lags slightly under zero-time (within vanilla's
+tick variance; travel speed exact) — accepted per the fluctuating-TPS decision.
 
 **Strategic boundary (CPU):** TPS 5 exists to cut simulation cost. "TPS-agnostic" therefore means
 wall-clock-correct *outcomes* for gameplay-relevant mechanics — not sub-stepping the whole game
@@ -106,22 +116,30 @@ gameplay-relevant property — is correct; only the sprite cadence is slow. Acce
 extra steps would require passing real `time`, which reintroduces the ms-accumulator over-count. Position
 correctness > animation smoothness.
 
-### Stage 3 — projectiles + debris: AUDITED, DEFERRED (not built) — necessity is marginal on this server
+### Stage 3 — projectiles + debris: IMPLEMENTED (2026-07-14) — prefix sub-step + combat probe
 
-| Site | Mechanism (verified) | Why deferred |
+Both are server-simulated whenever a farmer is in/viewing the location (`GameLocation.UpdateWhenCurrentLocation`
+lines 4152/4155; `MineShaft.UpdateMines` `Game1.cs:5842`; `IsMasterGame` always true here). The fix is a
+**prefix** sub-step (not a postfix, unlike movement) because both `Projectile.update` and `Debris.updateChunks`
+return a `bool` the location's `RemoveWhere` consumes to delete the entity, and check collision inside the
+method — a postfix couldn't honor the return or a mid-flight collision.
+
+| Site | Mechanism (verified) | Fix |
 |---|---|---|
-| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile`) | `velocity += acceleration; position += velocity` per call (all `NetField.Value`), unscaled — a fireball at TPS 5 travels 1/12 speed | **The server DOES simulate these** (correction — an earlier draft wrongly said it never does): mine monster AI + firing is gated on `Game1.IsMasterGame`, which is always true here (`multiplayerMode=2`, per `masterplayer-is-player-on-server`), and `MineShaft.UpdateMines` (`Game1.cs:5842`, in the server update loop) ticks every level in `activeMines` — a level is active whenever a client is in it. So a client fighting in the mines at `SERVER_TPS=5` faces server-simulated projectiles crawling at 1/12 speed (trivially dodgeable) — a **real gameplay defect**. Deferred anyway because: (1) **collision is checked OUTSIDE the physics step** — `Projectile.update` calls `updatePosition` then `isColliding` ONCE per tick, so sub-stepping only `updatePosition` still tunnels; a correct fix must sub-step the collision-bearing slice of `update` and count its `travelTime += ms` grace-period timer once (the zero-time technique); (2) **no E2E test spawns a monster/projectile and there is no `/test` combat probe**, so there is no runtime gate to validate a fix per this plan's own gate standard. This is a genuine deferral (build a combat probe + fix), NOT a proven-no-effect. |
-| `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/Euler, unscaled | Physics + pickup + bounce checks are all self-contained in `updateChunks` (no external-collision tunneling, unlike projectiles — more tractable). Still DEFERRED for the same reason (3): no test exercises debris landing/pickup at low TPS, so no runtime gate. Debris settles ~12× slower at TPS 5 (item drops drift longer before resting) — a real but low-severity cosmetic-adjacent effect. |
+| `Projectile.update` / `updatePosition` (`Projectile.cs:326-412`; `BasicProjectile.cs:95-106`, `DebuffingProjectile.cs:69-80`) | `velocity += acceleration; position += velocity` per call, unscaled. Collision checked ONCE per `update` (after the single `updatePosition`, `Projectile.cs:389`); `travelTime += ms` grace timer (`:365`), `hostTimeUntilAttackable -= TotalSeconds` (`:334`), and `DebuffingProjectile` wavy phase are ms/wall-clock. | **Prefix sub-step (`Projectile_Update_Prefix` → `RunUpdateSubSteps`)** — runs `floor(carry)-1` extra full `update` calls with `ZeroElapsedGameTime` (each re-checks collision → no tunneling; ms grace timers count once on the real call). If an extra step returns `true` (collided/expired), skip the real call and hand that to `RemoveWhere`. |
+| `Debris.updateChunks` (`Debris.cs:631-912`) | `position += velocity`, `yVelocity -= 0.25f/0.4f` gravity, bounce damping — all per-tick constants, self-contained (no external collision). `timeSinceDoneBouncing += ms` (`:637`), `timeBeforeReturnToDroppingPlayer -= ms` (`:675`) are ms lifetime timers. Returns `bool` for `RemoveWhere`. | **Same prefix sub-step (`Debris_UpdateChunks_Prefix`)** — zero-time extra calls advance the gravity/velocity constants while the ms lifetime timers count once. |
 
-**TODO (concrete, per `holistic-or-explicit-todo`):** to close projectiles+debris, add a `/test/spawn_monster`
-+ `/test/fire_projectile` + `/test/drop_debris` endpoint set and a WeddingTests-style measurement test
-(walk/fire at TPS 5 vs 60, ±10% wall-clock), then implement: Projectile = sub-step the collision-bearing
-slice of `Projectile.update` (collision checked per sub-step, `travelTime` counted once via the same
-zero-time technique); Debris = sub-step `updateChunks` (self-contained, zero-time for any ms terms). Until
-that harness exists these stay audited-not-fixed — mechanism known, fix shape known, blocked on validation.
-| `Debris` chunk physics (`Debris.cs:763-824`) | *(promoted from Stage 2 audit)* `xVelocity += 0.8f` (capped 8f), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity Euler integration, unscaled | Same as projectiles — sub-step the whole chunk update (velocity accumulation inside each sub-step). Simulation authority + whether debris landing position matters for pickup at low TPS. Gameplay-relevant (debris = collectible drops) |
+**Combat probe (runtime gate):** `/test/pacing_probe_spawn` + `/test/pacing_probe_state` (both `Env.IsTest`-gated,
+`ApiService.TestEndpoints.cs`) spawn a projectile/debris/monster in the HOST's own location (open Farm on an idle
+server — the host is there and `IsMasterGame` simulates it, so no client needed) and read back the measured
+quantity. `PacingProbeTests` (API-only, `Clients=0`, Exclusive) asserts wall-clock-correct pacing at the reduced
+test TPS: projectile `travelDistance ≥ 500px` in 3s (bounces to stay in-map), all debris chunks finished falling
+(`bounces > 2`), bat displacement toward the host. Sized so an unpatched/kill-switch-off build (12× slow) fails.
 
-**Stage 3 audit progress (2026-07-13):** Verified `Monster.MovePosition` (`Monster.cs:1011-1130`) — the knockback/velocity branch's self-substep is real: `num3 = ceil(|velocity|/bbox_dim)`, then `for (i=1..num3)` lerps the bbox and runs `isCollidingPosition` per sub-step (`:1025-1050`) — vanilla's own sub-step precedent, so the technique is engine-sanctioned. The walk-portion step (the non-velocity movement, further in the body) is the part still needing the Stage 1 sub-step primitive; `slideAnimationTimer -= ElapsedGameTime.Milliseconds` (`:1073`) is already ms-based. NOT yet fixed — Stage 3 fixes need the runtime CPU gate (compat item 4) which requires a full run.
+**Also folded in — flyer-monster velocity/rotation** (Stage 2 finding, row 1 of that table): **DONE** — the
+root cause turned out to be the velocity-decay-over-substep bug (the shipped `MovePosition` sub-step
+over-applied per-call friction to velocity-driven movement), fixed in two parts (knockback + glider AI-tick
+sub-step). See the "Velocity-decay-over-substep bug" section below and "Remaining work" item 4.
 
 ### Verified already TPS-agnostic — do NOT touch (prevents re-litigation)
 
@@ -164,11 +182,17 @@ Sweep the server-simulated + per-instance update paths for the remaining instanc
 Output: this file's inventory tables extended until the sweep list is empty. The audit is part of
 the plan's deliverable — "Stage 1 shipped" does not close the plan.
 
-#### Stage 2 audit progress (2026-07-13, in progress — NOT yet complete)
+#### Stage 2 audit progress — COMPLETE (2026-07-14)
+
+The full sweep (Utility ambient spawns, `GameLocation.updateEvenIfFarmerIsntHere`/`UpdateWhenCurrentLocation`
+non-character constants, world-update int-timers, `Monster.behaviorAtGameTick`/per-type timers) is done.
+**One new genuinely-broken gameplay-relevant site was found — flyer-monster steering (row 1 below).** Everything
+else is already-ms-scaled, already-classified (`MovePosition`), or cosmetic/real-client-only.
 
 | Site | Mechanism | Authority | Classification |
 |---|---|---|---|
-| `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity integration, unscaled | Server-simulated (location update) + per-instance | **Stage 3-class** (physics integration like projectiles) — sub-step the whole update. Gameplay-relevant (debris = item drops the player collects); move to Stage 3 table. NOT yet fixed. |
+| **Flyer-monster steering + velocity ramp** (`Bat.cs:630/634/642/643`, `Fly.cs:192/196/204/205`, `Serpent.cs:503/507/515/516`, `Ghost.cs:224/228/236/237`, `AngryRoger.cs:142/146/154/155`) | Homing flight: `rotation ±= Sign(...)*(Math.PI/64f)` (turn rate) + `xVelocity/yVelocity += (…)*num4/6f` (accel ramp), both bare per-tick constants (no `ElapsedGameTime`). Their attack/state timers ARE ms-scaled — only the flight steering isn't. | Server-authoritative. **Bat**: steering is in `behaviorAtGameTick` → master-only gate (`Monster.cs:704`). **Fly/Serpent/Ghost/AngryRoger**: steering is in `updateAnimation` → called unconditionally (`Monster.cs:719`) BUT rotation is master-authoritative (synched to clients, `Monster.cs:722`) and velocity drives the master's `MovePosition`. (Corrects the audit's claim that ALL five are in `updateAnimation` — Bat is the outlier.) | **BROKEN — gameplay-relevant.** At TPS 5 these fliers turn ~12× slower and accelerate to terminal velocity ~12× slower → sluggish, trivially evadable. Distinct from the already-fixed `Monster.MovePosition` sub-step: that integrates the *already-computed* velocity into position, but does NOT fix the *rate at which velocity/rotation are generated* here (runs once per tick, AFTER MovePosition). Fix = the velocity-decay-over-substep two-part fix below (glider AI-tick sub-step). **FIXED + validated** — Bat homing 649-766px/3s at TPS 5 (was ~15-19px), combat-probe gated. |
+| `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity integration, unscaled | Server-simulated (location update) + per-instance | **Stage 3-class** (physics integration like projectiles). **FIXED + validated** via the shared `Debris.updateChunks` prefix sub-step — combat-probe gated (all chunks finish falling in 3s at TPS 5). See the Stage 3 table. |
 | `Event` viewport pan (`Event.cs:5165-5200`, `viewportTarget`) | `Game1.viewport.X/Y += (int)viewportTarget` per tick — camera pan, unscaled | Per-instance (event copy) | **Cosmetic** — pans the *camera* (`Game1.viewport`), does not gate event progression (no arrival/collision). No-op on render-suppressed host; on the test client it only changes recording framing. Candidate scaled-step ONLY if a recording gate shows a panned cutscene is misframed; otherwise proven-no-effect. Pending decision. |
 | `GameLocation.UpdateWhenCurrentLocation` splash VFX (`GameLocation.cs:4091,4097,4112,4114`) | `random.NextDouble() < 0.1/0.005/0.5/0.9` per tick → `TemporaryAnimatedSprite` + `PlayLocal` sound | Current-location only (render-relevant) | **Cosmetic, proven-no-effect** — ambient water-splash sprites + local sounds; no gameplay state. Current-location-gated, so never runs on inactive server locations; render-only on the client. Matches the plan's "probability rolls are mostly cosmetic" prediction. |
 | `TerrainFeatures/Tree` shake (`Tree.cs:449`) | `shakeTimer -= time.ElapsedGameTime.Milliseconds` | Server + per-instance | **Already ms-scaled** — do not touch. |
@@ -177,7 +201,13 @@ the plan's deliverable — "Stage 1 shipped" does not close the plan.
 | `WitchEvent.tickUpdate` (`WitchEvent.cs:108-161`) | `timerSinceFade += ms`, `witchPosition.X -= ms*0.4f`; Y-bob uses `TotalGameTime.Milliseconds` cosine phase (wall-clock, not per-tick accum) | Server (`FarmEvent`) | **Already ms-scaled** — proven-no-effect. |
 | `BirthingEvent` / `PlayerCoupleBirthingEvent` / `SoundInTheNightEvent` / `QuestionEvent` | Each references `ElapsedGameTime` (or has no per-tick motion — `QuestionEvent` only advances a `worldDate`); grep found ZERO bare per-tick float constants | Server (`FarmEvent`) | **Already ms-scaled / motionless** — proven-no-effect. |
 
-Remaining sweep list (NOT yet audited): `Utility` ambient spawns, `GameLocation.updateEvenIfFarmerIsntHere` non-character per-tick constants (beyond the current-location splash VFX already cleared), int-countdown timers across the world-update paths, `Monster.behaviorAtGameTick` timers (overlaps Stage 3). Emerging pattern: SDV *event/buff/FarmEvent* code is consistently ms-based (already TPS-agnostic); the per-tick-constant defect is concentrated in *character movement* + *fades* (Stage 1) and *physics integration* (Debris/projectiles → Stage 3). Stage 2 does NOT close until every entry lands fixed-or-proven.
+**Sweep list — CLEARED (2026-07-14).** Audited fixed/proven-no-effect:
+- `Utility` ambient spawns: CLEAN — `Utility.cs` has zero `ElapsedGameTime` refs and no per-tick accumulator method (stateless helper library); lightning update runs off the ms 10-minute clock, not per tick.
+- `GameLocation.updateEvenIfFarmerIsntHere`: CLEAN — only delegates to already-classified paths (`updateCharacters`, `TemporaryAnimatedSprite`, buildings/animals). `UpdateWhenCurrentLocation`: sole non-ms mutation is `updateWater` `waterPosition += 0.1f` (`GameLocation.cs:4304`), current-location-only cosmetic water scroll; companion `waterAnimationTimer` is ms-scaled.
+- World-update int-timers (`Game1.cs` clock/update): ms-scaled — `gameTimeInterval += ms` (`:6054`, the 10-min clock gating all time progression), `pauseThenDoFunctionTimer`/`thumbstickMotionMargin` ms/input-only. Location-file timers overwhelmingly ms-scaled (`Woods.statueTimer`, `WizardHouse.cauldronTimer`, `IslandNorth.boulderKnockTimer`, …); non-ms hits are bus-warp cutscene motion (`BusStop.cs:336`/`Desert.cs:476`, driven by the local player's own warp — **real-client-only**) and draw-overlay alpha fades (`MermaidHouse`/`MineShaft.fogAlpha`/`CommunityCenter.messageAlpha` — cosmetic).
+- `Monster.behaviorAtGameTick` + per-type timers: ms-scaled EXCEPT the flyer steering (row 1). Base `invincibleCountdown`/`stunTime`/`timeBeforeAIMovementAgain` and per-type `nextShot`/`timeUntilExplode`/`nextMoveCheck`/slime jump timers all `-= ms`/`TotalSeconds`. `GreenSlime.cs:999 position -= speed` idle drift is a per-tick `random<0.1` idle wander (cosmetic — the jump-attack toward the player is ms-scaled).
+
+Confirmed pattern: SDV *event/buff/FarmEvent/world-clock* code is consistently ms-based (already TPS-agnostic); the per-tick-constant defect is concentrated in *character movement* + *fades* (Stage 1), *physics integration* (Debris/projectiles → Stage 3), and now *flyer-monster velocity/rotation generation* (→ Stage 3). Stage 2 sweep is CLEAR; the one broken site (fliers) is tracked in Stage 3.
 
 ## Fix framework (three primitives, shared by all stages)
 
@@ -315,8 +345,20 @@ server-side (`IsDedicatedHost=false`), not client-side.**
    This also quantifies the production schedule-lag claim empirically — if inactive-location NPCs
    turn out to teleport along schedules (unverified vanilla behavior), scope the win statement to
    active-location movement.
-3. Fractional scale correctness: the TPS 20 case (scale 3.0) and an intentionally non-integer one
-   (e.g. TPS 25 → 2.4) show no drift (carry accumulator keeps long-run distance exact).
+3. **Fractional scale correctness — RESULT (run `2026-07-14T00-36-30Z_429fe85`, commit `429fe85`,
+   `SERVER_TPS=CLIENT_TPS=24` → scale 2.5, the never-before-run non-integer carry path):** `WeddingTests`
+   PASSED (1/1, ~94s test). Runtime-confirmed both hosts pinned the tick to `41.7ms` (`Server/Client TPS
+   set to 24`), so `TickScale = 41.7/16.67 = 2.5` and `_moveCarry` ran the alternating 1/2-extra-step
+   pattern — the fractional branch genuinely executed, not the integer scale-12 path every prior run took.
+   Both clients rendered BOTH ceremonies (`weddingsRendered == 2`, `renderedSoFar` 1→2 in the client log),
+   and — the decisive movement signal — **both clients' `waitForOtherPlayers weddingEnd<id>` gates
+   auto-readied on arrival** (`ready_check_transition numberReady:2` for both clients before the host
+   readied ceremony 2 via "other players ready"). Auto-ready fires only when the event farmer walks into
+   the fixed 16px arrival window, so the fractional sub-step delivered arrival correctly — no
+   tunneling/overshoot (which would hang the event) and no drift (ceremony spans ~31-34s, comparable to
+   the ~37s TPS-5 baseline — both pause-dominated, not tick-scaled-movement-dominated). No pacing
+   ERROR/hang/exception in the server log (the lone `ERROR game … Wave Bank.xwb` is the pre-existing
+   headless-audio-init line, before game load). `.env.test` restored to TPS 5 after the run. **Gate PASSED.**
 4. Full E2E suite green at TPS 5; CPU stats per compat item 4. **RESULT (run `2026-07-13T21-24-09Z`):
    129 passed, 6 skipped, 24 canceled (StopOnFail cascade), 1 FAILED — the single failure is an
    INFRASTRUCTURE flake unrelated to this change: `CabinPositionPersistenceTests.DummyCabin_After
@@ -332,19 +374,33 @@ server-side (`IsDedicatedHost=false`), not client-side.**
    31.89ms — ZERO samples above 100ms.** The server is never tick-bound, so the sub-step is noise-level
    (compat item 4 satisfied) AND this independently corroborates the 504 was proxy/network, not a slow
    game thread. Net: full-suite gate PASSED, no pacing regression.**
-5. Kill-switch off → 12× behavior returns (knob consumed). NOT yet exercised — the container env
-   doesn't wire `SDVD_TPS_AGNOSTIC_PACING`, so the A/B needs a `.WithEnvironment` addition first.
-6. Stage 3: a monster walk/attack sequence and a fired projectile measured at TPS 5 vs 60
-   match wall-clock ±10% (same probe harness as gate 2); Stage 2 closes with the inventory
-   showing zero unresolved entries (every row fixed or proven-no-effect).
+5. **Kill-switch A/B — PASSED (run `2026-07-14T17-22-47Z`, `SDVD_TPS_AGNOSTIC_PACING=false`).** The env
+   var is now wired into both container builders (`ServerContainer.cs`/`GameClientContainer.cs`), and the
+   A/B run's boot log on all 3 containers reads `TPS-agnostic pacing DISABLED via
+   SDVD_TPS_AGNOSTIC_PACING=false` — proving the knob is consumed end-to-end (container env → mod). With
+   it off, the fully-unpatched flyer probe read `monsterDisplacement=15px, speed=2.0` in 3s (near-
+   stationary), vs the wall-clock-correct behavior when on; WeddingTests still completed (generous
+   timeouts) with movement at the vanilla per-tick rate. `.env.test` restored to default-on after.
+6. **Stage 3 projectile+debris — PASSED (run `2026-07-14T17-13-54Z`, `PacingProbeTests`, fix ON, TPS 5).**
+   Projectile travelled **1536px in 3s** wall-clock (= ~512px/s, matching the 8px/update × 60/s real-time
+   rate; unpatched would be ~120px), all debris chunks finished falling within 3s, both via the shared
+   `RunUpdateSubSteps` prefix. All 3 probe spawn+state pairs fired end-to-end, no server error. Requires a
+   connected client (`Clients=1`) to unpause the server (see landmine).
+
+   **Flyer measurement (decides the velocity-ramp fix):** Bat homing at TPS 5, net displacement in 3s —
+   fix OFF (both patches off): **15px**; fix ON (MovePosition sub-step on, velocity-ramp NOT patched):
+   **38px**. Both are near-stationary vs the ~1920px a real 60-TPS bat would close. **Conclusion: the
+   shipped MovePosition sub-step does NOT fix fliers** — it integrates an un-ramped (~0) velocity 12×,
+   which is still ~0. The defect is in velocity *generation* (the per-tick ramp in `behaviorAtGameTick`/
+   `updateAnimation`), so the flyer needs its own fix. (Instantaneous `speed` sample is noisy — 2.0 OFF
+   vs 0.2 ON — because the homing velocity oscillates; displacement is the reliable cumulative signal.)
 
 ## Resolved decisions & remaining implementation choices
 
-1. **Stages 1 + Stage-3-creature-movement committed; creature/combat pacing being restored to vanilla
-   wall-clock difficulty** (user decision 2026-07-13). Update (2026-07-14): projectiles + debris are a
-   genuine open deferral (real server-side defect, blocked on a `/test` combat harness to validate) —
-   see "Remaining work" item 4. This is NOT "acceptable"/waved-off; it's tracked open work with a
-   concrete recipe. Everything else is fixed or proven-no-effect.
+1. **Stages 1 + 3 committed; creature/combat pacing restored to vanilla wall-clock difficulty**
+   (user decision 2026-07-13). **DONE (2026-07-14):** projectiles + debris built (prefix sub-step) and the
+   `/test` combat probe built + validated; the flyer/knockback velocity-decay bug found via that probe and
+   fixed in two parts. Full suite green (158 passed). Everything is fixed or proven-no-effect.
 2. Farmer event movement: **SETTLED — scale** (evidence, 2026-07-13). `Farmer.MovePositionImpl:8595`
    bypasses the collision probe for scripted event moves (`|| flag`), and the farmer event arrival
    margin self-scales (`16f + movementSpeed`, `Event.cs:5236`), so neither collision-tunnel nor
@@ -364,22 +420,121 @@ server-side (`IsDedicatedHost=false`), not client-side.**
    `= constant` assignment (state reset / threshold snap), not a per-tick stepper. So during a
    wedding `globalFade` the sole per-tick contributor IS `UpdateGlobalFade` — which the patch scales.
    The "terminal plunge" is therefore a `= constant` jump or completion-threshold snap in the
-   *baseline* trace, NOT a second per-tick stepper the patch must also compensate. The remaining
-   **runtime gate** (instrument `fadeToBlackAlpha` per tick in one wedding run) is now a confirmation
-   of this static conclusion, not an open mechanism question — deferred to the test-run phase.
+   *baseline* trace, NOT a second per-tick stepper the patch must also compensate. This is not open work:
+   the fade FIX is validated end-to-end (WeddingTests green — the wedding `globalFade` gates event
+   completion, and both ceremonies complete with no hang across every wedding run). A per-tick
+   `fadeToBlackAlpha` instrumentation would only redundantly confirm the already-resolved static
+   conclusion; it is not a gate the fix depends on.
+
+## Velocity-decay-over-substep bug (diagnosed 2026-07-14, fix DESIGN for review — NOT yet coded)
+
+**The defect.** Every `MovePosition` variant has TWO mutually-exclusive movement paths, chosen per call by
+`if (xVelocity != 0 || yVelocity != 0)`:
+- **Velocity path** — knockback/glider movement: `position += xVelocity; xVelocity -= xVelocity/k` (a
+  per-*call* multiplicative friction decay; `k = Slipperiness` for `Monster`, `k = 2` i.e. 50%/call for
+  `Character.applyVelocity`).
+- **Walk path** — pathfind/schedule movement driven by `speed + addedSpeed` (the per-tick constant that
+  SHOULD sub-step).
+
+The shipped Stage 1/3 sub-steps run the WHOLE method `floor(carry)` times. That correctly repeats the walk
+path, but it ALSO repeats the velocity path — so the friction decay applies N× per tick (~40%/tick for a
+Bat's Slipperiness≈24 at 12 sub-steps; ~99.98%/tick for Character's 50%/call). Result:
+- **Knockback** (all monsters + NPCs — `takeDamage`→`setTrajectory` sets velocity): monsters/NPCs get
+  knocked back far LESS than at 60 TPS (velocity collapses before it can carry them).
+- **Fliers/gliders** (`isGlider==true`: Bat, Fly, Serpent, Ghost, AngryRoger — ALWAYS velocity-driven, they
+  `return` before the walk path at `Monster.cs:1132`): their velocity ramp (`behaviorAtGameTick`/
+  `updateAnimation`, once/tick, `+= num4/6f`) can't outrun the N× decay, so they're near-stationary.
+  MEASURED at TPS 5: 15px (all off) / 38px (shipped patches on) net displacement in 3s vs ~1920px at 60 TPS.
+
+**Corrects a false claim in this plan:** the Stage 3 table said whole-method sub-step "reproduces vanilla's
+60Hz knockback decay exactly." It does the opposite — it MULTIPLIES the decay by the sub-step count.
+
+**Scope (verified by reading each override):** `Character.applyVelocity` (NPCs, `Character.cs:810`),
+`Monster` velocity path (`Monster.cs:1018-1134`). `FarmAnimal.MovePosition` has NO velocity/friction path
+(tile-based) — unaffected. `Child` inherits via the Character seam (rare knockback — low impact, same fix).
+
+**Fix design (two independent parts):**
+1. **Walkers' knockback — DONE + VALIDATED (2026-07-14, run `2026-07-14T20-37-22Z`).** A prefix
+   (`MovePosition_CaptureVelocity_Prefix`) captures pre-call velocity into `__state`; the sub-step postfix
+   skips the extra steps when `__state` is true (entity was velocity-driven this tick), so the velocity
+   path's per-call friction decay runs once per tick, not N×. Applied to all four seams (Character/Monster/
+   FarmAnimal/Child) via the shared prefix. Gated by a new `knockback` combat probe (spawn a GreenSlime,
+   `setTrajectory(100,0)` impulse, measure slide): **knockback carried the slime 396px at TPS 5** —
+   matching the ~400px 60-TPS distance (impulse 100 / Slipperiness¼-decay); pre-fix the 12×/tick decay
+   collapsed it to tens of px. Projectile (1536px) and debris (1/1) unchanged — no regression. LOW risk
+   confirmed: the change only skips erroneous extra decay; normal walking (velocity==0) sub-steps as before
+   (verified: `Character.MovePosition:841` walk vs velocity paths are mutually exclusive; NPC schedule walk
+   never sets `xVelocity`).
+2. **Gliders (fliers): need ramp + velocity-move both at wall-clock.** Part 1 makes a glider's velocity path
+   run once/tick — correct decay — but a glider is ALWAYS velocity-driven, so once/tick position advance =
+   `velocity` px/tick = 12× slow at TPS 5 (probe-confirmed: ~19px/3s with part 1). To move at wall-clock
+   speed the glider's per-tick VELOCITY GENERATION (the ramp in `behaviorAtGameTick`/`updateAnimation`) AND
+   its velocity integration (`MovePosition`) must both run ~12×/tick — i.e. **N×-replay the glider's whole
+   per-tick trio** (MovePosition + behaviorAtGameTick + updateAnimation), zero-time on the extra N-1 calls.
+
+   **Faithfulness audit DONE (2026-07-14, all 5 gliders, verified against source on the load-bearing lines).**
+   N×-replay-with-zero-time is SAFE — the zero-time trick is what makes it faithful and non-destructive:
+   - **Bat, Ghost, AngryRoger: fully N×-faithful.** Their rotation gate resets `wasHitCounter` to `0`
+     (`Bat.cs:637`, `Ghost.cs:231`, `AngryRoger.cs:149`), so the steering re-runs every replay call — exactly
+     what 60 TPS does every tick. Velocity/friction/position repeat correctly.
+   - **Fly, Serpent: travel SPEED faithful, HEADING slightly off.** Their rotation gate sets
+     `wasHitCounter = 5 + Game1.random.Next(-1,2)` (`Fly.cs:199`, `Serpent.cs:510`); under zero-time it never
+     decays across replays, so heading steps once per REAL tick instead of tracking the 60-TPS ~16ms decay.
+     Velocity integrates N× (travel speed correct); only turn-tracking lags slightly. This is the ONE
+     vanilla deviation.
+   - **All dangerous side effects are protected by zero-time.** The load-bearing one: Ghost's tongue-
+     projectile spawn (`Ghost.cs:393-399`) is gated by `stateTimer <= 0` (a `TotalSeconds` timer, `:317/379`)
+     that sets `stateTimer = 1f` on fire — zero-time freezes it so the projectile spawns AT MOST ONCE per
+     real tick (verified: nonzero elapsed on extra calls would spawn up to N projectiles). Sounds are
+     headless no-ops (audio disabled); LightSource/particle blocks are `currentLocation==Game1.currentLocation`
+     or `cursedDoll`/Putrid-variant gated (off for plain monsters on the render-suppressed server). Residual:
+     Ghost/AngryRoger's invincible-overlap teleport (`Ghost.cs:414-435`) isn't time-gated and can re-roll
+     2-3× per tick — but self-limits (`Halt()` + 64px position jump makes the next replay's `Intersects` fail).
+   - **ms-terms needing zero-time:** Bat `529/560/578/665`, Fly `156/161`, Serpent `470`, Ghost `168/317`;
+     AngryRoger has none.
+
+   **The fidelity/safety tension (Fly/Serpent heading):** the fix for the heading lag is to pass ~16ms (one
+   60-TPS tick) to extra calls instead of zero — then `wasHitCounter` decays exactly as across real ticks.
+   But ~16ms is UNSAFE for Ghost (it would un-freeze `stateTimer` and multiply the projectile). So exact
+   heading fidelity and side-effect safety can't both use a single global elapsed value — see the decision
+   below (per-type elapsed, or accept the minor heading lag).
+
+   **Part 2 — DONE + VALIDATED (2026-07-14, run `2026-07-14T21-10-30Z`, zero-time everywhere per user
+   decision).** A postfix on `Monster.update` (gated to `isGlider.Value`) replays the trio
+   `MovePosition` + `behaviorAtGameTick` + `updateAnimation` in vanilla order, `extraSteps` times with
+   `ZeroElapsedGameTime`. `updateAnimation` is `protected` so it's invoked via a per-concrete-type cached
+   `AccessTools.MethodDelegate` (virtual dispatch to the right override, no per-call reflection). The
+   `_inSubStep` guard suppresses the inner MovePosition postfix during replay; a `Health <= 0` break stops
+   replaying a monster that died mid-step. **Result: Bat homing displacement 15px (unpatched) → 19px
+   (part 1) → 766px (part 2)** in 3s at TPS 5, speed 0.2 → 5.4 (reaches terminal velocity) — it now reaches
+   the host and overshoots, faithful homing. No server error, boot log `ENABLED`. The `FlyerMonster` probe
+   test is tightened to `≥ 400px` (cleanly separates 766 fixed from ~19 unfixed).
+
+   Zero-time chosen over distributed-ms because TPS is a fluctuating target (TickScale already reads actual
+   per-tick ms), so the Fly/Serpent heading-lag is within vanilla's own tick variance; distributed-ms would
+   also un-freeze Ghost's `stateTimer` and multiply its projectile.
+
+   Seam note: replay the three METHODS directly (not the whole `Monster.update`) — `update` has
+   `parryEvent/trajectoryEvent/deathAnimEvent.Poll()` + `invincibleCountdown`/`stunTime` ms-timers
+   (`Monster.cs:690/712`) and `Character.update`'s emote/jump surface, none of which the faithfulness audit
+   covered; the trio is exactly what was audited safe.
+
+**Re-validation:** the combat probe already measures all of this — tighten `FlyerMonster` to a real
+threshold once the glider fix lands, and add a knockback probe (`takeDamage` the bat, measure knockback
+displacement) to gate part 1.
 
 ## Remaining work to close the plan (ordered; nothing left implicit)
 
 The plan closes only when every inventory row is fixed-or-proven and the mission gate (correct
 wall-clock at arbitrary TPS) is observed. What is left, in recommended order:
 
-1. **Non-integer-TPS runtime gate (highest value — the one untested code path).** Every test so far ran
-   at `SERVER_TPS=5` = integer scale 12.0; the fractional-carry branch (`_moveCarry` keeping ~0.4
-   remainders) has NEVER executed under test. Re-run `WeddingTests` (and ideally a schedule-walk probe)
-   at a non-integer `SERVER_TPS` (e.g. 24 → scale 2.5) and confirm NPC/Lewis movement completes in the
-   same wall-clock ±10% with no drift/jitter. Worst case if skipped: at a non-integer production TPS,
-   NPCs walk subtly wrong. Cheapest close: one `make test-llm FILTER=WeddingTests` run with
-   `SERVER_TPS`/`CLIENT_TPS` overridden to 24.
+1. **Non-integer-TPS runtime gate — DONE (2026-07-14, run `2026-07-14T00-36-30Z_429fe85`).** Ran
+   `WeddingTests` with `SERVER_TPS=CLIENT_TPS=24` (scale 2.5) — the fractional-carry branch's first
+   execution under test. PASSED: both hosts confirmed at `41.7ms`/tick, both clients rendered both
+   ceremonies, and both event-farmer `waitForOtherPlayers` gates auto-readied on arrival (proof the
+   fractional sub-step hits the fixed 16px arrival window — no tunnel/overshoot), ceremony spans
+   ~31-34s (comparable to the ~37s TPS-5 baseline, both pause-dominated), no pacing error. `.env.test`
+   restored to TPS 5. Full write-up under "Runtime post-condition gates" → gate 3.
 2. **Kill-switch A/B + config-consumed gate.** Wire `SDVD_TPS_AGNOSTIC_PACING` into the container env
    (`ServerContainer.cs` + the client container builder, via `.WithEnvironment` reading
    `TestEnvLoader.Get`), then run `WeddingTests` with it `=false` and confirm movement reverts to ~12×
@@ -387,19 +542,39 @@ wall-clock at arbitrary TPS) is observed. What is left, in recommended order:
    any user-facing docs yet, so no operator is currently misled; if/when it's documented, this gate must
    pass first. Worst case if skipped: the documented escape hatch silently doesn't disable — low
    severity (default-on is the tested path).
-3. **Stage 2 sweep — finish the audit.** Remaining unclassified per-tick sites: `Utility` ambient
-   spawns, `GameLocation.updateEvenIfFarmerIsntHere` non-character per-tick constants, world-update
-   int-countdown timers. Classify each fixed / proven-no-effect (most SDV world code has been ms-based
-   so far — expect mostly proven-no-effect). Extend the Stage 2 table until the sweep list is empty.
-4. **Stage 3 projectiles + debris (genuine deferral — real defect, needs a harness).** The server DOES
-   simulate mine monsters/projectiles (resolved above), so a fireball at low TPS really crawls for a
-   client in the mines. To close: (a) add a `/test/spawn_monster` + `/test/fire_projectile` +
-   `/test/drop_debris` endpoint set and a measurement test (fire at TPS 5 vs 60, ±10% wall-clock); then
-   (b) implement — Projectile: sub-step the collision-bearing slice of `Projectile.update` (so
-   `isColliding` runs per sub-step, no tunneling) with `travelTime += ms` counted once via the zero-time
-   technique; Debris: sub-step `updateChunks` (self-contained — physics+pickup+bounce all in one loop —
-   zero-time for any ms terms). The creature-movement half already fixes the monsters' *walking*; only
-   their *projectiles* remain slow.
+3. **Stage 2 sweep — DONE (2026-07-14).** Full audit complete (see the Stage 2 progress section): every
+   site fixed or proven-no-effect. The one broken site it surfaced (flyer velocity/rotation) traced to the
+   velocity-decay-over-substep bug, now fixed.
+4. **Stage 3 projectiles + debris — DONE + validated (2026-07-14).** Prefix sub-step for
+   `Projectile.update` (collision per sub-step, no tunneling, `travelTime` counted once via zero-time) and
+   `Debris.updateChunks`; combat probe (`/test/pacing_probe_spawn` + `_state`) + `PacingProbeTests` gate it
+   (projectile 1536px, debris settles). The velocity-decay bug found via the same probe is fixed (parts 1+2
+   above). Full suite green.
+
+**Landmine (glider sub-step, hit + fixed 2026-07-14):** `AccessTools.Method(type, "update")` name-only
+lookup on `Monster.update` threw `AmbiguousMatchException` at runtime (`Apply()` → "Mod crashed on entry",
+so NO patches applied that run) — because `Character` has two `update` overloads (`(GameTime,GameLocation)`
+and `(GameTime,GameLocation,long,bool)`). `dotnet build` is BLIND to this (it's a runtime reflection
+resolve). Fix: pass explicit parameter types `new[]{typeof(GameTime),typeof(GameLocation)}`. Rule: any
+Harmony `AccessTools.Method` targeting a method that has overloads (anywhere in its inheritance chain) MUST
+specify parameter types; a green build does not prove the registration resolves.
+
+**Landmine (combat probe, hit + fixed 2026-07-14):** the empty (player-less) server auto-pauses
+(`AlwaysOn.HandleAutoPause` sets `netWorldState.IsPaused` when `otherFarmers.Count == 0`), and
+`Game1.HostPaused` then gates out the ENTIRE `UpdateCharacters`/`UpdateLocations` block (`Game1.cs:4308`)
+— so on a `Clients=0` server NOTHING in the world ticks and every probe reads `0,0`. (This is a distinct
+gate from `shouldTimePass()`/`IsTimePaused`, which I'd checked; `IsPaused`→`HostPaused` gates the update
+call itself, one level up.) Fix: `PacingProbeTests` connects one client (`Clients=1`) to unpause — also the
+realistic scenario, since a present player is exactly when these entities simulate.
+
+**Landmine (combat probe, hit + fixed 2026-07-14):** `ApiService` is reflected by the `openapi-generator`
+at Docker build time via `Assembly.GetType("…ApiService")` across the net10-tool / net6-mod boundary. A
+StardewValley-typed **field** on `ApiService` (the probe stored `Projectile?`/`Debris?`/`Monster?`/`Vector2`)
+makes that `GetType` return null → build fails "ApiService type not found" — even though `dotnet build` is
+green (the field types load fine in-process, just not in the tool's reflection context). Fix: store probe
+entities as `object?` + coords as `float`, cast back inside the game-thread handlers. Extends
+`openapi-generator-reflection-invoke` from method-args to field-types. Reproduce locally before a run:
+`dotnet tools/openapi-generator/bin/Release/net10.0/openapi-generator.dll mod/JunimoServer/bin/Debug/net6.0/JunimoServer.dll out.json`.
 
 **One durable landmine to remember:** the movement sub-step passes `ZeroElapsedGameTime` to extra steps
 so ms-based accumulators count once. Any future patch that sub-steps a method must apply the same

--- a/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
+++ b/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
@@ -1,11 +1,35 @@
 # Make gameplay TPS-agnostic at arbitrary TPS (fades, movement, and the tick-scaled-logic audit)
 
-Planned 2026-07-13, no code changes yet. **Mission:** the server must produce *correct, wall-clock
-gameplay* at any `SERVER_TPS` (production runs arbitrary values; 5 is the proven test/CI value, 60
-the vanilla reference), and the test client must behave like a real-time client at any
-`CLIENT_TPS`. Test speed is a beneficiary, not the goal. Every mechanism claim below was verified
-by reading the cited decompiled source; items not yet read are listed as explicit audit tasks with
-a recipe — nothing is assumed.
+Planned 2026-07-13. **Mission:** the server must produce *correct, wall-clock gameplay* at any
+`SERVER_TPS` (production runs arbitrary values; 5 is the proven test/CI value, 60 the vanilla
+reference), and the test client must behave like a real-time client at any `CLIENT_TPS`. Test speed
+is a beneficiary, not the goal. Every mechanism claim below was verified by reading the cited
+decompiled source; items not yet read are listed as explicit audit tasks with a recipe — nothing is
+assumed.
+
+## STATUS (2026-07-14) — implemented on branch `bugfix/tps-agnostic-pacing`
+
+Worktree: `repos/server-worktrees/tps-agnostic-pacing` (branched off `master`, NOT the sibling
+`wedding-speedup` worktree which a different session owns). **3 commits, NOT pushed** — awaiting
+review:
+- `61cb065` perf: Stage 1 — fade scaled-step, NPC/event-actor sub-step, farmer-event scale, kill-switch, both-mod registration.
+- `5617a33` fix: corrected the wrong `IsDedicatedHost=false` comments + recorded Stage 1 validation.
+- `a4f4c50` perf: Stage 3 creature movement (Monster/FarmAnimal/Child sub-step) + the zero-time ms-timer correctness fix.
+
+All code lives in `mod/JunimoServer.Shared/TpsAgnosticPacing.cs`, registered from
+`mod/JunimoServer/ModEntry.cs` (`LoadServiceDependencies`) and `tests/test-client/ModEntry.cs`
+(`Entry`). Six patches: `ScreenFade.UpdateGlobalFade`, `Character/Monster/FarmAnimal/Child.MovePosition`,
+`Farmer.getMovementSpeed`. Kill-switch env var `SDVD_TPS_AGNOSTIC_PACING` (default on).
+
+**DONE + validated:** Stage 1 (fades + NPC/farmer-event movement) and Stage 3 creature movement.
+WeddingTests green twice (both clients render both ceremonies — scenario confirmed via log, not just
+the check); full suite 129 passed (the lone failure was an unrelated 504 infra flake that passes in
+isolation); CPU noise-level (median tick 0.22ms / 200ms budget).
+
+**OPEN (see "Remaining work to close the plan" at the bottom):**
+1. Stage 2 audit — a few sweep items still unclassified (Utility ambient spawns, world-update int-timers).
+2. Stage 3 projectiles + debris — audited, NOT built; the server DOES simulate mine monsters/projectiles (master-authority), so this is a genuine deferral needing a `/test` combat probe to validate.
+3. Two unexercised runtime gates — kill-switch A/B (not wired into container env) and the arbitrary/non-integer-TPS matrix (the fractional-carry path has never run in a test).
 
 **Strategic boundary (CPU):** TPS 5 exists to cut simulation cost. "TPS-agnostic" therefore means
 wall-clock-correct *outcomes* for gameplay-relevant mechanics — not sub-stepping the whole game
@@ -86,7 +110,7 @@ correctness > animation smoothness.
 
 | Site | Mechanism (verified) | Why deferred |
 |---|---|---|
-| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile`) | `velocity += acceleration; position += velocity` per call (all `NetField.Value`), unscaled — a fireball at TPS 5 travels 1/12 speed | (1) **Collision is checked OUTSIDE the physics step** — `Projectile.update` calls `updatePosition` then `isColliding` ONCE per tick, so sub-stepping only `updatePosition` still tunnels; a correct fix must sub-step the collision-bearing slice of `update` and avoid N-counting its `travelTime += ms` grace-period timer. (2) **All projectile-firing monsters are MINE/dungeon monsters** (Ghost, Skeleton, ShadowShaman, SquidKid…) — the dedicated farm server never simulates them; real players fight them client-side at 60 TPS. (3) **No E2E test spawns a monster/projectile and there's no `/test` combat probe**, so no runtime gate exists to validate a fix per the plan's own gate standard. Necessity on this server's actual deployment is marginal; building a combat-probe harness is a disproportionate sub-project. |
+| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile`) | `velocity += acceleration; position += velocity` per call (all `NetField.Value`), unscaled — a fireball at TPS 5 travels 1/12 speed | **The server DOES simulate these** (correction — an earlier draft wrongly said it never does): mine monster AI + firing is gated on `Game1.IsMasterGame`, which is always true here (`multiplayerMode=2`, per `masterplayer-is-player-on-server`), and `MineShaft.UpdateMines` (`Game1.cs:5842`, in the server update loop) ticks every level in `activeMines` — a level is active whenever a client is in it. So a client fighting in the mines at `SERVER_TPS=5` faces server-simulated projectiles crawling at 1/12 speed (trivially dodgeable) — a **real gameplay defect**. Deferred anyway because: (1) **collision is checked OUTSIDE the physics step** — `Projectile.update` calls `updatePosition` then `isColliding` ONCE per tick, so sub-stepping only `updatePosition` still tunnels; a correct fix must sub-step the collision-bearing slice of `update` and count its `travelTime += ms` grace-period timer once (the zero-time technique); (2) **no E2E test spawns a monster/projectile and there is no `/test` combat probe**, so there is no runtime gate to validate a fix per this plan's own gate standard. This is a genuine deferral (build a combat probe + fix), NOT a proven-no-effect. |
 | `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/Euler, unscaled | Physics + pickup + bounce checks are all self-contained in `updateChunks` (no external-collision tunneling, unlike projectiles — more tractable). Still DEFERRED for the same reason (3): no test exercises debris landing/pickup at low TPS, so no runtime gate. Debris settles ~12× slower at TPS 5 (item drops drift longer before resting) — a real but low-severity cosmetic-adjacent effect. |
 
 **TODO (concrete, per `holistic-or-explicit-todo`):** to close projectiles+debris, add a `/test/spawn_monster`
@@ -316,18 +340,21 @@ server-side (`IsDedicatedHost=false`), not client-side.**
 
 ## Resolved decisions & remaining implementation choices
 
-1. **All three stages committed; creature/combat pacing fixed to vanilla wall-clock difficulty**
-   (user decision 2026-07-13). Audit outcomes are restricted to fixed or proven-no-effect —
-   nothing deferred, nothing "acceptable".
+1. **Stages 1 + Stage-3-creature-movement committed; creature/combat pacing being restored to vanilla
+   wall-clock difficulty** (user decision 2026-07-13). Update (2026-07-14): projectiles + debris are a
+   genuine open deferral (real server-side defect, blocked on a `/test` combat harness to validate) —
+   see "Remaining work" item 4. This is NOT "acceptable"/waved-off; it's tracked open work with a
+   concrete recipe. Everything else is fixed or proven-no-effect.
 2. Farmer event movement: **SETTLED — scale** (evidence, 2026-07-13). `Farmer.MovePositionImpl:8595`
    bypasses the collision probe for scripted event moves (`|| flag`), and the farmer event arrival
    margin self-scales (`16f + movementSpeed`, `Event.cs:5236`), so neither collision-tunnel nor
    arrival-overshoot applies — scaling is provably safe here (the two reasons NPCs need sub-step are
    both absent). Sub-step remains the drop-in fallback if a runtime gate shows the groom teleporting.
-3. Projectile/debris simulation authority: the audit determination selects the fix SITE — a
-   host-side patch if server-simulated, or a recorded proof that only real 60 TPS vanilla
-   clients execute the code (in which case there is no defect on any instance we run). Either
-   way the inventory entry closes as fixed-or-proven, never waved off.
+3. Projectile/debris simulation authority: **RESOLVED — server-simulated** (2026-07-14). Monster AI +
+   firing is gated on `Game1.IsMasterGame` (always true here, `multiplayerMode=2`), and
+   `MineShaft.UpdateMines` (`Game1.cs:5842`, server update loop) ticks every level a client is in. So
+   the fix SITE is a **host-side patch** — the defect is real on our server whenever a client is in the
+   mines. (Corrects an earlier draft that wrongly claimed the server never simulates mine monsters.)
 4. The wedding fade's measured ~10s vs the naive 28.6s model: slow phase matches 0.007/tick
    exactly; the terminal ~4s plunge has an unidentified second contributor. **Static narrowing
    done (2026-07-13):** grepping every `fadeToBlackAlpha` writer in `ScreenFade.cs` + `Game1.cs`
@@ -340,3 +367,42 @@ server-side (`IsDedicatedHost=false`), not client-side.**
    *baseline* trace, NOT a second per-tick stepper the patch must also compensate. The remaining
    **runtime gate** (instrument `fadeToBlackAlpha` per tick in one wedding run) is now a confirmation
    of this static conclusion, not an open mechanism question — deferred to the test-run phase.
+
+## Remaining work to close the plan (ordered; nothing left implicit)
+
+The plan closes only when every inventory row is fixed-or-proven and the mission gate (correct
+wall-clock at arbitrary TPS) is observed. What is left, in recommended order:
+
+1. **Non-integer-TPS runtime gate (highest value — the one untested code path).** Every test so far ran
+   at `SERVER_TPS=5` = integer scale 12.0; the fractional-carry branch (`_moveCarry` keeping ~0.4
+   remainders) has NEVER executed under test. Re-run `WeddingTests` (and ideally a schedule-walk probe)
+   at a non-integer `SERVER_TPS` (e.g. 24 → scale 2.5) and confirm NPC/Lewis movement completes in the
+   same wall-clock ±10% with no drift/jitter. Worst case if skipped: at a non-integer production TPS,
+   NPCs walk subtly wrong. Cheapest close: one `make test-llm FILTER=WeddingTests` run with
+   `SERVER_TPS`/`CLIENT_TPS` overridden to 24.
+2. **Kill-switch A/B + config-consumed gate.** Wire `SDVD_TPS_AGNOSTIC_PACING` into the container env
+   (`ServerContainer.cs` + the client container builder, via `.WithEnvironment` reading
+   `TestEnvLoader.Get`), then run `WeddingTests` with it `=false` and confirm movement reverts to ~12×
+   slow (proves the knob is consumed, per `verify-documented-config-is-consumed`). The env var is NOT in
+   any user-facing docs yet, so no operator is currently misled; if/when it's documented, this gate must
+   pass first. Worst case if skipped: the documented escape hatch silently doesn't disable — low
+   severity (default-on is the tested path).
+3. **Stage 2 sweep — finish the audit.** Remaining unclassified per-tick sites: `Utility` ambient
+   spawns, `GameLocation.updateEvenIfFarmerIsntHere` non-character per-tick constants, world-update
+   int-countdown timers. Classify each fixed / proven-no-effect (most SDV world code has been ms-based
+   so far — expect mostly proven-no-effect). Extend the Stage 2 table until the sweep list is empty.
+4. **Stage 3 projectiles + debris (genuine deferral — real defect, needs a harness).** The server DOES
+   simulate mine monsters/projectiles (resolved above), so a fireball at low TPS really crawls for a
+   client in the mines. To close: (a) add a `/test/spawn_monster` + `/test/fire_projectile` +
+   `/test/drop_debris` endpoint set and a measurement test (fire at TPS 5 vs 60, ±10% wall-clock); then
+   (b) implement — Projectile: sub-step the collision-bearing slice of `Projectile.update` (so
+   `isColliding` runs per sub-step, no tunneling) with `travelTime += ms` counted once via the zero-time
+   technique; Debris: sub-step `updateChunks` (self-contained — physics+pickup+bounce all in one loop —
+   zero-time for any ms terms). The creature-movement half already fixes the monsters' *walking*; only
+   their *projectiles* remain slow.
+
+**One durable landmine to remember:** the movement sub-step passes `ZeroElapsedGameTime` to extra steps
+so ms-based accumulators count once. Any future patch that sub-steps a method must apply the same
+technique for any ms-based term inside it (`blockedInterval`, `travelTime`, timers) — running them N×
+per tick is the recurring bug class. The position/velocity per-tick constants are what SHOULD sub-step;
+ms-based timers/corrections must NOT.

--- a/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
+++ b/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
@@ -51,7 +51,7 @@ Registered on both mods (`JunimoServer/ModEntry.cs` `LoadServiceDependencies`, `
 
 | Site | Mechanism (verified) | Fix (primitive) | Impact at TPS 5 |
 |---|---|---|---|
-| `ScreenFade.UpdateGlobalFade()` (`ScreenFade.cs:128-170`) | `fadeToBlackAlpha ±= globalFadeSpeed` per call, unscaled; single call site `Game1.cs:3921-3923`. `globalFadeSpeed` is read only inside this method (grep-confirmed across the decompiled tree) | **Scaled step (1)** — prefix inflates `globalFadeSpeed *= TickScale`, vanilla runs its own body + completion + `IsDedicatedHost` snap, postfix restores. No private-field re-implementation. NO-OP on the render-suppressed host (fade snaps instantly there); bites on the real test client | Cutscene fades ~12× slow (wedding: ~10s measured vs ~2.4s real-time) |
+| `ScreenFade.UpdateGlobalFade()` (`ScreenFade.cs:128-170`) | `fadeToBlackAlpha ±= globalFadeSpeed` per call, unscaled; single call site `Game1.cs:3921-3923`. `globalFadeSpeed` is read only inside this method (grep-confirmed across the decompiled tree) | **Scaled step (1)** — prefix inflates `globalFadeSpeed *= TickScale`, vanilla runs its own body + completion + `IsDedicatedHost` snap, postfix restores. No private-field re-implementation. **CORRECTION (verified 2026-07-13, was wrong in the original plan):** `IsDedicatedHost` is **FALSE** on this server — the mod deliberately does NOT set `hasDedicatedHost` (`AlwaysOn.OnSaveLoaded:212`; confirmed by the existing comment at `AlwaysOn.cs:673` "IsDedicatedHost is false here"). So the server runs the *incremental* fade branch and the patch is **LIVE and load-bearing server-side** (a wedding `globalFade` gates the host's event completion ~12× slow). On the **test client** the fade is instead forced INSTANT by the pre-existing `ConvenienceTweaks.PatchInstantFades` (a separate `UpdateGlobalFade` postfix snapping alpha to terminus, in place since 2026-02-08) — so this scaling is **overridden there** (intended: the harness wants instant, not merely fast, fades). Net: fade patch fixes the **server**, inert on the test client. | Server-side wedding `globalFade` ~12× slow (gates event completion) |
 | `Character.MovePosition` (`Character.cs:824-975`) | `position ±= speed + addedSpeed` per direction, gated by per-step `isCollidingPosition(nextPosition(dir))`; `time` used only for animation + `blockedInterval` (ms-scaled). `NPC.MovePosition` (`NPC.cs:3085-3092`) is a thin `movementPause` gate over `base.MovePosition`, so one seam covers villagers AND event actors | **Sub-step (2)** — postfix runs `floor(carry += TickScale) − 1` extra full vanilla steps under a re-entrancy guard; never scales the per-step delta (would tunnel the collision probe / overshoot the fixed-16px event NPC arrival window at `Event.cs:5259`) | All NPC walking 12× slow **server-wide** — verified: `_UpdateLocation` → `updateEvenIfFarmerIsntHere` (`Game1.cs:5871`) runs `updateCharacters` → `NPC.update` → `MovePosition` for EVERY location each tick (`Utility.ForEachLocation`), so inactive-location villagers walk (not teleport) their schedules and lag the real-time clock. Event choreography crawls (Lewis: 6.4s vs 0.5s) |
 | `Farmer.getMovementSpeed()` event branch (`Farmer.cs:8083`) | `Max(1, speed + farmerAddedSpeed…)` per tick — unscaled (the free-move branch `:8069-8081` already ms-scales by `ElapsedGameTime.Milliseconds`) | **Scaled step (1)** — postfix scales `__result *= TickScale` only on the event branch (detected by `CurrentEvent != null && !playerControlSequence`). Safe to scale (unlike NPCs): scripted event moves BYPASS the collision probe (`Farmer.MovePositionImpl:8595` `\|\| flag` where `flag = eventUp && !isFestival && !playerControlSequence`), so no collider to tunnel, and the farmer event arrival margin self-scales with the returned speed (`16f + movementSpeed`, `Event.cs:5236`), so no overshoot. *(Plan's earlier "collisions cleared at Event.cs:10879" citation was wrong — that line RE-ENABLES collisions at event end; the real mechanism is the `flag` bypass in `MovePositionImpl`.)* | Farmer event/cutscene movement 12× slow |
 
@@ -63,6 +63,9 @@ Registered on both mods (`JunimoServer/ModEntry.cs` `LoadServiceDependencies`, `
 | `FarmAnimal.MovePosition` (`FarmAnimal.cs:2099+`) | Own implementation; `Game1.IsClient` early-return proves server-side simulation | Step mechanics, grazing/follow timers |
 | `Child.MovePosition` (`Child.cs:157+`) | Own implementation, bypasses the `Character` seam (verified via override grep) | Body unread — audit then fix (farmhouse children are world NPCs like any other) |
 | `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile.cs:69-80`) | `position += velocity; velocity += acceleration` per call, unscaled — a shaman fireball at TPS 5 travels at 1/12 speed (trivially dodgeable). Projectile *timers* are ms-based (`Projectile.cs:334,365,431`) | Simulation authority (host vs client-with-location); `Debris` physics same question. Fix note: sub-step the WHOLE `updatePosition` (velocity += acceleration inside each sub-step) — that reproduces vanilla's 60Hz Euler integration exactly, so trajectories match a real client bit-for-bit; scaling only the position delta would distort them |
+| `Debris` chunk physics (`Debris.cs:763-824`) | *(promoted from Stage 2 audit)* `xVelocity += 0.8f` (capped 8f), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity Euler integration, unscaled | Same as projectiles — sub-step the whole chunk update (velocity accumulation inside each sub-step). Simulation authority + whether debris landing position matters for pickup at low TPS. Gameplay-relevant (debris = collectible drops) |
+
+**Stage 3 audit progress (2026-07-13):** Verified `Monster.MovePosition` (`Monster.cs:1011-1130`) — the knockback/velocity branch's self-substep is real: `num3 = ceil(|velocity|/bbox_dim)`, then `for (i=1..num3)` lerps the bbox and runs `isCollidingPosition` per sub-step (`:1025-1050`) — vanilla's own sub-step precedent, so the technique is engine-sanctioned. The walk-portion step (the non-velocity movement, further in the body) is the part still needing the Stage 1 sub-step primitive; `slideAnimationTimer -= ElapsedGameTime.Milliseconds` (`:1073`) is already ms-based. NOT yet fixed — Stage 3 fixes need the runtime CPU gate (compat item 4) which requires a full run.
 
 ### Verified already TPS-agnostic — do NOT touch (prevents re-litigation)
 
@@ -104,6 +107,21 @@ Sweep the server-simulated + per-instance update paths for the remaining instanc
 
 Output: this file's inventory tables extended until the sweep list is empty. The audit is part of
 the plan's deliverable — "Stage 1 shipped" does not close the plan.
+
+#### Stage 2 audit progress (2026-07-13, in progress — NOT yet complete)
+
+| Site | Mechanism | Authority | Classification |
+|---|---|---|---|
+| `Debris` chunk physics (`Debris.cs:763-824`) | `xVelocity += 0.8f` (capped), `position += velocity`, `yVelocity -= 0.25f/0.4f` per tick — gravity/velocity integration, unscaled | Server-simulated (location update) + per-instance | **Stage 3-class** (physics integration like projectiles) — sub-step the whole update. Gameplay-relevant (debris = item drops the player collects); move to Stage 3 table. NOT yet fixed. |
+| `Event` viewport pan (`Event.cs:5165-5200`, `viewportTarget`) | `Game1.viewport.X/Y += (int)viewportTarget` per tick — camera pan, unscaled | Per-instance (event copy) | **Cosmetic** — pans the *camera* (`Game1.viewport`), does not gate event progression (no arrival/collision). No-op on render-suppressed host; on the test client it only changes recording framing. Candidate scaled-step ONLY if a recording gate shows a panned cutscene is misframed; otherwise proven-no-effect. Pending decision. |
+| `GameLocation.UpdateWhenCurrentLocation` splash VFX (`GameLocation.cs:4091,4097,4112,4114`) | `random.NextDouble() < 0.1/0.005/0.5/0.9` per tick → `TemporaryAnimatedSprite` + `PlayLocal` sound | Current-location only (render-relevant) | **Cosmetic, proven-no-effect** — ambient water-splash sprites + local sounds; no gameplay state. Current-location-gated, so never runs on inactive server locations; render-only on the client. Matches the plan's "probability rolls are mostly cosmetic" prediction. |
+| `TerrainFeatures/Tree` shake (`Tree.cs:449`) | `shakeTimer -= time.ElapsedGameTime.Milliseconds` | Server + per-instance | **Already ms-scaled** — do not touch. |
+| `Buff.update` (`Buff.cs:229-249`) | `millisecondsDuration -= time.ElapsedGameTime.Milliseconds` | Server + per-instance | **Already ms-scaled** — proven-no-effect. |
+| `FairyEvent.tickUpdate` (`FairyEvent.cs:66-171`) | `timerSinceFade += ms`, `fairyPosition.X -= ms*0.1f`, `fairyPosition.Y -= ms*0.2f` | Server (`FarmEvent`) | **Already ms-scaled** — proven-no-effect. |
+| `WitchEvent.tickUpdate` (`WitchEvent.cs:108-161`) | `timerSinceFade += ms`, `witchPosition.X -= ms*0.4f`; Y-bob uses `TotalGameTime.Milliseconds` cosine phase (wall-clock, not per-tick accum) | Server (`FarmEvent`) | **Already ms-scaled** — proven-no-effect. |
+| `BirthingEvent` / `PlayerCoupleBirthingEvent` / `SoundInTheNightEvent` / `QuestionEvent` | Each references `ElapsedGameTime` (or has no per-tick motion — `QuestionEvent` only advances a `worldDate`); grep found ZERO bare per-tick float constants | Server (`FarmEvent`) | **Already ms-scaled / motionless** — proven-no-effect. |
+
+Remaining sweep list (NOT yet audited): `Utility` ambient spawns, `GameLocation.updateEvenIfFarmerIsntHere` non-character per-tick constants (beyond the current-location splash VFX already cleared), int-countdown timers across the world-update paths, `Monster.behaviorAtGameTick` timers (overlaps Stage 3). Emerging pattern: SDV *event/buff/FarmEvent* code is consistently ms-based (already TPS-agnostic); the per-tick-constant defect is concentrated in *character movement* + *fades* (Stage 1) and *physics integration* (Debris/projectiles → Stage 3). Stage 2 does NOT close until every entry lands fixed-or-proven.
 
 ## Fix framework (three primitives, shared by all stages)
 
@@ -216,9 +234,25 @@ tick-inflated parts either. The existing test-client wedding tweaks need no chan
 
 ## Runtime post-condition gates (observe, don't infer)
 
-1. Wedding E2E at TPS 5: fade-out region in the client recording ~10s → ~2.5s (same luminance
-   method as baseline); Lewis's walk no longer a multi-second crawl; per-ceremony span drops
-   ~12–14s; `weddingsRendered == 2` per client and all host gates green.
+**Gate 1 RESULT (run `2026-07-13T20-58-27Z_61cb065`, commit `61cb065`, this branch):** `WeddingTests`
+PASSED (1/1, ~180s). Both clients rendered BOTH ceremonies (`weddingsRendered == 2`, two distinct
+`weddingEnd<id>` gates each — verified in the client-log `ceremony STARTED/COMPLETED` timestamps, not
+just the green check per `passing-test-isnt-proof-the-scenario-ran`); host readied both gates, no hang.
+So Stage 1 is **no-regression** ✅. **The fade-timing sub-gate could NOT be measured on this branch**
+for two reasons discovered during the run: (a) the client fade is forced instant by the pre-existing
+`ConvenienceTweaks` tweak (so the client recording shows zero fade-to-black — my scaling is overridden
+there, as intended); (b) this branch lacks the `WeddingPaceCompressor`/`WeddingDialogueSpeedup` tweaks
+(sibling branch), so the ~37s per-ceremony span is dominated by uncapped scripted pauses + un-sped
+dialogue, swamping the fade/walk delta. Client luminance at 1fps: no frame below Y≈47. The movement
+half is validated by no-regression + source-verified mechanism (user decision 2026-07-13); a
+quantified A/B was deemed unnecessary. **Original gate-1 text below is retained but was written on the
+false premise that the client fade was 12× slow — it is instant there; the live fade defect is
+server-side (`IsDedicatedHost=false`), not client-side.**
+
+1. ~~Wedding E2E at TPS 5: fade-out region in the client recording ~10s → ~2.5s~~ — SUPERSEDED (client
+   fade is instant via `ConvenienceTweaks`). The server-side fade IS the real defect (gates event
+   completion), but the server recording is render-suppressed/1fps so it also shows no fade-to-black.
+   `weddingsRendered == 2` per client and all host gates green — CONFIRMED.
 2. **Arbitrary-TPS matrix probe** (the mission gate): a scripted NPC walk leg measured at
    SERVER_TPS ∈ {5, 20, 60} completes in the same wall-clock ±10% (instrument once via a `/test`
    probe or log timestamps). Same for a `globalFadeToBlack(0.02)` triggered via test endpoint.
@@ -227,8 +261,23 @@ tick-inflated parts either. The existing test-client wedding tweaks need no chan
    active-location movement.
 3. Fractional scale correctness: the TPS 20 case (scale 3.0) and an intentionally non-integer one
    (e.g. TPS 25 → 2.4) show no drift (carry accumulator keeps long-run distance exact).
-4. Full E2E suite green at TPS 5; CPU stats per compat item 4.
-5. Kill-switch off → 12× behavior returns (knob consumed).
+4. Full E2E suite green at TPS 5; CPU stats per compat item 4. **RESULT (run `2026-07-13T21-24-09Z`):
+   129 passed, 6 skipped, 24 canceled (StopOnFail cascade), 1 FAILED — the single failure is an
+   INFRASTRUCTURE flake unrelated to this change: `CabinPositionPersistenceTests.DummyCabin_After
+   MoveAndReconnect_...` got a `504 Gateway Timeout` on `POST /newgame` after the request stalled
+   ~120s at the `mac` host's reverse proxy under end-of-run saturation (this test queued ~933s; host
+   was running 21 concurrent extractions). Evidence it is NOT a pacing regression: (a) `failureCategory
+   == "infrastructure"`; (b) the SAME server instance (`server-6`) ran `/newgame` in 8s/15s/12s
+   repeatedly minutes earlier — no systemic slowdown; (c) across the whole run `/newgame` was ~17-19s
+   normally, only 2 outliers both at the ~120s proxy ceiling; (d) no server-side ERROR/hang in the
+   window; (e) the test is cabin-position code — no fades, no NPC/farmer movement, nothing this change
+   touches. **Isolated re-run CONFIRMED it passes (1/1) off the saturated host** — flake settled.
+   **CPU stats (13,438 `avgTickMs` samples, TPS-5 budget = 200ms): median 0.22ms, p90 5.28ms, max
+   31.89ms — ZERO samples above 100ms.** The server is never tick-bound, so the sub-step is noise-level
+   (compat item 4 satisfied) AND this independently corroborates the 504 was proxy/network, not a slow
+   game thread. Net: full-suite gate PASSED, no pacing regression.**
+5. Kill-switch off → 12× behavior returns (knob consumed). NOT yet exercised — the container env
+   doesn't wire `SDVD_TPS_AGNOSTIC_PACING`, so the A/B needs a `.WithEnvironment` addition first.
 6. Stage 3: a monster walk/attack sequence and a fired projectile measured at TPS 5 vs 60
    match wall-clock ±10% (same probe harness as gate 2); Stage 2 closes with the inventory
    showing zero unresolved entries (every row fixed or proven-no-effect).

--- a/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
+++ b/.claude/plans/bugs/tick-scaled-pacing-fades-movement.md
@@ -1,0 +1,261 @@
+# Make gameplay TPS-agnostic at arbitrary TPS (fades, movement, and the tick-scaled-logic audit)
+
+Planned 2026-07-13, no code changes yet. **Mission:** the server must produce *correct, wall-clock
+gameplay* at any `SERVER_TPS` (production runs arbitrary values; 5 is the proven test/CI value, 60
+the vanilla reference), and the test client must behave like a real-time client at any
+`CLIENT_TPS`. Test speed is a beneficiary, not the goal. Every mechanism claim below was verified
+by reading the cited decompiled source; items not yet read are listed as explicit audit tasks with
+a recipe — nothing is assumed.
+
+**Strategic boundary (CPU):** TPS 5 exists to cut simulation cost. "TPS-agnostic" therefore means
+wall-clock-correct *outcomes* for gameplay-relevant mechanics — not sub-stepping the whole game
+back to 60 TPS cost. Sub-stepping is applied per-subsystem (movement-class code is a small slice
+of tick cost; per `sdv-perf-static-audit-findings` the expensive paths are presence-gated), and
+each stage's CPU is measured, not assumed.
+
+## Background: the two timing styles
+
+Vanilla runs hard-fixed at 60 ticks/sec, so it freely mixes millisecond-accumulating code
+(`x -= time.ElapsedGameTime.Milliseconds` — stays real-time at any TPS) with per-tick constants
+(`x += 0.007f` per Update — runs `60/TPS`× slower). Our mods pin
+`TargetElapsedTime = 1000/TPS` (server: `ServerOptimizer.cs:286`; test client:
+`tests/test-client/ModEntry.cs:167`), making `ElapsedGameTime` = `1000/TPS` ms per tick. Only the
+per-tick-constant class breaks; the job is to find and compensate every *gameplay-relevant*
+instance.
+
+Sibling plan: [`one-second-handlers-fire-every-12s.md`](one-second-handlers-fire-every-12s.md)
+owns the SMAPI-internal instance (`OneSecondUpdateTicked`'s hardcoded 60-tick divisor —
+unpatchable via Harmony, needs the SMAPI source patch). This plan owns all *game-code* instances
+(Harmony-patchable from the mods).
+
+## The authority dimension: who executes what
+
+Every audited site gets classified by where it runs in our topology, because that decides impact:
+
+- **Real-player clients (vanilla, 60 TPS):** their own farmer movement, fishing, tools, menus,
+  local VFX — unaffected by server TPS. Out of scope by construction.
+- **Server-simulated:** NPCs, monsters, farm animals, world/location updates, hosted festivals,
+  day transitions — tick-scaled defects here leak into every player's gameplay (e.g. villagers
+  visibly walking at 1/12 speed while the in-game clock runs real-time, so schedules lag).
+- **Per-instance (events):** each instance runs its own event copy (weddings/festivals), so both
+  the render-suppressed host AND our TPS-throttled test clients are affected.
+- **To-determine per site:** projectiles/debris — updated from location update paths whose
+  simulation authority (host vs whichever client has the location active) must be read, not
+  guessed. An audit column, filled before fixing.
+
+## Verified inventory
+
+### Tick-scaled, gameplay-relevant — Stage 1 IMPLEMENTED (`mod/JunimoServer.Shared/TpsAgnosticPacing.cs`)
+
+Registered on both mods (`JunimoServer/ModEntry.cs` `LoadServiceDependencies`, `test-client/ModEntry.cs` `Entry`). Kill-switch `SDVD_TPS_AGNOSTIC_PACING=false`. `TickScale` reads `Game1.currentGameTime`; the per-tick sub-step carry is keyed on `Game1.ticks`. (Implemented on a fresh worktree off `master`, branch `bugfix/tps-agnostic-pacing`.)
+
+| Site | Mechanism (verified) | Fix (primitive) | Impact at TPS 5 |
+|---|---|---|---|
+| `ScreenFade.UpdateGlobalFade()` (`ScreenFade.cs:128-170`) | `fadeToBlackAlpha ±= globalFadeSpeed` per call, unscaled; single call site `Game1.cs:3921-3923`. `globalFadeSpeed` is read only inside this method (grep-confirmed across the decompiled tree) | **Scaled step (1)** — prefix inflates `globalFadeSpeed *= TickScale`, vanilla runs its own body + completion + `IsDedicatedHost` snap, postfix restores. No private-field re-implementation. NO-OP on the render-suppressed host (fade snaps instantly there); bites on the real test client | Cutscene fades ~12× slow (wedding: ~10s measured vs ~2.4s real-time) |
+| `Character.MovePosition` (`Character.cs:824-975`) | `position ±= speed + addedSpeed` per direction, gated by per-step `isCollidingPosition(nextPosition(dir))`; `time` used only for animation + `blockedInterval` (ms-scaled). `NPC.MovePosition` (`NPC.cs:3085-3092`) is a thin `movementPause` gate over `base.MovePosition`, so one seam covers villagers AND event actors | **Sub-step (2)** — postfix runs `floor(carry += TickScale) − 1` extra full vanilla steps under a re-entrancy guard; never scales the per-step delta (would tunnel the collision probe / overshoot the fixed-16px event NPC arrival window at `Event.cs:5259`) | All NPC walking 12× slow **server-wide** — verified: `_UpdateLocation` → `updateEvenIfFarmerIsntHere` (`Game1.cs:5871`) runs `updateCharacters` → `NPC.update` → `MovePosition` for EVERY location each tick (`Utility.ForEachLocation`), so inactive-location villagers walk (not teleport) their schedules and lag the real-time clock. Event choreography crawls (Lewis: 6.4s vs 0.5s) |
+| `Farmer.getMovementSpeed()` event branch (`Farmer.cs:8083`) | `Max(1, speed + farmerAddedSpeed…)` per tick — unscaled (the free-move branch `:8069-8081` already ms-scales by `ElapsedGameTime.Milliseconds`) | **Scaled step (1)** — postfix scales `__result *= TickScale` only on the event branch (detected by `CurrentEvent != null && !playerControlSequence`). Safe to scale (unlike NPCs): scripted event moves BYPASS the collision probe (`Farmer.MovePositionImpl:8595` `\|\| flag` where `flag = eventUp && !isFestival && !playerControlSequence`), so no collider to tunnel, and the farmer event arrival margin self-scales with the returned speed (`16f + movementSpeed`, `Event.cs:5236`), so no overshoot. *(Plan's earlier "collisions cleared at Event.cs:10879" citation was wrong — that line RE-ENABLES collisions at event end; the real mechanism is the `flag` bypass in `MovePositionImpl`.)* | Farmer event/cutscene movement 12× slow |
+
+### Tick-scaled, gameplay-relevant — audit the full body, then fix (Stage 3)
+
+| Site | Verified so far | To audit before fixing |
+|---|---|---|
+| `Monster.MovePosition` (`Monster.cs:1011+`) | Own implementation, does NOT route through the `Character` seam (no `base.MovePosition` call). Knockback branch already self-substeps large velocities (`ceil(|v|/bbox)` loop, `:1030-1040`) — vanilla precedent for the technique | The walk portion's step mechanics; knockback decay factors; `behaviorAtGameTick` timers. Decided: fix to vanilla wall-clock combat pacing |
+| `FarmAnimal.MovePosition` (`FarmAnimal.cs:2099+`) | Own implementation; `Game1.IsClient` early-return proves server-side simulation | Step mechanics, grazing/follow timers |
+| `Child.MovePosition` (`Child.cs:157+`) | Own implementation, bypasses the `Character` seam (verified via override grep) | Body unread — audit then fix (farmhouse children are world NPCs like any other) |
+| `Projectile.updatePosition` overrides (`BasicProjectile.cs:95-106`, `DebuffingProjectile.cs:69-80`) | `position += velocity; velocity += acceleration` per call, unscaled — a shaman fireball at TPS 5 travels at 1/12 speed (trivially dodgeable). Projectile *timers* are ms-based (`Projectile.cs:334,365,431`) | Simulation authority (host vs client-with-location); `Debris` physics same question. Fix note: sub-step the WHOLE `updatePosition` (velocity += acceleration inside each sub-step) — that reproduces vanilla's 60Hz Euler integration exactly, so trajectories match a real client bit-for-bit; scaling only the position delta would distort them |
+
+### Verified already TPS-agnostic — do NOT touch (prevents re-litigation)
+
+- Warp/screen fades: `UpdateFadeAlpha` scales by elapsed ms (`ScreenFade.cs:70,75`).
+- Farmer free movement: ms-scaled (`Farmer.cs:8071-8073`); its large per-tick step at 200ms
+  (~66px) is pre-existing behavior, separate concern.
+- `Game1.pauseTime` (`Game1.cs:5398`), `DialogueBox.safetyTimer` (`DialogueBox.cs:773`),
+  `Event.Speak` throttle (`Event.cs:171`), in-game clock (`gameTimeInterval += elapsed ms`,
+  `Game1.cs:6054`), `TemporaryAnimatedSprite` (`:1689`, `TotalMilliseconds`), projectile timers.
+
+### Remaining classified sites
+
+- `Game1.UpdateTitleScreen` fade (`Game1.cs:5663-5669`, ±0.02/tick): title screen only.
+  Stage 2 item with a required resolution — measure whether a test-client cold boot waits on
+  it; if it costs boot time, fix with primitive 1; otherwise record the proof that no boot
+  path waits on it. Not left open.
+- Structural per-tick quantization — one input sample, one network pump, one event-command
+  advance per tick: these ARE the tick; compensating them would mean changing the tick rate
+  itself, which is the rejected TPS raise. Excluded by definition, not by judgment.
+
+### Stage 2 — the completion audit (recipes, not vibes)
+
+Sweep the server-simulated + per-instance update paths for the remaining instances. Concretely:
+
+1. **Per-tick constants:** for each class in {`NPC`, `GameLocation.UpdateWhenCurrentLocation` /
+   `updateEvenIfFarmerIsntHere`, `Debris`, `Buff`, `Event` (viewport pan, `screenGlow`, shake),
+   `FarmEvent` subclasses, `Utility` ambient spawns}: read the update method(s); classify every
+   mutation as ms-scaled / per-tick / cosmetic. Grep seeds: `+= 0.0`, `-= 0.0`,
+   `ElapsedGameTime` *absence* in `update(` bodies, `Game1.ticks %`, `TicksElapsed`.
+2. **Int-countdown timers:** timers decremented by a constant per tick (`x--` / `x -= 1` in
+   update paths) — same classification.
+3. **Per-tick probability rolls:** `random.NextDouble() < p` inside per-tick update paths (event
+   frequency scales with TPS: 12× *rarer* per real second at TPS 5). Expected mostly cosmetic —
+   the gameplay spawn/regen systems hang off the ms-based 10-minute clock
+   (`performTenMinuteUpdate`) — but verify per hit; compensate gameplay-relevant ones with
+   `p' = 1 − (1−p)^scale`.
+4. **Authority column:** for every hit, record who executes it here (server / real client /
+   per-instance) before deciding to fix; real-client-only sites are dropped.
+
+Output: this file's inventory tables extended until the sweep list is empty. The audit is part of
+the plan's deliverable — "Stage 1 shipped" does not close the plan.
+
+## Fix framework (three primitives, shared by all stages)
+
+`TickScale` (float) `= ElapsedGameTime.TotalMilliseconds / (1000/60.0)` read from
+`Game1.currentGameTime` per tick — correct whenever each mod sets `TargetElapsedTime` (the test
+client sets it on first tick), and exactly 1.0 at 60 TPS (structural no-op, production default).
+**Arbitrary TPS means non-integer scales** (TPS 25 → 2.4): primitives must handle fractions.
+
+1. **Scaled step** — for continuous quantities with no collision/trigger semantics (fades):
+   multiply the per-tick delta by `TickScale`. Fractions are exact. Fade fix: Harmony prefix
+   replacing `UpdateGlobalFade` with the same body stepping `globalFadeSpeed * TickScale`,
+   preserving the `IsDedicatedHost` short-circuits and the completes-before-step ordering.
+2. **Sub-step with fractional carry** — for stepwise logic with per-step collision/arrival/
+   trigger semantics (movement): run the vanilla per-tick step `floor(carry += TickScale)` times
+   (subtracting the executed steps from the carry), never scaling the per-step delta. Rationale:
+   scaled deltas tunnel through collision probes (`isCollidingPosition(nextPosition(d))`) and
+   overshoot the event NPC arrival window (fixed 16px, `Event.cs:5259`) — an overshot arrival is
+   an event hang. The carry is per-tick global (one accumulator recomputed per game tick), so all
+   characters advance uniformly. NPC fix: Harmony postfix on `Character.MovePosition` invoking
+   the method `steps − 1` extra times under a re-entrancy guard (virtual dispatch re-enters via
+   `NPC.MovePosition`'s pause gate — correct — and the guard stops recursion; `Farmer`/`Monster`/
+   `FarmAnimal`/`Child` overrides do NOT route through this seam — verified — so they are
+   unaffected until their own stage).
+3. **Probability compensation** — for per-tick random rolls found gameplay-relevant in Stage 2:
+   replace `p` with `1 − (1−p)^TickScale` (≈ `p × TickScale` for small p), preserving expected
+   events per wall-clock second.
+
+Farmer event movement uses primitive 1 (postfix scaling `getMovementSpeed`'s event branch by
+`TickScale`): safe HERE specifically because the event arrival margin self-scales with the
+returned speed (`16f + movementSpeed`, `Event.cs:5236`) and farmer collisions are disabled during
+events (`ignoreCollisions` cleared at `Event.cs:10879`) — and it mirrors how vanilla itself
+ms-scales the free branch. Fallback if review disagrees: sub-step `Farmer.MovePosition` gated on
+the event branch.
+
+### Where the code lives
+
+One shared helper (primitives + patches) in `mod/JunimoServer.Shared` (already game-API-dependent
+— `WeddingEvent.cs` — and referenced by both mods), registered from each mod's Harmony instance:
+server-side in an unconditionally-constructed service (`harmony-patch-reachability.md` — NOT
+`PasswordProtectionService`), test-client alongside the existing GameTweaks. Open verification:
+confirm Shared can reference HarmonyLib (both hosts ship it via SMAPI); if not, duplicate the
+~40 lines per mod with keep-in-sync headers (`one-parser-per-contract.md` pointer style).
+
+**Kill-switch:** `SDVD_TPS_AGNOSTIC_PACING=false` disables all patches (default on). This changes
+long-standing behavior on low-TPS production servers; operators get an escape hatch. Consumer
+grep gate applies (`verify-documented-config-is-consumed.md`).
+
+## Staging
+
+All three stages are committed scope (decided 2026-07-13). The plan closes only when the sweep
+list is empty and every inventory entry carries one of exactly two outcomes: **fixed** with a
+primitive, or **proven-no-effect on our topology** with the proof recorded (e.g. render-only
+code that never executes on a render-suppressed instance, or code that only real 60 TPS
+vanilla clients execute). "Minor but tolerable" is not an outcome.
+
+1. **Stage 1 — fades + NPC/farmer-event movement** (table 1). Unblocks the wedding/festival test
+   pacing and fixes the most visible production defect (NPC walking). Gate before continuing.
+2. **Stage 2 — completion audit** (recipes above). Every hit gets fixed or proven-no-effect;
+   the inventory tables in this file are extended until the sweep list is empty.
+3. **Stage 3 — monsters, farm animals, children, projectiles/debris**: audit the override
+   bodies, then fix with the primitives. Decided: creature/combat pacing is restored to vanilla
+   wall-clock difficulty at any TPS — slow monsters and slow projectiles at low TPS are defects,
+   not features. The CPU cost is measured per compat item 4, not assumed.
+
+## Division of labor with the wedding-test plan
+
+[`tests-wedding-samedaytwoweddings-speedup.md`](tests-wedding-samedaytwoweddings-speedup.md)
+owns the wedding script's ms-based scripted pauses (a data-level cap — real-time holds, not a
+TPS artifact). This plan owns the ceremony's tick-inflated parts — the `globalFade`
+(~10s → ~2.4s at TPS 5) and Lewis's blocking walk (~6.4s → ~0.5s) — via the generic Stage 1
+patches. No per-script workaround exists for the tick-inflated parts, and none should be added.
+
+**Overlap review DONE (2026-07-13), no double-compensation.** NOTE: `WeddingPaceCompressor` /
+`WeddingDialogueSpeedup` live on the sibling `bugfix/wedding-samedaytwoweddings-speedup` branch
+(commit `b68be36`, unmerged), NOT on this branch's `master` base — the analysis below applies once
+the branches converge. Read the full `Data/Weddings` `default` EventScript: the timing commands are
+strictly sequential — `… move Lewis 0 3 3 true / pause 4000 / globalFade / viewport / pause 1000 /
+pause 500 / pause 4000 / waitForOtherPlayers / end`. The three mechanisms touch **disjoint** command
+types: `pause` (ms `Game1.pauseTime`, `WeddingPaceCompressor` caps to 800ms) ⊥ `globalFade` (single
+blocking command, this plan's scaled-step) ⊥ `move Lewis` (this plan's `Character.MovePosition`
+sub-step). No `pause` overlaps the `globalFade` (separate commands, event-advance is serial), so the
+pace compressor and the fade patch cannot compound. `WeddingCutscenePlayer`'s wall-clock beats
+(`BeatPauseMs`) gate the auto-clicker, which only acts while a `DialogueBox` is up — and no dialogue
+box is open during the `move`/`globalFade`/`pause` tail, so the beats don't interact with the
+tick-inflated parts either. The existing test-client wedding tweaks need no change.
+
+## Compatibility verification (per stage, per `plan-discipline.md`)
+
+1. **AlwaysOn wedding teardown** (`AlwaysOn.cs:756-782`): with real-time fades, `afterFade`
+   callbacks (e.g. `incrementCommandAfterFade`) start actually firing on the host — re-verify the
+   documented fade-clear-before-`eventFinished()` NRE ordering against the faster timeline. The
+   gate-identity guard (`_handledWeddingGate`) is position-independent by design
+   (`host-automation.md` invariant 9) — WeddingTests + FestivalTests are the gate.
+2. **Host-automation invariants** (`host-automation.md`): festival start/end, sleep flow, QiPlane
+   (draw-coupled, not update-fade-coupled — unaffected). Full-suite run required.
+3. **Replication:** NPC positions replicate from the host as data; sub-stepped movement changes
+   only per-tick distance. `Farmer.position.UpdateExtrapolation(getMovementSpeed())`
+   (`Farmer.cs:7011`) consumes the scaled event speed — watch one multi-client run for NPC/farmer
+   rubber-banding (open verification).
+4. **CPU:** compare `instance-stats.jsonl` server tick stats before/after a full run per stage.
+   Movement-class sub-stepping restores that subsystem's 60-TPS cost only; expect noise-level —
+   measure, don't assume.
+5. **Recordings/validators:** faster transitions shorten recorded segments;
+   `recorder-anchor-first-frame.md` invariants reference timing flags/anchors, not fade
+   durations — confirm with one recorded run through the validator.
+6. **Committed configs** (`preflight-check-vs-committed-config.md`): nothing is rejected;
+   TickScale=1.0 at the production-default TPS 60; CI/`.env.test` (TPS 5) → 12.0.
+7. **Interpolation** (`netfield-revert-pattern.md` adjacency): no NetField writes are reverted or
+   fought; only local simulation stepping changes.
+
+## Runtime post-condition gates (observe, don't infer)
+
+1. Wedding E2E at TPS 5: fade-out region in the client recording ~10s → ~2.5s (same luminance
+   method as baseline); Lewis's walk no longer a multi-second crawl; per-ceremony span drops
+   ~12–14s; `weddingsRendered == 2` per client and all host gates green.
+2. **Arbitrary-TPS matrix probe** (the mission gate): a scripted NPC walk leg measured at
+   SERVER_TPS ∈ {5, 20, 60} completes in the same wall-clock ±10% (instrument once via a `/test`
+   probe or log timestamps). Same for a `globalFadeToBlack(0.02)` triggered via test endpoint.
+   This also quantifies the production schedule-lag claim empirically — if inactive-location NPCs
+   turn out to teleport along schedules (unverified vanilla behavior), scope the win statement to
+   active-location movement.
+3. Fractional scale correctness: the TPS 20 case (scale 3.0) and an intentionally non-integer one
+   (e.g. TPS 25 → 2.4) show no drift (carry accumulator keeps long-run distance exact).
+4. Full E2E suite green at TPS 5; CPU stats per compat item 4.
+5. Kill-switch off → 12× behavior returns (knob consumed).
+6. Stage 3: a monster walk/attack sequence and a fired projectile measured at TPS 5 vs 60
+   match wall-clock ±10% (same probe harness as gate 2); Stage 2 closes with the inventory
+   showing zero unresolved entries (every row fixed or proven-no-effect).
+
+## Resolved decisions & remaining implementation choices
+
+1. **All three stages committed; creature/combat pacing fixed to vanilla wall-clock difficulty**
+   (user decision 2026-07-13). Audit outcomes are restricted to fixed or proven-no-effect —
+   nothing deferred, nothing "acceptable".
+2. Farmer event movement: **SETTLED — scale** (evidence, 2026-07-13). `Farmer.MovePositionImpl:8595`
+   bypasses the collision probe for scripted event moves (`|| flag`), and the farmer event arrival
+   margin self-scales (`16f + movementSpeed`, `Event.cs:5236`), so neither collision-tunnel nor
+   arrival-overshoot applies — scaling is provably safe here (the two reasons NPCs need sub-step are
+   both absent). Sub-step remains the drop-in fallback if a runtime gate shows the groom teleporting.
+3. Projectile/debris simulation authority: the audit determination selects the fix SITE — a
+   host-side patch if server-simulated, or a recorded proof that only real 60 TPS vanilla
+   clients execute the code (in which case there is no defect on any instance we run). Either
+   way the inventory entry closes as fixed-or-proven, never waved off.
+4. The wedding fade's measured ~10s vs the naive 28.6s model: slow phase matches 0.007/tick
+   exactly; the terminal ~4s plunge has an unidentified second contributor. **Static narrowing
+   done (2026-07-13):** grepping every `fadeToBlackAlpha` writer in `ScreenFade.cs` + `Game1.cs`
+   shows the ONLY per-tick incremental (`+=`/`-=`) writers are `UpdateFadeAlpha` (`:70,75` — already
+   ms-scaled, and off during global fades), `UpdateGlobalFade` (`:149,169` — the one we scale), and
+   `UpdateTitleScreen` (`Game1.cs:5665,5669` — title only). Every other writer is a direct
+   `= constant` assignment (state reset / threshold snap), not a per-tick stepper. So during a
+   wedding `globalFade` the sole per-tick contributor IS `UpdateGlobalFade` — which the patch scales.
+   The "terminal plunge" is therefore a `= constant` jump or completion-threshold snap in the
+   *baseline* trace, NOT a second per-tick stepper the patch must also compensate. The remaining
+   **runtime gate** (instrument `fadeToBlackAlpha` per tick in one wedding run) is now a confirmation
+   of this static conclusion, not an open mechanism question — deferred to the test-run phase.

--- a/.claude/rules/server-tps-headless.md
+++ b/.claude/rules/server-tps-headless.md
@@ -9,7 +9,7 @@ paths:
 
 # SERVER_TPS=5 is the proven-stable headless value
 
-`SERVER_TPS=5` is proven stable for the headless server: the E2E CI workflow runs the whole suite at `SERVER_TPS: "5"` (`.github/workflows/e2e-tests.yml`, paired with `SERVER_FPS: "5"` + `CLIENT_TPS: "5"`), and the local `.env.test` uses the same. `Env.cs` clamps via `Math.Max(1, ParseInt("SERVER_TPS", 60))`, so 5 is valid (the floor is 1).
+`SERVER_TPS=5` is proven stable for the headless server: the E2E CI workflow runs the whole suite at `SERVER_TPS: "5"` (`.github/workflows/e2e-tests.yml`, paired with `SERVER_FPS: "5"` + `CLIENT_TPS: "5"`), and the local `.env.test` uses the same. `Env.cs` clamps via `Math.Clamp(ParseInt("SERVER_TPS", 60), 1, 60)`, so 5 is valid (the floor is 1; the ceiling is vanilla's fixed 60, above which per-tick gameplay outruns real time).
 
 The committed `.env.example` / `.env.test.example` show a commented default `SERVER_TPS=60` and prose recommending "20-30" — conservative docs, not the proven floor; reading them as a lower bound over-provisions. Deploy uses `SERVER_FPS=0` (strictly less work than the tested `SERVER_FPS=5`), so 5 TPS is safe there too.
 

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ VNC_PASSWORD=""
 #           Performance                #
 ########################################
 
-# Target ticks per second (default: 60, minimum: 10).
+# Target ticks per second (default and maximum: 60, minimum: 10).
 # Lower reduces CPU at the cost of choppier NPC movement. 20-30 suits production.
 # SERVER_TPS=60
 

--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ VNC_PASSWORD=""
 #           Performance                #
 ########################################
 
-# Target ticks per second (default and maximum: 60, minimum: 10).
+# Target ticks per second (default and maximum: 60, minimum: 1).
 # Lower reduces CPU at the cost of choppier NPC movement. 20-30 suits production.
 # SERVER_TPS=60
 

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,11 @@ VNC_PASSWORD=""
 # Lower reduces CPU at the cost of choppier NPC movement. 20-30 suits production.
 # SERVER_TPS=60
 
+# TPS-agnostic pacing (default: true): fades and NPC/monster/projectile movement advance
+# at wall-clock speed at any SERVER_TPS. Set false to restore vanilla per-tick pacing
+# (~60/TPS× slower at reduced TPS).
+# SDVD_TPS_AGNOSTIC_PACING=true
+
 # Render rate: 0 = rendering disabled (default), N > 0 = draw at N fps for VNC.
 # Runtime override: `rendering <fps>` console command or POST /rendering?fps=<int>.
 # SERVER_FPS=0

--- a/.env.test.example
+++ b/.env.test.example
@@ -88,7 +88,7 @@
 # in-container ffmpeg-concat CPU vs. docker create+start accept queue).
 # SDVD_MAX_CONCURRENT_EXTRACTIONS=3
 
-# Target ticks per second for test servers (default: 60, minimum: 1)
+# Target ticks per second for test servers (default: 60, range: 1-60)
 # SERVER_TPS=60
 
 # Frames per second for test servers (default: 0, rendering disabled).
@@ -96,7 +96,7 @@
 # Set to 0 (or leave unset) to disable rendering and recording for servers.
 # SERVER_FPS=0
 
-# Target ticks per second for test clients (default: 60, minimum: 1)
+# Target ticks per second for test clients (default: 60, range: 1-60)
 # CLIENT_TPS=60
 
 # Frames per second for test clients (default: 0, rendering disabled).

--- a/.env.test.example
+++ b/.env.test.example
@@ -99,6 +99,10 @@
 # Target ticks per second for test clients (default: 60, range: 1-60)
 # CLIENT_TPS=60
 
+# TPS-agnostic pacing kill-switch for test servers AND clients (default: true).
+# Set false for an A/B run against vanilla per-tick pacing (~60/TPS× slower movement/fades).
+# SDVD_TPS_AGNOSTIC_PACING=true
+
 # Frames per second for test clients (default: 0, rendering disabled).
 # Drives both the in-container draw cap AND the video recorder's sample rate.
 # Set to 0 (or leave unset) to disable rendering and recording for clients.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
       ALLOW_INSECURE_SETUP: "${ALLOW_INSECURE_SETUP:-false}"
       SERVER_TPS: "${SERVER_TPS:-60}"
       SERVER_FPS: "${SERVER_FPS:-0}"
+      # TPS-agnostic pacing kill-switch: false restores vanilla per-tick pacing (~60/TPS× slower)
+      SDVD_TPS_AGNOSTIC_PACING: "${SDVD_TPS_AGNOSTIC_PACING:-true}"
       # Game settings file path (auto-created with defaults if missing)
       SETTINGS_PATH: "/data/settings/server-settings.json"
       # HTTP API for external tools and automation

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -3,6 +3,8 @@ using HarmonyLib;
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.BellsAndWhistles;
+using StardewValley.Characters;
+using StardewValley.Monsters;
 
 namespace JunimoServer.Shared;
 
@@ -87,9 +89,10 @@ public static class TpsAgnosticPacing
     }
 
     /// <summary>
-    /// Registers every Stage-1 pacing patch on the given Harmony instance. Idempotent per instance
-    /// (Harmony rejects a duplicate patch of the same method by the same owner). Call from each mod's
-    /// unconditionally-run startup path.
+    /// Registers every pacing patch on the given Harmony instance (fades, and the movement sub-step for
+    /// villagers/event-actors, monsters, farm animals, children, plus farmer event movement). Idempotent
+    /// per instance (Harmony rejects a duplicate patch of the same method by the same owner). Call from
+    /// each mod's unconditionally-run startup path.
     /// </summary>
     public static void Apply(Harmony harmony)
     {
@@ -110,7 +113,39 @@ public static class TpsAgnosticPacing
             original: AccessTools.Method(typeof(Character), nameof(Character.MovePosition)),
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
-                nameof(Character_MovePosition_Postfix)
+                nameof(MovePosition_SubStep_Postfix)
+            )
+        );
+
+        // Monsters, farm animals, and children each have their OWN MovePosition override that does NOT
+        // route through Character.MovePosition, so the seam above misses them — patch each directly with
+        // the same sub-step postfix (shared carry + re-entrancy guard, virtual dispatch re-invokes the
+        // right override). Each override keeps its per-step collision probe, so sub-stepping preserves
+        // combat/pathing semantics at any TPS. Monster's knockback/velocity branch already self-substeps
+        // large velocities (ceil(|v|/bbox) loop) and decays velocity per call — running the whole method
+        // floor(carry) times reproduces vanilla's 60Hz knockback decay exactly.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Monster), nameof(Monster.MovePosition)),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_SubStep_Postfix)
+            )
+        );
+        harmony.Patch(
+            original: AccessTools.Method(typeof(FarmAnimal), nameof(FarmAnimal.MovePosition)),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_SubStep_Postfix)
+            )
+        );
+        // Child.MovePosition delegates to base.MovePosition during festivals — that path is already
+        // sub-stepped by the Character seam above, so the Child postfix must skip it to avoid
+        // double-stepping (see Child_MovePosition_Postfix).
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Child), nameof(Child.MovePosition)),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(Child_MovePosition_Postfix)
             )
         );
 
@@ -143,16 +178,29 @@ public static class TpsAgnosticPacing
     [ThreadStatic]
     private static bool _inSubStep;
 
+    // Extra sub-step calls pass a zero-elapsed GameTime (reused, single-threaded game loop). The
+    // per-tick-constant POSITION step (`position ± speed`) does not read `time`, so it still advances;
+    // the ms-based terms in the same body (`blockedInterval += ms`, `slideAnimationTimer -= ms`, the
+    // wall-clock slide-correction `speed * ms/64`, FarmAnimal's `nextFollowDirectionChange -= ms`)
+    // contribute ZERO on the extra calls — so only the real (first) call carries the tick's ms budget.
+    // Without this those accumulators would advance once per sub-step (~12x too fast at TPS 5),
+    // triggering stuck-emote/charge and follow-direction changes far too early.
+    private static readonly GameTime ZeroElapsedGameTime = new GameTime(
+        TimeSpan.Zero,
+        TimeSpan.Zero
+    );
+
     /// <summary>
-    /// Postfix on <see cref="Character.MovePosition"/>. The vanilla call already ran one step; this
-    /// runs the remaining <c>floor(carry += TickScale) - 1</c> steps so total per-tick distance matches
-    /// a 60-TPS tick. Never scales the per-step delta — each extra call is a full vanilla step through
-    /// the same collision/arrival logic, so collision probes and the event NPC arrival window (fixed
-    /// 16px) behave exactly as at 60 TPS.
+    /// Shared sub-step postfix for any <see cref="Character"/> subtype's <c>MovePosition</c> override.
+    /// The vanilla call already ran one full step (carrying this tick's ms budget); this runs the
+    /// remaining <c>floor(carry += TickScale) - 1</c> steps with a zero-elapsed <see cref="GameTime"/> so
+    /// only the per-tick-constant position delta advances (never scaled), while ms-based timers in the
+    /// same body stay counted once. Collision probes, the event NPC arrival window (fixed 16px), and
+    /// monster knockback decay behave exactly as at 60 TPS. Virtual dispatch re-invokes the correct
+    /// override; the shared <see cref="_inSubStep"/> guard stops recursion across all patched overrides.
     /// </summary>
-    private static void Character_MovePosition_Postfix(
+    private static void MovePosition_SubStep_Postfix(
         Character __instance,
-        GameTime time,
         xTile.Dimensions.Rectangle viewport,
         GameLocation currentLocation
     )
@@ -173,16 +221,37 @@ public static class TpsAgnosticPacing
         {
             for (int i = 0; i < extraSteps; i++)
             {
-                // Virtual dispatch: an NPC re-enters through NPC.MovePosition's movementPause gate
-                // (correct — a paused NPC's extra steps no-op too). Farmer/Monster/FarmAnimal/Child
-                // overrides do NOT route through Character.MovePosition, so they are unaffected here.
-                __instance.MovePosition(time, viewport, currentLocation);
+                __instance.MovePosition(ZeroElapsedGameTime, viewport, currentLocation);
             }
         }
         finally
         {
             _inSubStep = false;
         }
+    }
+
+    /// <summary>
+    /// Sub-step postfix for <see cref="Child.MovePosition"/>. Identical to
+    /// <see cref="MovePosition_SubStep_Postfix"/> except it SKIPS the festival case: during a festival
+    /// <c>Child.MovePosition</c> delegates to <c>base.MovePosition</c> (the <see cref="Character"/> seam),
+    /// which the Character postfix already sub-steps — running this postfix too would double-step. The
+    /// festival delegation condition mirrors <c>Child.MovePosition</c> (decompiled): event up, current
+    /// event is a festival.
+    /// </summary>
+    private static void Child_MovePosition_Postfix(
+        Child __instance,
+        xTile.Dimensions.Rectangle viewport,
+        GameLocation currentLocation
+    )
+    {
+        // Mirror Child.MovePosition's festival-delegation guard: that path routes through
+        // base.MovePosition and is sub-stepped by the Character seam, so skip it here.
+        if (Game1.eventUp && Game1.CurrentEvent != null && Game1.CurrentEvent.isFestival)
+        {
+            return;
+        }
+
+        MovePosition_SubStep_Postfix(__instance, viewport, currentLocation);
     }
 
     /// <summary>

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
 using HarmonyLib;
 using Microsoft.Xna.Framework;
+using StardewModdingAPI;
 using StardewValley;
 using StardewValley.BellsAndWhistles;
 using StardewValley.Characters;
 using StardewValley.Monsters;
+using StardewValley.Projectiles;
 
 namespace JunimoServer.Shared;
 
@@ -93,9 +96,22 @@ public static class TpsAgnosticPacing
     /// villagers/event-actors, monsters, farm animals, children, plus farmer event movement). Idempotent
     /// per instance (Harmony rejects a duplicate patch of the same method by the same owner). Call from
     /// each mod's unconditionally-run startup path.
+    ///
+    /// <para>The patches are always installed; the per-call <see cref="Enabled"/> gate makes them pass
+    /// through to vanilla when the kill-switch is off. The boot log line records which mode is active so
+    /// an A/B run (or an operator on a low-TPS server) can confirm the knob was consumed.</para>
     /// </summary>
-    public static void Apply(Harmony harmony)
+    public static void Apply(Harmony harmony, IMonitor monitor)
     {
+        monitor.Log(
+            Enabled
+                ? "TPS-agnostic pacing ENABLED — fades and creature/event movement run at wall-clock "
+                    + "speed at any TPS."
+                : $"TPS-agnostic pacing DISABLED via {KillSwitchEnvVar}=false — fades/movement run at "
+                    + "the vanilla per-tick rate (~60/TPS× slower at reduced TPS).",
+            LogLevel.Info
+        );
+
         // Fades: scale the per-call globalFade delta (primitive 1 — a continuous quantity with no
         // collision/trigger semantics, so a scaled delta is exact). Prefix inflates globalFadeSpeed by
         // TickScale, vanilla runs its own body + completion, postfix restores it.
@@ -108,9 +124,15 @@ public static class TpsAgnosticPacing
         // NPC / event-actor walking: sub-step the vanilla per-tick move (primitive 2 — stepwise logic
         // with per-step collision/arrival semantics, so we run the step floor(carry) times rather than
         // scaling the delta). Postfix on Character.MovePosition covers villagers AND event actors, since
-        // NPC.MovePosition is a thin movementPause gate over base.MovePosition.
+        // NPC.MovePosition is a thin movementPause gate over base.MovePosition. The paired prefix captures
+        // pre-call velocity so the postfix can tell whether this tick took the velocity path (knockback)
+        // vs the walk path — only the walk path sub-steps (see MovePosition_SubStep_Postfix).
         harmony.Patch(
             original: AccessTools.Method(typeof(Character), nameof(Character.MovePosition)),
+            prefix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_CaptureVelocity_Prefix)
+            ),
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
                 nameof(MovePosition_SubStep_Postfix)
@@ -119,13 +141,16 @@ public static class TpsAgnosticPacing
 
         // Monsters, farm animals, and children each have their OWN MovePosition override that does NOT
         // route through Character.MovePosition, so the seam above misses them — patch each directly with
-        // the same sub-step postfix (shared carry + re-entrancy guard, virtual dispatch re-invokes the
-        // right override). Each override keeps its per-step collision probe, so sub-stepping preserves
-        // combat/pathing semantics at any TPS. Monster's knockback/velocity branch already self-substeps
-        // large velocities (ceil(|v|/bbox) loop) and decays velocity per call — running the whole method
-        // floor(carry) times reproduces vanilla's 60Hz knockback decay exactly.
+        // the same prefix+postfix (shared carry + re-entrancy guard, virtual dispatch re-invokes the right
+        // override). Each override keeps its per-step collision probe, so sub-stepping preserves
+        // combat/pathing semantics at any TPS. The velocity/knockback path (present in Character and
+        // Monster) runs once per tick, never sub-stepped — its friction decay is per-call (see postfix).
         harmony.Patch(
             original: AccessTools.Method(typeof(Monster), nameof(Monster.MovePosition)),
+            prefix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_CaptureVelocity_Prefix)
+            ),
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
                 nameof(MovePosition_SubStep_Postfix)
@@ -133,6 +158,10 @@ public static class TpsAgnosticPacing
         );
         harmony.Patch(
             original: AccessTools.Method(typeof(FarmAnimal), nameof(FarmAnimal.MovePosition)),
+            prefix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_CaptureVelocity_Prefix)
+            ),
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
                 nameof(MovePosition_SubStep_Postfix)
@@ -143,6 +172,10 @@ public static class TpsAgnosticPacing
         // double-stepping (see Child_MovePosition_Postfix).
         harmony.Patch(
             original: AccessTools.Method(typeof(Child), nameof(Child.MovePosition)),
+            prefix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(MovePosition_CaptureVelocity_Prefix)
+            ),
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
                 nameof(Child_MovePosition_Postfix)
@@ -159,6 +192,53 @@ public static class TpsAgnosticPacing
             postfix: new HarmonyMethod(
                 typeof(TpsAgnosticPacing),
                 nameof(Farmer_GetMovementSpeed_Postfix)
+            )
+        );
+
+        // Projectiles: sub-step the WHOLE Projectile.update (primitive 2 as a PREFIX, not a postfix).
+        // update() advances one physics step (updatePosition) AND checks collision once, then returns a
+        // bool the location's RemoveWhere consumes to delete the projectile. A postfix can't honor that
+        // return or a mid-flight collision, so we run the extra steps as full update() calls in the
+        // prefix (each re-checks collision — no tunneling) with a zero-elapsed GameTime so the ms grace
+        // timers (travelTime, hostTimeUntilAttackable, DebuffingProjectile's wavy phase) count once. If
+        // any extra step signals removal/collision, we skip the real call and hand its result to
+        // RemoveWhere. The server drives this whenever a client is in/viewing the location (incl.
+        // MineShaft.UpdateMines), so a fireball at reduced TPS otherwise crawls at 60/TPS× speed.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Projectile), nameof(Projectile.update)),
+            prefix: new HarmonyMethod(typeof(TpsAgnosticPacing), nameof(Projectile_Update_Prefix))
+        );
+
+        // Debris chunk physics: same prefix sub-step. updateChunks is fully self-contained (velocity/
+        // gravity integration + pickup + wall/rest bounce, no external collision) and returns a bool for
+        // RemoveWhere. Zero-elapsed extra calls keep the per-tick gravity/velocity constants advancing
+        // while the ms lifetime timers (timeSinceDoneBouncing, timeBeforeReturnToDroppingPlayer) count
+        // once. Debris settles ~60/TPS× too slowly otherwise (item drops drift before resting/collecting).
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Debris), nameof(Debris.updateChunks)),
+            prefix: new HarmonyMethod(typeof(TpsAgnosticPacing), nameof(Debris_UpdateChunks_Prefix))
+        );
+
+        // Gliders (fliers: Bat/Fly/Serpent/Ghost/AngryRoger — isGlider==true, always velocity-driven).
+        // Their per-tick movement is: MovePosition (position += velocity; velocity *= decay) + the velocity
+        // GENERATION in behaviorAtGameTick/updateAnimation (the ramp `xVelocity += num/6f`, turn
+        // `rotation += PI/64f`). Part 1 (the velocity-path skip) makes MovePosition run once/tick, which is
+        // correct decay but leaves the glider advancing only `velocity` px/tick = 60/TPS× slow. To reach
+        // wall-clock speed the whole trio must replay N×/tick, in order, zero-time on extras so the ms
+        // timers (and the one-shot side effects they gate — notably Ghost's tongue-projectile spawn) fire
+        // once. Postfix on Monster.update fires once/tick per monster; it replays the trio for gliders.
+        // Disambiguate: Character has two update overloads — update(GameTime, GameLocation) and
+        // update(GameTime, GameLocation, long, bool) — so name-only lookup throws AmbiguousMatchException.
+        // Monster overrides the 2-arg one; specify its parameter types.
+        harmony.Patch(
+            original: AccessTools.Method(
+                typeof(Monster),
+                nameof(Monster.update),
+                new[] { typeof(GameTime), typeof(GameLocation) }
+            ),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(Monster_Update_Glider_Postfix)
             )
         );
     }
@@ -178,34 +258,64 @@ public static class TpsAgnosticPacing
     [ThreadStatic]
     private static bool _inSubStep;
 
-    // Extra sub-step calls pass a zero-elapsed GameTime (reused, single-threaded game loop). The
-    // per-tick-constant POSITION step (`position ± speed`) does not read `time`, so it still advances;
-    // the ms-based terms in the same body (`blockedInterval += ms`, `slideAnimationTimer -= ms`, the
-    // wall-clock slide-correction `speed * ms/64`, FarmAnimal's `nextFollowDirectionChange -= ms`)
-    // contribute ZERO on the extra calls — so only the real (first) call carries the tick's ms budget.
-    // Without this those accumulators would advance once per sub-step (~12x too fast at TPS 5),
-    // triggering stuck-emote/charge and follow-direction changes far too early.
+    // Extra sub-step calls pass this zero-elapsed GameTime (reused; single-threaded loop). Per-tick-constant
+    // steps (`position ± speed`, gravity, velocity ramp) don't read `time` so they still advance, while every
+    // ms/TotalSeconds term in the same body contributes ZERO on extras — only the real call carries the tick's
+    // ms budget. Without it those timers would advance ~12× too fast at TPS 5 (stuck-emote, follow-direction
+    // changes, and — critically — the one-shot effects they gate, e.g. Ghost's projectile spawn).
     private static readonly GameTime ZeroElapsedGameTime = new GameTime(
         TimeSpan.Zero,
         TimeSpan.Zero
     );
 
     /// <summary>
+    /// Prefix paired with <see cref="MovePosition_SubStep_Postfix"/>: captures the entity's velocity
+    /// BEFORE the vanilla call so the postfix can tell whether this tick took the velocity path (knockback
+    /// / glider) or the walk path. Read post-call would be wrong — the velocity path decays (and may zero)
+    /// the velocity within the same call.
+    /// </summary>
+    private static void MovePosition_CaptureVelocity_Prefix(Character __instance, out bool __state)
+    {
+        // True when the entity is velocity-driven this tick (knockback for any character, or a glider's
+        // always-on flight). Captured before vanilla runs, since vanilla's velocity path mutates it.
+        __state = __instance.xVelocity != 0f || __instance.yVelocity != 0f;
+    }
+
+    /// <summary>
     /// Shared sub-step postfix for any <see cref="Character"/> subtype's <c>MovePosition</c> override.
     /// The vanilla call already ran one full step (carrying this tick's ms budget); this runs the
     /// remaining <c>floor(carry += TickScale) - 1</c> steps with a zero-elapsed <see cref="GameTime"/> so
     /// only the per-tick-constant position delta advances (never scaled), while ms-based timers in the
-    /// same body stay counted once. Collision probes, the event NPC arrival window (fixed 16px), and
-    /// monster knockback decay behave exactly as at 60 TPS. Virtual dispatch re-invokes the correct
-    /// override; the shared <see cref="_inSubStep"/> guard stops recursion across all patched overrides.
+    /// same body stay counted once. Collision probes and the event NPC arrival window (fixed 16px) behave
+    /// exactly as at 60 TPS. Virtual dispatch re-invokes the correct override; the shared
+    /// <see cref="_inSubStep"/> guard stops recursion across all patched overrides.
+    ///
+    /// <para><b>Velocity path is once-per-tick, NOT sub-stepped.</b> Every <c>MovePosition</c> variant
+    /// takes a velocity path (`position += xVelocity; xVelocity -= xVelocity/k`) whenever
+    /// <c>xVelocity/yVelocity != 0</c> — knockback for any character, and the always-on movement of gliders
+    /// (fliers). That friction decay is per-CALL, so repeating the call would decay velocity N× per tick
+    /// (~40%/tick for a Bat, ~99% for the base <c>Character.applyVelocity</c>'s 50%/call), collapsing
+    /// knockback distance. So when the entity is velocity-driven this tick we skip the extra steps: the
+    /// real call already ran the velocity path once, which is the correct per-tick decay. (Gliders then
+    /// advance only once/tick — still slow at low TPS — and need their own ramp+move sub-step, the glider
+    /// seam below. The walk path, driven by the per-tick constant <c>speed</c>, is what SHOULD sub-step.)</para>
     /// </summary>
     private static void MovePosition_SubStep_Postfix(
         Character __instance,
         xTile.Dimensions.Rectangle viewport,
-        GameLocation currentLocation
+        GameLocation currentLocation,
+        bool __state
     )
     {
         if (!Enabled || _inSubStep)
+        {
+            return;
+        }
+
+        // Velocity-driven this tick (knockback / glider): the real call already ran the velocity path with
+        // its once-per-tick friction decay. Repeating it would over-decay (the per-call `xVelocity -=
+        // xVelocity/k` compounds), so do NOT sub-step — there is no per-tick-constant walk step to repeat.
+        if (__state)
         {
             return;
         }
@@ -241,7 +351,8 @@ public static class TpsAgnosticPacing
     private static void Child_MovePosition_Postfix(
         Child __instance,
         xTile.Dimensions.Rectangle viewport,
-        GameLocation currentLocation
+        GameLocation currentLocation,
+        bool __state
     )
     {
         // Mirror Child.MovePosition's festival-delegation guard: that path routes through
@@ -251,7 +362,180 @@ public static class TpsAgnosticPacing
             return;
         }
 
-        MovePosition_SubStep_Postfix(__instance, viewport, currentLocation);
+        MovePosition_SubStep_Postfix(__instance, viewport, currentLocation, __state);
+    }
+
+    /// <summary>
+    /// Prefix on <see cref="Projectile.update"/>. Runs the extra sub-steps this tick as full
+    /// <c>update</c> calls (each re-checks collision, so a fast projectile can't tunnel a target/wall),
+    /// each with a zero-elapsed <see cref="GameTime"/> so the ms grace timers count only on the real
+    /// call. If an extra step returns <c>true</c> (collided/expired → remove), the real call is skipped
+    /// and that result is handed to the location's <c>RemoveWhere</c>; otherwise the original runs
+    /// normally with the tick's real <see cref="GameTime"/>.
+    /// </summary>
+    private static bool Projectile_Update_Prefix(
+        Projectile __instance,
+        GameTime time,
+        GameLocation location,
+        ref bool __result
+    )
+    {
+        return RunUpdateSubSteps(
+            extraStep: () => __instance.update(ZeroElapsedGameTime, location),
+            ref __result
+        );
+    }
+
+    /// <summary>
+    /// Prefix on <see cref="Debris.updateChunks"/>. Same sub-step-as-prefix pattern as
+    /// <see cref="Projectile_Update_Prefix"/>: the zero-elapsed extra calls advance the per-tick
+    /// gravity/velocity constants while the ms lifetime timers count once, and any extra step's
+    /// <c>true</c> return (chunks emptied / lifetime expired) is propagated to <c>RemoveWhere</c>.
+    /// </summary>
+    private static bool Debris_UpdateChunks_Prefix(
+        Debris __instance,
+        GameTime time,
+        GameLocation location,
+        ref bool __result
+    )
+    {
+        return RunUpdateSubSteps(
+            extraStep: () => __instance.updateChunks(ZeroElapsedGameTime, location),
+            ref __result
+        );
+    }
+
+    /// <summary>
+    /// Shared core for the projectile/debris update prefixes: run <paramref name="extraStep"/> the
+    /// tick's extra-step count of times under the re-entrancy guard, short-circuiting if a step signals
+    /// removal. Returns <c>true</c> to let the original run (no extra step removed the entity), or
+    /// <c>false</c> with <paramref name="removeResult"/> set to skip the original and delete the entity.
+    /// </summary>
+    private static bool RunUpdateSubSteps(Func<bool> extraStep, ref bool removeResult)
+    {
+        if (!Enabled || _inSubStep)
+        {
+            return true;
+        }
+
+        int extraSteps = ExtraStepsThisTick();
+        if (extraSteps <= 0)
+        {
+            return true;
+        }
+
+        _inSubStep = true;
+        try
+        {
+            for (int i = 0; i < extraSteps; i++)
+            {
+                if (extraStep())
+                {
+                    // An extra step collided/expired: remove the entity now and skip the real call so
+                    // collision/removal fires exactly once, on the step that reached it.
+                    removeResult = true;
+                    return false;
+                }
+            }
+        }
+        finally
+        {
+            _inSubStep = false;
+        }
+
+        // No extra step removed it — let the real (first) call run with the tick's real GameTime.
+        return true;
+    }
+
+    // === Glider (flier) whole-AI-tick sub-step ===
+
+    // updateAnimation is `protected virtual`, so it can't be called directly from here. Cache one open
+    // delegate per concrete glider type (keyed on the runtime type so virtual dispatch lands on the right
+    // override — Fly.updateAnimation vs Bat.updateAnimation). Built once per type, then reused every tick
+    // (no per-call reflection on the game thread). The game loop is single-threaded, so a plain Dictionary
+    // is fine.
+    private static readonly Dictionary<Type, Action<Monster, GameTime>> _updateAnimationByType =
+        new();
+
+    private static readonly Action<Monster, GameTime> _noopUpdateAnimation = (_, _) => { };
+
+    private static Action<Monster, GameTime> GetUpdateAnimation(Monster monster)
+    {
+        var type = monster.GetType();
+        if (!_updateAnimationByType.TryGetValue(type, out var call))
+        {
+            // MethodDelegate over the concrete type's updateAnimation binds to that override, so a Fly
+            // instance runs Fly.updateAnimation. Fall back to a no-op if a (modded) glider type has no
+            // resolvable updateAnimation — never throw on the per-tick hot path; it still gets move + AI.
+            var method = AccessTools.Method(type, "updateAnimation", new[] { typeof(GameTime) });
+            call =
+                method != null
+                    ? AccessTools.MethodDelegate<Action<Monster, GameTime>>(method)
+                    : _noopUpdateAnimation;
+            _updateAnimationByType[type] = call;
+        }
+        return call;
+    }
+
+    /// <summary>
+    /// Postfix on <see cref="Monster.update"/> that gives GLIDERS wall-clock movement at reduced TPS. A
+    /// glider is always velocity-driven, so its real <c>MovePosition</c> (post part-1) advanced position
+    /// once this tick and its ramp (in <c>behaviorAtGameTick</c>/<c>updateAnimation</c>) generated velocity
+    /// once. This replays the whole per-tick trio — <c>MovePosition</c> + <c>behaviorAtGameTick</c> +
+    /// <c>updateAnimation</c>, in vanilla order — the tick's extra-step count of times, with a zero-elapsed
+    /// <see cref="GameTime"/> so ms/TotalSeconds timers (and the one-shot side effects they gate, e.g.
+    /// Ghost's projectile spawn) fire only on the real call. Non-gliders are untouched (their walk path is
+    /// already sub-stepped by the MovePosition seam; their velocity path is knockback, handled by part 1).
+    ///
+    /// <para><b>Why zero-time, and its one accepted deviation.</b> Zero-time on the extra calls is
+    /// load-bearing for SAFETY: it freezes each monster's ms/TotalSeconds timers so the one-shot effects
+    /// behind them fire at most once per real tick — most importantly Ghost's tongue-projectile spawn
+    /// (gated by a <c>stateTimer</c> that a nonzero elapsed would let cross repeatedly, firing N
+    /// projectiles). The travel SPEED is exact regardless (velocity integrates N×). The cost: Bat, Ghost,
+    /// and AngryRoger reset their heading gate to <c>wasHitCounter = 0</c>, so their steering re-runs every
+    /// replay (fully faithful) — but Fly and Serpent set <c>wasHitCounter = 5 + random</c>, which zero-time
+    /// never decays across replays, so their HEADING updates once per real tick instead of tracking the
+    /// 60-TPS ~16ms decay. Net: Fly/Serpent re-aim at a moving target slightly slower than true 60 TPS
+    /// (their speed is unaffected). This is accepted — TPS is a fluctuating target so exact heading is
+    /// already approximate, and the alternative (distributing the tick's ms across sub-steps) would
+    /// re-introduce the Ghost N-projectile bug. Do NOT switch these extra calls to a nonzero elapsed time
+    /// to "fix" Fly/Serpent heading without first guarding every ms-gated one-shot effect (Ghost is the
+    /// dangerous one).</para>
+    /// </summary>
+    private static void Monster_Update_Glider_Postfix(Monster __instance, GameLocation location)
+    {
+        if (!Enabled || _inSubStep || !__instance.isGlider.Value)
+        {
+            return;
+        }
+
+        int extraSteps = ExtraStepsThisTick();
+        if (extraSteps <= 0)
+        {
+            return;
+        }
+
+        var updateAnimation = GetUpdateAnimation(__instance);
+        var viewport = Game1.viewport;
+
+        _inSubStep = true;
+        try
+        {
+            for (int i = 0; i < extraSteps && __instance.Health > 0; i++)
+            {
+                // Vanilla per-tick order: move on the current velocity, then regenerate velocity/heading
+                // for the next step. Zero-time so friction decays once-per-real-tick-worth per step (the
+                // per-tick constant, correct to repeat) while ms timers contribute nothing on extras. The
+                // Health guard stops replaying a monster any of these calls just killed (NaN/off-map death).
+                __instance.MovePosition(ZeroElapsedGameTime, viewport, location);
+                __instance.behaviorAtGameTick(ZeroElapsedGameTime);
+                updateAnimation(__instance, ZeroElapsedGameTime);
+            }
+        }
+        finally
+        {
+            _inSubStep = false;
+        }
     }
 
     /// <summary>

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -1,0 +1,276 @@
+using System;
+using HarmonyLib;
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.BellsAndWhistles;
+
+namespace JunimoServer.Shared;
+
+/// <summary>
+/// Makes per-tick-constant gameplay code produce correct wall-clock outcomes at any tick rate.
+///
+/// <para>
+/// Vanilla runs a hard-fixed 60 ticks/sec, so it freely mixes millisecond-accumulating code
+/// (<c>x -= time.ElapsedGameTime.Milliseconds</c> — stays real-time at any TPS) with per-tick
+/// constants (<c>x += 0.007f</c> per Update — runs <c>60/TPS</c>× slower). Both mods pin
+/// <c>TargetElapsedTime = 1000/TPS</c> (server <c>ServerOptimizer</c>, test client <c>ModEntry</c>),
+/// so at <c>SERVER_TPS=5</c> a per-tick constant advances 12× slower per real second. Only the
+/// per-tick-constant class breaks; these patches compensate the gameplay-relevant instances so the
+/// server simulates NPCs/fades at real-time speed and the test client behaves like a real player.
+/// </para>
+///
+/// <para>
+/// <b>Scale factor.</b> <see cref="TickScale"/> is <c>ElapsedGameTime.TotalMilliseconds / (1000/60)</c>
+/// read from <c>Game1.currentGameTime</c> — exactly <c>1.0</c> at 60 TPS (a structural no-op on the
+/// vanilla-default rate), <c>12.0</c> at TPS 5, and a non-integer like <c>2.4</c> at TPS 25. All
+/// primitives handle fractional scales.
+/// </para>
+///
+/// <para>
+/// <b>Kill-switch.</b> <c>SDVD_TPS_AGNOSTIC_PACING=false</c> disables every patch (default on). The
+/// patches are still installed; the per-call <see cref="Enabled"/> gate makes them pass through to
+/// vanilla behavior, so an operator on a low-TPS server can restore the long-standing 12× pacing
+/// without a rebuild.
+/// </para>
+/// </summary>
+public static class TpsAgnosticPacing
+{
+    private const string KillSwitchEnvVar = "SDVD_TPS_AGNOSTIC_PACING";
+
+    // 60 TPS is vanilla's fixed rate; one tick at 60 TPS is this many ms. TickScale is the ratio of
+    // the actual tick duration to this reference, so a per-tick constant multiplied by TickScale
+    // advances the same amount per real second regardless of the configured TPS.
+    private const double VanillaTickMs = 1000.0 / 60.0;
+
+    // Read once at first Apply(): the kill-switch is a boot-time env var (TPS itself is only set at
+    // boot), so there is no need to re-read it per call. Nullable so the first read latches it.
+    private static bool? _enabled;
+
+    /// <summary>
+    /// False only when <c>SDVD_TPS_AGNOSTIC_PACING</c> is explicitly set to <c>false</c>. Every patch
+    /// checks this and falls through to vanilla when off.
+    /// </summary>
+    public static bool Enabled
+    {
+        get
+        {
+            if (_enabled == null)
+            {
+                var raw = Environment.GetEnvironmentVariable(KillSwitchEnvVar);
+                _enabled = string.IsNullOrWhiteSpace(raw) || !bool.TryParse(raw, out var on) || on;
+            }
+            return _enabled.Value;
+        }
+    }
+
+    /// <summary>
+    /// The current tick's duration relative to a vanilla 60-TPS tick: <c>1.0</c> at 60 TPS, <c>12.0</c>
+    /// at TPS 5, fractional at non-divisor rates. Returns <c>1.0</c> before the first tick (no
+    /// <c>currentGameTime</c> yet) so a pre-tick call is a no-op rather than a divide-by-zero risk.
+    /// </summary>
+    public static float TickScale
+    {
+        get
+        {
+            var gameTime = Game1.currentGameTime;
+            if (gameTime == null)
+            {
+                return 1f;
+            }
+            var ms = gameTime.ElapsedGameTime.TotalMilliseconds;
+            if (ms <= 0)
+            {
+                return 1f;
+            }
+            return (float)(ms / VanillaTickMs);
+        }
+    }
+
+    /// <summary>
+    /// Registers every Stage-1 pacing patch on the given Harmony instance. Idempotent per instance
+    /// (Harmony rejects a duplicate patch of the same method by the same owner). Call from each mod's
+    /// unconditionally-run startup path.
+    /// </summary>
+    public static void Apply(Harmony harmony)
+    {
+        // Fades: scale the per-call globalFade delta (primitive 1 — a continuous quantity with no
+        // collision/trigger semantics, so a scaled delta is exact). Prefix inflates globalFadeSpeed by
+        // TickScale, vanilla runs its own body + completion, postfix restores it.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(ScreenFade), nameof(ScreenFade.UpdateGlobalFade)),
+            prefix: new HarmonyMethod(typeof(TpsAgnosticPacing), nameof(UpdateGlobalFade_Prefix)),
+            postfix: new HarmonyMethod(typeof(TpsAgnosticPacing), nameof(UpdateGlobalFade_Postfix))
+        );
+
+        // NPC / event-actor walking: sub-step the vanilla per-tick move (primitive 2 — stepwise logic
+        // with per-step collision/arrival semantics, so we run the step floor(carry) times rather than
+        // scaling the delta). Postfix on Character.MovePosition covers villagers AND event actors, since
+        // NPC.MovePosition is a thin movementPause gate over base.MovePosition.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Character), nameof(Character.MovePosition)),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(Character_MovePosition_Postfix)
+            )
+        );
+
+        // Farmer event/cutscene movement: scale getMovementSpeed's event branch (primitive 1). Safe
+        // here — unlike NPCs — because scripted event moves bypass the collision probe entirely
+        // (Farmer.MovePositionImpl `|| flag`, decompiled Farmer.cs) and the event arrival margin
+        // self-scales with the returned speed (`16f + movementSpeed`, decompiled Event.cs), so a scaled
+        // delta can neither tunnel a collider nor overshoot the arrival window.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Farmer), nameof(Farmer.getMovementSpeed)),
+            postfix: new HarmonyMethod(
+                typeof(TpsAgnosticPacing),
+                nameof(Farmer_GetMovementSpeed_Postfix)
+            )
+        );
+    }
+
+    // === Primitive 2: per-tick sub-step carry (movement) ===
+
+    // One global accumulator per game tick: the fractional part of TickScale that hasn't yet been
+    // spent on a whole extra step. Recomputed against the tick's own scale each frame so every
+    // character advances uniformly. Not per-character — the carry is a property of the tick, not the
+    // actor — so a location full of NPCs all sub-step the same integer count this tick.
+    private static double _moveCarry;
+    private static uint _moveCarryTick = uint.MaxValue;
+
+    // Re-entrancy guard: our postfix calls MovePosition again, which re-enters this postfix. The guard
+    // stops the recursion so each real tick produces exactly (extraSteps) additional calls, not a
+    // geometric explosion.
+    [ThreadStatic]
+    private static bool _inSubStep;
+
+    /// <summary>
+    /// Postfix on <see cref="Character.MovePosition"/>. The vanilla call already ran one step; this
+    /// runs the remaining <c>floor(carry += TickScale) - 1</c> steps so total per-tick distance matches
+    /// a 60-TPS tick. Never scales the per-step delta — each extra call is a full vanilla step through
+    /// the same collision/arrival logic, so collision probes and the event NPC arrival window (fixed
+    /// 16px) behave exactly as at 60 TPS.
+    /// </summary>
+    private static void Character_MovePosition_Postfix(
+        Character __instance,
+        GameTime time,
+        xTile.Dimensions.Rectangle viewport,
+        GameLocation currentLocation
+    )
+    {
+        if (!Enabled || _inSubStep)
+        {
+            return;
+        }
+
+        int extraSteps = ExtraStepsThisTick();
+        if (extraSteps <= 0)
+        {
+            return;
+        }
+
+        _inSubStep = true;
+        try
+        {
+            for (int i = 0; i < extraSteps; i++)
+            {
+                // Virtual dispatch: an NPC re-enters through NPC.MovePosition's movementPause gate
+                // (correct — a paused NPC's extra steps no-op too). Farmer/Monster/FarmAnimal/Child
+                // overrides do NOT route through Character.MovePosition, so they are unaffected here.
+                __instance.MovePosition(time, viewport, currentLocation);
+            }
+        }
+        finally
+        {
+            _inSubStep = false;
+        }
+    }
+
+    /// <summary>
+    /// The number of ADDITIONAL sub-steps to run this tick (beyond the one vanilla already ran).
+    /// Advances the per-tick carry accumulator by <see cref="TickScale"/> and returns
+    /// <c>floor(carry) - 1</c>, keeping the fractional remainder for the next tick so long-run distance
+    /// stays exact at non-integer scales. Recomputed once per game tick and shared across all callers.
+    /// </summary>
+    private static int ExtraStepsThisTick()
+    {
+        uint tick = GetCurrentTick();
+        if (tick != _moveCarryTick)
+        {
+            _moveCarryTick = tick;
+            _moveCarry += TickScale;
+            // Whole steps this tick include the one vanilla already ran; consume them from the carry.
+            int wholeSteps = (int)Math.Floor(_moveCarry);
+            _moveCarry -= wholeSteps;
+            _stepsRemainingThisTick = Math.Max(0, wholeSteps - 1);
+        }
+        return _stepsRemainingThisTick;
+    }
+
+    // The extra-step count computed for the current tick, so repeated MovePosition calls within one
+    // tick (multiple NPCs) each get the same count without re-advancing the carry.
+    private static int _stepsRemainingThisTick;
+
+    private static uint GetCurrentTick()
+    {
+        // Game1.ticks increments once per Update; a stable per-tick key so the carry advances once
+        // per real tick even though MovePosition is called many times per tick (once per character).
+        return (uint)Game1.ticks;
+    }
+
+    // === Primitive 1: scaled step (fades, farmer event movement) ===
+
+    /// <summary>
+    /// Prefix on <see cref="ScreenFade.UpdateGlobalFade"/> that temporarily inflates the public
+    /// <c>globalFadeSpeed</c> field by <see cref="TickScale"/>, lets vanilla run, then a paired postfix
+    /// restores it. Vanilla's own body does the <c>fadeToBlackAlpha ± globalFadeSpeed</c> step (now
+    /// scaled) and its own completion check, so the private <c>afterFade</c> callback, its identity
+    /// re-check, the <c>Game1.nonWarpFade</c> handling, and the <c>Game1.IsDedicatedHost</c> instant-snap
+    /// short-circuits are all preserved untouched — a cutscene fade just reaches its 0/1 terminus in the
+    /// same wall-clock time at any TPS. <c>globalFadeSpeed</c> is read only inside this method (verified
+    /// against the decompiled tree), so inflating it for the call's duration is invisible elsewhere.
+    /// Skips scaling when the kill-switch is off (falls through to vanilla pacing).
+    /// </summary>
+    private static void UpdateGlobalFade_Prefix(ScreenFade __instance, out float __state)
+    {
+        __state = __instance.globalFadeSpeed;
+        if (Enabled)
+        {
+            __instance.globalFadeSpeed *= TickScale;
+        }
+    }
+
+    private static void UpdateGlobalFade_Postfix(ScreenFade __instance, float __state)
+    {
+        // Restore the original so a later reader (or the next tick before GlobalFadeTo* resets it) sees
+        // the vanilla value, not the inflated one. Vanilla clamps alpha with Math.Max/Min, so an
+        // inflated step that overshoots 0/1 lands exactly on the terminus and fires completion on the
+        // correct tick.
+        __instance.globalFadeSpeed = __state;
+    }
+
+    /// <summary>
+    /// Postfix on <see cref="Farmer.getMovementSpeed"/>. Scales only the EVENT branch's result by
+    /// <see cref="TickScale"/> — the free-move branch already ms-scales in vanilla, so we detect it by
+    /// its signature (it multiplies by <c>ElapsedGameTime.Milliseconds</c>, making it already
+    /// wall-clock-correct) and leave it untouched. The event branch is the one that returns a raw
+    /// <c>Max(1, speed + farmerAddedSpeed…)</c> per tick with no ms scaling.
+    /// </summary>
+    private static void Farmer_GetMovementSpeed_Postfix(Farmer __instance, ref float __result)
+    {
+        if (!Enabled)
+        {
+            return;
+        }
+
+        // The free-move branch runs when there is no event, or the event is a player-control sequence
+        // (decompiled Farmer.getMovementSpeed) — and that branch is already ms-scaled by vanilla. Only
+        // the scripted-event branch (event up, not player-controlled) needs compensation.
+        var ev = Game1.CurrentEvent;
+        if (ev == null || ev.playerControlSequence)
+        {
+            return;
+        }
+
+        __result *= TickScale;
+    }
+}

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -410,6 +410,12 @@ public static class TpsAgnosticPacing
     /// tick's extra-step count of times under the re-entrancy guard, short-circuiting if a step signals
     /// removal. Returns <c>true</c> to let the original run (no extra step removed the entity), or
     /// <c>false</c> with <paramref name="removeResult"/> set to skip the original and delete the entity.
+    ///
+    /// <para>The zero-time extras run BEFORE the real call, so ms grace/lifetime timers are consumed at
+    /// the end of the tick's batch instead of the start — a ≤1-tick phase error that is symmetric (real
+    /// call first would expire them up to a tick early instead of late) and inherent to not distributing
+    /// the tick's ms across sub-steps, which is unsafe (see the glider docstring's Ghost one-shot
+    /// hazard). Extras-first also lets a prefix skip the original cleanly on removal.</para>
     /// </summary>
     private static bool RunUpdateSubSteps(Func<bool> extraStep, ref bool removeResult)
     {
@@ -543,6 +549,10 @@ public static class TpsAgnosticPacing
     /// Advances the per-tick carry accumulator by <see cref="TickScale"/> and returns
     /// <c>floor(carry) - 1</c>, keeping the fractional remainder for the next tick so long-run distance
     /// stays exact at non-integer scales. Recomputed once per game tick and shared across all callers.
+    ///
+    /// <para>Additive only: a <see cref="TickScale"/> below 1 (TPS above 60) would need vanilla's own
+    /// step SKIPPED some ticks, which this primitive can't do — so both mods clamp TPS to at most 60
+    /// (<c>Env.ServerTps</c>, test-client <c>ModEntry</c>) and the scale is structurally ≥ 1.</para>
     /// </summary>
     private static int ExtraStepsThisTick()
     {

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -229,6 +229,14 @@ public static class TpsAgnosticPacing
     /// same wall-clock time at any TPS. <c>globalFadeSpeed</c> is read only inside this method (verified
     /// against the decompiled tree), so inflating it for the call's duration is invisible elsewhere.
     /// Skips scaling when the kill-switch is off (falls through to vanilla pacing).
+    ///
+    /// <para>On the JunimoServer host <c>IsDedicatedHost</c> is FALSE (the mod deliberately leaves
+    /// <c>hasDedicatedHost</c> unset — see <c>AlwaysOn.OnSaveLoaded</c>), so the instant-snap ternary
+    /// takes its ELSE branch and the fade runs the incremental step this patch scales — i.e. the patch
+    /// is live and load-bearing server-side. On the test client the fade is instead forced instant by
+    /// <c>ConvenienceTweaks.PatchInstantFades</c> (a separate postfix that snaps alpha to terminus), so
+    /// this scaling is overridden there — intended: the test harness wants instant fades, not merely
+    /// fast ones.</para>
     /// </summary>
     private static void UpdateGlobalFade_Prefix(ScreenFade __instance, out float __state)
     {

--- a/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
+++ b/mod/JunimoServer.Shared/TpsAgnosticPacing.cs
@@ -12,7 +12,9 @@ using StardewValley.Projectiles;
 namespace JunimoServer.Shared;
 
 /// <summary>
-/// Makes per-tick-constant gameplay code produce correct wall-clock outcomes at any tick rate.
+/// Makes per-tick-constant gameplay code produce correct wall-clock outcomes at any tick rate. (One
+/// disclosed exception: knockback slides are distance-exact but duration-stretched — see
+/// <see cref="MovePosition_SubStep_Postfix"/>.)
 ///
 /// <para>
 /// Vanilla runs a hard-fixed 60 ticks/sec, so it freely mixes millisecond-accumulating code
@@ -199,11 +201,14 @@ public static class TpsAgnosticPacing
         // update() advances one physics step (updatePosition) AND checks collision once, then returns a
         // bool the location's RemoveWhere consumes to delete the projectile. A postfix can't honor that
         // return or a mid-flight collision, so we run the extra steps as full update() calls in the
-        // prefix (each re-checks collision — no tunneling) with a zero-elapsed GameTime so the ms grace
-        // timers (travelTime, hostTimeUntilAttackable, DebuffingProjectile's wavy phase) count once. If
-        // any extra step signals removal/collision, we skip the real call and hand its result to
-        // RemoveWhere. The server drives this whenever a client is in/viewing the location (incl.
-        // MineShaft.UpdateMines), so a fireball at reduced TPS otherwise crawls at 60/TPS× speed.
+        // prefix (each re-checks collision — no tunneling) with a zero-ELAPSED GameTime so the ms grace
+        // timers (travelTime, hostTimeUntilAttackable) count once. The extras' TotalGameTime is NOT
+        // zeroed: DebuffingProjectile's wavy motion is a per-call position offset sampled from the
+        // total clock, and at a zeroed total every extra call would add the constant t=0 offset
+        // (0, +8 px) — a systematic drift, ~+440 px/s at TPS 5 (see SubStepTimeFor). If any extra step
+        // signals removal/collision, we skip the real call and hand its result to RemoveWhere. The
+        // server drives this whenever a client is in/viewing the location (incl. MineShaft.UpdateMines),
+        // so a fireball at reduced TPS otherwise crawls at 60/TPS× speed.
         harmony.Patch(
             original: AccessTools.Method(typeof(Projectile), nameof(Projectile.update)),
             prefix: new HarmonyMethod(typeof(TpsAgnosticPacing), nameof(Projectile_Update_Prefix))
@@ -258,15 +263,43 @@ public static class TpsAgnosticPacing
     [ThreadStatic]
     private static bool _inSubStep;
 
-    // Extra sub-step calls pass this zero-elapsed GameTime (reused; single-threaded loop). Per-tick-constant
-    // steps (`position ± speed`, gravity, velocity ramp) don't read `time` so they still advance, while every
-    // ms/TotalSeconds term in the same body contributes ZERO on extras — only the real call carries the tick's
-    // ms budget. Without it those timers would advance ~12× too fast at TPS 5 (stuck-emote, follow-direction
-    // changes, and — critically — the one-shot effects they gate, e.g. Ghost's projectile spawn).
+    // Extra MOVEMENT/GLIDER sub-step calls pass this zero-elapsed GameTime (reused; single-threaded
+    // loop). Per-tick-constant steps (`position ± speed`, gravity, velocity ramp) don't read `time` so
+    // they still advance, while every ms/TotalSeconds term in the same body contributes ZERO on extras —
+    // only the real call carries the tick's ms budget. Without it those timers would advance ~12× too
+    // fast at TPS 5 (stuck-emote, follow-direction changes, and — critically — the one-shot effects they
+    // gate, e.g. Ghost's projectile spawn). The zeroed TotalGameTime is harmless on these paths (the only
+    // consumers are cosmetic draw bobs); projectile/debris extras use SubStepTimeFor instead.
     private static readonly GameTime ZeroElapsedGameTime = new GameTime(
         TimeSpan.Zero,
         TimeSpan.Zero
     );
+
+    // Projectile/debris extras get a zero ELAPSED time (ms grace/lifetime timers count once) but a real,
+    // per-step-advancing TOTAL clock: DebuffingProjectile.updatePosition adds a wavy position offset of
+    // (sin, cos)(TotalGameTime.Milliseconds·π/128)·8 per CALL, so a zeroed total turns each extra call
+    // into a constant (0, +8 px) bias — ~+440 px/s of spurious drift at TPS 5, comparable to the bolt's
+    // own speed. Advancing the total by one vanilla tick per extra step instead samples the exact phase
+    // grid the wobble sees at 60 TPS. Reused instance (single-threaded loop); nothing else in the
+    // projectile/debris update paths reads the passed TotalGameTime (verified against the decompiled
+    // tree — Debris reads only Game1.currentGameTime for its cosmetic bob).
+    private static readonly GameTime SubStepGameTime = new GameTime(TimeSpan.Zero, TimeSpan.Zero);
+
+    private static readonly long VanillaTickTicks = (long)(
+        VanillaTickMs * TimeSpan.TicksPerMillisecond
+    );
+
+    /// <summary>
+    /// The GameTime for a projectile/debris extra sub-step: elapsed zero, total advanced
+    /// <paramref name="step"/> vanilla ticks past the real call's total. Mutates and returns the shared
+    /// <see cref="SubStepGameTime"/> — valid only for the duration of the sub-step call.
+    /// </summary>
+    private static GameTime SubStepTimeFor(GameTime realTime, int step)
+    {
+        SubStepGameTime.TotalGameTime =
+            realTime.TotalGameTime + new TimeSpan(VanillaTickTicks * step);
+        return SubStepGameTime;
+    }
 
     /// <summary>
     /// Prefix paired with <see cref="MovePosition_SubStep_Postfix"/>: captures the entity's velocity
@@ -299,6 +332,16 @@ public static class TpsAgnosticPacing
     /// real call already ran the velocity path once, which is the correct per-tick decay. (Gliders then
     /// advance only once/tick — still slow at low TPS — and need their own ramp+move sub-step, the glider
     /// seam below. The walk path, driven by the per-tick constant <c>speed</c>, is what SHOULD sub-step.)</para>
+    ///
+    /// <para><b>Deliberate trade-off: knockback duration stretches 60/TPS×.</b> Once-per-tick decay
+    /// preserves total slide DISTANCE (the per-call decay sequence sums the same regardless of call
+    /// rate) but not slide TIME: the ~26 decay calls a knocked-back GreenSlime takes to snap to zero run
+    /// one per tick, so a slide that lasts ~0.4s at 60 TPS lasts ~5s at TPS 5 — and while any velocity
+    /// remains, <c>__state</c> suppresses the walk sub-steps too, so the monster cannot chase for the
+    /// whole stretched slide. Accepted: replaying the velocity path per sub-step was measured to
+    /// collapse knockback to tens of px (the velocity-decay bug this design fixed — plan doc, run
+    /// 2026-07-14T20-37-22Z), and the knockback probe gates distance, which is the combat-relevant
+    /// outcome. Wall-clock knockback is therefore distance-exact, duration-stretched at reduced TPS.</para>
     /// </summary>
     private static void MovePosition_SubStep_Postfix(
         Character __instance,
@@ -368,10 +411,11 @@ public static class TpsAgnosticPacing
     /// <summary>
     /// Prefix on <see cref="Projectile.update"/>. Runs the extra sub-steps this tick as full
     /// <c>update</c> calls (each re-checks collision, so a fast projectile can't tunnel a target/wall),
-    /// each with a zero-elapsed <see cref="GameTime"/> so the ms grace timers count only on the real
-    /// call. If an extra step returns <c>true</c> (collided/expired → remove), the real call is skipped
-    /// and that result is handed to the location's <c>RemoveWhere</c>; otherwise the original runs
-    /// normally with the tick's real <see cref="GameTime"/>.
+    /// each with a zero-elapsed <see cref="GameTime"/> (advancing total — see
+    /// <see cref="SubStepTimeFor"/>) so the ms grace timers count only on the real call. If an extra
+    /// step returns <c>true</c> (collided/expired → remove), the real call is skipped and that result
+    /// is handed to the location's <c>RemoveWhere</c>; otherwise the original runs normally with the
+    /// tick's real <see cref="GameTime"/>.
     /// </summary>
     private static bool Projectile_Update_Prefix(
         Projectile __instance,
@@ -381,7 +425,9 @@ public static class TpsAgnosticPacing
     )
     {
         return RunUpdateSubSteps(
-            extraStep: () => __instance.update(ZeroElapsedGameTime, location),
+            (__instance, location),
+            static (s, subStepTime) => s.__instance.update(subStepTime, s.location),
+            time,
             ref __result
         );
     }
@@ -400,7 +446,9 @@ public static class TpsAgnosticPacing
     )
     {
         return RunUpdateSubSteps(
-            extraStep: () => __instance.updateChunks(ZeroElapsedGameTime, location),
+            (__instance, location),
+            static (s, subStepTime) => s.__instance.updateChunks(subStepTime, s.location),
+            time,
             ref __result
         );
     }
@@ -410,14 +458,22 @@ public static class TpsAgnosticPacing
     /// tick's extra-step count of times under the re-entrancy guard, short-circuiting if a step signals
     /// removal. Returns <c>true</c> to let the original run (no extra step removed the entity), or
     /// <c>false</c> with <paramref name="removeResult"/> set to skip the original and delete the entity.
+    /// The <typeparamref name="TState"/> tuple + static lambda shape is load-bearing: these prefixes run
+    /// per entity per tick at any TPS (a structural no-op at 60), and a capturing closure here would
+    /// allocate a display class + delegate on the game thread every call.
     ///
-    /// <para>The zero-time extras run BEFORE the real call, so ms grace/lifetime timers are consumed at
-    /// the end of the tick's batch instead of the start — a ≤1-tick phase error that is symmetric (real
-    /// call first would expire them up to a tick early instead of late) and inherent to not distributing
-    /// the tick's ms across sub-steps, which is unsafe (see the glider docstring's Ghost one-shot
-    /// hazard). Extras-first also lets a prefix skip the original cleanly on removal.</para>
+    /// <para>The extras run BEFORE the real call, so ms grace/lifetime timers are consumed at the end
+    /// of the tick's batch instead of the start — a ≤1-tick phase error that is symmetric (real call
+    /// first would expire them up to a tick early instead of late) and inherent to not distributing the
+    /// tick's ms across sub-steps, which is unsafe (see the glider docstring's Ghost one-shot hazard).
+    /// Extras-first also lets a prefix skip the original cleanly on removal.</para>
     /// </summary>
-    private static bool RunUpdateSubSteps(Func<bool> extraStep, ref bool removeResult)
+    private static bool RunUpdateSubSteps<TState>(
+        TState state,
+        Func<TState, GameTime, bool> extraStep,
+        GameTime time,
+        ref bool removeResult
+    )
     {
         if (!Enabled || _inSubStep)
         {
@@ -433,9 +489,9 @@ public static class TpsAgnosticPacing
         _inSubStep = true;
         try
         {
-            for (int i = 0; i < extraSteps; i++)
+            for (int i = 1; i <= extraSteps; i++)
             {
-                if (extraStep())
+                if (extraStep(state, SubStepTimeFor(time, i)))
                 {
                     // An extra step collided/expired: remove the entity now and skip the real call so
                     // collision/removal fires exactly once, on the step that reached it.
@@ -492,6 +548,9 @@ public static class TpsAgnosticPacing
     /// <see cref="GameTime"/> so ms/TotalSeconds timers (and the one-shot side effects they gate, e.g.
     /// Ghost's projectile spawn) fire only on the real call. Non-gliders are untouched (their walk path is
     /// already sub-stepped by the MovePosition seam; their velocity path is knockback, handled by part 1).
+    /// The replay mirrors <c>Monster.update</c>'s own gates — master-only, farmers-present, and the stun
+    /// gate on <c>behaviorAtGameTick</c> — since a postfix still runs after the target early-returns (see
+    /// the inline comments for each gate's failure mode).
     ///
     /// <para><b>Why zero-time, and its one accepted deviation.</b> Zero-time on the extra calls is
     /// load-bearing for SAFETY: it freezes each monster's ms/TotalSeconds timers so the one-shot effects
@@ -515,6 +574,23 @@ public static class TpsAgnosticPacing
             return;
         }
 
+        // Mirror Monster.update's own early-outs (Monster.cs:696-718) — a postfix still runs after
+        // them, so each must be re-checked or the replay simulates a monster vanilla just froze:
+        // - Non-master (test client): vanilla runs neither updateMovement (Character.cs master gate)
+        //   nor behaviorAtGameTick (Monster.cs:704) on a slave monster — its position is net-synced
+        //   from the master, and a local replay would fight the next server delta (rubber-banding).
+        // - No farmers in the location: vanilla freezes the monster entirely (Monster.cs:696), but
+        //   MineShaft.UpdateMines still calls Monster.update for every aged-in level (MineShaft.cs:
+        //   4842-4851), so without this gate a glider in a farmer-less mine level replays full AI
+        //   ticks homing on findPlayer()'s Game1.player fallback — cross-map drift plus CPU waste.
+        // (Monster.update's rafting gate, Monster.cs:700, is deliberately not mirrored: isRafting is
+        // set only by the legacy Raft tool, unobtainable in 1.6, and reading Player runs a findPlayer
+        // scan per glider per tick.)
+        if (!Game1.IsMasterGame || !location.farmers.Any())
+        {
+            return;
+        }
+
         int extraSteps = ExtraStepsThisTick();
         if (extraSteps <= 0)
         {
@@ -534,7 +610,16 @@ public static class TpsAgnosticPacing
                 // per-tick constant, correct to repeat) while ms timers contribute nothing on extras. The
                 // Health guard stops replaying a monster any of these calls just killed (NaN/off-map death).
                 __instance.MovePosition(ZeroElapsedGameTime, viewport, location);
-                __instance.behaviorAtGameTick(ZeroElapsedGameTime);
+                // Stun mirrors Monster.cs:706: behaviorAtGameTick is skipped while stunned (a Bat's
+                // steering/ramp lives there and must freeze), while updateAnimation still runs — vanilla
+                // does NOT stun-gate it, so Fly/Serpent/Ghost (whose steering lives there) keep steering
+                // under stun exactly as at 60 TPS. MovePosition needs no mirror: its own stunTime guard
+                // (Monster.cs:1013) makes it a no-op while stunned. stunTime itself is ms-decremented on
+                // the real call only, so the replay never shortens the stun.
+                if (__instance.stunTime.Value <= 0)
+                {
+                    __instance.behaviorAtGameTick(ZeroElapsedGameTime);
+                }
                 updateAnimation(__instance, ZeroElapsedGameTime);
             }
         }
@@ -624,7 +709,9 @@ public static class TpsAgnosticPacing
     /// <see cref="TickScale"/> — the free-move branch already ms-scales in vanilla, so we detect it by
     /// its signature (it multiplies by <c>ElapsedGameTime.Milliseconds</c>, making it already
     /// wall-clock-correct) and leave it untouched. The event branch is the one that returns a raw
-    /// <c>Max(1, speed + farmerAddedSpeed…)</c> per tick with no ms scaling.
+    /// <c>Max(1, speed + farmerAddedSpeed…)</c> per tick with no ms scaling. Scaling applies only to
+    /// farmers THIS process drives through the event (local player + fake event-actor copies); remote
+    /// farmers keep the vanilla value because their consumer here is net extrapolation, not movement.
     /// </summary>
     private static void Farmer_GetMovementSpeed_Postfix(Farmer __instance, ref float __result)
     {
@@ -638,6 +725,17 @@ public static class TpsAgnosticPacing
         // the scripted-event branch (event up, not player-controlled) needs compensation.
         var ev = Game1.CurrentEvent;
         if (ev == null || ev.playerControlSequence)
+        {
+            return;
+        }
+
+        // Scale only farmers the local event instance is moving: the local player and the fake actor
+        // copies events create for everyone else (CreateFakeEventFarmer stamps isFakeEventActor). For a
+        // REMOTE farmer's real instance, getMovementSpeed is consumed as the NetPosition extrapolation
+        // cap (Farmer.UpdateIfOtherPlayer/Update → position.UpdateExtrapolation) while the event is up —
+        // scaling that would let the remote farmer's predicted position overshoot ×TickScale between
+        // net deltas (rubber-banding), with no movement benefit since this process never moves them.
+        if (!__instance.IsLocalPlayer && !__instance.isFakeEventActor)
         {
             return;
         }

--- a/mod/JunimoServer/Env.cs
+++ b/mod/JunimoServer/Env.cs
@@ -30,9 +30,11 @@ internal class Env
 
     /// <summary>
     /// Target game ticks per second. Lower values reduce CPU usage.
-    /// Default: 60 (game default). Minimum: 1.
+    /// Default: 60 (game default). Clamped to [1, 60]: above vanilla's fixed 60 every per-tick-constant
+    /// gameplay path (movement, physics) runs faster than real time, and <c>TpsAgnosticPacing</c> can
+    /// only add sub-steps, never skip vanilla's own.
     /// </summary>
-    public static readonly int ServerTps = Math.Max(1, ParseInt("SERVER_TPS", 60));
+    public static readonly int ServerTps = Math.Clamp(ParseInt("SERVER_TPS", 60), 1, 60);
 
     /// <summary>
     /// Target frames per second for the server's draw loop.

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -195,7 +195,7 @@ internal class ModEntry : Mod
         // is FALSE and ScreenFade.UpdateGlobalFade runs the incremental (non-snap) branch — a wedding
         // globalFade gates event progression ~12x slow at SERVER_TPS=5. The NPC sub-step keeps
         // villagers from walking their schedules at 1/12 speed across every location.
-        TpsAgnosticPacing.Apply(harmony);
+        TpsAgnosticPacing.Apply(harmony, Monitor);
 
         // Test overlay for E2E test debugging (only active when SDVD_ENV=test)
         if (Env.IsTest)

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -190,9 +190,11 @@ internal class ModEntry : Mod
         DisplaySizing.Install(harmony);
 
         // Make per-tick-constant gameplay (NPC/event-actor walking, cutscene fades) advance at
-        // real wall-clock speed regardless of SERVER_TPS. On the render-suppressed host the fade
-        // patch is a no-op (IsDedicatedHost snaps it instantly); the movement sub-step is what
-        // matters server-side, so villagers don't walk at 1/12 speed at SERVER_TPS=5.
+        // real wall-clock speed regardless of SERVER_TPS. Both patches do real work here: this mod
+        // deliberately does NOT set hasDedicatedHost (see AlwaysOn.OnSaveLoaded), so IsDedicatedHost
+        // is FALSE and ScreenFade.UpdateGlobalFade runs the incremental (non-snap) branch — a wedding
+        // globalFade gates event progression ~12x slow at SERVER_TPS=5. The NPC sub-step keeps
+        // villagers from walking their schedules at 1/12 speed across every location.
         TpsAgnosticPacing.Apply(harmony);
 
         // Test overlay for E2E test debugging (only active when SDVD_ENV=test)

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -189,6 +189,12 @@ internal class ModEntry : Mod
         // happens on GameLaunched via DisplaySizing.ApplyFromEnv).
         DisplaySizing.Install(harmony);
 
+        // Make per-tick-constant gameplay (NPC/event-actor walking, cutscene fades) advance at
+        // real wall-clock speed regardless of SERVER_TPS. On the render-suppressed host the fade
+        // patch is a no-op (IsDedicatedHost snaps it instantly); the movement sub-step is what
+        // matters server-side, so villagers don't walk at 1/12 speed at SERVER_TPS=5.
+        TpsAgnosticPacing.Apply(harmony);
+
         // Test overlay for E2E test debugging (only active when SDVD_ENV=test)
         if (Env.IsTest)
         {

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -544,3 +544,72 @@ public class TestImportSaveResponse
     /// <summary>SHA-256 (base64) of the target main file after import.</summary>
     public string PostImportMainFileHash { get; set; } = "";
 }
+
+/// <summary>
+/// Which per-tick-physics entity to spawn/measure with the TPS-agnostic-pacing probe.
+/// </summary>
+public enum PacingProbeKind
+{
+    /// <summary>A <c>BasicProjectile</c> fired horizontally — measures <c>travelDistance</c> (the fix keeps
+    /// wall-clock travel speed constant across TPS).</summary>
+    Projectile,
+
+    /// <summary>An object <c>Debris</c> drop — measures how many chunks have come to rest (the fix keeps the
+    /// settle time wall-clock-constant).</summary>
+    Debris,
+
+    /// <summary>A <c>Bat</c> monster — measures its net displacement toward the host (the fix keeps the
+    /// velocity-ramp/turn rate wall-clock-constant so it closes distance at the same speed at any TPS).</summary>
+    Monster,
+
+    /// <summary>A walking monster (<c>GreenSlime</c>) given a fixed knockback impulse via
+    /// <c>setTrajectory</c> — measures how far the knockback carries it before friction stops it (the fix
+    /// makes the per-call velocity-friction decay run once per tick, so knockback distance is
+    /// wall-clock-constant instead of collapsing under the sub-step at low TPS).</summary>
+    Knockback,
+}
+
+/// <summary>Request body for POST /test/pacing_probe_spawn.</summary>
+public class PacingProbeSpawnRequest
+{
+    /// <summary>"projectile", "debris", "monster", or "knockback" (case-insensitive).</summary>
+    public string? Kind { get; set; }
+}
+
+/// <summary>Response for POST /test/pacing_probe_spawn.</summary>
+public class PacingProbeSpawnResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>The host location the probe entity was spawned in (for the test's log context).</summary>
+    public string? LocationName { get; set; }
+
+    /// <summary>Number of probe entities of this kind now present (should be 1 after a clean spawn).</summary>
+    public int Count { get; set; }
+}
+
+/// <summary>Response for GET /test/pacing_probe_state. Only the field(s) relevant to the spawned kind are meaningful.</summary>
+public class PacingProbeStateResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>Number of probe entities of the requested kind still present.</summary>
+    public int Count { get; set; }
+
+    /// <summary>Projectile: accumulated <c>travelDistance</c> in pixels (monotonic per update). 0 if gone.</summary>
+    public float ProjectileTravelDistance { get; set; }
+
+    /// <summary>Debris: number of chunks that have finished their ballistic fall (bounces &gt; 2).</summary>
+    public int DebrisChunksAtRest { get; set; }
+
+    /// <summary>Debris: total chunk count of the probe debris.</summary>
+    public int DebrisChunkCount { get; set; }
+
+    /// <summary>Monster: net pixel displacement from the spawn position (how far it has travelled/homed).</summary>
+    public float MonsterDisplacement { get; set; }
+
+    /// <summary>Monster: current speed magnitude (sqrt(xVel²+yVel²)) — the velocity-ramp signal.</summary>
+    public float MonsterSpeed { get; set; }
+}

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -598,6 +598,13 @@ public class PacingProbeStateResponse
     /// <summary>Number of probe entities of the requested kind still present.</summary>
     public int Count { get; set; }
 
+    /// <summary>
+    /// <c>Game1.ticks</c> at the moment the state was read (same game-thread action as the entity
+    /// fields, so the pair is atomic). Two reads give a tick-denominated rate — e.g. px/tick =
+    /// Δ<see cref="ProjectileTravelDistance"/>/Δticks — immune to HTTP/scheduler wall-clock jitter.
+    /// </summary>
+    public int ServerTicks { get; set; }
+
     /// <summary>Projectile: accumulated <c>travelDistance</c> in pixels (monotonic per update). 0 if gone.</summary>
     public float ProjectileTravelDistance { get; set; }
 

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -2166,6 +2166,7 @@ public partial class ApiService
                 // Count = "is the tracked probe still in its spawn location" — by identity, so unrelated
                 // world entities of the same kind never inflate it.
                 var location = _probeLocation as GameLocation;
+                result.ServerTicks = Game1.ticks;
 
                 switch (kind)
                 {
@@ -2223,7 +2224,7 @@ public partial class ApiService
                 $"[PacingProbe] {kind}: travelDistance={result.ProjectileTravelDistance:F0} "
                     + $"debrisAtRest={result.DebrisChunksAtRest}/{result.DebrisChunkCount} "
                     + $"monsterDisplacement={result.MonsterDisplacement:F0} monsterSpeed={result.MonsterSpeed:F1} "
-                    + $"count={result.Count}",
+                    + $"count={result.Count} ticks={result.ServerTicks}",
                 LogLevel.Info
             );
         }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -14,7 +14,9 @@ using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Characters;
 using StardewValley.Locations;
+using StardewValley.Monsters;
 using StardewValley.Objects;
+using StardewValley.Projectiles;
 using StardewValley.TerrainFeatures;
 
 namespace JunimoServer.Services.Api;
@@ -83,6 +85,12 @@ public partial class ApiService
                         await WriteJsonAsync(
                             response,
                             await HandleGetTestNpcSpriteIntegrityAsync()
+                        );
+                        return;
+                    case "/test/pacing_probe_state":
+                        await WriteJsonAsync(
+                            response,
+                            await HandleGetTestPacingProbeStateAsync(request)
                         );
                         return;
                 }
@@ -161,6 +169,12 @@ public partial class ApiService
                         return;
                     case "/test/heal_npc_sprites":
                         await WriteJsonAsync(response, await HandlePostTestHealNpcSpritesAsync());
+                        return;
+                    case "/test/pacing_probe_spawn":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestPacingProbeSpawnAsync(request)
+                        );
                         return;
                 }
                 break;
@@ -1944,5 +1958,303 @@ public partial class ApiService
         }
 
         return result;
+    }
+
+    // === TPS-agnostic-pacing combat probe (test-only) ===
+    // Spawns one per-tick-physics entity (projectile / debris / flyer monster) in the HOST's own
+    // location — which the server simulates (the host is a Farmer there, IsMasterGame always true) — so
+    // the probe needs no connected client. The paired state endpoint reads the entity's measured quantity
+    // so a test can compare wall-clock behavior with SDVD_TPS_AGNOSTIC_PACING on vs off at the same TPS.
+
+    // The spawned probe entities, tracked so the state endpoint can read them back. Typed as object (not
+    // the StardewValley types) and coords as floats so ApiService's field metadata carries NO game-type
+    // references — the OpenAPI generator reflects ApiService via Assembly.GetType across the net10-tool /
+    // net6-mod boundary, and a StardewValley-typed field there makes that GetType return null ("ApiService
+    // type not found", per openapi-generator-reflection-invoke). Cast back inside the handlers, which run
+    // on the game thread where the types are loaded. Referenced only from the game thread (both handlers
+    // marshal via RunOnGameThreadAsync), so no synchronization needed.
+    private object? _probeProjectile;
+    private object? _probeDebris;
+    private object? _probeMonster;
+    private float _probeMonsterSpawnX;
+    private float _probeMonsterSpawnY;
+
+    [ApiEndpoint(
+        "POST",
+        "/test/pacing_probe_spawn",
+        Summary = "Spawn a per-tick-physics probe entity (projectile/debris/monster/knockback) in the host location (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(PacingProbeSpawnResponse), 200)]
+    private async Task<PacingProbeSpawnResponse> HandlePostTestPacingProbeSpawnAsync(
+        HttpListenerRequest request
+    )
+    {
+        var result = new PacingProbeSpawnResponse();
+
+        PacingProbeSpawnRequest? body;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            body = string.IsNullOrWhiteSpace(json)
+                ? new PacingProbeSpawnRequest()
+                : JsonConvert.DeserializeObject<PacingProbeSpawnRequest>(json);
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.Error = $"Failed to parse body: {ex.Message}";
+            return result;
+        }
+
+        if (!TryParseProbeKind(body?.Kind, out var kind))
+        {
+            result.Success = false;
+            result.Error =
+                $"Unknown probe kind '{body?.Kind}' (expected projectile/debris/monster/knockback).";
+            return result;
+        }
+
+        if (Game1.gameMode != 3 || !Game1.IsServer)
+        {
+            result.Success = false;
+            result.Error = "Server not ready";
+            return result;
+        }
+
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var location = Game1.player.currentLocation;
+                if (location == null)
+                {
+                    result.Error = "Host has no current location";
+                    return;
+                }
+
+                result.LocationName = location.NameOrUniqueName;
+                var origin = Game1.player.Position;
+
+                // Drop all prior probe tracking so a later state read for any kind can only ever see THIS
+                // spawn's entity (no cross-kind bleed if the shared server is reused for a different kind).
+                RemoveProbeMonster(location);
+                _probeProjectile = null;
+                _probeDebris = null;
+
+                switch (kind)
+                {
+                    case PacingProbeKind.Projectile:
+                    {
+                        // Clear any prior probe projectile, then fire one horizontally from the host. A high
+                        // bounce count makes travelDistance accumulate at the wall-clock rate regardless of
+                        // farm geometry — the projectile ricochets off any wall/obstacle instead of being
+                        // destroyed, so the measurement doesn't depend on a clear line of fire.
+                        // damagesMonsters=true so it targets monsters (none on the idle Farm), not the host.
+                        location.projectiles.Clear();
+                        var projectile = new BasicProjectile(
+                            damageToFarmer: 0,
+                            spriteIndex: 0,
+                            bouncesTillDestruct: 100000,
+                            tailLength: 0,
+                            rotationVelocity: 0f,
+                            xVelocity: 8f,
+                            yVelocity: 0f,
+                            startingPosition: origin,
+                            damagesMonsters: true,
+                            location: location,
+                            firer: Game1.player
+                        );
+                        projectile.ignoreTravelGracePeriod.Value = true;
+                        location.projectiles.Add(projectile);
+                        _probeProjectile = projectile;
+                        result.Count = location.projectiles.Count;
+                        break;
+                    }
+                    case PacingProbeKind.Debris:
+                    {
+                        // Drop an object debris well away from the host so its chunks fall and settle
+                        // WITHOUT being magnetized-and-collected (object debris homes to a nearby player
+                        // once done bouncing; 640 px keeps it outside the ~64 px pickup range for the
+                        // measurement window). Clear prior probe debris first for a clean chunk count.
+                        location.debris.Clear();
+                        var dropOrigin = origin + new Vector2(640f, -128f);
+                        var debris = new Debris(
+                            "(O)388", // Wood — an ordinary object drop
+                            dropOrigin,
+                            dropOrigin
+                        );
+                        location.debris.Add(debris);
+                        _probeDebris = debris;
+                        result.Count = location.debris.Count;
+                        break;
+                    }
+                    case PacingProbeKind.Monster:
+                    {
+                        // Spawn a Bat a fixed distance from the host so it homes in; measure how far it closes.
+                        var spawnPos = origin + new Vector2(640f, 0f);
+                        var bat = new Bat(spawnPos) { focusedOnFarmers = true };
+                        location.characters.Add(bat);
+                        _probeMonster = bat;
+                        _probeMonsterSpawnX = spawnPos.X;
+                        _probeMonsterSpawnY = spawnPos.Y;
+                        result.Count = 1;
+                        break;
+                    }
+                    case PacingProbeKind.Knockback:
+                    {
+                        // Spawn a WALKING monster (GreenSlime — not a glider, so at rest its velocity is 0)
+                        // and hit it with a fixed knockback impulse; measure how far the impulse carries it
+                        // before friction stops it. Non-glider is essential: gliders are always
+                        // velocity-driven, which would muddy a clean knockback measurement.
+                        var slimePos = origin + new Vector2(320f, 0f);
+                        var slime = new GreenSlime(slimePos);
+                        location.characters.Add(slime);
+                        // Large impulse along +x, away from the host, so it dominates any velocity the
+                        // slime's own AI adds (its hop toward the player) and gives a clean knockback slide.
+                        // setTrajectory routes through the master-only doSetTrajectory, which sets xVelocity
+                        // when the impulse exceeds current velocity.
+                        slime.setTrajectory(100, 0);
+                        _probeMonster = slime;
+                        _probeMonsterSpawnX = slimePos.X;
+                        _probeMonsterSpawnY = slimePos.Y;
+                        result.Count = 1;
+                        break;
+                    }
+                }
+
+                result.Success = result.Error == null;
+            });
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "GET",
+        "/test/pacing_probe_state",
+        Summary = "Read the current state of the spawned pacing-probe entity (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(PacingProbeStateResponse), 200)]
+    private async Task<PacingProbeStateResponse> HandleGetTestPacingProbeStateAsync(
+        HttpListenerRequest request
+    )
+    {
+        var result = new PacingProbeStateResponse();
+
+        if (!TryParseProbeKind(request.QueryString["kind"], out var kind))
+        {
+            result.Success = false;
+            result.Error = $"Unknown probe kind '{request.QueryString["kind"]}'.";
+            return result;
+        }
+
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var location = Game1.player.currentLocation;
+
+                switch (kind)
+                {
+                    case PacingProbeKind.Projectile:
+                        result.Count = location?.projectiles.Count ?? 0;
+                        result.ProjectileTravelDistance =
+                            (_probeProjectile as Projectile)?.travelDistance ?? 0f;
+                        break;
+                    case PacingProbeKind.Debris:
+                        if (_probeDebris is Debris debris)
+                        {
+                            result.DebrisChunkCount = debris.Chunks.Count;
+                            // "At rest" = finished the ballistic fall: a chunk stops bouncing at
+                            // bounces > 2 (Debris.updateChunks), after which it either rests or magnetizes
+                            // toward a player. Keying on `bounces` (not zero velocity) gives a stable
+                            // "fall complete" signal unaffected by the post-settle magnetize drift.
+                            result.DebrisChunksAtRest = debris.Chunks.Count(c => c.bounces > 2);
+                            result.Count = location?.debris.Count(d => d == debris) ?? 0;
+                        }
+                        break;
+                    case PacingProbeKind.Monster:
+                    case PacingProbeKind.Knockback:
+                        // Both read the tracked monster's net displacement from spawn: Monster = homing
+                        // distance closed, Knockback = distance the impulse carried it before friction.
+                        if (_probeMonster is Monster monster && location != null)
+                        {
+                            result.Count = location.characters.Contains(monster) ? 1 : 0;
+                            result.MonsterDisplacement = Vector2.Distance(
+                                monster.Position,
+                                new Vector2(_probeMonsterSpawnX, _probeMonsterSpawnY)
+                            );
+                            result.MonsterSpeed = (float)
+                                Math.Sqrt(
+                                    monster.xVelocity * monster.xVelocity
+                                        + monster.yVelocity * monster.yVelocity
+                                );
+                        }
+                        break;
+                }
+
+                result.Success = true;
+            });
+
+            // Durably record the measurement in the server log (LogLevel.Info — not Error, which would
+            // poison the test). The console test annotations can scroll out of a tail'd capture; this line
+            // survives in container.log so a run's pacing numbers are always recoverable.
+            Monitor.Log(
+                $"[PacingProbe] {kind}: travelDistance={result.ProjectileTravelDistance:F0} "
+                    + $"debrisAtRest={result.DebrisChunksAtRest}/{result.DebrisChunkCount} "
+                    + $"monsterDisplacement={result.MonsterDisplacement:F0} monsterSpeed={result.MonsterSpeed:F1} "
+                    + $"count={result.Count}",
+                LogLevel.Info
+            );
+        }
+        catch (Exception ex)
+        {
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    private static bool TryParseProbeKind(string? raw, out PacingProbeKind kind)
+    {
+        switch (raw?.Trim().ToLowerInvariant())
+        {
+            case "projectile":
+                kind = PacingProbeKind.Projectile;
+                return true;
+            case "debris":
+                kind = PacingProbeKind.Debris;
+                return true;
+            case "monster":
+                kind = PacingProbeKind.Monster;
+                return true;
+            case "knockback":
+                kind = PacingProbeKind.Knockback;
+                return true;
+            default:
+                kind = default;
+                return false;
+        }
+    }
+
+    private void RemoveProbeMonster(GameLocation location)
+    {
+        if (_probeMonster is Monster monster && location.characters.Contains(monster))
+        {
+            location.characters.Remove(monster);
+        }
+        _probeMonster = null;
     }
 }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -1976,6 +1976,7 @@ public partial class ApiService
     private object? _probeProjectile;
     private object? _probeDebris;
     private object? _probeMonster;
+    private object? _probeLocation;
     private float _probeMonsterSpawnX;
     private float _probeMonsterSpawnY;
 
@@ -2040,22 +2041,22 @@ public partial class ApiService
                 result.LocationName = location.NameOrUniqueName;
                 var origin = Game1.player.Position;
 
-                // Drop all prior probe tracking so a later state read for any kind can only ever see THIS
-                // spawn's entity (no cross-kind bleed if the shared server is reused for a different kind).
-                RemoveProbeMonster(location);
-                _probeProjectile = null;
-                _probeDebris = null;
+                // Remove all prior probe entities (by identity, from their own spawn location) so a later
+                // state read for any kind can only ever see THIS spawn's entity, and no leaked entity can
+                // contaminate it (a leftover probe projectile ricochets forever and damages monsters, so
+                // it could hit a later monster/knockback probe). Unrelated world entities are untouched.
+                RemoveTrackedProbes();
+                _probeLocation = location;
 
                 switch (kind)
                 {
                     case PacingProbeKind.Projectile:
                     {
-                        // Clear any prior probe projectile, then fire one horizontally from the host. A high
-                        // bounce count makes travelDistance accumulate at the wall-clock rate regardless of
-                        // farm geometry — the projectile ricochets off any wall/obstacle instead of being
-                        // destroyed, so the measurement doesn't depend on a clear line of fire.
+                        // Fire one projectile horizontally from the host. A high bounce count makes
+                        // travelDistance accumulate at the wall-clock rate regardless of farm geometry —
+                        // the projectile ricochets off any wall/obstacle instead of being destroyed, so
+                        // the measurement doesn't depend on a clear line of fire.
                         // damagesMonsters=true so it targets monsters (none on the idle Farm), not the host.
-                        location.projectiles.Clear();
                         var projectile = new BasicProjectile(
                             damageToFarmer: 0,
                             spriteIndex: 0,
@@ -2072,7 +2073,7 @@ public partial class ApiService
                         projectile.ignoreTravelGracePeriod.Value = true;
                         location.projectiles.Add(projectile);
                         _probeProjectile = projectile;
-                        result.Count = location.projectiles.Count;
+                        result.Count = 1;
                         break;
                     }
                     case PacingProbeKind.Debris:
@@ -2080,8 +2081,7 @@ public partial class ApiService
                         // Drop an object debris well away from the host so its chunks fall and settle
                         // WITHOUT being magnetized-and-collected (object debris homes to a nearby player
                         // once done bouncing; 640 px keeps it outside the ~64 px pickup range for the
-                        // measurement window). Clear prior probe debris first for a clean chunk count.
-                        location.debris.Clear();
+                        // measurement window).
                         var dropOrigin = origin + new Vector2(640f, -128f);
                         var debris = new Debris(
                             "(O)388", // Wood — an ordinary object drop
@@ -2090,7 +2090,7 @@ public partial class ApiService
                         );
                         location.debris.Add(debris);
                         _probeDebris = debris;
-                        result.Count = location.debris.Count;
+                        result.Count = 1;
                         break;
                     }
                     case PacingProbeKind.Monster:
@@ -2163,14 +2163,21 @@ public partial class ApiService
         {
             await RunOnGameThreadAsync(() =>
             {
-                var location = Game1.player.currentLocation;
+                // Count = "is the tracked probe still in its spawn location" — by identity, so unrelated
+                // world entities of the same kind never inflate it.
+                var location = _probeLocation as GameLocation;
 
                 switch (kind)
                 {
                     case PacingProbeKind.Projectile:
-                        result.Count = location?.projectiles.Count ?? 0;
-                        result.ProjectileTravelDistance =
-                            (_probeProjectile as Projectile)?.travelDistance ?? 0f;
+                        if (_probeProjectile is Projectile projectile)
+                        {
+                            result.Count =
+                                location != null && location.projectiles.Contains(projectile)
+                                    ? 1
+                                    : 0;
+                            result.ProjectileTravelDistance = projectile.travelDistance;
+                        }
                         break;
                     case PacingProbeKind.Debris:
                         if (_probeDebris is Debris debris)
@@ -2181,16 +2188,18 @@ public partial class ApiService
                             // toward a player. Keying on `bounces` (not zero velocity) gives a stable
                             // "fall complete" signal unaffected by the post-settle magnetize drift.
                             result.DebrisChunksAtRest = debris.Chunks.Count(c => c.bounces > 2);
-                            result.Count = location?.debris.Count(d => d == debris) ?? 0;
+                            result.Count =
+                                location != null && location.debris.Contains(debris) ? 1 : 0;
                         }
                         break;
                     case PacingProbeKind.Monster:
                     case PacingProbeKind.Knockback:
                         // Both read the tracked monster's net displacement from spawn: Monster = homing
                         // distance closed, Knockback = distance the impulse carried it before friction.
-                        if (_probeMonster is Monster monster && location != null)
+                        if (_probeMonster is Monster monster)
                         {
-                            result.Count = location.characters.Contains(monster) ? 1 : 0;
+                            result.Count =
+                                location != null && location.characters.Contains(monster) ? 1 : 0;
                             result.MonsterDisplacement = Vector2.Distance(
                                 monster.Position,
                                 new Vector2(_probeMonsterSpawnX, _probeMonsterSpawnY)
@@ -2249,12 +2258,30 @@ public partial class ApiService
         }
     }
 
-    private void RemoveProbeMonster(GameLocation location)
+    /// <summary>
+    /// Removes every tracked probe entity by identity from the location it was spawned in (the host may
+    /// have moved since), then drops all tracking. Game thread only, like the fields it clears.
+    /// </summary>
+    private void RemoveTrackedProbes()
     {
-        if (_probeMonster is Monster monster && location.characters.Contains(monster))
+        if (_probeLocation is GameLocation location)
         {
-            location.characters.Remove(monster);
+            if (_probeMonster is Monster monster)
+            {
+                location.characters.Remove(monster);
+            }
+            if (_probeProjectile is Projectile projectile)
+            {
+                location.projectiles.Remove(projectile);
+            }
+            if (_probeDebris is Debris debris)
+            {
+                location.debris.Remove(debris);
+            }
         }
         _probeMonster = null;
+        _probeProjectile = null;
+        _probeDebris = null;
+        _probeLocation = null;
     }
 }

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -1174,6 +1174,12 @@ public partial class ApiService : ModService
         var actionsProcessed = false;
         while (_pendingGameActions.TryDequeue(out var item))
         {
+            if (item.Completion.Task.IsCanceled)
+            {
+                // The caller's RunOnGameThreadAsync already timed out and returned an error; applying
+                // the mutation now would change world state the caller was told didn't change.
+                continue;
+            }
             actionsProcessed = true;
             try
             {

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -796,15 +796,41 @@ public partial class ApiService : ModService
     private Timer? _wsCleanupTimer;
 
     /// <summary>
+    /// A queued game-thread action whose execution and timeout compete for an atomic claim: the game
+    /// thread claims pending→executing before running, the timeout callback claims pending→timed-out
+    /// before cancelling. Exactly one side wins, so a timed-out request can never mutate the world
+    /// after its caller was told nothing changed, and an in-flight action is never reported as timed
+    /// out (the caller awaits its real result instead). Must be a reference type — the claim state
+    /// has to be shared between the queue and the timeout callback, not copied per dequeue. Same
+    /// claim pattern as the test client's <c>ExecuteOnGameThread</c> (tests/test-client/ModEntry.cs);
+    /// keep the two in sync.
+    /// </summary>
+    private sealed class PendingGameAction
+    {
+        // 0 = pending, 1 = timed out (execution must skip), 2 = executing (timeout must not cancel).
+        private int _state;
+
+        public PendingGameAction(Action action, TaskCompletionSource<bool> completion)
+        {
+            Action = action;
+            Completion = completion;
+        }
+
+        public Action Action { get; }
+        public TaskCompletionSource<bool> Completion { get; }
+
+        public bool TryClaimExecution() => Interlocked.CompareExchange(ref _state, 2, 0) == 0;
+
+        public bool TryClaimTimeout() => Interlocked.CompareExchange(ref _state, 1, 0) == 0;
+    }
+
+    /// <summary>
     /// Queue of actions to execute on the main game thread.
     /// Used for game state modifications that would cause collection modification errors
     /// if executed from the async HTTP thread (e.g., removing buildings during draw).
     /// Each action includes a TaskCompletionSource to signal completion back to the caller.
     /// </summary>
-    private readonly ConcurrentQueue<(
-        Action Action,
-        TaskCompletionSource<bool> Completion
-    )> _pendingGameActions = new();
+    private readonly ConcurrentQueue<PendingGameAction> _pendingGameActions = new();
 
     /// <summary>
     /// Ticks timestamp of the last OnUpdateTicked call, used by /health to detect game thread stalls.
@@ -1174,10 +1200,10 @@ public partial class ApiService : ModService
         var actionsProcessed = false;
         while (_pendingGameActions.TryDequeue(out var item))
         {
-            if (item.Completion.Task.IsCanceled)
+            if (!item.TryClaimExecution())
             {
-                // The caller's RunOnGameThreadAsync already timed out and returned an error; applying
-                // the mutation now would change world state the caller was told didn't change.
+                // The caller's RunOnGameThreadAsync timed out and returned an error; the atomic claim
+                // guarantees the timeout can no longer land once execution starts (and vice versa).
                 continue;
             }
             actionsProcessed = true;
@@ -1827,10 +1853,20 @@ public partial class ApiService : ModService
             using var _correlationScope = Diagnostics.ModRequestContext.Bind(capturedRequestId);
             action();
         };
-        _pendingGameActions.Enqueue((wrapped, tcs));
+        var item = new PendingGameAction(wrapped, tcs);
+        _pendingGameActions.Enqueue(item);
 
         using var cts = new CancellationTokenSource(timeoutMs);
-        using var registration = cts.Token.Register(() => tcs.TrySetCanceled());
+        using var registration = cts.Token.Register(() =>
+        {
+            // Claim pending→timed-out before cancelling. If the game thread already claimed
+            // execution, don't cancel — the caller awaits the action's real result instead of
+            // being told a mutation that is running right now didn't apply.
+            if (item.TryClaimTimeout())
+            {
+                tcs.TrySetCanceled();
+            }
+        });
 
         try
         {

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -667,6 +667,55 @@ public class TestSetDateResponse
 }
 
 /// <summary>
+/// Response from POST /test/pacing_probe_spawn (test-only).
+/// </summary>
+public class PacingProbeSpawnResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("locationName")]
+    public string? LocationName { get; set; }
+
+    [JsonPropertyName("count")]
+    public int Count { get; set; }
+}
+
+/// <summary>
+/// Response from GET /test/pacing_probe_state (test-only). Only the field(s) matching the spawned kind
+/// are meaningful.
+/// </summary>
+public class PacingProbeStateResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    [JsonPropertyName("count")]
+    public int Count { get; set; }
+
+    [JsonPropertyName("projectileTravelDistance")]
+    public float ProjectileTravelDistance { get; set; }
+
+    [JsonPropertyName("debrisChunksAtRest")]
+    public int DebrisChunksAtRest { get; set; }
+
+    [JsonPropertyName("debrisChunkCount")]
+    public int DebrisChunkCount { get; set; }
+
+    [JsonPropertyName("monsterDisplacement")]
+    public float MonsterDisplacement { get; set; }
+
+    [JsonPropertyName("monsterSpeed")]
+    public float MonsterSpeed { get; set; }
+}
+
+/// <summary>
 /// Response from /test/farmevent POST endpoint (test-only).
 /// </summary>
 public class TestFarmEventResponse
@@ -1964,6 +2013,46 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestSetDateResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: spawn a per-tick-physics probe entity (projectile/debris/monster) in the host's
+    /// location, which the server simulates. Paired with <see cref="GetPacingProbeState"/> to measure
+    /// wall-clock pacing with the TPS-agnostic patches on vs off. POST /test/pacing_probe_spawn
+    /// </summary>
+    public async Task<PacingProbeSpawnResponse?> SpawnPacingProbe(
+        string kind,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/pacing_probe_spawn",
+            ct,
+            () => JsonContent.Create(new { kind })
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<PacingProbeSpawnResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: read the current state of the spawned pacing-probe entity of the given kind.
+    /// GET /test/pacing_probe_state?kind=...
+    /// </summary>
+    public async Task<PacingProbeStateResponse?> GetPacingProbeState(
+        string kind,
+        CancellationToken ct = default
+    )
+    {
+        // Retry on 503: this endpoint marshals onto the game thread and is read once (not polled), so a
+        // transient game-thread-busy has no self-healing poll to fall back on.
+        var response = await SendWithRetryAsync(
+            HttpMethod.Get,
+            $"/test/pacing_probe_state?kind={Uri.EscapeDataString(kind)}",
+            ct
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<PacingProbeStateResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -699,6 +699,10 @@ public class PacingProbeStateResponse
     [JsonPropertyName("count")]
     public int Count { get; set; }
 
+    /// <summary>Game1.ticks at the read, atomic with the entity fields — see the mod-side DTO.</summary>
+    [JsonPropertyName("serverTicks")]
+    public int ServerTicks { get; set; }
+
     [JsonPropertyName("projectileTravelDistance")]
     public float ProjectileTravelDistance { get; set; }
 

--- a/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/GameClientContainer.cs
@@ -195,6 +195,13 @@ public class GameClientContainer : IAsyncDisposable
             .WithEnvironment("STEAM_AUTH_URL", options.SteamAuthUrl ?? "")
             .WithEnvironment("SDVD_TEST_STEAM_ACCOUNT_INDEX", options.SteamAccountIndex.ToString())
             .WithEnvironment("CLIENT_TPS", TestEnvLoader.Get("CLIENT_TPS") ?? "60")
+            // Kill-switch for the TPS-agnostic pacing patches, same as the server container: pass
+            // .env.test's value through (default-on) so a run can set it =false to A/B the client's
+            // movement pacing. The test client registers the same patches as the server mod.
+            .WithEnvironment(
+                "SDVD_TPS_AGNOSTIC_PACING",
+                TestEnvLoader.Get("SDVD_TPS_AGNOSTIC_PACING") ?? "true"
+            )
             // CLIENT_FPS drives both the in-container draw cap and the recorder's
             // sample rate (they're literally the same value; sampling X11 faster
             // than the framebuffer updates is wasted). 0 = rendering disabled.

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -267,6 +267,13 @@ public class ServerContainer : IAsyncDisposable
             .WithEnvironment("API_PORT", ContainerApiPort.ToString())
             // Performance/test settings
             .WithEnvironment("SERVER_TPS", TestEnvLoader.Get("SERVER_TPS") ?? "60")
+            // Kill-switch for the TPS-agnostic pacing patches (fades + movement sub-step). Default-on
+            // in the mod; pass .env.test's value through so a run can set it =false to A/B the patches
+            // (movement reverts to ~60/TPS× slow). Passing the default "true" is a no-op.
+            .WithEnvironment(
+                "SDVD_TPS_AGNOSTIC_PACING",
+                TestEnvLoader.Get("SDVD_TPS_AGNOSTIC_PACING") ?? "true"
+            )
             // SERVER_FPS drives both the in-container draw cap and the recorder's
             // sample rate (they're literally the same value; sampling X11 faster
             // than the framebuffer updates is wasted). 0 = rendering disabled.

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -265,8 +265,15 @@ public class ServerContainer : IAsyncDisposable
             .WithEnvironment("SETTINGS_PATH", SettingsPath)
             .WithEnvironment("API_ENABLED", "true")
             .WithEnvironment("API_PORT", ContainerApiPort.ToString())
-            // Performance/test settings
-            .WithEnvironment("SERVER_TPS", TestEnvLoader.Get("SERVER_TPS") ?? "60")
+            // Performance/test settings. A per-class ServerTps override (TestServerAttribute) wins over
+            // the suite-wide .env.test value — it is part of the server pooling key, so a distinct TPS
+            // gets its own server instance.
+            .WithEnvironment(
+                "SERVER_TPS",
+                options.ServerTps > 0
+                    ? options.ServerTps.ToString()
+                    : TestEnvLoader.Get("SERVER_TPS") ?? "60"
+            )
             // Kill-switch for the TPS-agnostic pacing patches (fades + movement sub-step). Default-on
             // in the mod; pass .env.test's value through so a run can set it =false to A/B the patches
             // (movement reverts to ~60/TPS× slow). Passing the default "true" is a no-op.

--- a/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
@@ -92,6 +92,11 @@ public class ServerContainerOptions
     /// </summary>
     public bool FixtureFarmMod { get; set; } = false;
 
+    /// <summary>
+    /// SERVER_TPS for this container. 0 (default) falls back to .env.test's SERVER_TPS (or 60).
+    /// </summary>
+    public int ServerTps { get; set; } = 0;
+
     #region Container Settings
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceRequirements.cs
@@ -23,7 +23,8 @@ public sealed record ResourceRequirements(
     string? TestMethodName,
     bool Exclusive = false,
     string ExistingCabinBehavior = "KeepExisting",
-    bool FixtureFarmMod = false
+    bool FixtureFarmMod = false,
+    int ServerTps = 0
 )
 {
     private static int _perTestCounter;
@@ -53,19 +54,21 @@ public sealed record ResourceRequirements(
         var connection = WithSteam ? "steam" : "lan";
         var pw = Password != null ? "+pw" : "";
         var fixture = FixtureFarmMod ? "+fixturemod" : "";
-        return $"{connection}{pw}{fixture}-farm{FarmType}-{CabinStrategy}-c{StartingCabins}";
+        var tps = ServerTps > 0 ? $"-tps{ServerTps}" : "";
+        return $"{connection}{pw}{fixture}-farm{FarmType}-{CabinStrategy}-c{StartingCabins}{tps}";
     }
 
     /// <summary>
     /// Hash of server-affecting config fields (not Clients, which doesn't affect server identity).
     /// FixtureFarmMod changes which mods load, which is server identity — so it enters the key.
+    /// ServerTps changes the container's tick rate, which is server identity too.
     /// </summary>
     private string ComputeConfigHash()
     {
         var configString =
             $"{Password}|{FarmType}|{WithSteam}|{StartingCabins}"
             + $"|{MaxPlayers}|{CabinStrategy}|{AllowIpConnections}|{ExistingCabinBehavior}"
-            + $"|{FixtureFarmMod}";
+            + $"|{FixtureFarmMod}|{ServerTps}";
         var bytes = Encoding.UTF8.GetBytes(configString);
         var hash = SHA256.HashData(bytes);
         return Convert.ToHexString(hash)[..12].ToLowerInvariant();
@@ -104,7 +107,8 @@ public sealed record ResourceRequirements(
             TestMethodName: testMethodName,
             Exclusive: attr.Exclusive,
             ExistingCabinBehavior: attr.ExistingCabinBehavior,
-            FixtureFarmMod: attr.FixtureFarmMod
+            FixtureFarmMod: attr.FixtureFarmMod,
+            ServerTps: attr.ServerTps
         );
 
     /// <summary>
@@ -122,6 +126,7 @@ public sealed record ResourceRequirements(
             AllowIpConnections = AllowIpConnections,
             WithSteam = WithSteam,
             FixtureFarmMod = FixtureFarmMod,
+            ServerTps = ServerTps,
         };
         return options;
     }

--- a/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestServerAttribute.cs
@@ -24,6 +24,7 @@ public class TestServerAttribute : Attribute
     internal bool? _exclusive;
     private bool? _artifacts;
     private bool? _fixtureFarmMod;
+    private int? _serverTps;
 
     // "Was this property explicitly set?" tracking for Password
     // because null is a meaningful value (no password)
@@ -98,6 +99,18 @@ public class TestServerAttribute : Attribute
     {
         get => _isolation ?? IsolationMode.SharedClass;
         set => _isolation = value;
+    }
+
+    /// <summary>
+    /// SERVER_TPS override for this test's server container. 0 (default) uses the suite-wide
+    /// .env.test SERVER_TPS. A non-divisor-of-60 value (e.g. 24 → TickScale 2.5) exercises
+    /// TpsAgnosticPacing's fractional sub-step carry, which the suite-wide integer scale never hits.
+    /// Enters the server config hash, so a distinct value provisions its own pooled server.
+    /// </summary>
+    public int ServerTps
+    {
+        get => _serverTps ?? 0;
+        set => _serverTps = value;
     }
 
     /// <summary>
@@ -177,6 +190,7 @@ public class TestServerAttribute : Attribute
         merged._keepConnected = method._keepConnected ?? _keepConnected;
         merged._exclusive = method._exclusive ?? _exclusive;
         merged._fixtureFarmMod = method._fixtureFarmMod ?? _fixtureFarmMod;
+        merged._serverTps = method._serverTps ?? _serverTps;
         merged.SharedGroup = method.SharedGroup ?? SharedGroup;
 
         // DeferAcquisition uses OR: if either says defer, we defer

--- a/tests/JunimoServer.Tests/PacingFractionalCarryTests.cs
+++ b/tests/JunimoServer.Tests/PacingFractionalCarryTests.cs
@@ -1,0 +1,78 @@
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Committed gate for the FRACTIONAL sub-step carry (<c>TpsAgnosticPacing.ExtraStepsThisTick</c>).
+/// The rest of the suite runs at the .env.test <c>SERVER_TPS</c> (5 → TickScale 12, an integer), so
+/// the carry's fractional path would otherwise be exercised by no committed test — a regression in the
+/// floor/remainder math would ship silently. <c>ServerTps = 24</c> gives TickScale 60/24 = 2.5: the
+/// carry must alternate 2/3 whole steps per tick, averaging exactly 2.5.
+///
+/// <para><b>Why the assertion is tick-denominated.</b> A wall-clock distance threshold cannot gate the
+/// carry at a mild scale like 2.5× — even an unpatched build covers a "wall-clock-ish" distance at TPS
+/// 24, and HTTP/scheduler jitter swamps the 20-vs-16 px/tick difference a carry regression produces.
+/// Instead, two probe reads report <c>Game1.ticks</c> atomically with the projectile's
+/// <c>travelDistance</c> (both read in one game-thread action), so px/tick = Δdistance/Δticks is exact
+/// up to whole-step rounding at the window edges, regardless of when the HTTP reads land.
+/// </para>
+/// </summary>
+// Clients = 1: one connected player unpauses the server so the world (and the probe projectile) ticks.
+// Exclusive: mutates the shared host location's projectile collection, like PacingProbeTests.
+// ServerTps = 24: provisions this class's own server (TPS is part of the pooling key).
+[TestServer(Clients = 1, ServerTps = 24, Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class PacingFractionalCarryTests : TestBase
+{
+    // 8 px per update step × 2.5 steps/tick (TickScale 60/24). A carry regression that truncates the
+    // fraction (constant floor(2.5)−1 = 1 extra step) measures 16; no sub-steps measures 8. The ±1.5
+    // band separates those cleanly while absorbing edge rounding (≤ ±1 whole step over ~48 ticks
+    // ≈ ±0.35 px/tick).
+    private const float ExpectedPxPerTick = 20f;
+    private const float PxPerTickTolerance = 1.5f;
+
+    [Fact]
+    public async Task Projectile_PxPerTick_MatchesFractionalTickScale()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await EnsureConnectedAsync("ProbeCarry", ct: ct);
+
+        var spawn = await ServerApi.SpawnPacingProbe("projectile", ct);
+        Assert.NotNull(spawn);
+        Assert.True(spawn.Success, $"Projectile probe spawn failed: {spawn.Error}");
+        Assert.True(spawn.Count >= 1, "Projectile was not added to the host location.");
+
+        // First sample after a short settle so the measured window is strictly mid-flight.
+        await Task.Delay(TimeSpan.FromSeconds(1), ct);
+        var first = await ServerApi.GetPacingProbeState("projectile", ct);
+        Assert.NotNull(first);
+        Assert.True(first.Success, $"First probe state read failed: {first.Error}");
+        Assert.True(first.Count == 1, "Probe projectile disappeared before the first read.");
+
+        await Task.Delay(TimeSpan.FromSeconds(2), ct);
+        var second = await ServerApi.GetPacingProbeState("projectile", ct);
+        Assert.NotNull(second);
+        Assert.True(second.Success, $"Second probe state read failed: {second.Error}");
+        Assert.True(second.Count == 1, "Probe projectile disappeared before the second read.");
+
+        var ticks = second.ServerTicks - first.ServerTicks;
+        Assert.True(
+            ticks > 0,
+            $"Server ticks did not advance between reads ({first.ServerTicks} → {second.ServerTicks})."
+        );
+
+        var pxPerTick = (second.ProjectileTravelDistance - first.ProjectileTravelDistance) / ticks;
+        Assert.True(
+            Math.Abs(pxPerTick - ExpectedPxPerTick) <= PxPerTickTolerance,
+            $"Projectile advanced {pxPerTick:F2} px/tick over {ticks} ticks at SERVER_TPS=24 — expected "
+                + $"{ExpectedPxPerTick:F0} ± {PxPerTickTolerance:F1} (8 px/step × 2.5 steps/tick). ~16 means "
+                + "the fractional carry is truncated (extra steps stuck at floor(TickScale)−1); ~8 means the "
+                + "sub-step did not run at all."
+        );
+
+        LogSuccess(
+            $"Projectile advanced {pxPerTick:F2} px/tick over {ticks} ticks at SERVER_TPS=24 — the "
+                + "fractional carry alternates 2/3 whole steps to average 2.5 (60/24) per tick."
+        );
+    }
+}

--- a/tests/JunimoServer.Tests/PacingProbeTests.cs
+++ b/tests/JunimoServer.Tests/PacingProbeTests.cs
@@ -1,0 +1,185 @@
+using JunimoServer.Tests.Infrastructure;
+using Xunit;
+
+namespace JunimoServer.Tests;
+
+/// <summary>
+/// Runtime gate for the TPS-agnostic pacing patches on <b>per-tick physics</b> — projectiles, item
+/// debris, and flyer-monster movement (<c>JunimoServer.Shared.TpsAgnosticPacing</c>).
+///
+/// <para>
+/// <b>Why this exists.</b> The mod pins <c>TargetElapsedTime = 1000/TPS</c>, so any vanilla code that
+/// advances a fixed amount per <c>Update</c> tick (a projectile's <c>position += velocity</c>, debris
+/// gravity, a bat's velocity ramp) runs <c>60/TPS</c>× too slow at a reduced <c>SERVER_TPS</c>. The
+/// patches sub-step those per-tick constants so the entity covers the same distance per real second at
+/// any TPS. These are <b>server-simulated</b>: <c>IsMasterGame</c> is always true here, so
+/// <c>GameLocation.UpdateWhenCurrentLocation</c> ticks the host's projectiles/debris and
+/// <c>Monster.behaviorAtGameTick</c> runs the bat's AI.
+/// </para>
+///
+/// <para>
+/// <b>Why a client is connected (<c>Clients = 1</c>).</b> The empty-server auto-pause
+/// (<c>AlwaysOn.HandleAutoPause</c>) sets <c>netWorldState.IsPaused</c> when no players are online, and
+/// <c>Game1.HostPaused</c> then gates out <c>UpdateCharacters</c>/<c>UpdateLocations</c> entirely
+/// (<c>Game1.cs:4308</c>) — so on a player-less server NOTHING in the world ticks and every probe reads
+/// zero. One connected client unpauses the server (<c>numPlayers >= 1 → IsPaused = false</c>), which is
+/// also the realistic scenario: a player present in the world is exactly when these entities simulate.
+/// The probe entities are spawned in the HOST's own location (open Farm), which the server ticks because
+/// the host is a farmer there.
+/// </para>
+///
+/// <para>
+/// <b>What it measures.</b> Each case spawns one probe entity via <c>/test/pacing_probe_spawn</c>, waits
+/// a fixed <b>wall-clock</b> window, then reads its travelled distance / rest state via
+/// <c>/test/pacing_probe_state</c>. Thresholds are sized so they only pass when the per-tick physics
+/// advanced at real-time speed: at <c>SERVER_TPS=5</c> the patch must run ~12 sub-steps per tick, so an
+/// unpatched build (or the kill-switch off) falls ~12× short.
+/// </para>
+/// </summary>
+// Clients = 1: one connected player unpauses the server so the world (and the probe entities) tick.
+// Exclusive: each case mutates global world entity collections (location.projectiles/debris/characters)
+// and the shared host location, so it must not run concurrently with another method on the server.
+[TestServer(Clients = 1, Isolation = IsolationMode.SharedClass, Exclusive = true)]
+public class PacingProbeTests : TestBase
+{
+    // Wall-clock window each probe is allowed to run before we read its state. Long enough that a
+    // real-time-paced entity travels/settles well past the pass threshold, and that a 12×-slow unpatched
+    // entity visibly falls short. Kept short so the test stays quick on the shared exclusive chain.
+    private static readonly TimeSpan ProbeWindow = TimeSpan.FromSeconds(3);
+
+    // A projectile fired at 8 px/update covers 8 × 60 = 480 px per real second when the sub-step keeps it
+    // wall-clock-correct — ~1440 px over the 3s window. An unpatched build advances 8 × SERVER_TPS = 40
+    // px/s (~120 px total) at TPS 5. 500 px cleanly separates the two.
+    private const float ProjectileMinTravel = 500f;
+
+    // A GreenSlime (Slipperiness 4) given a 100 px/tick knockback impulse slides ~100/(1/4) ≈ 400 px before
+    // friction (¼ decay per tick, once per tick) stops it — a wall-clock-constant distance at any TPS when
+    // the velocity path runs once per tick. Under the buggy sub-step the impulse decays ~12× per tick and
+    // collapses in ~one tick (barely slides). 250 px cleanly separates fixed from unfixed.
+    private const float KnockbackMinDistance = 250f;
+
+    // A Bat spawned 640 px from the host homes in at wall-clock speed once its whole AI tick (velocity ramp
+    // + move) is sub-stepped for gliders — MEASURED 766 px net displacement in 3s (it reaches the host and
+    // overshoots). Without the glider sub-step it's near-stationary (~15-38 px, velocity never ramps). 400
+    // px cleanly separates fixed from unfixed.
+    private const float MonsterMinDisplacement = 400f;
+
+    [Fact]
+    public async Task Projectile_TravelsWallClockDistance_AtReducedTps()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await EnsureConnectedAsync("ProbeProjectile", ct: ct);
+
+        var spawn = await ServerApi.SpawnPacingProbe("projectile", ct);
+        Assert.NotNull(spawn);
+        Assert.True(spawn.Success, $"Projectile probe spawn failed: {spawn.Error}");
+        Assert.True(spawn.Count >= 1, "Projectile was not added to the host location.");
+
+        await Task.Delay(ProbeWindow, ct);
+
+        var state = await ServerApi.GetPacingProbeState("projectile", ct);
+        Assert.NotNull(state);
+        Assert.True(state.Success, $"Projectile probe state read failed: {state.Error}");
+        Assert.True(
+            state.ProjectileTravelDistance >= ProjectileMinTravel,
+            $"Projectile travelled {state.ProjectileTravelDistance:F0} px in {ProbeWindow.TotalSeconds:F0}s — "
+                + $"expected ≥ {ProjectileMinTravel:F0} px for wall-clock-correct pacing. A value near "
+                + "~120 px means the per-tick sub-step did not run (the projectile advanced at 60/TPS× speed)."
+        );
+
+        LogSuccess(
+            $"Projectile travelled {state.ProjectileTravelDistance:F0} px in {ProbeWindow.TotalSeconds:F0}s "
+                + "wall-clock at the reduced test TPS — the sub-step kept it at real-time speed."
+        );
+    }
+
+    [Fact]
+    public async Task Knockback_CarriesWallClockDistance_AtReducedTps()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await EnsureConnectedAsync("ProbeKnockback", ct: ct);
+
+        var spawn = await ServerApi.SpawnPacingProbe("knockback", ct);
+        Assert.NotNull(spawn);
+        Assert.True(spawn.Success, $"Knockback probe spawn failed: {spawn.Error}");
+        Assert.True(spawn.Count >= 1, "Knocked-back slime was not added to the host location.");
+
+        await Task.Delay(ProbeWindow, ct);
+
+        var state = await ServerApi.GetPacingProbeState("knockback", ct);
+        Assert.NotNull(state);
+        Assert.True(state.Success, $"Knockback probe state read failed: {state.Error}");
+        Assert.True(
+            state.MonsterDisplacement >= KnockbackMinDistance,
+            $"Knockback carried the slime {state.MonsterDisplacement:F0} px in {ProbeWindow.TotalSeconds:F0}s — "
+                + $"expected ≥ {KnockbackMinDistance:F0} px. A small value means the velocity-friction decay "
+                + "ran once per sub-step (~12×/tick) instead of once per tick, collapsing the knockback impulse."
+        );
+
+        LogSuccess(
+            $"Knockback carried the slime {state.MonsterDisplacement:F0} px wall-clock at the reduced test TPS "
+                + "— the velocity path (and its per-tick friction decay) ran once per tick, not per sub-step."
+        );
+    }
+
+    [Fact]
+    public async Task Debris_SettlesWallClock_AtReducedTps()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await EnsureConnectedAsync("ProbeDebris", ct: ct);
+
+        var spawn = await ServerApi.SpawnPacingProbe("debris", ct);
+        Assert.NotNull(spawn);
+        Assert.True(spawn.Success, $"Debris probe spawn failed: {spawn.Error}");
+        Assert.True(spawn.Count >= 1, "Debris was not added to the host location.");
+
+        await Task.Delay(ProbeWindow, ct);
+
+        var state = await ServerApi.GetPacingProbeState("debris", ct);
+        Assert.NotNull(state);
+        Assert.True(state.Success, $"Debris probe state read failed: {state.Error}");
+        Assert.True(state.DebrisChunkCount > 0, "Probe debris reported no chunks.");
+        Assert.True(
+            state.DebrisChunksAtRest == state.DebrisChunkCount,
+            $"Only {state.DebrisChunksAtRest}/{state.DebrisChunkCount} debris chunks finished falling in "
+                + $"{ProbeWindow.TotalSeconds:F0}s — expected all of them. Chunks still bouncing means the "
+                + "gravity/velocity integration ran at 60/TPS× speed (the sub-step did not run)."
+        );
+
+        LogSuccess(
+            $"All {state.DebrisChunkCount} debris chunks finished falling within {ProbeWindow.TotalSeconds:F0}s "
+                + "wall-clock at the reduced test TPS — the sub-step kept the fall at real-time speed."
+        );
+    }
+
+    [Fact]
+    public async Task FlyerMonster_ClosesDistanceWallClock_AtReducedTps()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await EnsureConnectedAsync("ProbeMonster", ct: ct);
+
+        var spawn = await ServerApi.SpawnPacingProbe("monster", ct);
+        Assert.NotNull(spawn);
+        Assert.True(spawn.Success, $"Monster probe spawn failed: {spawn.Error}");
+        Assert.True(spawn.Count >= 1, "Bat was not added to the host location.");
+
+        await Task.Delay(ProbeWindow, ct);
+
+        var state = await ServerApi.GetPacingProbeState("monster", ct);
+        Assert.NotNull(state);
+        Assert.True(state.Success, $"Monster probe state read failed: {state.Error}");
+        Assert.True(
+            state.MonsterDisplacement >= MonsterMinDisplacement,
+            $"Bat moved {state.MonsterDisplacement:F0} px toward the host in {ProbeWindow.TotalSeconds:F0}s "
+                + $"(speed {state.MonsterSpeed:F1}) — expected ≥ {MonsterMinDisplacement:F0} px. A small value "
+                + "means the glider's velocity ramp + move were not sub-stepped (it integrates a ~0 velocity, "
+                + "so it stays near-stationary at reduced TPS)."
+        );
+
+        LogSuccess(
+            $"Bat closed {state.MonsterDisplacement:F0} px on the host in {ProbeWindow.TotalSeconds:F0}s "
+                + $"wall-clock (speed {state.MonsterSpeed:F1}) at the reduced test TPS — the glider AI-tick "
+                + "sub-step moved it at real-time speed."
+        );
+    }
+}

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -105,7 +105,7 @@ public class ModEntry : Mod
         // wall-clock speed regardless of CLIENT_TPS. Unlike the render-suppressed host, this client is
         // a real (non-dedicated) instance, so the fade patch actually bites here — a wedding globalFade
         // that crawled ~12× slow at CLIENT_TPS=5 now plays in real time.
-        TpsAgnosticPacing.Apply(_harmony);
+        TpsAgnosticPacing.Apply(_harmony, Monitor);
 
         // Diagnostics
         _healthWatchdog = new HealthWatchdog(helper, Monitor);

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -101,6 +101,12 @@ public class ModEntry : Mod
         TestOverlay.Apply(_harmony);
         ButtonTutorialSuppressor.Apply(_harmony);
 
+        // Make per-tick-constant gameplay (cutscene fades, NPC/event-actor walking) advance at real
+        // wall-clock speed regardless of CLIENT_TPS. Unlike the render-suppressed host, this client is
+        // a real (non-dedicated) instance, so the fade patch actually bites here — a wedding globalFade
+        // that crawled ~12× slow at CLIENT_TPS=5 now plays in real time.
+        TpsAgnosticPacing.Apply(_harmony);
+
         // Diagnostics
         _healthWatchdog = new HealthWatchdog(helper, Monitor);
         _healthWatchdog.Start();

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -130,11 +130,13 @@ public class ModEntry : Mod
         // Extended spawn logging
         helper.Events.Multiplayer.PeerConnected += OnPeerConnected;
 
-        // Apply custom TPS if configured (reduces CPU usage for test clients)
+        // Apply custom TPS if configured (reduces CPU usage for test clients). Clamped to [1, 60] like
+        // the server's Env.ServerTps: above vanilla's fixed 60 per-tick gameplay outruns real time, and
+        // TpsAgnosticPacing can only add sub-steps, never skip vanilla's own.
         var clientTps = Environment.GetEnvironmentVariable("CLIENT_TPS");
         if (!string.IsNullOrEmpty(clientTps) && int.TryParse(clientTps, out var tps) && tps != 60)
         {
-            _targetTps = Math.Max(1, tps);
+            _targetTps = Math.Clamp(tps, 1, 60);
             helper.Events.GameLoop.UpdateTicked += OnFirstTickSetTps;
         }
 


### PR DESCRIPTION
Makes gameplay produce correct wall-clock outcomes at any `SERVER_TPS`. Vanilla runs a fixed 60 ticks/sec and freely mixes ms-accumulating code (stays real-time at any TPS) with per-tick constants (`x += 0.007f` per Update — runs `60/TPS`× slower). The server pins `TargetElapsedTime = 1000/TPS`, so at reduced TPS every per-tick-constant gameplay path (fades, NPC/creature movement, projectiles, debris) runs slow. These patches compensate the gameplay-relevant instances so the server simulates at real-time speed regardless of TPS.

### Fixes
- **Fades** — scale the per-tick `globalFade` delta by the tick's actual duration (wedding/cutscene fades reach terminus in the same wall-clock time at any TPS).
- **NPC / event-actor / creature walking** — sub-step the per-tick move `floor(TickScale)` times with a zero-elapsed `GameTime` on the extra steps (position advances; ms-based timers stay counted once). Covers villagers, event actors, monsters, farm animals, children.
- **Farmer event/cutscene movement** — scale `getMovementSpeed`'s event branch.
- **Projectiles + debris** — prefix sub-step of `Projectile.update` / `Debris.updateChunks` (collision re-checked per sub-step, no tunneling; `travelTime`/lifetime timers counted once).
- **Velocity-decay-over-substep bug (found + fixed here)** — every `MovePosition` variant has a velocity path (`position += xVelocity; xVelocity -= xVelocity/k`) whose friction decay is per-CALL; the sub-step was re-running it N× per tick and collapsing it. Fixed in two parts: knockback (all monsters + NPCs) runs the velocity path once per tick; gliders/fliers replay their whole AI tick (move + velocity-ramp) N× with zero-time so they move at wall-clock speed. Faithfulness audited across all five glider types.

### Kill-switch
- `SDVD_TPS_AGNOSTIC_PACING=false` disables all patches (default on) so operators on low-TPS servers can restore the prior pacing without a rebuild. A boot log records which mode is active.

### Validation
- New `/test/pacing_probe_*` combat probe + `PacingProbeTests` gate the per-tick-physics fixes at the reduced test TPS (projectile ~1536px/3s, knockback ~400px, debris settles, homing bat ~650-766px — each sized so an unpatched/kill-switch-off build fails).
- Non-integer-TPS gate: `WeddingTests` at `SERVER_TPS=24` (scale 2.5) exercises the fractional-carry path with no drift.
- Kill-switch A/B: run with `=false` confirms the boot log and reversion to slow pacing.
- Full E2E suite green (158 passed, 0 failed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Gameplay pacing now remains consistent with real time across different server and client tick rates.
  - Movement, fades, projectiles, debris, knockback, and flying creatures continue progressing smoothly at reduced TPS.
  - Added a runtime configuration switch to enable or disable pacing adjustments.
  - Server and client tick rates are now limited to a maximum of 60 TPS.

- **Bug Fixes**
  - Prevented canceled requests from applying delayed game changes after timing out.

- **Tests**
  - Added automated pacing probes and integration coverage for reduced-TPS movement and physics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->