### PR TITLE
fix(tests): stop the NIC-cut outage from poisoning its own server mid-test

### DIFF
--- a/.claude/plans/bugs/tests-galaxyoutage-notfound-mid-test-poison.md
+++ b/.claude/plans/bugs/tests-galaxyoutage-notfound-mid-test-poison.md
@@ -1,6 +1,13 @@
 # GalaxyOutageReproTests NotFound flake — NIC-cut server error poisons the server mid-test
 
-Status: INVESTIGATED, not fixed. Intermittent. The failing run's artifacts are NOT local
+Status: FIXED on branch `bugfix/galaxyoutage-notfound-mid-test-poison` (PR #498). Lever 1
+implemented as the outage-scoped variant — `SuspendHealthChecks(includeLogErrorScan: true)`, so
+new-game/reload keep the log-error scan live — with the scan→poison wiring moved to a
+lifetime `ServerContainer.OnErrorDetected` event (survives `ClearErrors`; replays
+pre-subscription errors at subscribe, at-least-once, so a boot-window ERROR on a
+ready server still poisons). Lever 2: 404-tolerant
+reconnect (returns false), while a pre-cut vanish now fails fast as an invalid outage setup.
+Intermittent. The failing run's artifacts are NOT local
 (this test is 15/15 pass locally across runs since it was added in #440, 2026-06-18), so the
 mechanism below is from reading the harness path end-to-end, not from a pass/fail artifact diff.
 It is coherent and `TotalConnectivityLoss` is the one test structurally exposed to it.

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -770,12 +770,40 @@ public class ServerContainer : IAsyncDisposable
         }
     }
 
+    private Action<string>? _onErrorDetected;
+
     /// <summary>
-    /// Gets a cancellation token that triggers when a server error is detected.
+    /// Raised once per detected server error (a flushed SMAPI ERROR/FATAL block) with the
+    /// full error text. Errors detected before a handler attaches are replayed to it at
+    /// subscription — a subscriber that wires up after boot cannot miss a boot-window
+    /// error — so delivery is at-least-once and handlers must be idempotent. Handlers
+    /// stay attached for the container's lifetime — <see cref="ClearErrors"/> resets the
+    /// accumulated error list, not this event.
     /// </summary>
-    public CancellationToken GetErrorCancellationToken()
+    public event Action<string> OnErrorDetected
     {
-        return _errorCancellation?.Token ?? CancellationToken.None;
+        add
+        {
+            string[] pending;
+            lock (_serverErrorsLock)
+            {
+                _onErrorDetected += value;
+                pending = _serverErrors.ToArray();
+            }
+            // Replay outside the lock: handlers do nontrivial work (poison → drain →
+            // dispose), and a throw here surfaces in the subscriber's own context.
+            foreach (var error in pending)
+            {
+                value(error);
+            }
+        }
+        remove
+        {
+            lock (_serverErrorsLock)
+            {
+                _onErrorDetected -= value;
+            }
+        }
     }
 
     /// <summary>
@@ -1031,6 +1059,13 @@ public class ServerContainer : IAsyncDisposable
         try
         {
             _errorCancellation?.Cancel();
+        }
+        catch { }
+        // Guarded like the Cancel above: a throwing handler must not kill the log pump
+        // (it also feeds recording and error accumulation).
+        try
+        {
+            _onErrorDetected?.Invoke(fullError);
         }
         catch { }
 

--- a/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
+++ b/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
@@ -98,8 +98,13 @@ public class GalaxyOutageReproTests : TestBase
         // can't find it once the container is detached), then cut the network.
         var managed = Lease.Managed;
         var networkId = await NetworkOutageHelper.GetAttachedNetworkIdAsync(Lease, ct);
+        Assert.False(
+            string.IsNullOrEmpty(networkId),
+            "Expected the server container to be attached to a network before the cut — a null id "
+                + "means the container was already gone, so the outage setup is invalid."
+        );
         managed.SuspendHealthChecks();
-        Log($"Health checks suspended; cutting network {networkId[..12]}…");
+        Log($"Health checks suspended; cutting network {networkId![..12]}…");
         // Anchor every post-cut event wait to this instant so the server's own initial-boot
         // emissions (a first steam_session_connected, the pre-outage auth_steam_lobby_created)
         // can never satisfy an outage-recovery wait.

--- a/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
+++ b/tests/JunimoServer.Tests/GalaxyOutageReproTests.cs
@@ -94,8 +94,9 @@ public class GalaxyOutageReproTests : TestBase
         var inviteCode = InviteCode;
         Log($"Steam client connected; invite code = {inviteCode}");
 
-        // ── 2. Suspend the health watchdog and capture the network id (the inspect
-        // can't find it once the container is detached), then cut the network.
+        // ── 2. Capture the network id (the inspect can't find it once the container is
+        // detached), suspend both poison paths (watchdog + log-error scan — the cut makes
+        // SMAPI log expected Steam/Galaxy ERRORs), then cut the network.
         var managed = Lease.Managed;
         var networkId = await NetworkOutageHelper.GetAttachedNetworkIdAsync(Lease, ct);
         Assert.False(
@@ -103,13 +104,13 @@ public class GalaxyOutageReproTests : TestBase
             "Expected the server container to be attached to a network before the cut — a null id "
                 + "means the container was already gone, so the outage setup is invalid."
         );
-        managed.SuspendHealthChecks();
+        managed.SuspendHealthChecks(includeLogErrorScan: true);
         Log($"Health checks suspended; cutting network {networkId![..12]}…");
         // Anchor every post-cut event wait to this instant so the server's own initial-boot
         // emissions (a first steam_session_connected, the pre-outage auth_steam_lobby_created)
         // can never satisfy an outage-recovery wait.
         var outageStart = DateTime.UtcNow;
-        await NetworkOutageHelper.DisconnectAsync(Lease, ct);
+        await NetworkOutageHelper.DisconnectAsync(Lease, networkId!, ct);
 
         try
         {
@@ -155,8 +156,16 @@ public class GalaxyOutageReproTests : TestBase
             // the API anyway — the verdict and the Steam-recovery check both read the
             // stdout-backed infrastructure.jsonl, which DOES flow once connectivity is back.
             using var restoreCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-            await NetworkOutageHelper.ReconnectAsync(Lease, networkId, restoreCts.Token);
-            Log("Network reconnected (health checks stay suspended; API unreachable on remote).");
+            var reconnected = await NetworkOutageHelper.ReconnectAsync(
+                Lease,
+                networkId!,
+                restoreCts.Token
+            );
+            Log(
+                reconnected
+                    ? "Network reconnected (health checks stay suspended; API unreachable on remote)."
+                    : "Network restore skipped — the container is already gone, nothing to reconnect."
+            );
         }
 
         // ── 6. Steam side must recover (the shipped #391 behavior). Harness invariant —

--- a/tests/JunimoServer.Tests/Helpers/NetworkOutageHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/NetworkOutageHelper.cs
@@ -23,10 +23,12 @@ namespace JunimoServer.Tests.Helpers;
 ///
 /// This helper does NOT touch the health watchdog. The caller must bracket the
 /// outage with <see cref="ManagedServer.SuspendHealthChecks"/> /
-/// <see cref="ManagedServer.ResumeHealthChecks"/> — otherwise the watchdog poisons
-/// the server ~25s into the cut (5 failed /health probes). Keeping that bracket at
-/// the call site mirrors how ReloadAsync/CreateNewGameAsync wrap intentional
-/// transitions and keeps the suspend/resume visible.
+/// <see cref="ManagedServer.ResumeHealthChecks"/> — otherwise the server is poisoned
+/// during the cut, either by the watchdog (~25s in, 5 failed /health probes) or by
+/// the log-error scan (the cut makes SMAPI log Steam/Galaxy ERRORs). One suspend
+/// gates both poison paths. Keeping that bracket at the call site mirrors how
+/// ReloadAsync/CreateNewGameAsync wrap intentional transitions and keeps the
+/// suspend/resume visible.
 /// </summary>
 internal static class NetworkOutageHelper
 {
@@ -41,54 +43,99 @@ internal static class NetworkOutageHelper
         var client = lease.Host.ApiClient;
         var containerId = lease.Server.Container.Id;
         var networkId = await ResolveAttachedNetworkIdAsync(client, containerId, ct);
+        // A null id means the container is already gone (see ResolveAttachedNetworkIdAsync) —
+        // nothing to disconnect.
+        if (networkId == null)
+        {
+            return;
+        }
 
-        await client.Networks.DisconnectNetworkAsync(
-            networkId,
-            new NetworkDisconnectParameters { Container = containerId, Force = true },
-            ct
-        );
+        try
+        {
+            await client.Networks.DisconnectNetworkAsync(
+                networkId,
+                new NetworkDisconnectParameters { Container = containerId, Force = true },
+                ct
+            );
+        }
+        catch (DockerContainerNotFoundException)
+        { /* container vanished mid-outage (e.g. a poison drain removed it); nothing to cut */
+        }
+        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
+        { /* container or network gone; nothing to cut */
+        }
     }
 
     /// <summary>
     /// Reconnects the server container to the given test network. The network id is
     /// captured by <see cref="DisconnectAsync"/>'s caller via
     /// <see cref="GetAttachedNetworkIdAsync"/> before the cut, because once the
-    /// container is detached an inspect no longer reports the network.
+    /// container is detached an inspect no longer reports the network. A null id (the
+    /// container was already gone at capture time) is a no-op.
     /// </summary>
     public static async Task ReconnectAsync(
         ResourceLease lease,
-        string networkId,
+        string? networkId,
         CancellationToken ct = default
     )
     {
+        if (networkId == null)
+        {
+            return;
+        }
+
         var client = lease.Host.ApiClient;
         var containerId = lease.Server.Container.Id;
 
-        await client.Networks.ConnectNetworkAsync(
-            networkId,
-            new NetworkConnectParameters { Container = containerId },
-            ct
-        );
+        try
+        {
+            await client.Networks.ConnectNetworkAsync(
+                networkId,
+                new NetworkConnectParameters { Container = containerId },
+                ct
+            );
+        }
+        catch (DockerContainerNotFoundException)
+        { /* container gone (e.g. a mid-outage poison drain disposed it); nothing to reconnect */
+        }
+        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
+        { /* container or network gone; nothing to reconnect */
+        }
     }
 
     /// <summary>
     /// Returns the id of the (single non-loopback) Docker network the server
-    /// container is currently attached to. Call this BEFORE disconnecting and keep
-    /// the result to pass to <see cref="ReconnectAsync"/> — after the cut the
-    /// container has no network to inspect.
+    /// container is currently attached to, or <c>null</c> if the container is already
+    /// gone. Call this BEFORE disconnecting and keep the result to pass to
+    /// <see cref="ReconnectAsync"/> — after the cut the container has no network to inspect.
     /// </summary>
-    public static Task<string> GetAttachedNetworkIdAsync(
+    public static Task<string?> GetAttachedNetworkIdAsync(
         ResourceLease lease,
         CancellationToken ct = default
     ) => ResolveAttachedNetworkIdAsync(lease.Host.ApiClient, lease.Server.Container.Id, ct);
 
-    private static async Task<string> ResolveAttachedNetworkIdAsync(
+    private static async Task<string?> ResolveAttachedNetworkIdAsync(
         DockerClient client,
         string containerId,
         CancellationToken ct
     )
     {
-        var inspect = await client.Containers.InspectContainerAsync(containerId, ct);
+        ContainerInspectResponse inspect;
+        try
+        {
+            inspect = await client.Containers.InspectContainerAsync(containerId, ct);
+        }
+        catch (DockerContainerNotFoundException)
+        {
+            // Container vanished (e.g. a mid-outage poison drain removed it). Not a raw
+            // NotFound for the caller to surface — there's no network to cut or restore.
+            return null;
+        }
+        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
+        {
+            return null;
+        }
+
         var networks = inspect.NetworkSettings?.Networks;
         if (networks == null || networks.Count == 0)
         {

--- a/tests/JunimoServer.Tests/Helpers/NetworkOutageHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/NetworkOutageHelper.cs
@@ -22,34 +22,33 @@ namespace JunimoServer.Tests.Helpers;
 /// reconnect.
 ///
 /// This helper does NOT touch the health watchdog. The caller must bracket the
-/// outage with <see cref="ManagedServer.SuspendHealthChecks"/> /
-/// <see cref="ManagedServer.ResumeHealthChecks"/> — otherwise the server is poisoned
-/// during the cut, either by the watchdog (~25s in, 5 failed /health probes) or by
-/// the log-error scan (the cut makes SMAPI log Steam/Galaxy ERRORs). One suspend
-/// gates both poison paths. Keeping that bracket at the call site mirrors how
+/// outage with <see cref="ManagedServer.SuspendHealthChecks"/> (pass
+/// includeLogErrorScan: true) / <see cref="ManagedServer.ResumeHealthChecks"/> —
+/// otherwise the server is poisoned during the cut, either by the watchdog (~25s in,
+/// 5 failed /health probes) or by the log-error scan (the cut makes SMAPI log
+/// Steam/Galaxy ERRORs). Keeping that bracket at the call site mirrors how
 /// ReloadAsync/CreateNewGameAsync wrap intentional transitions and keeps the
 /// suspend/resume visible.
 /// </summary>
 internal static class NetworkOutageHelper
 {
     /// <summary>
-    /// Disconnects the server container from its test network (force=true, so the
-    /// daemon drops the endpoint even though the container is running). Resolves the
-    /// network by inspecting the container — robust against the test-network name/id
-    /// not being derivable from the lease.
+    /// Disconnects the server container from the given test network (force=true, so the
+    /// daemon drops the endpoint even though the container is running). The network id
+    /// comes from <see cref="GetAttachedNetworkIdAsync"/>, captured by the caller before
+    /// the cut and shared with <see cref="ReconnectAsync"/>. A 404 means the container or
+    /// network vanished between capture and cut — that invalidates the outage setup, so
+    /// this throws immediately instead of leaving the caller to wait out a doomed
+    /// steam_session_lost gate and blame the cut for a container that was already gone.
     /// </summary>
-    public static async Task DisconnectAsync(ResourceLease lease, CancellationToken ct = default)
+    public static async Task DisconnectAsync(
+        ResourceLease lease,
+        string networkId,
+        CancellationToken ct = default
+    )
     {
         var client = lease.Host.ApiClient;
         var containerId = lease.Server.Container.Id;
-        var networkId = await ResolveAttachedNetworkIdAsync(client, containerId, ct);
-        // A null id means the container is already gone (see ResolveAttachedNetworkIdAsync) —
-        // nothing to disconnect.
-        if (networkId == null)
-        {
-            return;
-        }
-
         try
         {
             await client.Networks.DisconnectNetworkAsync(
@@ -58,11 +57,14 @@ internal static class NetworkOutageHelper
                 ct
             );
         }
-        catch (DockerContainerNotFoundException)
-        { /* container vanished mid-outage (e.g. a poison drain removed it); nothing to cut */
-        }
-        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
-        { /* container or network gone; nothing to cut */
+        catch (DockerApiException ex)
+            when (ex is DockerContainerNotFoundException || (int)ex.StatusCode == 404)
+        {
+            throw new InvalidOperationException(
+                $"Cannot cut network {networkId[..12]}: container {containerId[..12]} (or the "
+                    + "network) vanished before the disconnect, so the outage setup is invalid.",
+                ex
+            );
         }
     }
 
@@ -70,20 +72,17 @@ internal static class NetworkOutageHelper
     /// Reconnects the server container to the given test network. The network id is
     /// captured by <see cref="DisconnectAsync"/>'s caller via
     /// <see cref="GetAttachedNetworkIdAsync"/> before the cut, because once the
-    /// container is detached an inspect no longer reports the network. A null id (the
-    /// container was already gone at capture time) is a no-op.
+    /// container is detached an inspect no longer reports the network. Returns false —
+    /// without throwing, because this runs in the caller's cleanup path where a raw
+    /// NotFound would mask the test's real failure — when the container or network is
+    /// already gone and there was nothing to reconnect; the caller's log must say so.
     /// </summary>
-    public static async Task ReconnectAsync(
+    public static async Task<bool> ReconnectAsync(
         ResourceLease lease,
-        string? networkId,
+        string networkId,
         CancellationToken ct = default
     )
     {
-        if (networkId == null)
-        {
-            return;
-        }
-
         var client = lease.Host.ApiClient;
         var containerId = lease.Server.Container.Id;
 
@@ -94,12 +93,12 @@ internal static class NetworkOutageHelper
                 new NetworkConnectParameters { Container = containerId },
                 ct
             );
+            return true;
         }
-        catch (DockerContainerNotFoundException)
-        { /* container gone (e.g. a mid-outage poison drain disposed it); nothing to reconnect */
-        }
-        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
-        { /* container or network gone; nothing to reconnect */
+        catch (DockerApiException ex)
+            when (ex is DockerContainerNotFoundException || (int)ex.StatusCode == 404)
+        {
+            return false;
         }
     }
 
@@ -107,32 +106,26 @@ internal static class NetworkOutageHelper
     /// Returns the id of the (single non-loopback) Docker network the server
     /// container is currently attached to, or <c>null</c> if the container is already
     /// gone. Call this BEFORE disconnecting and keep the result to pass to
-    /// <see cref="ReconnectAsync"/> — after the cut the container has no network to inspect.
+    /// <see cref="DisconnectAsync"/> / <see cref="ReconnectAsync"/> — after the cut the
+    /// container has no network to inspect.
     /// </summary>
-    public static Task<string?> GetAttachedNetworkIdAsync(
+    public static async Task<string?> GetAttachedNetworkIdAsync(
         ResourceLease lease,
         CancellationToken ct = default
-    ) => ResolveAttachedNetworkIdAsync(lease.Host.ApiClient, lease.Server.Container.Id, ct);
-
-    private static async Task<string?> ResolveAttachedNetworkIdAsync(
-        DockerClient client,
-        string containerId,
-        CancellationToken ct
     )
     {
+        var client = lease.Host.ApiClient;
+        var containerId = lease.Server.Container.Id;
         ContainerInspectResponse inspect;
         try
         {
             inspect = await client.Containers.InspectContainerAsync(containerId, ct);
         }
-        catch (DockerContainerNotFoundException)
+        catch (DockerApiException ex)
+            when (ex is DockerContainerNotFoundException || (int)ex.StatusCode == 404)
         {
-            // Container vanished (e.g. a mid-outage poison drain removed it). Not a raw
-            // NotFound for the caller to surface — there's no network to cut or restore.
-            return null;
-        }
-        catch (DockerApiException ex) when ((int)ex.StatusCode == 404)
-        {
+            // Container already gone at capture time. Null (not a raw NotFound throw) so
+            // the caller's pre-cut assert reports the invalid outage setup with context.
             return null;
         }
 

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -989,12 +989,16 @@ internal sealed class ManagedServer : IAsyncDisposable
         StartHealthWatchdog();
 
         // Wire ServerContainer's error detection (SMAPI ERROR/FATAL, Docker API failures)
-        // to ManagedServer's poison mechanism so tests abort immediately.
+        // to ManagedServer's poison mechanism so tests abort immediately. SuspendHealthChecks
+        // gates this too: an intentional transition (new game, reload, network outage) is
+        // expected to emit server ERRORs, and treating those as a poison-worthy crash would
+        // dispose the container mid-test — so one suspend bracket covers both the watchdog and
+        // this log-error scan (see NetworkOutageHelper's class doc).
         Server
             .GetErrorCancellationToken()
             .Register(() =>
             {
-                if (!_poisoned && !ShutdownCoordinator.IsShuttingDown)
+                if (!_poisoned && !_healthSuspended && !ShutdownCoordinator.IsShuttingDown)
                 {
                     var errors = Server.Errors;
                     var reason =

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -760,6 +760,7 @@ internal sealed class ManagedServer : IAsyncDisposable
     private CancellationTokenSource? _healthCts;
     private Task? _healthTask;
     private volatile bool _healthSuspended;
+    private volatile bool _logErrorScanSuspended;
 
     private Action<ManagedServer>? _onPoisoned;
 
@@ -988,35 +989,50 @@ internal sealed class ManagedServer : IAsyncDisposable
         _initialized = true;
         StartHealthWatchdog();
 
-        // Wire ServerContainer's error detection (SMAPI ERROR/FATAL, Docker API failures)
-        // to ManagedServer's poison mechanism so tests abort immediately. SuspendHealthChecks
-        // gates this too: an intentional transition (new game, reload, network outage) is
-        // expected to emit server ERRORs, and treating those as a poison-worthy crash would
-        // dispose the container mid-test — so one suspend bracket covers both the watchdog and
-        // this log-error scan (see NetworkOutageHelper's class doc).
-        Server
-            .GetErrorCancellationToken()
-            .Register(() =>
+        // Wire ServerContainer's error detection (SMAPI ERROR/FATAL) to the poison mechanism
+        // so tests abort immediately. The handler stays attached for the container's whole
+        // life (ClearErrors resets the error list, not this event), and errors flushed
+        // before this line replay at subscribe (at-least-once; the _poisoned guard makes
+        // repeats no-ops), so a boot-window ERROR on a server that still became ready
+        // poisons it here rather than being silently dropped. Only the network-outage
+        // bracket gates it — SuspendHealthChecks(includeLogErrorScan: true) — because a NIC
+        // cut makes SMAPI log expected Steam/Galaxy ERRORs (see NetworkOutageHelper's class
+        // doc). New-game/reload transitions keep the scan live: a mod ERROR there (e.g. a
+        // failed cabin build during OnSaveLoaded) is a genuine failure, not transition noise.
+        Server.OnErrorDetected += error =>
+        {
+            if (!_poisoned && !_logErrorScanSuspended && !ShutdownCoordinator.IsShuttingDown)
             {
-                if (!_poisoned && !_healthSuspended && !ShutdownCoordinator.IsShuttingDown)
-                {
-                    var errors = Server.Errors;
-                    var reason =
-                        errors.Count > 0 ? errors[0] : "Server error detected via log stream";
-                    PoisonServer(reason, PoisonReasonCode.ServerLogError);
-                }
-            });
+                PoisonServer(error, PoisonReasonCode.ServerLogError);
+            }
+        };
     }
 
     /// <summary>
-    /// Suspends health checks during intentional server transitions (e.g., new game creation).
+    /// Suspends the health watchdog during intentional server transitions (e.g., new game
+    /// creation). <paramref name="includeLogErrorScan"/> additionally gates the log-error
+    /// poison hook; reserve it for windows where server ERRORs are expected (the network
+    /// outage cut). New-game/reload leave the scan live so a genuine mod error mid-transition
+    /// still poisons loudly.
     /// </summary>
-    public void SuspendHealthChecks() => _healthSuspended = true;
+    public void SuspendHealthChecks(bool includeLogErrorScan = false)
+    {
+        _healthSuspended = true;
+        if (includeLogErrorScan)
+        {
+            _logErrorScanSuspended = true;
+        }
+    }
 
     /// <summary>
-    /// Resumes health checks after a server transition completes.
+    /// Resumes health checks (and the log-error scan, if it was gated) after a server
+    /// transition completes.
     /// </summary>
-    public void ResumeHealthChecks() => _healthSuspended = false;
+    public void ResumeHealthChecks()
+    {
+        _healthSuspended = false;
+        _logErrorScanSuspended = false;
+    }
 
     private void StartHealthWatchdog()
     {


### PR DESCRIPTION
## Problem

`GalaxyOutageReproTests.TotalConnectivityLoss_RecordsGalaxyReauthSignal` intermittently failed with a bare `Docker API responded with status code='NotFound'` in `phase: test_body` — a Docker call hitting a container that had already been removed.

The test cuts the server container's only network to simulate total connectivity loss. That makes the headless SMAPI server log `ERROR`/`FATAL` (Steam/Galaxy/socket failures). `ServerContainer`'s log-error scan matches `\b(ERROR|FATAL)\b` and triggers the poison path — which was **not** gated by `SuspendHealthChecks()`. So the test poisoned its own server during the intentional outage. Poison then drains for 60s and disposes the container while the test's ~10 min recovery body is still running, after which an unguarded `NetworkOutageHelper` Docker call hits the removed container.

## Changes

- **Root cause:** gate the log-error → poison hook only where server ERRORs are expected. `SuspendHealthChecks(includeLogErrorScan: true)` is passed solely by the network-outage bracket; new-game/reload transitions keep the scan live, so a genuine mod ERROR during those windows (e.g. a failed cabin build during `OnSaveLoaded`) still poisons instead of being masked by the shared suspend flag.
- **Mechanism:** move the scan→poison wiring from a one-shot error-token registration to a lifetime `ServerContainer.OnErrorDetected` event. The registration could die silently: `ClearErrors` recreates the token source (orphaning registrations), and a token cancelled during a suspended window can never re-fire. The event is raised per flushed error block and replays pre-subscription errors at subscribe (at-least-once delivery; the poison handler is idempotent), so a boot-window ERROR on a server that still became ready poisons it instead of being dropped.
- **`NetworkOutageHelper` hardening:** the test captures the network id once and passes it to both disconnect and reconnect. A container gone before the cut fails fast with a descriptive `InvalidOperationException` (invalid outage setup) instead of a bare Docker `NotFound`; `ReconnectAsync` tolerates 404 in the cleanup path (returns `false`, logged) so a mid-test dispose can't mask the test's real failure.
- Add a pre-cut assertion that the container is network-attached before the outage.

## Verification

Regression gate (per the investigation): **no `server_log_error` poison during the outage window** — the only `server_poisoned` event must be the intended end-of-test `test_retired_server` retire — and the outage scenario must genuinely run (server `container.log`: `steam_session_lost` → Galaxy recovery via re-login or auto-recreate → `auth_steam_lobby_created`).

Runs against the current revision: pending (focused + full suite to follow).
