### PR TITLE
feat(test-runner): persist runner in-memory-only state to disk diagnostics sinks

### DIFF
--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -473,9 +473,14 @@ run-metadata.json       # coordinator writes
 summary.json            # passed/failed/canceled counts + degradation
 ctrf-report.json        # CTRF format
 diagnostics/
-  infrastructure.jsonl  # structured event stream; host_id field on host-fanned
-                        #   events (container_started/stopped/oom_killed,
-                        #   docker_preflight, image_transfer_*, capacity_*).
+  infrastructure.jsonl    # structured event stream; host_id field on host-fanned
+                          #   events (container_started/stopped/oom_killed,
+                          #   docker_preflight, image_transfer_*, capacity_*).
+  instance-stats.jsonl    # per-instance container/game stats history
+  instance-history.jsonl  # per-instance lifecycle (leased/poisoned/…) + final state
+  run-events.jsonl        # UI event stream; only on-disk home for xUnit diag/error
+  test-details.jsonl      # per-test output, ordering/timing, used instances
+  setup-phases.jsonl      # prestart/warmup phase + step breakdown
 flakiness.jsonl
 tests/
   {Class}.{Method}/     # per-test artifacts (screenshots, recordings)

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -81,7 +81,7 @@ var hostPool = HostPool.Instance;
 // — minutes of work on a cold remote host) can still write summary.json. The
 // renderer never owns this state — the writer fires from Program.cs's outer
 // finally regardless of which renderer mode is active.
-var recorder = new RunRecorder();
+var recorder = new RunRecorder(CollectKnownSecrets);
 recorder.SeedRunIdentity(TestArtifacts.RunDir, RunMetadata.RunId!);
 
 // Create renderer based on mode, then wrap in a fault-isolation guard so a
@@ -1160,10 +1160,11 @@ static bool IsCIEnvironment() =>
 static string ScrubForLog(string message) => ReportRedactor.Scrub(message, CollectKnownSecrets());
 
 /// <summary>
-/// Collects the sensitive values the runner knows, for the report redactor to mask out
-/// of the published (public) snapshot: Steam credentials from <c>STEAM_ACCOUNTS</c> and
-/// each remote host's <c>user@host</c> + bare host from <see cref="HostPool"/>. Best-effort
-/// — any failure yields an empty set (the redactor's regex pass still runs).
+/// Collects the sensitive values the runner knows, for <see cref="ReportRedactor"/> to mask
+/// out of everything published — the report snapshot, the diagnostics jsonl sinks, CI log
+/// lines: Steam credentials from <c>STEAM_ACCOUNTS</c> and each remote host's
+/// <c>user@host</c> + bare host from <see cref="HostPool"/>. Best-effort — any failure
+/// yields an empty set (the redactor's regex pass still runs).
 /// </summary>
 static IReadOnlyCollection<string> CollectKnownSecrets()
 {

--- a/tests/JunimoServer.TestRunner/Program.cs
+++ b/tests/JunimoServer.TestRunner/Program.cs
@@ -1126,6 +1126,12 @@ finally
     // without blocking a thread-pool thread.
     await InfrastructureEventLog.ShutdownAsync();
 
+    // The infra logs are appended live by their own writers (child + parent), so
+    // they can only be scrubbed here, after both have closed. run-metadata.json
+    // gets the same pass: in local mode the test child writes it directly,
+    // bypassing the artifact writer's scrubbed rewrite.
+    ScrubRunFilesInPlace();
+
     JunimoServer.Tests.Helpers.ShutdownCoordinator.SignalGracefulComplete();
 
     // Clean exit only: skip the EmergencyCleanup bulk Docker sweep on
@@ -1158,6 +1164,42 @@ static bool IsCIEnvironment() =>
 /// published report, so masking is consistent everywhere (e.g. <c>***.***.***.188</c>).
 /// </summary>
 static string ScrubForLog(string message) => ReportRedactor.Scrub(message, CollectKnownSecrets());
+
+/// <summary>
+/// Rewrites the run files whose producers append live during the run (so a
+/// scrub-at-write isn't possible) with their secrets masked: the child- and
+/// parent-process infrastructure logs, plus the child-written run-metadata.json.
+/// Best-effort per file; a failure leaves that file unscrubbed and logs why.
+/// </summary>
+static void ScrubRunFilesInPlace()
+{
+    var secrets = CollectKnownSecrets();
+    var diagnosticsDir = Path.Combine(TestArtifacts.RunDir, RunArtifactNames.DiagnosticsDir);
+    string[] paths =
+    [
+        Path.Combine(diagnosticsDir, RunArtifactNames.InfrastructureJsonl),
+        Path.Combine(diagnosticsDir, RunArtifactNames.ParentInfrastructureJsonl),
+        Path.Combine(TestArtifacts.RunDir, RunArtifactNames.RunMetadataJson),
+    ];
+    foreach (var path in paths)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            File.WriteAllText(path, ReportRedactor.Scrub(File.ReadAllText(path), secrets));
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[ArtifactWriter] scrub of {Path.GetFileName(path)} failed: {ex.Message}"
+            );
+        }
+    }
+}
 
 /// <summary>
 /// Collects the sensitive values the runner knows, for <see cref="ReportRedactor"/> to mask

--- a/tests/JunimoServer.TestRunner/Rendering/RendererDispatchGuard.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/RendererDispatchGuard.cs
@@ -256,7 +256,7 @@ public sealed class RendererDispatchGuard : ITestRenderer
     {
         // ApplyRunMetadata is void+idempotent; SerializeRunMetadataEvent
         // produces the broadcast JSON and has the AddEventLog side-effect
-        // that contributes to the WS-snapshot history.
+        // that lands the event in run-events.jsonl.
         ApplyState(nameof(OnRunMetadata) + ":apply", () => _recorder.State.ApplyRunMetadata(e));
         string? json = null;
         try

--- a/tests/JunimoServer.TestRunner/Rendering/RunRecorder.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/RunRecorder.cs
@@ -28,6 +28,11 @@ public sealed class RunRecorder
 {
     private readonly TestRunArtifactWriter _writer = new();
 
+    // Deferred to write time (not captured at construction): the secrets set
+    // includes each remote host's SSH destination, and HostPool is only
+    // populated during preflight — after this recorder is constructed.
+    private readonly Func<IReadOnlyCollection<string>> _collectKnownSecrets;
+
     // Volatile because OnRunFinished writes from the dispatch thread and
     // BeginAbort's force-kill thread reads from a thread-pool thread. Without it
     // the abort handler can label a graceful run as aborted via a stale read.
@@ -39,6 +44,11 @@ public sealed class RunRecorder
     private string? _externalAbortReason;
 
     public TestRunState State { get; } = new();
+
+    public RunRecorder(Func<IReadOnlyCollection<string>> collectKnownSecrets)
+    {
+        _collectKnownSecrets = collectKnownSecrets;
+    }
 
     public bool IsRunFinished => _isRunFinished;
 
@@ -67,6 +77,6 @@ public sealed class RunRecorder
         // _instances (not projected into the per-test RunArtifactView), and only
         // TestRunState can serialize it (the InstanceState/-StatsEntry types are
         // private nested). The writer reads it under TestRunState's own lock.
-        _writer.WriteIfNotWritten(view, State);
+        _writer.WriteIfNotWritten(view, State, _collectKnownSecrets());
     }
 }

--- a/tests/JunimoServer.TestRunner/Rendering/Web/ReportRedactor.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/ReportRedactor.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
 
 namespace JunimoServer.TestRunner.Rendering.Web;
@@ -12,7 +13,9 @@ namespace JunimoServer.TestRunner.Rendering.Web;
 /// would corrupt benign version strings like <c>Unix 6.1.0.17</c>):</para>
 /// <list type="number">
 ///   <item>Known-value pass — literal replacement of values the runner actually knows
-///   (VPS host/IP, Steam credentials), longest-first. Zero ambiguity.</item>
+///   (VPS host/IP, Steam credentials), longest-first, in both raw and JSON-escaped
+///   form so a secret embedded in serialized JSON text is still matched. Zero
+///   ambiguity.</item>
 ///   <item>High-confidence regex — shapes that don't collide with benign text: private-key
 ///   blocks, <c>/run/secrets</c> snippets, <c>key=value</c> secret assignments, SSH
 ///   <c>user@host</c> destinations.</item>
@@ -69,13 +72,22 @@ public static class ReportRedactor
         var result = snapshotJson;
 
         // 1. Known values — longest-first so e.g. "user@host" is masked before the bare
-        //    "host" substring it contains.
+        //    "host" substring it contains. Each secret is replaced in both its raw and
+        //    JSON-escaped form: the emitters' default encoder escapes quotes, backslashes,
+        //    non-ASCII, and HTML-sensitive chars like '+', so a secret containing any of
+        //    those appears in serialized JSON only as its escaped spelling.
         foreach (
             var secret in knownSecrets.Where(s => s.Length >= 3).OrderByDescending(s => s.Length)
         )
         {
             var masked = LooksLikeIp(secret) ? MaskIp(secret) : MaskValue(secret);
             result = result.Replace(secret, masked);
+
+            var escaped = JsonSerializer.Serialize(secret)[1..^1];
+            if (escaped != secret)
+            {
+                result = result.Replace(escaped, masked);
+            }
         }
 
         // 2. High-confidence regex.

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
@@ -123,6 +123,48 @@ public sealed class TestRunArtifactWriter
 
             try
             {
+                WriteInstanceHistory(state);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[ArtifactWriter] instance-history.jsonl failed: {ex.Message}"
+                );
+            }
+
+            try
+            {
+                WriteRunEvents(state);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[ArtifactWriter] run-events.jsonl failed: {ex.Message}");
+            }
+
+            try
+            {
+                WriteTestDetails(state);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[ArtifactWriter] test-details.jsonl failed: {ex.Message}"
+                );
+            }
+
+            try
+            {
+                WriteSetupPhases(state);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[ArtifactWriter] setup-phases.jsonl failed: {ex.Message}"
+                );
+            }
+
+            try
+            {
                 WriteLatestPointer();
             }
             catch (Exception ex)
@@ -495,6 +537,58 @@ public sealed class TestRunArtifactWriter
         Directory.CreateDirectory(diagnosticsDir);
         state.WriteInstanceStatsJsonl(
             Path.Combine(diagnosticsDir, RunArtifactNames.InstanceStatsJsonl)
+        );
+    }
+
+    /// <summary>
+    /// Flushes the per-instance lifecycle narrative to
+    /// <c>diagnostics/instance-history.jsonl</c> — which test held which
+    /// container and why it was poisoned, otherwise only in memory for the UI.
+    /// </summary>
+    private void WriteInstanceHistory(TestRunState state)
+    {
+        var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
+        Directory.CreateDirectory(diagnosticsDir);
+        state.WriteInstanceHistoryJsonl(
+            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceHistoryJsonl)
+        );
+    }
+
+    /// <summary>
+    /// Flushes the UI event stream to <c>diagnostics/run-events.jsonl</c> — the
+    /// only on-disk home for xUnit-level diagnostic/error events and the run's
+    /// unified event ordering.
+    /// </summary>
+    private void WriteRunEvents(TestRunState state)
+    {
+        var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
+        Directory.CreateDirectory(diagnosticsDir);
+        state.WriteRunEventsJsonl(Path.Combine(diagnosticsDir, RunArtifactNames.RunEventsJsonl));
+    }
+
+    /// <summary>
+    /// Flushes per-test UI-only extras to <c>diagnostics/test-details.jsonl</c> —
+    /// output, non-failed stack traces, ordering/timing that summary/ctrf omit.
+    /// </summary>
+    private void WriteTestDetails(TestRunState state)
+    {
+        var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
+        Directory.CreateDirectory(diagnosticsDir);
+        state.WriteTestDetailsJsonl(
+            Path.Combine(diagnosticsDir, RunArtifactNames.TestDetailsJsonl)
+        );
+    }
+
+    /// <summary>
+    /// Flushes the prestart/warmup narrative to
+    /// <c>diagnostics/setup-phases.jsonl</c> — the run-start phase/step breakdown.
+    /// </summary>
+    private void WriteSetupPhases(TestRunState state)
+    {
+        var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
+        Directory.CreateDirectory(diagnosticsDir);
+        state.WriteSetupPhasesJsonl(
+            Path.Combine(diagnosticsDir, RunArtifactNames.SetupPhasesJsonl)
         );
     }
 

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
@@ -47,9 +47,14 @@ public sealed class TestRunArtifactWriter
     /// <paramref name="state"/> is the live <see cref="TestRunState"/>; it carries
     /// the per-instance stats history that <see cref="RunArtifactView"/> does not
     /// (those types are private nested in TestRunState), serialized here under the
-    /// state's own lock.
+    /// state's own lock. <paramref name="knownSecrets"/> is masked out of every
+    /// diagnostics jsonl sink — the runs tree is uploaded as a public CI artifact.
     /// </summary>
-    public void WriteIfNotWritten(RunArtifactView view, TestRunState state)
+    public void WriteIfNotWritten(
+        RunArtifactView view,
+        TestRunState state,
+        IReadOnlyCollection<string> knownSecrets
+    )
     {
         lock (_lock)
         {
@@ -112,7 +117,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteInstanceStats(state);
+                WriteInstanceStats(state, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -123,7 +128,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteInstanceHistory(state);
+                WriteInstanceHistory(state, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -134,7 +139,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteRunEvents(state);
+                WriteRunEvents(state, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -143,7 +148,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteTestDetails(state);
+                WriteTestDetails(state, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -154,7 +159,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteSetupPhases(state);
+                WriteSetupPhases(state, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -531,26 +536,30 @@ public sealed class TestRunArtifactWriter
     /// WebSocket (<c>SetupEventBus</c> is disk-free); this is the only on-disk
     /// sink for post-mortem container-load analysis.
     /// </summary>
-    private void WriteInstanceStats(TestRunState state)
+    private void WriteInstanceStats(TestRunState state, IReadOnlyCollection<string> knownSecrets)
     {
         var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
         Directory.CreateDirectory(diagnosticsDir);
         state.WriteInstanceStatsJsonl(
-            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceStatsJsonl)
+            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceStatsJsonl),
+            knownSecrets
         );
     }
 
     /// <summary>
     /// Flushes the per-instance lifecycle narrative to
-    /// <c>diagnostics/instance-history.jsonl</c> — which test held which
-    /// container and why it was poisoned, otherwise only in memory for the UI.
+    /// <c>diagnostics/instance-history.jsonl</c> — the instance-keyed
+    /// consolidated view (final state, connect/disconnect transitions,
+    /// VNC/recording paths) that <c>infrastructure.jsonl</c>'s event stream
+    /// doesn't carry.
     /// </summary>
-    private void WriteInstanceHistory(TestRunState state)
+    private void WriteInstanceHistory(TestRunState state, IReadOnlyCollection<string> knownSecrets)
     {
         var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
         Directory.CreateDirectory(diagnosticsDir);
         state.WriteInstanceHistoryJsonl(
-            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceHistoryJsonl)
+            Path.Combine(diagnosticsDir, RunArtifactNames.InstanceHistoryJsonl),
+            knownSecrets
         );
     }
 
@@ -559,23 +568,27 @@ public sealed class TestRunArtifactWriter
     /// only on-disk home for xUnit-level diagnostic/error events and the run's
     /// unified event ordering.
     /// </summary>
-    private void WriteRunEvents(TestRunState state)
+    private void WriteRunEvents(TestRunState state, IReadOnlyCollection<string> knownSecrets)
     {
         var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
         Directory.CreateDirectory(diagnosticsDir);
-        state.WriteRunEventsJsonl(Path.Combine(diagnosticsDir, RunArtifactNames.RunEventsJsonl));
+        state.WriteRunEventsJsonl(
+            Path.Combine(diagnosticsDir, RunArtifactNames.RunEventsJsonl),
+            knownSecrets
+        );
     }
 
     /// <summary>
     /// Flushes per-test UI-only extras to <c>diagnostics/test-details.jsonl</c> —
     /// output, non-failed stack traces, ordering/timing that summary/ctrf omit.
     /// </summary>
-    private void WriteTestDetails(TestRunState state)
+    private void WriteTestDetails(TestRunState state, IReadOnlyCollection<string> knownSecrets)
     {
         var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
         Directory.CreateDirectory(diagnosticsDir);
         state.WriteTestDetailsJsonl(
-            Path.Combine(diagnosticsDir, RunArtifactNames.TestDetailsJsonl)
+            Path.Combine(diagnosticsDir, RunArtifactNames.TestDetailsJsonl),
+            knownSecrets
         );
     }
 
@@ -583,12 +596,13 @@ public sealed class TestRunArtifactWriter
     /// Flushes the prestart/warmup narrative to
     /// <c>diagnostics/setup-phases.jsonl</c> — the run-start phase/step breakdown.
     /// </summary>
-    private void WriteSetupPhases(TestRunState state)
+    private void WriteSetupPhases(TestRunState state, IReadOnlyCollection<string> knownSecrets)
     {
         var diagnosticsDir = Path.Combine(_runDir!, RunArtifactNames.DiagnosticsDir);
         Directory.CreateDirectory(diagnosticsDir);
         state.WriteSetupPhasesJsonl(
-            Path.Combine(diagnosticsDir, RunArtifactNames.SetupPhasesJsonl)
+            Path.Combine(diagnosticsDir, RunArtifactNames.SetupPhasesJsonl),
+            knownSecrets
         );
     }
 

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunArtifactWriter.cs
@@ -48,7 +48,8 @@ public sealed class TestRunArtifactWriter
     /// the per-instance stats history that <see cref="RunArtifactView"/> does not
     /// (those types are private nested in TestRunState), serialized here under the
     /// state's own lock. <paramref name="knownSecrets"/> is masked out of every
-    /// diagnostics jsonl sink — the runs tree is uploaded as a public CI artifact.
+    /// artifact this writer produces (the json reports and the diagnostics jsonl
+    /// sinks) — the runs tree is uploaded as a public CI artifact.
     /// </summary>
     public void WriteIfNotWritten(
         RunArtifactView view,
@@ -79,7 +80,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteSummaryJson(view);
+                WriteSummaryJson(view, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -88,7 +89,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteCtrfReport(view);
+                WriteCtrfReport(view, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -97,7 +98,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteRunOutput(view);
+                WriteRunOutput(view, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -106,7 +107,7 @@ public sealed class TestRunArtifactWriter
 
             try
             {
-                WriteRunMetadataMerged(view);
+                WriteRunMetadataMerged(view, knownSecrets);
             }
             catch (Exception ex)
             {
@@ -179,7 +180,7 @@ public sealed class TestRunArtifactWriter
         }
     }
 
-    private void WriteSummaryJson(RunArtifactView v)
+    private void WriteSummaryJson(RunArtifactView v, IReadOnlyCollection<string> knownSecrets)
     {
         var failures = new List<Dictionary<string, object?>>();
         long activeDurationTotalMs = 0;
@@ -259,7 +260,7 @@ public sealed class TestRunArtifactWriter
         };
 
         Directory.CreateDirectory(_runDir!);
-        var json = ArtifactPrettyJson.Serialize(summary);
+        var json = ReportRedactor.Scrub(ArtifactPrettyJson.Serialize(summary), knownSecrets);
         File.WriteAllText(Path.Combine(_runDir!, RunArtifactNames.SummaryJson), json);
     }
 
@@ -310,7 +311,7 @@ public sealed class TestRunArtifactWriter
         };
     }
 
-    private void WriteCtrfReport(RunArtifactView v)
+    private void WriteCtrfReport(RunArtifactView v, IReadOnlyCollection<string> knownSecrets)
     {
         var tests = new List<Dictionary<string, object?>>();
 
@@ -441,7 +442,7 @@ public sealed class TestRunArtifactWriter
         };
 
         Directory.CreateDirectory(_runDir!);
-        var json = ArtifactPrettyJson.Serialize(report);
+        var json = ReportRedactor.Scrub(ArtifactPrettyJson.Serialize(report), knownSecrets);
         File.WriteAllText(Path.Combine(_runDir!, RunArtifactNames.CtrfReport), json);
     }
 
@@ -458,7 +459,7 @@ public sealed class TestRunArtifactWriter
     /// contract and its consumers are untouched.
     /// </para>
     /// </summary>
-    private void WriteRunOutput(RunArtifactView v)
+    private void WriteRunOutput(RunArtifactView v, IReadOnlyCollection<string> knownSecrets)
     {
         var status = v.Aborted ? "aborted" : ResultStatus(v);
         var degradation = BuildDegradation(v);
@@ -484,11 +485,11 @@ public sealed class TestRunArtifactWriter
         };
 
         Directory.CreateDirectory(_runDir!);
-        var json = ArtifactPrettyJson.Serialize(output);
+        var json = ReportRedactor.Scrub(ArtifactPrettyJson.Serialize(output), knownSecrets);
         File.WriteAllText(Path.Combine(_runDir!, RunArtifactNames.RunOutputJson), json);
 
         // One-line JSON to stdout so CI scrapers can parse the run summary directly.
-        Console.WriteLine(JsonSerializer.Serialize(output));
+        Console.WriteLine(ReportRedactor.Scrub(JsonSerializer.Serialize(output), knownSecrets));
     }
 
     /// <summary>
@@ -498,7 +499,7 @@ public sealed class TestRunArtifactWriter
     /// is null and this writer is a no-op (the local test-child already wrote
     /// its own run-metadata.json directly).
     /// </summary>
-    private void WriteRunMetadataMerged(RunArtifactView v)
+    private void WriteRunMetadataMerged(RunArtifactView v, IReadOnlyCollection<string> knownSecrets)
     {
         if (v.WorkerRunMetadata is null || v.WorkerRunMetadata.Count == 0)
         {
@@ -525,7 +526,7 @@ public sealed class TestRunArtifactWriter
         merged["workers"] = v.WorkerRunMetadata.Select(w => (object)w.Clone()).ToList();
 
         Directory.CreateDirectory(_runDir!);
-        var json = ArtifactPrettyJson.Serialize(merged);
+        var json = ReportRedactor.Scrub(ArtifactPrettyJson.Serialize(merged), knownSecrets);
         File.WriteAllText(Path.Combine(_runDir!, RunArtifactNames.RunMetadataJson), json);
     }
 

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -1673,7 +1673,7 @@ public sealed class TestRunState
                                     t.StackTrace,
                                     t.FailureContext,
                                     RecordingSkipReasons = t.RecordingSkipReasons.Count > 0
-                                        ? new Dictionary<string, string>(t.RecordingSkipReasons)
+                                        ? t.RecordingSkipReasons
                                         : null,
                                     UsedInstances = t.UsedInstances.Count > 0
                                         ? t.UsedInstances

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -1540,6 +1540,235 @@ public sealed class TestRunState
     }
 
     /// <summary>
+    /// Writes the per-instance lifecycle narrative to <paramref name="path"/>:
+    /// one compact JSON line per <c>History</c> entry (created/leased/returned/
+    /// disposed/poisoned/connected/disconnected), each carrying the instance
+    /// identity — so a post-mortem reader can reconstruct which test held which
+    /// container and why it was poisoned. The <c>SetupEventBus</c> is disk-free,
+    /// so this is the only on-disk home for that narrative.
+    /// Instances with no history are skipped, so the file is empty when no
+    /// instance lifecycle was recorded.
+    /// </summary>
+    public void WriteInstanceHistoryJsonl(string path)
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            foreach (var inst in _instances.Values)
+            {
+                foreach (var h in inst.History)
+                {
+                    lines.Add(
+                        Serialize(
+                            new
+                            {
+                                inst.InstanceId,
+                                inst.HostId,
+                                inst.InstanceType,
+                                inst.ServerKey,
+                                inst.Label,
+                                h.Timestamp,
+                                h.Event,
+                                h.TestName,
+                                h.Reason,
+                                h.ServerInstanceId,
+                                h.ClientInstanceId,
+                            }
+                        )
+                    );
+                }
+
+                // Trailing final-state line so the current status fields (which the
+                // history transitions don't fully carry) survive too.
+                lines.Add(
+                    Serialize(
+                        new
+                        {
+                            inst.InstanceId,
+                            inst.HostId,
+                            inst.InstanceType,
+                            inst.ServerKey,
+                            inst.Label,
+                            Event = "final_state",
+                            inst.Status,
+                            inst.Connected,
+                            inst.Disposed,
+                            inst.CurrentTest,
+                            inst.PoisonReason,
+                            inst.ConnectedServerId,
+                            inst.VncUrl,
+                            inst.SetupStatus,
+                            inst.RecordingPath,
+                        }
+                    )
+                );
+            }
+
+            File.WriteAllLines(path, lines);
+        }
+    }
+
+    /// <summary>
+    /// Writes the runner's in-memory UI event stream (the sequence the UI replays
+    /// to late-connecting clients) to <paramref name="path"/>, one compact JSON
+    /// line per <c>_eventLog</c> entry. Uniquely preserves the <c>diagnostic</c>
+    /// and <c>error</c> events (from xUnit's <c>OnDiagnosticMessage</c>/
+    /// <c>OnErrorMessage</c>), which land nowhere else on disk, plus the unified
+    /// ordering of the run's event stream.
+    /// <para>
+    /// <c>_eventLog</c> is a bounded ring buffer (<see cref="MaxEventLogSize"/>);
+    /// a normal run stays well under the cap, but if it was full at flush this
+    /// prepends a <c>run_events_truncated</c> marker so a ring-buffer-evicted log
+    /// is never mistaken for a complete one. The cap bounds live memory and is
+    /// deliberately not raised here.
+    /// </para>
+    /// </summary>
+    public void WriteRunEventsJsonl(string path)
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            if (_eventLog.Count >= MaxEventLogSize)
+            {
+                lines.Add(Serialize(new { Event = "run_events_truncated", Cap = MaxEventLogSize }));
+            }
+
+            foreach (var evt in _eventLog)
+            {
+                lines.Add(Serialize(evt));
+            }
+
+            File.WriteAllLines(path, lines);
+        }
+    }
+
+    /// <summary>
+    /// Writes the per-test UI-only extras to <paramref name="path"/>, one compact
+    /// JSON line per test — the fields that <c>summary.json</c>/<c>ctrf</c> don't
+    /// carry for non-failed tests (output, non-failed stack traces, failure
+    /// context, ordering/timing, used instances). The internal-only
+    /// reconciliation-provenance fields (<c>EnrichmentOutcome</c>,
+    /// <c>OutcomeSource</c>) are deliberately excluded — they're not observable
+    /// state.
+    /// </summary>
+    public void WriteTestDetailsJsonl(string path)
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            foreach (var col in _collections.Values)
+            {
+                foreach (var cls in col.Classes.Values)
+                {
+                    foreach (var t in cls.Tests.Values)
+                    {
+                        lines.Add(
+                            Serialize(
+                                new
+                                {
+                                    t.ClassName,
+                                    t.DisplayName,
+                                    t.Status,
+                                    Output = t.Output.Count > 0 ? t.Output : null,
+                                    t.StackTrace,
+                                    t.FailureContext,
+                                    RecordingSkipReasons = t.RecordingSkipReasons.Count > 0
+                                        ? new Dictionary<string, string>(t.RecordingSkipReasons)
+                                        : null,
+                                    UsedInstances = t.UsedInstances.Count > 0
+                                        ? t.UsedInstances
+                                        : null,
+                                    t.DiscoveryOrder,
+                                    t.ExecutionOrder,
+                                    t.StartTime,
+                                    t.RunningStartTime,
+                                    Recordings = t.Recordings.Count > 0
+                                        ? t
+                                            .Recordings.Select(r => new
+                                            {
+                                                r.Path,
+                                                r.Source,
+                                                r.TimelineOffset,
+                                                r.WallClockDuration,
+                                            })
+                                            .ToList()
+                                        : null,
+                                }
+                            )
+                        );
+                    }
+                }
+            }
+
+            File.WriteAllLines(path, lines);
+        }
+    }
+
+    /// <summary>
+    /// Writes the run-start prestart/warmup narrative to <paramref name="path"/>,
+    /// one compact JSON line per <c>(phase, step)</c> from <c>_setupPhases</c> —
+    /// the parent-side phases (preflight, cleanup, image/game-data distribution)
+    /// and child-side per-collection prestart phases with their step-level
+    /// breakdown. Scope is prestart-only: mid-run per-instance re-provisioning
+    /// lives in <see cref="WriteInstanceHistoryJsonl"/>, not here.
+    /// A phase with no steps still writes its own line so an in-progress or
+    /// failed phase is visible.
+    /// </summary>
+    public void WriteSetupPhasesJsonl(string path)
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            foreach (var p in _setupPhases)
+            {
+                if (p.Steps.Count == 0)
+                {
+                    lines.Add(
+                        Serialize(
+                            new
+                            {
+                                p.Category,
+                                Phase = p.PhaseName,
+                                p.CollectionName,
+                                p.Status,
+                                p.StartTime,
+                                p.EndTime,
+                                Error = p.ErrorMessage,
+                            }
+                        )
+                    );
+                    continue;
+                }
+
+                foreach (var s in p.Steps)
+                {
+                    lines.Add(
+                        Serialize(
+                            new
+                            {
+                                p.Category,
+                                Phase = p.PhaseName,
+                                p.CollectionName,
+                                p.Status,
+                                p.StartTime,
+                                p.EndTime,
+                                Error = p.ErrorMessage,
+                                Step = s.StepName,
+                                StepStatus = s.Status,
+                                s.Details,
+                                Output = s.Output.Count > 0 ? s.Output : null,
+                                s.Timestamp,
+                            }
+                        )
+                    );
+                }
+            }
+
+            File.WriteAllLines(path, lines);
+        }
+    }
+
+    /// <summary>
     /// Run-level view for the report's social-media meta tags + OG card. Counts
     /// come from the same test-tree iteration BuildSnapshot uses (the _passed/
     /// _failed fields are only set at run_finished), so they match the published

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -46,6 +46,7 @@ public sealed class TestRunState
     // Event log (bounded)
     private const int MaxEventLogSize = 5000;
     private readonly List<object> _eventLog = new();
+    private int _evictedEventCount;
 
     // Errors
     private readonly List<ErrorState> _errors = new();
@@ -1627,10 +1628,10 @@ public sealed class TestRunState
     /// on disk, plus the unified ordering of the run's event stream.
     /// <para>
     /// <c>_eventLog</c> is a bounded ring buffer (<see cref="MaxEventLogSize"/>);
-    /// a normal run stays well under the cap, but if it was full at flush this
-    /// prepends a <c>run_events_truncated</c> marker so a ring-buffer-evicted log
-    /// is never mistaken for a complete one. The cap bounds live memory and is
-    /// deliberately not raised here.
+    /// a normal run stays well under the cap, but if entries were evicted this
+    /// prepends a <c>run_events_truncated</c> marker (with the evicted count) so
+    /// a ring-buffer-evicted log is never mistaken for a complete one. The cap
+    /// bounds live memory and is deliberately not raised here.
     /// </para>
     /// </summary>
     public void WriteRunEventsJsonl(string path, IReadOnlyCollection<string> knownSecrets)
@@ -1638,9 +1639,18 @@ public sealed class TestRunState
         lock (_lock)
         {
             var lines = new List<string>();
-            if (_eventLog.Count >= MaxEventLogSize)
+            if (_evictedEventCount > 0)
             {
-                lines.Add(Serialize(new { Event = "run_events_truncated", Cap = MaxEventLogSize }));
+                lines.Add(
+                    Serialize(
+                        new
+                        {
+                            Event = "run_events_truncated",
+                            Cap = MaxEventLogSize,
+                            Evicted = _evictedEventCount,
+                        }
+                    )
+                );
             }
 
             foreach (var evt in _eventLog)
@@ -2321,6 +2331,7 @@ public sealed class TestRunState
         if (_eventLog.Count >= MaxEventLogSize)
         {
             _eventLog.RemoveAt(0);
+            _evictedEventCount++;
         }
 
         _eventLog.Add(evt);

--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -503,7 +503,9 @@ public sealed class TestRunState
                 e.DisplayName,
                 DurationMs = test.DurationMs,
                 QueueDurationMs = test.QueueDurationMs,
-                Output = test.Output,
+                // Copy: the stored event is re-serialized at the run-events flush;
+                // a live reference would leak later-appended lines into it.
+                Output = test.Output.ToList(),
             };
             AddEventLog(evt);
             return Serialize(evt);
@@ -558,7 +560,8 @@ public sealed class TestRunState
                 e.ExceptionType,
                 StackTrace = RendererBase.SanitizeStackTrace(e.StackTrace ?? ""),
                 e.ScreenshotPath,
-                Output = test.Output,
+                // Copy — see ApplyTestPassed (screenshots append to Output after this).
+                Output = test.Output.ToList(),
             };
             AddEventLog(evt);
             return Serialize(evt);
@@ -860,15 +863,18 @@ public sealed class TestRunState
     /// </summary>
     public string SerializeRunMetadataEvent(RunMetadataEvent e)
     {
-        var evt = new
+        lock (_lock)
         {
-            Event = "run_metadata",
-            e.Timestamp,
-            RunDir = e.RunDir,
-            Data = e.Data,
-        };
-        AddEventLog(evt);
-        return Serialize(evt);
+            var evt = new
+            {
+                Event = "run_metadata",
+                e.Timestamp,
+                RunDir = e.RunDir,
+                Data = e.Data,
+            };
+            AddEventLog(evt);
+            return Serialize(evt);
+        }
     }
 
     /// <summary>
@@ -1492,7 +1498,7 @@ public sealed class TestRunState
     /// Instances with no samples are skipped, so the file is empty (or absent if
     /// the caller skips an empty write) when <c>SDVD_TEST_STATS=none</c>.
     /// </summary>
-    public void WriteInstanceStatsJsonl(string path)
+    public void WriteInstanceStatsJsonl(string path, IReadOnlyCollection<string> knownSecrets)
     {
         lock (_lock)
         {
@@ -1535,21 +1541,24 @@ public sealed class TestRunState
                 }
             }
 
-            File.WriteAllLines(path, lines);
+            WriteRedactedLines(path, lines, knownSecrets);
         }
     }
 
     /// <summary>
     /// Writes the per-instance lifecycle narrative to <paramref name="path"/>:
-    /// one compact JSON line per <c>History</c> entry (created/leased/returned/
-    /// disposed/poisoned/connected/disconnected), each carrying the instance
-    /// identity — so a post-mortem reader can reconstruct which test held which
-    /// container and why it was poisoned. The <c>SetupEventBus</c> is disk-free,
-    /// so this is the only on-disk home for that narrative.
-    /// Instances with no history are skipped, so the file is empty when no
-    /// instance lifecycle was recorded.
+    /// one compact JSON line per <c>History</c> entry (every event
+    /// <see cref="ApplyInstanceCreated"/>/<see cref="ApplyInstanceStatus"/>
+    /// record), each carrying the instance identity, plus a trailing
+    /// <c>final_state</c> line per instance — so the file is empty only when no
+    /// instances were registered. The lifecycle is also on disk in
+    /// <c>infrastructure.jsonl</c> (event-by-event <c>server_*</c>/<c>client_*</c>
+    /// entries with test attribution); this sink adds the instance-keyed
+    /// consolidated view plus what the infra log doesn't carry:
+    /// <c>final_state</c>, connect/disconnect transitions, <c>VncUrl</c>,
+    /// <c>RecordingPath</c>.
     /// </summary>
-    public void WriteInstanceHistoryJsonl(string path)
+    public void WriteInstanceHistoryJsonl(string path, IReadOnlyCollection<string> knownSecrets)
     {
         lock (_lock)
         {
@@ -1604,17 +1613,18 @@ public sealed class TestRunState
                 );
             }
 
-            File.WriteAllLines(path, lines);
+            WriteRedactedLines(path, lines, knownSecrets);
         }
     }
 
     /// <summary>
-    /// Writes the runner's in-memory UI event stream (the sequence the UI replays
-    /// to late-connecting clients) to <paramref name="path"/>, one compact JSON
-    /// line per <c>_eventLog</c> entry. Uniquely preserves the <c>diagnostic</c>
-    /// and <c>error</c> events (from xUnit's <c>OnDiagnosticMessage</c>/
-    /// <c>OnErrorMessage</c>), which land nowhere else on disk, plus the unified
-    /// ordering of the run's event stream.
+    /// Writes the runner's in-memory UI event log (every event broadcast live to
+    /// WebSocket clients; late-connecting clients hydrate from the snapshot, so
+    /// this flush is the log's only reader) to <paramref name="path"/>, one
+    /// compact JSON line per <c>_eventLog</c> entry. Uniquely preserves the
+    /// <c>diagnostic</c> and <c>error</c> events (from xUnit's
+    /// <c>OnDiagnosticMessage</c>/<c>OnErrorMessage</c>), which land nowhere else
+    /// on disk, plus the unified ordering of the run's event stream.
     /// <para>
     /// <c>_eventLog</c> is a bounded ring buffer (<see cref="MaxEventLogSize"/>);
     /// a normal run stays well under the cap, but if it was full at flush this
@@ -1623,7 +1633,7 @@ public sealed class TestRunState
     /// deliberately not raised here.
     /// </para>
     /// </summary>
-    public void WriteRunEventsJsonl(string path)
+    public void WriteRunEventsJsonl(string path, IReadOnlyCollection<string> knownSecrets)
     {
         lock (_lock)
         {
@@ -1638,7 +1648,7 @@ public sealed class TestRunState
                 lines.Add(Serialize(evt));
             }
 
-            File.WriteAllLines(path, lines);
+            WriteRedactedLines(path, lines, knownSecrets);
         }
     }
 
@@ -1651,7 +1661,7 @@ public sealed class TestRunState
     /// <c>OutcomeSource</c>) are deliberately excluded — they're not observable
     /// state.
     /// </summary>
-    public void WriteTestDetailsJsonl(string path)
+    public void WriteTestDetailsJsonl(string path, IReadOnlyCollection<string> knownSecrets)
     {
         lock (_lock)
         {
@@ -1700,7 +1710,7 @@ public sealed class TestRunState
                 }
             }
 
-            File.WriteAllLines(path, lines);
+            WriteRedactedLines(path, lines, knownSecrets);
         }
     }
 
@@ -1714,7 +1724,7 @@ public sealed class TestRunState
     /// A phase with no steps still writes its own line so an in-progress or
     /// failed phase is visible.
     /// </summary>
-    public void WriteSetupPhasesJsonl(string path)
+    public void WriteSetupPhasesJsonl(string path, IReadOnlyCollection<string> knownSecrets)
     {
         lock (_lock)
         {
@@ -1764,8 +1774,22 @@ public sealed class TestRunState
                 }
             }
 
-            File.WriteAllLines(path, lines);
+            WriteRedactedLines(path, lines, knownSecrets);
         }
+    }
+
+    /// <summary>
+    /// The diagnostics tree rides in CI's public run-artifact upload, so every
+    /// sink line is scrubbed through <see cref="ReportRedactor"/> (same secrets
+    /// set as the published report) before it reaches disk.
+    /// </summary>
+    private static void WriteRedactedLines(
+        string path,
+        List<string> lines,
+        IReadOnlyCollection<string> knownSecrets
+    )
+    {
+        File.WriteAllLines(path, lines.Select(l => ReportRedactor.Scrub(l, knownSecrets)));
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
+++ b/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
@@ -6,7 +6,9 @@ namespace JunimoServer.Tests.Helpers;
 ///
 /// Layout under <see cref="TestArtifacts.OutputDir"/> / runs / {id}:
 ///   summary.json, ctrf-report.json, run-metadata.json, run-output.json
-///   diagnostics/infrastructure.jsonl, diagnostics/instance-stats.jsonl
+///   diagnostics/infrastructure.jsonl, diagnostics/instance-stats.jsonl,
+///   diagnostics/instance-history.jsonl, diagnostics/run-events.jsonl,
+///   diagnostics/test-details.jsonl, diagnostics/setup-phases.jsonl
 ///   flakiness.jsonl  (also exists at OutputDir for cross-run aggregation)
 ///   tests/{Class}.{Method}/
 ///   _workers/{worker_id}/   (distributed mode only)
@@ -30,6 +32,38 @@ public static class RunArtifactNames
     /// the live UI reads the same data over the WebSocket, not this file.
     /// </summary>
     public const string InstanceStatsJsonl = "instance-stats.jsonl";
+
+    /// <summary>
+    /// Per-instance lifecycle narrative (created/leased/returned/disposed/
+    /// poisoned/connected/disconnected + a trailing final-state line) under
+    /// <see cref="DiagnosticsDir"/>. Flushed at run-end from the runner's
+    /// in-memory state; the live UI reads the same data over the WebSocket.
+    /// </summary>
+    public const string InstanceHistoryJsonl = "instance-history.jsonl";
+
+    /// <summary>
+    /// The runner's UI event stream (the sequence replayed to late-connecting
+    /// clients) under <see cref="DiagnosticsDir"/> — uniquely the only on-disk
+    /// home for xUnit-level <c>diagnostic</c>/<c>error</c> events. Sourced from a
+    /// bounded ring buffer; a leading <c>run_events_truncated</c> marker appears
+    /// if the buffer was full at flush.
+    /// </summary>
+    public const string RunEventsJsonl = "run-events.jsonl";
+
+    /// <summary>
+    /// Per-test UI-only extras (output, non-failed stack traces, failure context,
+    /// ordering/timing, used instances) under <see cref="DiagnosticsDir"/> —
+    /// the fields <see cref="SummaryJson"/>/<see cref="CtrfReport"/> carry only
+    /// for failed tests, here for all tests.
+    /// </summary>
+    public const string TestDetailsJsonl = "test-details.jsonl";
+
+    /// <summary>
+    /// Prestart/warmup phase narrative (per phase + step, with timestamps) under
+    /// <see cref="DiagnosticsDir"/>. Run-start scope only; mid-run per-instance
+    /// re-provisioning lives in <see cref="InstanceHistoryJsonl"/>.
+    /// </summary>
+    public const string SetupPhasesJsonl = "setup-phases.jsonl";
 
     /// <summary>
     /// Cross-run sidecar (<c>{hostId → bytes}</c>) at <see cref="TestArtifacts.OutputDir"/>

--- a/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
+++ b/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
@@ -34,16 +34,18 @@ public static class RunArtifactNames
     public const string InstanceStatsJsonl = "instance-stats.jsonl";
 
     /// <summary>
-    /// Per-instance lifecycle narrative (created/leased/returned/disposed/
-    /// poisoned/connected/disconnected + a trailing final-state line) under
-    /// <see cref="DiagnosticsDir"/>. Flushed at run-end from the runner's
-    /// in-memory state; the live UI reads the same data over the WebSocket.
+    /// Per-instance lifecycle narrative under <see cref="DiagnosticsDir"/>: one
+    /// line per history event <c>TestRunState</c> records, plus a trailing
+    /// final-state line per instance. Complements <see cref="InfrastructureJsonl"/>
+    /// (the event-by-event lifecycle with test attribution) with the
+    /// instance-keyed consolidated view, connect/disconnect transitions and
+    /// VNC/recording paths. Flushed at run-end from the runner's in-memory state.
     /// </summary>
     public const string InstanceHistoryJsonl = "instance-history.jsonl";
 
     /// <summary>
-    /// The runner's UI event stream (the sequence replayed to late-connecting
-    /// clients) under <see cref="DiagnosticsDir"/> — uniquely the only on-disk
+    /// The runner's UI event stream (every event broadcast live over the
+    /// WebSocket) under <see cref="DiagnosticsDir"/> — uniquely the only on-disk
     /// home for xUnit-level <c>diagnostic</c>/<c>error</c> events. Sourced from a
     /// bounded ring buffer; a leading <c>run_events_truncated</c> marker appears
     /// if the buffer was full at flush.

--- a/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
+++ b/tests/JunimoServer.Tests/Helpers/RunArtifactNames.cs
@@ -47,8 +47,8 @@ public static class RunArtifactNames
     /// The runner's UI event stream (every event broadcast live over the
     /// WebSocket) under <see cref="DiagnosticsDir"/> — uniquely the only on-disk
     /// home for xUnit-level <c>diagnostic</c>/<c>error</c> events. Sourced from a
-    /// bounded ring buffer; a leading <c>run_events_truncated</c> marker appears
-    /// if the buffer was full at flush.
+    /// bounded ring buffer; a leading <c>run_events_truncated</c> marker (with
+    /// the evicted count) appears if the buffer evicted entries.
     /// </summary>
     public const string RunEventsJsonl = "run-events.jsonl";
 


### PR DESCRIPTION
The `SetupEventBus` is disk-free by design, so a large slice of the test runner's in-memory `TestRunState` reached only the live web UI and was lost on headless/CI runs (the report bundle that embeds the full snapshot no-ops unless the test-UI SPA is built, which those runs never do). This generalizes the existing `instance-stats.jsonl` template to persist the rest, so the full UI-visible state is recoverable from saved artifacts on every run.

## Changes

- Add four `diagnostics/*.jsonl` sinks, each following the shipped `instance-stats.jsonl` pattern (one `TestRunState` write method + one `RunArtifactNames` const + one independently-guarded write block and private helper in `TestRunArtifactWriter`):
  - `instance-history.jsonl` — per-instance lifecycle narrative (created/leased/returned/disposed/poisoned/connected/disconnected) plus a trailing `final_state` line per instance carrying current status fields (which test held which container, why it was poisoned, VNC/recording paths). Complements `infrastructure.jsonl`'s event-by-event lifecycle with the instance-keyed consolidated view.
  - `run-events.jsonl` — the runner's UI event log (every event broadcast live over the WebSocket); the only on-disk home for xUnit-level `diagnostic`/`error` events. Prepends a `run_events_truncated` marker line (with the evicted count) if the source ring buffer (5000-entry, pre-existing memory cap) evicted entries, so a truncated log is never mistaken for a complete one. The cap is not raised.
  - `test-details.jsonl` — per-test UI-only extras for all tests (output, non-failed stack traces, failure context, ordering/timing, used instances). The internal reconciliation-provenance fields (`EnrichmentOutcome`, `OutcomeSource`) are deliberately excluded.
  - `setup-phases.jsonl` — run-start prestart/warmup phase + step breakdown (parent-side preflight/cleanup/image/game-data distribution and child-side per-collection prestart phases).
- Each write block is independently `try/catch`-guarded so one failing sink can't suppress the others.
- Redact every artifact in the public CI run-artifact upload through `ReportRedactor` with the runner's known-secrets set — error/output text can embed SSH destinations and Steam credentials:
  - The five `TestRunState` jsonl sinks (including the pre-existing `instance-stats.jsonl`), scrubbed at write. Secrets are collected at write time (not recorder construction) because `HostPool` is only populated during preflight.
  - `summary.json`, `ctrf-report.json`, `run-output.json` (file + the CI-scraper stdout line), and the merged `run-metadata.json`, scrubbed at write.
  - The live-appended files, scrubbed in place after their writers close: child + parent infrastructure logs and the child-written `run-metadata.json`. Force-exit abort paths skip this pass (their writers never close).
  - Each known secret is replaced in both its raw and JSON-escaped form — the serializers' default encoder escapes quotes, backslashes, non-ASCII, and HTML-sensitive chars like `+`, so a secret containing any of those appears in serialized JSON only as its escaped spelling.
- Fix two event-log races the new `run-events.jsonl` flush would have observed: append the `run_metadata` event under the state lock (the only `AddEventLog` call site outside it), and copy test output lists into `test_passed`/`test_failed` events so the flush serializes the output as of the event instead of a live list screenshots append to.
- `RunRecorder` and the `WriteIfNotWritten` signature already thread the live `TestRunState`, so no further IPC plumbing was needed.
- Document all five `diagnostics/*.jsonl` files in the run-artifact layout in `e2e-testing.md` (the block previously listed only `infrastructure.jsonl`, omitting the already-shipped `instance-stats.jsonl` too).

## Verification

- Clean run (`CabinStrategyTests`, 8/8 pass): all four files written, every line `jq`-parses, field/ordering checks pass, internal fields excluded, zero writer errors.
- Preflight-abort run (unreachable host): observed live — the `error` residue in `run-events.jsonl`, the empty-file path (0-byte `instance-history.jsonl`, no throw), the abort-path write of all four sinks, and partial-but-honest early-failure files (`test-details` all-`pending`, `setup-phases` `Preflight: failed`).
- Concurrency: all `AddEventLog` call sites and all source-collection producers mutate under `_lock`; the write methods hold the same lock. Lock ordering is writer-lock → state-lock only.
- Escaped-form redaction: verified in isolation against the serializer defaults — a secret with umlaut/`+`/quote/backslash serializes to its `\uXXXX` spelling, a raw-only replace misses it, the raw+escaped replace masks it with the JSON still valid.

## Not exercised

- The `run_events_truncated` marker firing (requires a 5000+-event run; the source cap isn't hit by a normal run of ~700–1200 events). Its logic is verified against the ring buffer's cap invariant and its serialized output format is confirmed, but the branch has not fired live.
- The redaction wiring landed after the verification runs above; it is build-verified (plus the isolated escaped-form check) and reuses the published report's existing `ReportRedactor` path (masked output stays JSON-safe by contract), but the sinks have not been re-run through it live yet.
