### PR TITLE
chore(deps): cap typescript below 7.0 in test-ui and docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -202,6 +202,16 @@
             "allowedVersions": "<3.0.0"
         },
         {
+            "description": "CAP — typescript below 7.0 in test-ui and docs. TS 7 is the Go-native port: its npm package ships a platform binary plus a version stub (lib/ holds only tsc.js and version.cjs, and exports[\".\"] maps to lib/version.cjs), so the compiler JS API is gone until the API planned for 7.1. vue-tsc's engine @volar/typescript consumes that API, so `vue-tsc --noEmit` dies with ERR_PACKAGE_PATH_NOT_EXPORTED on './lib/tsc' — breaking `bun run build` in test-ui, which gates `make build-test-ui` and the Build test-UI SPA step in e2e-tests.yml. Verified against vue-tsc 3.3.9. vue-tsc's peer range (>=5.0.0) accepts 7.x, so nothing warns at install time. docs is capped in lockstep: its tsconfig includes .vitepress/**/*.vue, which tsgo cannot check, and vitepress build never invokes tsc — 7.x is all risk and no gain there. No versioning:semver here, unlike the nuget caps above: the bun manager uses npm versioning, which evaluates <7.0.0 correctly. Lift once Volar runs on the TS 7.1 API (vuejs/language-tools#5381).",
+            "matchManagers": ["bun"],
+            "matchFileNames": [
+                "tests/test-ui/package.json",
+                "docs/package.json"
+            ],
+            "matchPackageNames": ["typescript"],
+            "allowedVersions": "<7.0.0"
+        },
+        {
             "description": "MAJOR — every major update gets its own PR, no exceptions. Clears the per-module groupName for any major bump (last-match-wins), so each major lands standalone. Must stay last to override every group above.",
             "matchUpdateTypes": ["major"],
             "groupName": null


### PR DESCRIPTION
Caps `typescript` below 7.0 for `tests/test-ui` and `docs`, so Renovate stops proposing the
major. Closes #487.

## Why

TypeScript 7 is the Go-native port. Its npm package ships a platform binary plus a version stub
(`lib/` holds only `tsc.js` and `version.cjs`, and `exports["."]` maps to `lib/version.cjs`), so
the compiler JS API is gone until the API planned for 7.1.

`vue-tsc`'s engine `@volar/typescript` consumes that API, so `vue-tsc --noEmit` dies:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not defined by "exports"
    at resolveTscPath (node_modules/vue-tsc/index.js:73:43)
```

That breaks `bun run build` in test-ui, which gates `make build-test-ui` and the *Build test-UI
SPA* step in `e2e-tests.yml`. `vue-tsc`'s peer range (`>=5.0.0`) accepts 7.x, so nothing warns at
install time — the failure only surfaces at build.

Upstream confirms the constraint: the TypeScript 7 announcement states that Vue, MDX, Astro and
Svelte workflows "will need to continue using TypeScript 6.0 for now", and vuejs/language-tools#5381
tracks the Volar side. Verified against `vue-tsc` 3.3.9, the latest release.

`docs` is capped in lockstep: its tsconfig includes `.vitepress/**/*.vue`, which tsgo cannot
check, and `vitepress build` never invokes `tsc` — 7.x is all risk and no gain there.

## Changes

- Add a `CAP` packageRule holding `typescript` to `<7.0.0` for `tests/test-ui/package.json` and
  `docs/package.json`
- No `versioning: semver` on this rule, unlike the NuGet caps above it: the `bun` manager uses
  npm versioning, which evaluates `<7.0.0` correctly

## Verification

`renovate --platform=local --dry-run=lookup`, run with and without the rule:

| Config | `typescript` lookup |
|---|---|
| without the cap | `newVersion: 7.0.2`, `newValue: ^7.0.0`, `updateType: major` — both files |
| with the cap | `"updates": []` — both files |

Lift once Volar runs on the TS 7.1 API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management settings to keep TypeScript versions below 7.0 in test UI and documentation projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->