### PR TITLE
chore(docker): bump base images from Debian 11 to Debian 13

### DIFF
--- a/.claude/plans/bugs/server-error-silent-cancellation.md
+++ b/.claude/plans/bugs/server-error-silent-cancellation.md
@@ -1,0 +1,43 @@
+# Server-error abort is reported as silent cancellation, never a failure
+
+**Status: traced, not fixed. Own PR — independent of the Debian 13 base bump it was found under.**
+
+When a server dies during creation (e.g. a fatal mod ERROR at boot), the run ends as
+`passed: 3, failed: 0, canceled: 164, aborted: false, abortReason: null` — zero failures, cause
+visible only in a `wait` diagnostic. An operator reading the summary sees a mysteriously canceled
+run, not a failing server.
+
+## Traced mechanism
+
+Test-side symbols, all in `tests/JunimoServer.Tests` unless noted:
+
+- `ServerContainer` scans server logs for `\b(ERROR|FATAL)\b` (`IgnoredErrorPatterns` has only
+  `"XACT"`); `FlushError` → `_errorCancellation.Cancel()`.
+- `TestLifecycle` treats any cancelled test CT as stopOnFail → `NotifyStopOnFail()` →
+  `TestResourceBroker`'s `_runCts.Cancel()` → mass cancel; each victim re-triggers. Because the
+  trigger is a cancellation, nothing is recorded as failed (`TestRunState.ApplyTestFailed`
+  classifies purely by exception type — `TaskCanceledException`/`OperationCanceledException` →
+  `"canceled"`).
+- `abortReason` is runner-side only (`RunRecorder.SetAbortReason`). `TestSummaryFixture.SetAborted()`
+  is called on the prestart-failure path but nothing reads it — a genuinely missing hop.
+- Machinery that already exists and should be reused: `RendererBase.ReclassifyCanceledAsFailed`
+  (wired to `test_enrichment` in CIRenderer/LLMRenderer/WebRenderer),
+  `ManagedServer.PoisonReasonCode.ServerLogError`, `Lease.IsPoisoned`/`Lease.ErrorToken`,
+  `RecordTestFailure`'s `"infrastructure"` stamp, and the `instance_poisoned` IPC event.
+
+## Open questions
+
+- **Which path actually cancelled the observed runs** was never identified: the prestart path did
+  not fire (no `Pre-start failed` text) and `run_stall_watchdog_tripped` was absent. Broker
+  `TestLog` output goes to the console, not into `TestResults/` — capture the console output when
+  reproducing.
+- The repro class needs a server that turns unhealthy *after* becoming ready: a server that
+  never becomes ready surfaces as real `failed` readiness-timeout entries instead (observed in
+  the 2026-08-08 Debian 13 runs).
+
+## Dead end — do not retry
+
+Subscribing `OnErrorDetected → PoisonServer(ServerLogError)` in the `ManagedServer` constructor
+plus a `RecordServerErrorFailure()` hop in TestBase/TestLifecycle was tried and reverted: it
+produced no poison events, and it cannot help the server-dies-during-creation case because it
+requires a `Lease` those tests never acquire.

--- a/.claude/plans/bugs/server-error-silent-cancellation.md
+++ b/.claude/plans/bugs/server-error-silent-cancellation.md
@@ -2,10 +2,16 @@
 
 **Status: traced, not fixed. Own PR — independent of the Debian 13 base bump it was found under.**
 
-When a server dies during creation (e.g. a fatal mod ERROR at boot), the run ends as
+When a server dies *after* becoming ready (e.g. a fatal mod ERROR during deferred init, once
+tests are already running against it), the run ends as
 `passed: 3, failed: 0, canceled: 164, aborted: false, abortReason: null` — zero failures, cause
 visible only in a `wait` diagnostic. An operator reading the summary sees a mysteriously canceled
-run, not a failing server.
+run, not a failing server. A server that never becomes ready is the *other* shape and already
+surfaces correctly, as real `failed` readiness-timeout entries — the silent shape is specific to
+post-ready deaths, where every victim is a cancellation: the first test's CT cancels, stopOnFail
+fans out via `TestResourceBroker`'s `_runCts`, and later acquisitions fail through
+`BuildAcquisitionFault` (whose `_stopOnFailNotified && !host.IsPoisoned` branch labels them as
+collateral rather than cause).
 
 ## Traced mechanism
 
@@ -31,13 +37,12 @@ Test-side symbols, all in `tests/JunimoServer.Tests` unless noted:
   not fire (no `Pre-start failed` text) and `run_stall_watchdog_tripped` was absent. Broker
   `TestLog` output goes to the console, not into `TestResults/` — capture the console output when
   reproducing.
-- The repro class needs a server that turns unhealthy *after* becoming ready: a server that
-  never becomes ready surfaces as real `failed` readiness-timeout entries instead (observed in
-  the 2026-08-08 Debian 13 runs).
+- Repro needs a server that turns unhealthy after becoming ready (see the shape distinction
+  above) — e.g. a mod command/flag that logs a fatal ERROR on demand mid-test.
 
 ## Dead end — do not retry
 
 Subscribing `OnErrorDetected → PoisonServer(ServerLogError)` in the `ManagedServer` constructor
 plus a `RecordServerErrorFailure()` hop in TestBase/TestLifecycle was tried and reverted: it
-produced no poison events, and it cannot help the server-dies-during-creation case because it
-requires a `Lease` those tests never acquire.
+produced no poison events, and it cannot cover the cancellation victims — they die inside
+acquisition and never hold the `Lease` that hop requires.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -136,7 +136,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 # ============================================================================
 # Stage 4: Final runtime image (no game files, downloads on first run)
 # ============================================================================
-FROM --platform=$BUILDPLATFORM jlesage/baseimage-gui:debian-11-v4.11.3 AS server
+FROM --platform=$BUILDPLATFORM jlesage/baseimage-gui:debian-13-v4.13 AS server
 
 ARG SMAPI_VERSION
 ARG TMUX_VERSION=3.7b
@@ -162,13 +162,16 @@ ENV APP_NAME="Stardew Dedicated Server" \
     SMAPI_VERSION=${SMAPI_VERSION} \
     SMAPI_MODS_PATH=/data/Mods
 
-# Install all apt packages in one layer to reduce image size and layers
-RUN apt-get update && apt-get install -y \
+# add-pkg (base image helper), not raw apt-get: it pre-creates /var/log's symlink target
+# (/config — a runtime volume, absent at build time, so tcpdump's postinst fails without it)
+# and installs --no-install-recommends, keeping out systemd, whose postinst dies on that
+# same symlink (mesa-utils recommends it). add-pkg cleans the apt cache itself.
+RUN add-pkg \
     # Base packages
     ca-certificates \
     curl \
     # .NET globalization (SMAPI FailFasts at startup without it)
-    libicu67 \
+    libicu76 \
     # SkiaSharp's native image decoder (Content Patcher EditImage) needs fontconfig to load
     libfontconfig1 \
     locales \
@@ -182,17 +185,13 @@ RUN apt-get update && apt-get install -y \
     # TigerVNC
     tigervnc-standalone-server \
     mesa-utils \
-    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen \
+    && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+    && locale-gen \
     # Configure TigerVNC
-    && cp /usr/bin/Xvnc /opt/base/bin/Xvnc \
-    # Clean up apt cache
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && cp /usr/bin/Xvnc /opt/base/bin/Xvnc
 
-# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch). Debian 11 ships 4.3.x with x11grab
-# timing bugs that break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
+# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch) rather than the distro package, whose
+# x11grab timing bugs break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
 # daily builds after 14 days (month-end builds live two years), and the "latest" tag drifts.
 RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1.tar.xz && \
     tar -xf /tmp/ffmpeg.tar.xz -C /tmp && \
@@ -222,7 +221,11 @@ RUN \
     # Prevent unnecessary logs
     rm -f /etc/cont-init.d/89-info.sh && \
     # Prevent overriding OpenGL drivers
-    rm -rf /etc/cont-env.d/LIBGL_DRIVERS_PATH
+    rm -rf /etc/cont-env.d/LIBGL_DRIVERS_PATH && \
+    # Pin the runtime HOME to match the ENV above — the base defaults it to /config, and
+    # Steam resolves steamclient.so via ~/.steam while startapp.sh links it into
+    # /root/.steam/sdk64; a mismatch fails SteamAPI_Init and with it GameServer.Init()
+    set-cont-env HOME /root
 
 # Copy pre-built tools from build stages
 COPY --from=mod-builder /output/dll-patcher /opt/dll-patcher

--- a/docker/Dockerfile.test-client
+++ b/docker/Dockerfile.test-client
@@ -93,7 +93,7 @@ RUN --mount=type=cache,target=/root/.nuget/packages \
 # ============================================================================
 # Stage 4: Final runtime image
 # ============================================================================
-FROM jlesage/baseimage-gui:debian-11-v4.11.3 AS client
+FROM jlesage/baseimage-gui:debian-13-v4.13 AS client
 
 ARG SMAPI_VERSION
 
@@ -120,11 +120,12 @@ ENV APP_NAME="Stardew Test Client" \
     # Test client API port (can be overridden per container)
     JUNIMO_TEST_PORT=5123
 
-# Install minimal packages needed for game client
-RUN apt-get update && apt-get install -y \
+# add-pkg (base image helper), not raw apt-get — see docker/Dockerfile for why: the base's
+# /var/log symlink breaks postinst scripts, and recommends drag in systemd. Cleans apt itself.
+RUN add-pkg \
     ca-certificates \
     curl \
-    libicu67 \
+    libicu76 \
     locales \
     procps \
     scrot \
@@ -134,13 +135,10 @@ RUN apt-get update && apt-get install -y \
     xz-utils \
     mesa-utils \
     && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
-    && locale-gen \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && locale-gen
 
-# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch). Debian 11 ships 4.3.x with x11grab
-# timing bugs that break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
+# Install ffmpeg 8.1.2 (BtbN build of the stable 8.1 branch) rather than the distro package, whose
+# x11grab timing bugs break the test-recording pipeline. Pin month-end autobuilds only: BtbN prunes
 # daily builds after 14 days (month-end builds live two years), and the "latest" tag drifts.
 # Must match the server image's ffmpeg pin so both ends of the recording pipeline behave identically.
 RUN curl -fL -o /tmp/ffmpeg.tar.xz https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n8.1.2-21-gce3c09c101-linux64-gpl-8.1.tar.xz && \
@@ -156,7 +154,10 @@ RUN \
     # Prevent unnecessary logs
     rm -f /etc/cont-init.d/89-info.sh && \
     # Prevent overriding OpenGL drivers
-    rm -rf /etc/cont-env.d/LIBGL_DRIVERS_PATH
+    rm -rf /etc/cont-env.d/LIBGL_DRIVERS_PATH && \
+    # Pin the runtime HOME to match the ENV above — see docker/Dockerfile: the base defaults
+    # it to /config, moving Steam's ~/.steam lookup off the /root/.steam/sdk64 startapp.sh uses
+    set-cont-env HOME /root
 
 # Copy SMAPI config (client-specific settings)
 COPY docker/rootfs-test-client/data/smapi-config.json /data/smapi-config.json

--- a/docker/rootfs/root/.nanorc
+++ b/docker/rootfs/root/.nanorc
@@ -1,51 +1,6 @@
 set linenumbers
 
-# Syntax highlighting
-include /usr/share/nano/asm.nanorc
-include /usr/share/nano/autoconf.nanorc
-include /usr/share/nano/awk.nanorc
-include /usr/share/nano/c.nanorc
-include /usr/share/nano/changelog.nanorc
-include /usr/share/nano/cmake.nanorc
-include /usr/share/nano/css.nanorc
-include /usr/share/nano/debian.nanorc
-include /usr/share/nano/default.nanorc
-include /usr/share/nano/elisp.nanorc
-include /usr/share/nano/email.nanorc
-include /usr/share/nano/extra/ada.nanorc
-include /usr/share/nano/extra/debian.nanorc
-include /usr/share/nano/extra/fortran.nanorc
-include /usr/share/nano/extra/gentoo.nanorc
-include /usr/share/nano/extra/haskell.nanorc
-include /usr/share/nano/extra/povray.nanorc
-include /usr/share/nano/extra/spec.nanorc
-include /usr/share/nano/go.nanorc
-include /usr/share/nano/groff.nanorc
-include /usr/share/nano/guile.nanorc
-include /usr/share/nano/haskell.nanorc
-include /usr/share/nano/html.nanorc
-include /usr/share/nano/java.nanorc
-include /usr/share/nano/javascript.nanorc
-include /usr/share/nano/json.nanorc
-include /usr/share/nano/lua.nanorc
-include /usr/share/nano/makefile.nanorc
-include /usr/share/nano/man.nanorc
-include /usr/share/nano/markdown.nanorc
-include /usr/share/nano/nanohelp.nanorc
-include /usr/share/nano/nanorc.nanorc
-include /usr/share/nano/nftables.nanorc
-include /usr/share/nano/objc.nanorc
-include /usr/share/nano/ocaml.nanorc
-include /usr/share/nano/patch.nanorc
-include /usr/share/nano/perl.nanorc
-include /usr/share/nano/php.nanorc
-include /usr/share/nano/po.nanorc
-include /usr/share/nano/python.nanorc
-include /usr/share/nano/ruby.nanorc
-include /usr/share/nano/rust.nanorc
-include /usr/share/nano/sh.nanorc
-include /usr/share/nano/sql.nanorc
-include /usr/share/nano/tcl.nanorc
-include /usr/share/nano/tex.nanorc
-include /usr/share/nano/texinfo.nanorc
-include /usr/share/nano/xml.nanorc
+# Syntax highlighting — globbed, because the shipped .nanorc set changes between Debian
+# releases (trixie dropped extra/debian and extra/gentoo, which nano then errors on).
+include /usr/share/nano/*.nanorc
+include /usr/share/nano/extra/*.nanorc

--- a/tools/steam-service/ExecstackPatcher.cs
+++ b/tools/steam-service/ExecstackPatcher.cs
@@ -1,0 +1,97 @@
+namespace SteamService;
+
+/// <summary>
+/// Clears the executable-stack marker (PT_GNU_STACK PF_X) on the GOG Galaxy native libraries in a
+/// game install. The flag is a vestige of old assembler sources; glibc >= 2.41 (Debian 13) refuses
+/// to dlopen any library that carries it, which kills the game's Galaxy init with
+/// DllNotFoundException. Clearing the bit at the download layer fixes every consumer (server,
+/// test client) without loader workarounds. Only libraries the game loads via dlopen are listed:
+/// for those, a cleared flag is strictly better than a refused dlopen, while startup-loaded
+/// libraries are out of scope (glibc still honors their flag at process start).
+/// </summary>
+public static class ExecstackPatcher
+{
+    // Loaded via DllImport (dlopen) by the game's GalaxyCSharp bindings.
+    private static readonly string[] GalaxyLibs = ["libGalaxy64.so", "libGalaxyCSharpGlue.so"];
+
+    private const uint PtGnuStack = 0x6474E551;
+    private const uint PfExec = 1;
+
+    /// <summary>Clears the execstack flag on the known Galaxy libraries under <paramref name="gameDir"/>.</summary>
+    public static void ClearGalaxyLibs(string gameDir, string logPrefix)
+    {
+        foreach (var lib in GalaxyLibs)
+        {
+            var path = Path.Combine(gameDir, lib);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            try
+            {
+                if (TryClearExecstack(path))
+                {
+                    Logger.Log($"{logPrefix} Cleared executable-stack flag on {lib}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"{logPrefix} WARN: could not patch {lib}: {ex.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Clears PF_X on the PT_GNU_STACK program header of an ELF64 little-endian binary.
+    /// Returns true if the file was modified, false if the flag was already clear.
+    /// </summary>
+    private static bool TryClearExecstack(string path)
+    {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite);
+        using var reader = new BinaryReader(fs);
+
+        var ident = reader.ReadBytes(16);
+        if (
+            ident.Length < 16
+            || ident[0] != 0x7F
+            || ident[1] != (byte)'E'
+            || ident[2] != (byte)'L'
+            || ident[3] != (byte)'F'
+            || ident[4] != 2 // ELFCLASS64
+            || ident[5] != 1 // little-endian
+        )
+        {
+            throw new InvalidDataException("not an ELF64 little-endian binary");
+        }
+
+        fs.Seek(0x20, SeekOrigin.Begin);
+        var phOff = reader.ReadInt64();
+        fs.Seek(0x36, SeekOrigin.Begin);
+        var phEntSize = reader.ReadUInt16();
+        var phNum = reader.ReadUInt16();
+
+        for (var i = 0; i < phNum; i++)
+        {
+            var entryOffset = phOff + (long)i * phEntSize;
+            fs.Seek(entryOffset, SeekOrigin.Begin);
+            var pType = reader.ReadUInt32();
+            var pFlags = reader.ReadUInt32();
+            if (pType != PtGnuStack)
+            {
+                continue;
+            }
+
+            if ((pFlags & PfExec) == 0)
+            {
+                return false;
+            }
+
+            fs.Seek(entryOffset + 4, SeekOrigin.Begin);
+            fs.Write(BitConverter.GetBytes(pFlags & ~PfExec));
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/tools/steam-service/ExecstackPatcher.cs
+++ b/tools/steam-service/ExecstackPatcher.cs
@@ -37,7 +37,14 @@ public static class ExecstackPatcher
             }
             catch (Exception ex)
             {
-                Logger.Log($"{logPrefix} WARN: could not patch {lib}: {ex.Message}");
+                // Deliberately non-fatal: a throw here would keep the download marker from being
+                // written (or fail startup), bricking the whole server over a feature-scoped
+                // problem. Unpatched libs degrade to "Galaxy init fails, LAN still works", and
+                // the startup hook retries the patch on every boot.
+                Logger.Log(
+                    $"{logPrefix} WARN: could not clear executable-stack flag on {lib} "
+                        + $"({ex.Message}) — Galaxy/invite codes will fail on glibc >= 2.41 hosts"
+                );
             }
         }
     }

--- a/tools/steam-service/Program.cs
+++ b/tools/steam-service/Program.cs
@@ -723,6 +723,15 @@ async Task RunHttpServerAsync(
     Console.WriteLine("  GET  /steam/refresh-token - Get refresh token (?account=N)");
     Console.WriteLine("  POST /steam/lobby/create  - Create lobby (?account=N)");
 
+    // Volumes provisioned before the execstack patch existed still carry the flag on the
+    // Galaxy libs; fresh downloads are handled by the download-completion hook. Only runs
+    // when the marker guarantees no download is writing these files.
+    var gameDownloadMarker = Path.Combine(gameDir, $".download-manifest-{StardewValleyAppId}");
+    if (File.Exists(gameDownloadMarker))
+    {
+        ExecstackPatcher.ClearGalaxyLibs(gameDir, "[SteamService]");
+    }
+
     // Auto-login all configured accounts in parallel
     var loginTasks = accts.Select(async kv =>
     {
@@ -752,7 +761,6 @@ async Task RunHttpServerAsync(
     // resumes rather than being mistaken for done. Runs off the request path (HTTP server + /health
     // come up first). On shutdown the task isn't cancelled — Disconnect() aborts the in-flight
     // download, which is resumable on the next boot; a failed download is likewise retried next boot.
-    var gameDownloadMarker = Path.Combine(gameDir, $".download-manifest-{StardewValleyAppId}");
     if (!File.Exists(gameDownloadMarker))
     {
         var bootstrapAccount = accts.Values.FirstOrDefault(s => s.IsLoggedIn);

--- a/tools/steam-service/SteamAuthService.cs
+++ b/tools/steam-service/SteamAuthService.cs
@@ -1815,6 +1815,10 @@ public class SteamAuthService
             // work instead of crashing.
             PruneContentManifest(downloadDir);
 
+            // glibc >= 2.41 refuses to dlopen the Galaxy libs unless their vestigial
+            // executable-stack flag is cleared (see ExecstackPatcher).
+            ExecstackPatcher.ClearGalaxyLibs(downloadDir, _logPrefix);
+
             // Save download marker to skip re-download next time
             SaveDownloadMarker(
                 downloadDir,

--- a/tools/xnb-unpacker/Dockerfile
+++ b/tools/xnb-unpacker/Dockerfile
@@ -2,7 +2,7 @@
 # Note: Debian is chosen over Alpine because Mesa/X11 libraries and glibc dependencies
 # are required by StardewXnbHack. Alpine would need extra compatibility layers and
 # end up larger and more complex.
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 
 # Install required packages and clean up apt cache in a single layer
 RUN apt-get update && \
@@ -10,7 +10,7 @@ RUN apt-get update && \
     ca-certificates \
     curl \
     unzip \
-    libicu67 \
+    libicu76 \
     xvfb \
     mesa-utils \
     x11-utils \


### PR DESCRIPTION
Bumps the server and test-client base images from Debian 11 (EOL) to Debian 13, and fixes the one real incompatibility that surfaced: glibc 2.41 refuses to `dlopen` the GOG Galaxy libraries.

## Changes

- **Base images**: `jlesage/baseimage-gui` `debian-11-v4.11.3` → `debian-13-v4.13` (server + test client); `libicu67` → `libicu76`
- **`add-pkg` instead of raw `apt-get`**: v4.13 makes `/var/log` a symlink into a runtime volume that is absent at build time, which breaks postinst scripts (`tcpdump`), and package recommends drag in `systemd`, whose postinst dies on the same symlink. The base image's helper pre-creates the target, skips recommends, and cleans the apt cache itself.
- **`set-cont-env HOME /root`**: v4.13 defaults `HOME=/config`, which moves Steam's `~/.steam` lookup away from the `/root/.steam/sdk64` link `startapp.sh` creates and fails `GameServer.Init()`.
- **Galaxy execstack fix (`steam-service`)**: glibc ≥ 2.41 refuses to `dlopen` shared objects that request an executable stack; `libGalaxy64.so` and `libGalaxyCSharpGlue.so` carry that vestigial marker, so Galaxy init died with `DllNotFoundException`. New `ExecstackPatcher` clears the `PT_GNU_STACK` execute bit at the game volume's single writer — on download completion and at service startup for already-provisioned volumes (marker-gated). Loader-level workarounds were rejected: the `glibc.rtld.execstack=2` tunable forces an executable stack, which breaks .NET main-thread stack-bounds detection on emulated amd64 hosts and deadlocks SMAPI's synchronized NewDay task.
- **`.nanorc`**: glob the syntax includes — the shipped set changes between Debian releases.
- **`xnb-unpacker`**: `bullseye-slim` → `trixie-slim` for consistency.

## Verification

- Both images build clean and boot healthy on Debian 13 (save created + loaded, host automation running, no ICU FailFast)
- Galaxy `dlopen` A/B-probed on both glibc versions; patched libs load with no loader workarounds, Galaxy SDK initializes, NewDay → Save completes
- Base-image contracts checked: `/etc/services.d` merge, cinit `min_running_time`, logmonitor tag format (byte-identical), Xvnc startup
- E2E suite run against a remote host: the previously failing Galaxy poison is gone (0 occurrences across all containers, all NewDay syncs complete); one run was aborted by a pre-existing SSH ControlMaster transport defect unrelated to this change (tracked in `.claude/plans/bugs/ssh-controlmaster-orphaned-on-abort.md`)

Also adds a plan for the separately-discovered infra defect where a fatal server error surfaces as silent test cancellations instead of failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated application and test environments to newer Debian-based runtimes and ICU libraries.
  - Improved game startup reliability by automatically correcting executable-stack settings in supported GOG Galaxy libraries.
  - Refined environment configuration and package handling for more consistent runtime behavior.
  - Updated built-in text-editor syntax highlighting to recognize all available language definitions.
  - Refreshed the XNB unpacker environment with the latest Debian base and ICU version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->