### PR TITLE
chore(claude): enforce worktree placement via WorktreeCreate hook

### DIFF
--- a/.claude/hooks/worktree-create.mjs
+++ b/.claude/hooks/worktree-create.mjs
@@ -1,0 +1,62 @@
+// WorktreeCreate hook: places Claude-created worktrees at ../worktrees/<name>
+// (project convention, see .claude/rules/universal/git-workflow.md) instead of
+// the default .claude/worktrees/ inside the repo. Claude Code does not process
+// .worktreeinclude when this hook is active, so the copy happens here.
+// Contract (code.claude.com/docs/en/hooks#worktreecreate): stdin JSON {name},
+// stdout = worktree path, non-zero exit = creation failure.
+import { execFileSync, execSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const git = (...args) =>
+  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }).trim();
+
+const input = JSON.parse(fs.readFileSync(0, "utf8"));
+const rawName = String(input.name ?? "").trim();
+if (!rawName) {
+  console.error("worktree-create hook: no worktree name in hook input");
+  process.exit(1);
+}
+
+// Resolve the main checkout even when invoked from inside another worktree.
+const mainCheckout = path.dirname(git("rev-parse", "--path-format=absolute", "--git-common-dir"));
+const dirName = rawName.replace(/[^A-Za-z0-9._-]/g, "-");
+const dest = path.join(path.dirname(mainCheckout), "worktrees", dirName);
+
+const registered = git("worktree", "list", "--porcelain")
+  .split(/\r?\n/)
+  .some((line) => line.startsWith("worktree ") && path.resolve(line.slice(9)) === path.resolve(dest));
+
+if (registered) {
+  console.log(dest); // reuse, mirroring `--worktree` semantics for an existing name
+  process.exit(0);
+}
+if (fs.existsSync(dest)) {
+  console.error(`worktree-create hook: ${dest} exists but is not a registered worktree`);
+  process.exit(1);
+}
+
+execFileSync("git", ["worktree", "add", "-b", rawName, dest, "master"], {
+  cwd: mainCheckout,
+  stdio: ["ignore", "ignore", "inherit"],
+});
+
+// .worktreeinclude entries are plain repo-relative paths, one per line.
+const includeFile = path.join(mainCheckout, ".worktreeinclude");
+if (fs.existsSync(includeFile)) {
+  for (const line of fs.readFileSync(includeFile, "utf8").split(/\r?\n/)) {
+    const rel = line.trim();
+    if (!rel || rel.startsWith("#")) continue;
+    const src = path.join(mainCheckout, rel);
+    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(dest, rel));
+  }
+}
+
+// Exit code ignored: on Windows `npm ci` exits non-zero at the `lefthook install`
+// postinstall (core.hooksPath already points at the main repo's hooks) with
+// node_modules complete and the hooks still firing.
+try {
+  execSync("npm ci", { cwd: dest, stdio: ["ignore", "ignore", "inherit"] });
+} catch {}
+
+console.log(dest);

--- a/.claude/hooks/worktree-create.mjs
+++ b/.claude/hooks/worktree-create.mjs
@@ -23,11 +23,24 @@ const mainCheckout = path.dirname(git("rev-parse", "--path-format=absolute", "--
 const dirName = rawName.replace(/[^A-Za-z0-9._-]/g, "-");
 const dest = path.join(path.dirname(mainCheckout), "worktrees", dirName);
 
-const registered = git("worktree", "list", "--porcelain")
-  .split(/\r?\n/)
-  .some((line) => line.startsWith("worktree ") && path.resolve(line.slice(9)) === path.resolve(dest));
+const worktrees = git("worktree", "list", "--porcelain")
+  .split(/\r?\n\r?\n/)
+  .map((block) => ({
+    path: block.match(/^worktree (.+)$/m)?.[1],
+    branch: block.match(/^branch refs\/heads\/(.+)$/m)?.[1],
+  }))
+  .filter((w) => w.path);
 
-if (registered) {
+const existing = worktrees.find((w) => path.resolve(w.path) === path.resolve(dest));
+if (existing) {
+  // Distinct names can flatten to the same directory (fix/a-b vs fix/a/b) —
+  // only reuse a worktree that is on the requested branch.
+  if (existing.branch !== rawName) {
+    console.error(
+      `worktree-create hook: ${dest} is on branch '${existing.branch}', not '${rawName}' — pick a name that flattens to a different directory`,
+    );
+    process.exit(1);
+  }
   console.log(dest); // reuse, mirroring `--worktree` semantics for an existing name
   process.exit(0);
 }
@@ -36,10 +49,19 @@ if (fs.existsSync(dest)) {
   process.exit(1);
 }
 
-execFileSync("git", ["worktree", "add", "-b", rawName, dest, "master"], {
-  cwd: mainCheckout,
-  stdio: ["ignore", "ignore", "inherit"],
-});
+// Check out the branch if it already exists (e.g. worktree removed, branch
+// kept for a PR); -b would reject it.
+let branchExists = true;
+try {
+  execFileSync("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${rawName}`], { stdio: "ignore" });
+} catch {
+  branchExists = false;
+}
+execFileSync(
+  "git",
+  branchExists ? ["worktree", "add", dest, rawName] : ["worktree", "add", "-b", rawName, dest, "master"],
+  { cwd: mainCheckout, stdio: ["ignore", "ignore", "inherit"] },
+);
 
 // .worktreeinclude entries are plain repo-relative paths, one per line.
 const includeFile = path.join(mainCheckout, ".worktreeinclude");
@@ -52,11 +74,20 @@ if (fs.existsSync(includeFile)) {
   }
 }
 
-// Exit code ignored: on Windows `npm ci` exits non-zero at the `lefthook install`
-// postinstall (core.hooksPath already points at the main repo's hooks) with
-// node_modules complete and the hooks still firing.
 try {
-  execSync("npm ci", { cwd: dest, stdio: ["ignore", "ignore", "inherit"] });
-} catch {}
+  execSync("npm ci", { cwd: dest, stdio: ["ignore", "ignore", "pipe"] });
+} catch (e) {
+  const stderr = e.stderr?.toString() ?? "";
+  process.stderr.write(stderr);
+  // On Windows `npm ci` exits non-zero at the `lefthook install` postinstall
+  // (core.hooksPath already points at the main repo's hooks) with node_modules
+  // complete and the hooks still firing — tolerate only that; any other
+  // failure means an unprovisioned worktree, so fail creation (the worktree
+  // stays on disk and a retry with the same name reuses it).
+  if (!/lefthook install/.test(stderr)) {
+    console.error("worktree-create hook: npm ci failed");
+    process.exit(1);
+  }
+}
 
 console.log(dest);

--- a/.claude/hooks/worktree-remove.mjs
+++ b/.claude/hooks/worktree-remove.mjs
@@ -12,11 +12,18 @@ const git = (...args) =>
 const input = JSON.parse(fs.readFileSync(0, "utf8"));
 const mainCheckout = path.dirname(git("rev-parse", "--path-format=absolute", "--git-common-dir"));
 const container = path.join(path.dirname(mainCheckout), "worktrees") + path.sep;
+const registered = new Set(
+  git("worktree", "list", "--porcelain")
+    .split(/\r?\n/)
+    .filter((l) => l.startsWith("worktree "))
+    .map((l) => path.resolve(l.slice(9))),
+);
 
 // The input field carrying the path is undocumented; try likely names first,
 // then any string value — but never ambient fields (`cwd` may be a live
-// worktree that is not the removal target). Only paths inside the convention
-// container qualify; anything else exits 1, leaving the worktree in place.
+// worktree that is not the removal target). Only registered worktrees inside
+// the convention container qualify; anything else exits 1, leaving the
+// worktree in place.
 const ambient = new Set(["cwd", "session_id", "transcript_path", "hook_event_name"]);
 const candidates = [
   input.worktree_path,
@@ -26,19 +33,23 @@ const candidates = [
 ].filter((v) => typeof v === "string" && v.trim());
 const target = candidates
   .map((v) => path.resolve(v.trim()))
-  .find((p) => (p + path.sep).startsWith(container));
+  .find((p) => (p + path.sep).startsWith(container) && p + path.sep !== container && registered.has(p));
 if (!target) {
-  console.error(`worktree-remove hook: no path inside ${container} in hook input: ${JSON.stringify(input)}`);
+  console.error(`worktree-remove hook: no registered worktree inside ${container} in hook input: ${JSON.stringify(input)}`);
   process.exit(1);
 }
 
 try {
   execFileSync("git", ["worktree", "remove", "--force", target], {
     cwd: mainCheckout,
-    stdio: ["ignore", "ignore", "inherit"],
+    stdio: ["ignore", "ignore", "pipe"],
   });
-} catch {
-  // Windows "Filename too long" fallback (deep node_modules paths).
+} catch (e) {
+  const stderr = e.stderr?.toString() ?? "";
+  process.stderr.write(stderr);
+  // Deep node_modules paths can exceed Windows path limits; anything else is a
+  // real git failure and must not fall through to a blind recursive delete.
+  if (!/too long/i.test(stderr)) process.exit(1);
   fs.rmSync(target, { recursive: true, force: true, maxRetries: 3 });
   execFileSync("git", ["worktree", "prune"], { cwd: mainCheckout, stdio: "ignore" });
 }

--- a/.claude/hooks/worktree-remove.mjs
+++ b/.claude/hooks/worktree-remove.mjs
@@ -1,0 +1,44 @@
+// WorktreeRemove hook: cleans up worktrees that worktree-create.mjs placed at
+// ../worktrees/<name>. Removes the worktree only, never its branch (a PR may
+// depend on it — see .claude/rules/universal/git-workflow.md).
+// Failures are logged by Claude Code in debug mode only and cannot block removal.
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const git = (...args) =>
+  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }).trim();
+
+const input = JSON.parse(fs.readFileSync(0, "utf8"));
+const mainCheckout = path.dirname(git("rev-parse", "--path-format=absolute", "--git-common-dir"));
+const container = path.join(path.dirname(mainCheckout), "worktrees") + path.sep;
+
+// The input field carrying the path is undocumented; try likely names first,
+// then any string value — but never ambient fields (`cwd` may be a live
+// worktree that is not the removal target). Only paths inside the convention
+// container qualify; anything else exits 1, leaving the worktree in place.
+const ambient = new Set(["cwd", "session_id", "transcript_path", "hook_event_name"]);
+const candidates = [
+  input.worktree_path,
+  input.path,
+  input.worktreePath,
+  ...Object.entries(input).flatMap(([k, v]) => (ambient.has(k) ? [] : [v])),
+].filter((v) => typeof v === "string" && v.trim());
+const target = candidates
+  .map((v) => path.resolve(v.trim()))
+  .find((p) => (p + path.sep).startsWith(container));
+if (!target) {
+  console.error(`worktree-remove hook: no path inside ${container} in hook input: ${JSON.stringify(input)}`);
+  process.exit(1);
+}
+
+try {
+  execFileSync("git", ["worktree", "remove", "--force", target], {
+    cwd: mainCheckout,
+    stdio: ["ignore", "ignore", "inherit"],
+  });
+} catch {
+  // Windows "Filename too long" fallback (deep node_modules paths).
+  fs.rmSync(target, { recursive: true, force: true, maxRetries: 3 });
+  execFileSync("git", ["worktree", "prune"], { cwd: mainCheckout, stdio: "ignore" });
+}

--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -30,13 +30,4 @@ Bullet points of changes. No co-author attributions.
 
 ## Worktrees
 
-Run these from the main checkout — the relative paths resolve wrong from inside another worktree (use absolute paths there). A fresh worktree is a clean checkout, so the gitignored things from the main checkout need setting up:
-
-```bash
-git worktree add -b <branch> "../worktrees/<name>" master
-cp .env .env.test .sdvd_runner_key "../worktrees/<name>/"   # skip if created via `claude --worktree` (.worktreeinclude)
-cd "../worktrees/<name>" && npm ci   # commitlint hook; never symlink the main repo's node_modules
-git worktree remove --force "../worktrees/<name>"   # cleanup — deletes uncommitted changes; keep the branch if a PR depends on it
-```
-
-`git worktree remove` can fail on Windows with `Filename too long` (deep `node_modules`/build paths). Fall back to `powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<abs-path>' -Recurse -Force"` then `git worktree prune`.
+Worktrees live at `../worktrees/<name>` — never inside the repo. Create them via EnterWorktree: the `WorktreeCreate` hook (`.claude/hooks/worktree-create.mjs`) places them there, branches `<name>` from `master` (so name it like a branch: `fix/...`, `feat/...`), copies the `.worktreeinclude` files, and runs `npm ci`. Don't hand-roll `git worktree add` — if the hook path is ever unavailable, replicate those steps yourself. `ExitWorktree` can leave but not remove a worktree mid-session; clean up with `git worktree remove --force "../worktrees/<name>"` (deletes uncommitted changes; keep the branch if a PR depends on it). On Windows `Filename too long`: `powershell.exe -NoProfile -Command "Remove-Item -LiteralPath '<abs-path>' -Recurse -Force"` then `git worktree prune`.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,46 @@
 {
     "autoMemoryEnabled": false,
+    "hooks": {
+        "WorktreeCreate": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node .claude/hooks/worktree-create.mjs",
+                        "timeout": 120,
+                        "statusMessage": "Creating worktree in ../worktrees/ (incl. npm ci)"
+                    }
+                ]
+            }
+        ],
+        "WorktreeRemove": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "node .claude/hooks/worktree-remove.mjs",
+                        "timeout": 60
+                    }
+                ]
+            }
+        ]
+    },
     "permissions": {
-        "allow": [],
+        "allow": [
+            "Bash(docker compose config *)",
+            "Bash(dotnet csharpier check *)",
+            "Bash(tasklist *)",
+            "Bash(unzip -p *)",
+            "PowerShell(Get-ChildItem *)",
+            "Bash(make test-container-log *)",
+            "Bash(make test-diagnose *)",
+            "Bash(make test-events *)",
+            "Bash(make test-flaky *)",
+            "Bash(make test-infra-log *)",
+            "Bash(make test-metadata *)",
+            "Bash(make test-slowest *)",
+            "Bash(make test-summary *)"
+        ],
         "deny": [],
         "ask": []
     }

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,6 +1,7 @@
-# Gitignored files copied into each new `claude --worktree`. .gitignore syntax.
+# Gitignored files copied into each Claude-created worktree by .claude/hooks/worktree-create.mjs.
+# Plain repo-relative paths, one per line (not full .gitignore syntax).
 # .env: build reads GAME_PATH via Directory.Build.props. .env.test: E2E tests.
-# node_modules is NOT copied — run `npm ci` per worktree (see git-workflow.md).
+# node_modules is NOT copied — the hook runs `npm ci` in the worktree instead.
 .env
 .env.test
 .sdvd_runner_key


### PR DESCRIPTION
Enforces the project worktree convention (`../worktrees/<name>`, outside the repo) for all Claude-created worktrees by replacing the default worktree logic with hooks.

- `WorktreeCreate` hook (`.claude/hooks/worktree-create.mjs`): creates the worktree at `../worktrees/<name>`, branches `<name>` from `master`, copies the `.worktreeinclude` files, and runs `npm ci` (benign lefthook postinstall failure swallowed). Reuses an existing registered worktree of the same name.
- `WorktreeRemove` hook (`.claude/hooks/worktree-remove.mjs`): removes only worktrees inside `../worktrees/`, never deletes branches; includes the Windows `Filename too long` fallback. Field name of the hook input path is undocumented upstream, so any string field resolving inside the container qualifies — except ambient ones (`cwd`), so a wrong guess can never delete the wrong worktree.
- `.claude/settings.json`: registers both hooks (also carries the refreshed permission allowlist that was pending on disk).
- `git-workflow.md`: worktree section reduced to the enforced convention.
- `.worktreeinclude`: comment reflects that the hook consumes it (plain paths) and runs `npm ci`.

Verified live: `EnterWorktree` lands at `../worktrees/<name>` with branch, env files, and `node_modules` in place; create hook measured at 9-25s (timeout 120s). Known limitation: `ExitWorktree` cannot remove hook-created worktrees mid-session — cleanup is `git worktree remove --force`, or the remove hook at session exit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated worktree creation and removal support.
  * Worktrees are initialized with selected project files and dependencies.
  * Added safeguards for invalid paths, conflicts, and cleanup failures.

* **Documentation**
  * Updated development guidance for the new worktree workflow.
  * Clarified which files are copied during worktree setup.

* **Chores**
  * Expanded approved command permissions for development and testing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->