### PR TITLE
chore(claude): update worktree conventions in git-workflow rule

### DIFF
--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -5,9 +5,8 @@ Project-specific git rules; generic git knowledge is assumed.
 ## Staging
 
 - Never use `git add .` or `git add -A`. Stage files explicitly by path.
-- Verify a path's ignore status with `git check-ignore -v <path>` before assuming a file is ignored. Parent directory patterns (e.g., `**/bin`) affect nested files.
-- For tracked files that now sit inside an ignored directory, either stage with `-f` or fix `.gitignore` with a negation pattern (e.g., `!docker/rootfs/opt/base/bin/`).
-- `git add <paths>` stages *your* files, but `git commit` commits the **entire index** — which may already hold changes you didn't stage (pre-staged by the user or a prior step). Always run `git diff --cached --name-only` and confirm it shows ONLY your intended files immediately before committing. If it lists extras, `git restore --staged <those>` first. (This session a commit swept in two pre-staged unrelated files — `CIRenderer.cs`, `test-broker-invariants.md` — that were already in the index; fixing it needed a `git reset --soft HEAD~1` + re-stage. The soft-reset is safe only while the commit is unpushed.)
+- Verify ignore status with `git check-ignore -v <path>`; parent patterns (e.g. `**/bin`) affect nested files. Tracked files inside an ignored directory: stage with `-f` or add a negation pattern.
+- `git commit` commits the **entire index**, not just what you staged. Run `git diff --cached --name-only` immediately before committing; `git restore --staged` any extras. Recovery for a bad commit: `git reset --soft HEAD~1` + re-stage — safe only while unpushed.
 
 ## Chained PRs
 
@@ -16,14 +15,12 @@ When a child PR depends on a parent PR, after the parent merges:
 ```bash
 gh pr edit <child-num> --base master
 git checkout <child-branch> && git rebase master && git push --force-with-lease
-sleep 2 && gh pr merge <child-num> --squash --admin
+sleep 2 && gh pr merge <child-num> --squash --admin   # sleep: GitHub reports "not mergeable" right after a force-push
 ```
-
-The `sleep 2` before `gh pr merge` avoids GitHub returning "not mergeable" right after a force-push (sync delay).
 
 ## Commit messages
 
-Conventional commits, enforced by a commitlint hook that extends `config-conventional` — so the body is capped at **100 chars/line** (an inherited default not written in `commitlint.config`). Wrap body lines (use `git commit -F <file>`) or the hook rejects the commit.
+Conventional commits, enforced by commitlint (`config-conventional`): body capped at 100 chars/line. Wrap body lines (use `git commit -F <file>`).
 
 ## PR Descriptions
 
@@ -31,15 +28,13 @@ Bullet points of changes. No co-author attributions.
 
 ## Worktrees
 
-A fresh worktree is a clean checkout, so the gitignored things from the main checkout need setting up:
+Run these from the main checkout — the relative paths resolve wrong from inside another worktree (use absolute paths there). A fresh worktree is a clean checkout, so the gitignored things from the main checkout need setting up:
 
 ```bash
-git worktree add -b <branch> "../server-worktrees/<name>" master
-cp .env .env.test "../server-worktrees/<name>/"   # build + tests; skip if created via `claude --worktree` (.worktreeinclude handles it)
-cp .sdvd_runner_key "../server-worktrees/<name>/"  # ONLY if the active SDVD_DOCKER_HOSTS uses a remote ssh:// host — see below
-cd "../server-worktrees/<name>" && npm ci          # commitlint hook needs node_modules; per-worktree, never symlink the main repo's
-git worktree remove --force "../server-worktrees/<name>"   # cleanup; keep the branch if a PR depends on it
+git worktree add -b <branch> "../worktrees/<name>" master
+cp .env .env.test .sdvd_runner_key "../worktrees/<name>/"   # skip if created via `claude --worktree` (.worktreeinclude)
+cd "../worktrees/<name>" && npm ci   # commitlint hook; never symlink the main repo's node_modules
+git worktree remove --force "../worktrees/<name>"   # cleanup; keep the branch if a PR depends on it
 ```
 
-- **SSH runner key.** When the active `SDVD_DOCKER_HOSTS` in `.env.test` points at a remote host (`endpoint: "ssh://…"` with `sshKey: "./.sdvd_runner_key"`), the E2E runner crashes at `HostPool` startup — `sshKey './.sdvd_runner_key' is neither inline key material … nor an existing file` — because the key is gitignored and absent in the fresh worktree. Copy it alongside `.env`. Not needed for a local-daemon `SDVD_DOCKER_HOSTS`.
-- **`git worktree remove` can fail on Windows** with `Filename too long` (deep `node_modules`/build paths exceed the path limit). Fall back to `powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<abs-path>' -Recurse -Force"` then `git worktree prune` to drop the registration.
+`git worktree remove` can fail on Windows with `Filename too long` (deep `node_modules`/build paths). Fall back to `powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<abs-path>' -Recurse -Force"` then `git worktree prune`.

--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -5,7 +5,7 @@ Project-specific git rules; generic git knowledge is assumed.
 ## Staging
 
 - Never use `git add .` or `git add -A`. Stage files explicitly by path.
-- Verify ignore status with `git check-ignore -v <path>`; parent patterns (e.g. `**/bin`) affect nested files. Tracked files inside an ignored directory: stage with `-f` or add a negation pattern.
+- Verify ignore status with `git check-ignore -v --no-index <path>` (without `--no-index` it reports nothing for tracked paths); parent patterns (e.g. `**/bin`) affect nested files. Tracked files inside an ignored directory: stage with `-f` or add a negation pattern.
 - `git commit` commits the **entire index**, not just what you staged. Run `git diff --cached --name-only` immediately before committing; `git restore --staged` any extras. Recovery for a bad commit: `git reset --soft HEAD~1` + re-stage — safe only while unpushed.
 
 ## Chained PRs
@@ -34,7 +34,7 @@ Run these from the main checkout — the relative paths resolve wrong from insid
 git worktree add -b <branch> "../worktrees/<name>" master
 cp .env .env.test .sdvd_runner_key "../worktrees/<name>/"   # skip if created via `claude --worktree` (.worktreeinclude)
 cd "../worktrees/<name>" && npm ci   # commitlint hook; never symlink the main repo's node_modules
-git worktree remove --force "../worktrees/<name>"   # cleanup; keep the branch if a PR depends on it
+git worktree remove --force "../worktrees/<name>"   # cleanup — deletes uncommitted changes; keep the branch if a PR depends on it
 ```
 
 `git worktree remove` can fail on Windows with `Filename too long` (deep `node_modules`/build paths). Fall back to `powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<abs-path>' -Recurse -Force"` then `git worktree prune`.

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -3,3 +3,4 @@
 # node_modules is NOT copied — run `npm ci` per worktree (see git-workflow.md).
 .env
 .env.test
+.sdvd_runner_key


### PR DESCRIPTION
- worktree location convention is `../worktrees/<name>`; setup commands run from the main checkout (relative paths resolve wrong from inside another worktree)
- always copy `.env`, `.env.test` and `.sdvd_runner_key` into a fresh worktree; `.sdvd_runner_key` added to `.worktreeinclude`
- compress the rule text (drop incident narratives, fold explanations into the command comments)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified version-control guidance for staging, reviewing, and committing changes.
  * Improved instructions for creating and preparing development workspaces, including dependency setup and required configuration and runner-key files.
  * Added guidance for handling ignored paths, delayed chained changes, and complete index verification before commits.
  * Documented workspace cleanup options for Windows.
  * Condensed commit-message recommendations while retaining the 100-character body limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->