### PR TITLE
fix(alwayson): warp the host to the Farm park spot after weddings, not the farmhouse bed

### DIFF
--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOn.cs
@@ -795,17 +795,15 @@ public class AlwaysOnServer : ModService
 
         // eventFinished() warped the host onto the open Farm map: the wedding's endBehaviors "wedding"
         // case sets the exit warp from getHomeOfFarmer(Game1.player).getPorchStandingSpot() (Event.cs
-        // "wedding"), and on the host Game1.player's home is the main FarmHouse, so the host lands at the
-        // farmhouse-porch tile on the Farm rather than in its FarmHouse — out of its normal hidden idle
-        // spot. Return it home, but ONLY once no wedding is still queued: on a multi-wedding day the next
-        // ceremony is started by StartNextQueuedWeddingIfIdle, which needs the host on a non-temporary
-        // location (FarmHouse won't trigger the queued Farm/Town wedding), so warping home between
-        // ceremonies would strand the next wedding unstarted. getAvailableWeddingEvent pops the running
+        // "wedding"), so the host lands at the farmhouse-porch tile rather than the canonical Farm park
+        // spot. Normalize that, but ONLY once no wedding is still queued: on a multi-wedding day the next
+        // ceremony is started by StartNextQueuedWeddingIfIdle, and re-warping the host between ceremonies
+        // could interleave with the next event start. getAvailableWeddingEvent pops the running
         // ceremony's farmer from weddingsToday before the event runs (Game1.cs:6096), so a remaining
         // Count > 0 reliably means "another wedding still queued".
         if (Game1.weddingsToday is not { Count: > 0 })
         {
-            WarpHostHomeAfterWeddings();
+            WarpHostToFarmAfterWeddings();
         }
 
         // Mark this ceremony handled and clear the timer so the next wedding's gate starts a fresh
@@ -821,58 +819,50 @@ public class AlwaysOnServer : ModService
     }
 
     /// <summary>
-    /// Return the host to its FarmHouse idle spot after the day's last wedding. <c>eventFinished()</c>
-    /// leaves the host on the open Farm map (the wedding exit warp targets the host's farmhouse porch via
-    /// <c>getHomeOfFarmer(Game1.player)</c>), but the host is meant to stay hidden in its FarmHouse — the
-    /// same place <see cref="HandleAutoSleep"/> keeps it. Reuses that handler's home-warp idiom:
-    /// <c>getLocationRequest(home)</c> + <c>warpFarmer</c> into the FarmHouse, then snap to the bed spot
-    /// and <c>Halt()</c>. Master-only and FarmHouse-targeted (no-ops if home doesn't resolve to one).
+    /// Warp the host to its standard Farm park spot after the day's last wedding — the same target
+    /// <c>HideHostActivity</c> warps it to on every day start (<see cref="AlwaysOnUtil.WarpToFarmDefaultSpawn"/>),
+    /// so the host's idle position stays the single invariant the rest of the system assumes (pacing
+    /// probes, cabin placement). The wedding exit warp already lands on the Farm (at the farmhouse
+    /// porch); this merely normalizes that to the canonical park tile. Master-only.
     /// </summary>
-    private void WarpHostHomeAfterWeddings()
+    private void WarpHostToFarmAfterWeddings()
     {
         if (!Game1.IsMasterGame)
         {
             return;
         }
 
-        var home = Game1.player.homeLocation.Value;
-        if (string.IsNullOrEmpty(home))
-        {
-            return;
-        }
+        int x = 0,
+            y = 0;
+        Utility.getDefaultWarpLocation("Farm", ref x, ref y);
 
-        // Already home (a single-tile-warp engine edge case): just snap to the bed and stop.
-        if (
-            Game1.currentLocation is FarmHouse here
-            && string.Equals(here.NameOrUniqueName, home, StringComparison.OrdinalIgnoreCase)
-        )
+        // Already on the Farm (eventFinished()'s exit warp can resolve in place before this runs):
+        // just snap to the park tile and stop.
+        if (Game1.currentLocation is Farm)
         {
-            Game1.player.position.Set(Utility.PointToVector2(here.GetPlayerBedSpot()) * 64f);
+            Game1.player.position.Set(new Microsoft.Xna.Framework.Vector2(x, y) * 64f);
             Game1.player.Halt();
             return;
         }
 
-        var req = Game1.getLocationRequest(home);
+        var req = Game1.getLocationRequest("Farm");
         req.OnWarp += () =>
         {
-            if (Game1.currentLocation is FarmHouse fh)
-            {
-                Game1.player.position.Set(Utility.PointToVector2(fh.GetPlayerBedSpot()) * 64f);
-            }
             Game1.player.Halt();
             // warpFarmer arms a fade-to-black; on the render-suppressed host the fade-in handler is
             // draw-coupled and stalls (same reason the teardown above clears the fade by hand), so clear
-            // it on arrival or the host sits on a black screen in its FarmHouse.
+            // it on arrival or the host sits on a black screen.
             Game1.fadeClear();
             Game1.fadeToBlackAlpha = 0f;
         };
-        // Coords are any valid tile inside the target FarmHouse; the OnWarp callback snaps to the bed
-        // spot. Mirrors HandleAutoSleep's home-warp (and DedicatedServer.cs:415). Issued right after
-        // eventFinished()'s own Farm-exit warpFarmer — performWarpFarmer just overwrites the single
-        // Game1.locationRequest, so this supersedes the Farm exit and the host warps straight home
-        // without first landing on the open Farm.
-        Game1.warpFarmer(req, 5, 9, Game1.player.FacingDirection);
-        Monitor.Log($"Warped host home to {home} after the day's last wedding.", LogLevel.Info);
+        // Issued right after eventFinished()'s own exit warpFarmer — performWarpFarmer just overwrites
+        // the single Game1.locationRequest, so this supersedes the porch exit and the host warps
+        // straight to the park tile.
+        Game1.warpFarmer(req, x, y, Game1.player.FacingDirection);
+        Monitor.Log(
+            "Parked host at the Farm park spot after the day's last wedding.",
+            LogLevel.Info
+        );
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -442,6 +442,16 @@ public class TestWeddingStateResponse
     /// the wedding automation re-establishes after the exit warp drops the host at the farmhouse-porch
     /// tile. Lets a test assert the host ended parked rather than just "not on a temporary map".</summary>
     public string? HostCurrentLocation { get; set; }
+
+    /// <summary>The host's current tile — diagnostics for a failed park assertion.</summary>
+    public int HostTileX { get; set; }
+    public int HostTileY { get; set; }
+
+    /// <summary>True when the host stands exactly on the Farm default warp tile (the canonical park
+    /// spot). The vanilla wedding exit warp also lands on the Farm — at the farmhouse porch — so this,
+    /// not <see cref="HostCurrentLocation"/>, is the signal that the post-wedding park normalization
+    /// actually ran.</summary>
+    public bool HostAtFarmParkSpot { get; set; }
 }
 
 /// <summary>Body for POST /test/console (test-only): a console command name + args to invoke.</summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -437,10 +437,10 @@ public class TestWeddingStateResponse
     /// Stuck-true after a wedding = the host never warped off the ceremony location.</summary>
     public bool HostLocationIsTemporary { get; set; }
 
-    /// <summary>The host's current location name. After the day's last wedding the host must be returned
-    /// to its FarmHouse idle spot — not left standing on the open Farm map where the wedding exit warp
-    /// drops it (the exit targets getHomeOfFarmer(Game1.player)'s porch). Lets a test assert the host
-    /// ended at home rather than just "not on a temporary map".</summary>
+    /// <summary>The host's current location name. After the day's last wedding the host must end parked
+    /// on the Farm — its standard park spot (HideHostActivity warps it there on every day start), which
+    /// the wedding automation re-establishes after the exit warp drops the host at the farmhouse-porch
+    /// tile. Lets a test assert the host ended parked rather than just "not on a temporary map".</summary>
     public string? HostCurrentLocation { get; set; }
 }
 

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -1816,6 +1816,19 @@ public partial class ApiService
                 result.HostLocationIsTemporary = Game1.currentLocation?.IsTemporary == true;
                 result.HostCurrentLocation = Game1.currentLocation?.NameOrUniqueName;
 
+                // Location alone can't pin the post-wedding park normalization — the vanilla wedding
+                // exit warp also lands on the Farm (at the farmhouse porch), so report whether the
+                // host stands exactly on the Farm default warp tile (the park target
+                // WarpHostToFarmAfterWeddings / HideHostActivity resolve via getDefaultWarpLocation).
+                var hostTile = Game1.player.TilePoint;
+                result.HostTileX = hostTile.X;
+                result.HostTileY = hostTile.Y;
+                int parkX = 0,
+                    parkY = 0;
+                Utility.getDefaultWarpLocation("Farm", ref parkX, ref parkY);
+                result.HostAtFarmParkSpot =
+                    Game1.currentLocation is Farm && hostTile.X == parkX && hostTile.Y == parkY;
+
                 if (farmhandId != 0)
                 {
                     // The host's view of the farmhand's spouse — used by the test to confirm the

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -1965,6 +1965,9 @@ public partial class ApiService
     // location — which the server simulates (the host is a Farmer there, IsMasterGame always true) — so
     // the probe needs no connected client. The paired state endpoint reads the entity's measured quantity
     // so a test can compare wall-clock behavior with SDVD_TPS_AGNOSTIC_PACING on vs off at the same TPS.
+    // The spawn offsets assume the host stands at its standard Farm park spot (HideHostActivity warps it
+    // there on every day start), where every offset has open in-bounds runway; the spawn handler
+    // fail-fasts if the host's actual position puts a spawn point outside the map.
 
     // The spawned probe entities, tracked so the state endpoint can read them back. Typed as object (not
     // the StardewValley types) and coords as floats so ApiService's field metadata carries NO game-type
@@ -2041,6 +2044,41 @@ public partial class ApiService
                 result.LocationName = location.NameOrUniqueName;
                 var origin = Game1.player.Position;
 
+                // One spawn point per kind, computed up front so the bounds guard below checks exactly
+                // what the spawn cases use.
+                var debrisDropOrigin = origin + new Vector2(640f, -128f);
+                var batSpawnPos = origin + new Vector2(640f, 0f);
+                var slimeSpawnPos = origin + new Vector2(320f, 0f);
+
+                // Fail fast if the probe's spawn point falls outside the host location's map: from an
+                // unexpected host spot (e.g. a small interior) the entity spawns out of bounds and
+                // vanilla deletes it on the first update tick — which would otherwise surface only as
+                // an empty state read seconds later.
+                var spawnPoint = kind switch
+                {
+                    // Debris chunks spawn at the drop origin − 32 px on each axis (Debris.InitializeChunks).
+                    PacingProbeKind.Debris => debrisDropOrigin - new Vector2(32f, 32f),
+                    PacingProbeKind.Monster => batSpawnPos,
+                    PacingProbeKind.Knockback => slimeSpawnPos,
+                    // The projectile fires from the host itself.
+                    _ => origin,
+                };
+                var map = location.map;
+                if (
+                    spawnPoint.X < 0
+                    || spawnPoint.Y < 0
+                    || spawnPoint.X > map.DisplayWidth
+                    || spawnPoint.Y > map.DisplayHeight
+                )
+                {
+                    result.Error =
+                        $"Probe spawn point ({spawnPoint.X:F0}, {spawnPoint.Y:F0}) is outside the map "
+                        + $"bounds of '{location.NameOrUniqueName}' ({map.DisplayWidth}x{map.DisplayHeight} px); "
+                        + $"host is at ({origin.X:F0}, {origin.Y:F0}). The probes assume the host stands "
+                        + "at its Farm park spot (HideHostActivity) — something moved it.";
+                    return;
+                }
+
                 // Remove all prior probe entities (by identity, from their own spawn location) so a later
                 // state read for any kind can only ever see THIS spawn's entity, and no leaked entity can
                 // contaminate it (a leftover probe projectile ricochets forever and damages monsters, so
@@ -2082,11 +2120,10 @@ public partial class ApiService
                         // WITHOUT being magnetized-and-collected (object debris homes to a nearby player
                         // once done bouncing; 640 px keeps it outside the ~64 px pickup range for the
                         // measurement window).
-                        var dropOrigin = origin + new Vector2(640f, -128f);
                         var debris = new Debris(
                             "(O)388", // Wood — an ordinary object drop
-                            dropOrigin,
-                            dropOrigin
+                            debrisDropOrigin,
+                            debrisDropOrigin
                         );
                         location.debris.Add(debris);
                         _probeDebris = debris;
@@ -2096,12 +2133,11 @@ public partial class ApiService
                     case PacingProbeKind.Monster:
                     {
                         // Spawn a Bat a fixed distance from the host so it homes in; measure how far it closes.
-                        var spawnPos = origin + new Vector2(640f, 0f);
-                        var bat = new Bat(spawnPos) { focusedOnFarmers = true };
+                        var bat = new Bat(batSpawnPos) { focusedOnFarmers = true };
                         location.characters.Add(bat);
                         _probeMonster = bat;
-                        _probeMonsterSpawnX = spawnPos.X;
-                        _probeMonsterSpawnY = spawnPos.Y;
+                        _probeMonsterSpawnX = batSpawnPos.X;
+                        _probeMonsterSpawnY = batSpawnPos.Y;
                         result.Count = 1;
                         break;
                     }
@@ -2111,8 +2147,7 @@ public partial class ApiService
                         // and hit it with a fixed knockback impulse; measure how far the impulse carries it
                         // before friction stops it. Non-glider is essential: gliders are always
                         // velocity-driven, which would muddy a clean knockback measurement.
-                        var slimePos = origin + new Vector2(320f, 0f);
-                        var slime = new GreenSlime(slimePos);
+                        var slime = new GreenSlime(slimeSpawnPos);
                         location.characters.Add(slime);
                         // Large impulse along +x, away from the host, so it dominates any velocity the
                         // slime's own AI adds (its hop toward the player) and gives a clean knockback slide.
@@ -2120,8 +2155,8 @@ public partial class ApiService
                         // when the impulse exceeds current velocity.
                         slime.setTrajectory(100, 0);
                         _probeMonster = slime;
-                        _probeMonsterSpawnX = slimePos.X;
-                        _probeMonsterSpawnY = slimePos.Y;
+                        _probeMonsterSpawnX = slimeSpawnPos.X;
+                        _probeMonsterSpawnY = slimeSpawnPos.Y;
                         result.Count = 1;
                         break;
                     }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -2080,8 +2080,8 @@ public partial class ApiService
                 if (
                     spawnPoint.X < 0
                     || spawnPoint.Y < 0
-                    || spawnPoint.X > map.DisplayWidth
-                    || spawnPoint.Y > map.DisplayHeight
+                    || spawnPoint.X >= map.DisplayWidth
+                    || spawnPoint.Y >= map.DisplayHeight
                 )
                 {
                     result.Error =

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -1980,7 +1980,7 @@ public partial class ApiService
     // so a test can compare wall-clock behavior with SDVD_TPS_AGNOSTIC_PACING on vs off at the same TPS.
     // The spawn offsets assume the host stands at its standard Farm park spot (HideHostActivity warps it
     // there on every day start), where every offset has open in-bounds runway; the spawn handler
-    // fail-fasts if the host's actual position puts a spawn point outside the map.
+    // fail-fasts if the host's actual position puts any part of a probe's motion envelope outside the map.
 
     // The spawned probe entities, tracked so the state endpoint can read them back. Typed as object (not
     // the StardewValley types) and coords as floats so ApiService's field metadata carries NO game-type
@@ -2063,30 +2063,45 @@ public partial class ApiService
                 var batSpawnPos = origin + new Vector2(640f, 0f);
                 var slimeSpawnPos = origin + new Vector2(320f, 0f);
 
-                // Fail fast if the probe's spawn point falls outside the host location's map: from an
-                // unexpected host spot (e.g. a small interior) the entity spawns out of bounds and
-                // vanilla deletes it on the first update tick — which would otherwise surface only as
-                // an empty state read seconds later.
-                var spawnPoint = kind switch
+                // Fail fast unless the probe's full MOTION ENVELOPE — spawn point plus everywhere the
+                // entity travels during the measurement — fits inside the host location's map. From an
+                // unexpected host spot, an entity that spawns or drifts out of bounds is deleted by
+                // vanilla mid-measurement, which would otherwise surface only as an empty/short state
+                // read seconds later.
+                var (envelopeMin, envelopeMax) = kind switch
                 {
-                    // Debris chunks spawn at the drop origin − 32 px on each axis (Debris.InitializeChunks).
-                    PacingProbeKind.Debris => debrisDropOrigin - new Vector2(32f, 32f),
-                    PacingProbeKind.Monster => batSpawnPos,
-                    PacingProbeKind.Knockback => slimeSpawnPos,
-                    // The projectile fires from the host itself.
-                    _ => origin,
+                    // Chunks spawn at the drop origin − 32 px on each axis (Debris.InitializeChunks)
+                    // and settle within ~64 px of the drop point (updateChunks bounce/drift).
+                    PacingProbeKind.Debris => (
+                        debrisDropOrigin - new Vector2(96f, 96f),
+                        debrisDropOrigin + new Vector2(96f, 96f)
+                    ),
+                    // Homes west from its spawn onto the host and overshoots a few tiles past it.
+                    PacingProbeKind.Monster => (
+                        origin - new Vector2(192f, 64f),
+                        batSpawnPos + new Vector2(64f, 64f)
+                    ),
+                    // The 100 px/tick knockback impulse slides it ~400 px further east before friction
+                    // stops it — the very distance the test measures.
+                    PacingProbeKind.Knockback => (
+                        slimeSpawnPos - new Vector2(64f, 64f),
+                        slimeSpawnPos + new Vector2(512f, 64f)
+                    ),
+                    // Fires from the host and ricochets off walls/obstacles — no free path needed.
+                    _ => (origin, origin),
                 };
                 var map = location.map;
                 if (
-                    spawnPoint.X < 0
-                    || spawnPoint.Y < 0
-                    || spawnPoint.X >= map.DisplayWidth
-                    || spawnPoint.Y >= map.DisplayHeight
+                    envelopeMin.X < 0
+                    || envelopeMin.Y < 0
+                    || envelopeMax.X >= map.DisplayWidth
+                    || envelopeMax.Y >= map.DisplayHeight
                 )
                 {
                     result.Error =
-                        $"Probe spawn point ({spawnPoint.X:F0}, {spawnPoint.Y:F0}) is outside the map "
-                        + $"bounds of '{location.NameOrUniqueName}' ({map.DisplayWidth}x{map.DisplayHeight} px); "
+                        $"Probe motion envelope ({envelopeMin.X:F0},{envelopeMin.Y:F0})–"
+                        + $"({envelopeMax.X:F0},{envelopeMax.Y:F0}) exceeds the map bounds of "
+                        + $"'{location.NameOrUniqueName}' ({map.DisplayWidth}x{map.DisplayHeight} px); "
                         + $"host is at ({origin.X:F0}, {origin.Y:F0}). The probes assume the host stands "
                         + "at its Farm park spot (HideHostActivity) — something moved it.";
                     return;

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -639,10 +639,23 @@ public class TestWeddingStateResponse
     [JsonPropertyName("hostLocationIsTemporary")]
     public bool HostLocationIsTemporary { get; set; }
 
-    // The host's current location name. After the last wedding the host must be back in its FarmHouse,
-    // not left on the open Farm map where the wedding exit warp drops it.
+    // The host's current location name. After the last wedding the host must end parked on the Farm
+    // (its standard park spot), not left in the FarmHouse or on a temporary ceremony map.
     [JsonPropertyName("hostCurrentLocation")]
     public string? HostCurrentLocation { get; set; }
+
+    // The host's current tile — diagnostics for a failed park assertion.
+    [JsonPropertyName("hostTileX")]
+    public int HostTileX { get; set; }
+
+    [JsonPropertyName("hostTileY")]
+    public int HostTileY { get; set; }
+
+    // True when the host stands exactly on the Farm default warp tile (the canonical park spot). The
+    // vanilla wedding exit warp also lands on the Farm — at the farmhouse porch — so this, not
+    // HostCurrentLocation, proves the post-wedding park normalization ran.
+    [JsonPropertyName("hostAtFarmParkSpot")]
+    public bool HostAtFarmParkSpot { get; set; }
 }
 
 /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -199,7 +199,7 @@ public enum WaitName
     Polling_Wedding_BothCeremoniesRan,
     Polling_Wedding_BothClientsRenderedBoth,
     Polling_Wedding_HostRecoveredAfterCeremonies,
-    Polling_Wedding_HostOnFarmAfterCeremonies,
+    Polling_Wedding_HostAtFarmParkSpotAfterCeremonies,
 
     // LobbyHomedSpouseTests.cs (4)
     Polling_LobbyHome_EngagementReplicated,

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -199,7 +199,7 @@ public enum WaitName
     Polling_Wedding_BothCeremoniesRan,
     Polling_Wedding_BothClientsRenderedBoth,
     Polling_Wedding_HostRecoveredAfterCeremonies,
-    Polling_Wedding_HostReturnedHomeAfterCeremonies,
+    Polling_Wedding_HostOnFarmAfterCeremonies,
 
     // LobbyHomedSpouseTests.cs (4)
     Polling_LobbyHome_EngagementReplicated,

--- a/tests/JunimoServer.Tests/PacingProbeTests.cs
+++ b/tests/JunimoServer.Tests/PacingProbeTests.cs
@@ -24,8 +24,17 @@ namespace JunimoServer.Tests;
 /// (<c>Game1.cs:4308</c>) — so on a player-less server NOTHING in the world ticks and every probe reads
 /// zero. One connected client unpauses the server (<c>numPlayers >= 1 → IsPaused = false</c>), which is
 /// also the realistic scenario: a player present in the world is exactly when these entities simulate.
-/// The probe entities are spawned in the HOST's own location (open Farm), which the server ticks because
-/// the host is a farmer there.
+/// The probe entities are spawned in the HOST's own location, which the server ticks because the host is
+/// a farmer there.
+/// </para>
+///
+/// <para>
+/// <b>Host-position contract.</b> The spawn offsets assume the host stands at its standard Farm park
+/// spot — where <c>HideHostActivity</c> warps it on every day start — with open in-bounds runway in every
+/// probe direction. Anything that leaves the host elsewhere (e.g. inside a small interior) puts a spawn
+/// point outside the map, and vanilla deletes out-of-bounds entities on their first update tick; the
+/// spawn endpoint fail-fasts with the host's location/position instead of letting that surface as an
+/// empty state read.
 /// </para>
 ///
 /// <para>
@@ -138,7 +147,13 @@ public class PacingProbeTests : TestBase
         var state = await ServerApi.GetPacingProbeState("debris", ct);
         Assert.NotNull(state);
         Assert.True(state.Success, $"Debris probe state read failed: {state.Error}");
-        Assert.True(state.DebrisChunkCount > 0, "Probe debris reported no chunks.");
+        Assert.True(
+            state.DebrisChunkCount > 0,
+            "Probe debris reported no chunks — the debris was deleted before the state read. Vanilla "
+                + "removes chunks that spawn outside the map on the first update tick, so the most likely "
+                + "cause is the host standing somewhere other than its Farm park spot (the spawn offsets "
+                + "assume that geometry); check the host's location/position in the server log."
+        );
         Assert.True(
             state.DebrisChunksAtRest == state.DebrisChunkCount,
             $"Only {state.DebrisChunksAtRest}/{state.DebrisChunkCount} debris chunks finished falling in "

--- a/tests/JunimoServer.Tests/PacingProbeTests.cs
+++ b/tests/JunimoServer.Tests/PacingProbeTests.cs
@@ -31,10 +31,10 @@ namespace JunimoServer.Tests;
 /// <para>
 /// <b>Host-position contract.</b> The spawn offsets assume the host stands at its standard Farm park
 /// spot — where <c>HideHostActivity</c> warps it on every day start — with open in-bounds runway in every
-/// probe direction. Anything that leaves the host elsewhere (e.g. inside a small interior) puts a spawn
-/// point outside the map, and vanilla deletes out-of-bounds entities on their first update tick; the
-/// spawn endpoint fail-fasts with the host's location/position instead of letting that surface as an
-/// empty state read.
+/// probe direction. Anything that leaves the host elsewhere (e.g. inside a small interior) puts part of
+/// a probe's motion envelope (spawn point plus the travel the test measures) outside the map, where
+/// vanilla deletes the entity mid-measurement; the spawn endpoint fail-fasts with the host's
+/// location/position instead of letting that surface as an empty or short state read.
 /// </para>
 ///
 /// <para>

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -335,35 +335,32 @@ public class WeddingTests : TestBase
             );
         }
 
-        // The host must be returned to its FarmHouse idle spot, not left standing on the open Farm map.
-        // The wedding's endBehaviors ("wedding" case) sets the exit warp from
-        // getHomeOfFarmer(Game1.player).getPorchStandingSpot(), which on the host resolves to the main
-        // farmhouse porch — so eventFinished() drops the host onto the Farm. The mod warps it home after
-        // the day's last ceremony; assert that here (separate from hostRecovered: "not stuck" is distinct
-        // from "back home", and the home-warp lands a tick or two after the temp map clears).
-        var hostHome = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_Wedding_HostReturnedHomeAfterCeremonies,
+        // The host must end parked on the Farm — its steady-state idle spot (HideHostActivity parks it
+        // there on every day start, and the pacing probes assume that geometry). The wedding's
+        // endBehaviors ("wedding" case) sets the exit warp from
+        // getHomeOfFarmer(Game1.player).getPorchStandingSpot(), so eventFinished() drops the host at the
+        // farmhouse-porch tile; the mod normalizes that to the canonical Farm park spot after the day's
+        // last ceremony. Assert that here (separate from hostRecovered: "not stuck / off the temp map" is
+        // distinct from "parked", and the park warp lands a tick or two after the temp map clears).
+        var hostOnFarm = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_HostOnFarmAfterCeremonies,
             async () =>
             {
                 var hs = await ServerApi.GetWeddingState(ct: ct);
-                return hs?.Success == true
-                    && hs.HostCurrentLocation?.StartsWith(
-                        "FarmHouse",
-                        System.StringComparison.Ordinal
-                    ) == true;
+                return hs?.Success == true && hs.HostCurrentLocation == "Farm";
             },
             timeout: TestTimings.NetworkSyncTimeout,
             cancellationToken: ct
         );
-        if (!hostHome)
+        if (!hostOnFarm)
         {
             var hs = await ServerApi.GetWeddingState(ct: ct);
             Assert.Fail(
-                "Host was not returned to its FarmHouse after the same-day weddings — it is left on the "
-                    + "open Farm map where the wedding exit warp drops it (the exit targets the host's "
-                    + "farmhouse porch via getHomeOfFarmer(Game1.player)). After the last ceremony the host "
-                    + "must warp back to its FarmHouse idle spot.\n"
-                    + $"  hostCurrentLocation={hs?.HostCurrentLocation ?? "null"} (expected to start with \"FarmHouse\")"
+                "Host did not end parked on the Farm after the same-day weddings. After the last ceremony "
+                    + "the host must be returned to its standard Farm park spot (the same idle spot "
+                    + "HideHostActivity parks it at on every day start) — leaving it anywhere else breaks "
+                    + "the park-spot invariant other tests rely on.\n"
+                    + $"  hostCurrentLocation={hs?.HostCurrentLocation ?? "null"} (expected \"Farm\")"
             );
         }
 

--- a/tests/JunimoServer.Tests/WeddingTests.cs
+++ b/tests/JunimoServer.Tests/WeddingTests.cs
@@ -342,25 +342,27 @@ public class WeddingTests : TestBase
         // farmhouse-porch tile; the mod normalizes that to the canonical Farm park spot after the day's
         // last ceremony. Assert that here (separate from hostRecovered: "not stuck / off the temp map" is
         // distinct from "parked", and the park warp lands a tick or two after the temp map clears).
-        var hostOnFarm = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_Wedding_HostOnFarmAfterCeremonies,
+        var hostAtParkSpot = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Wedding_HostAtFarmParkSpotAfterCeremonies,
             async () =>
             {
                 var hs = await ServerApi.GetWeddingState(ct: ct);
-                return hs?.Success == true && hs.HostCurrentLocation == "Farm";
+                return hs?.Success == true && hs.HostAtFarmParkSpot;
             },
             timeout: TestTimings.NetworkSyncTimeout,
             cancellationToken: ct
         );
-        if (!hostOnFarm)
+        if (!hostAtParkSpot)
         {
             var hs = await ServerApi.GetWeddingState(ct: ct);
             Assert.Fail(
-                "Host did not end parked on the Farm after the same-day weddings. After the last ceremony "
-                    + "the host must be returned to its standard Farm park spot (the same idle spot "
-                    + "HideHostActivity parks it at on every day start) — leaving it anywhere else breaks "
-                    + "the park-spot invariant other tests rely on.\n"
-                    + $"  hostCurrentLocation={hs?.HostCurrentLocation ?? "null"} (expected \"Farm\")"
+                "Host did not end parked at the Farm park spot after the same-day weddings. After the "
+                    + "last ceremony the host must be returned to the Farm default warp tile (the same "
+                    + "idle spot HideHostActivity parks it at on every day start) — merely being on the "
+                    + "Farm is not enough, since the vanilla wedding exit warp already lands there (at "
+                    + "the farmhouse porch).\n"
+                    + $"  hostCurrentLocation={hs?.HostCurrentLocation ?? "null"} "
+                    + $"hostTile=({hs?.HostTileX},{hs?.HostTileY}) (expected the Farm default warp tile)"
             );
         }
 

--- a/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
+++ b/tests/test-client/GameTweaks/WeddingCutscenePlayer.cs
@@ -255,7 +255,7 @@ public class WeddingCutscenePlayer
         // script's `pause` reads, so a linger still active when the next ceremony's first `pause` runs
         // swallows it (its expiry advances the event early). getAvailableWeddingEvent pops the running
         // ceremony's farmer before the event runs, so Count > 0 means another wedding is queued — same
-        // guard as AlwaysOn.WarpHostHomeAfterWeddings.
+        // guard as AlwaysOn.WarpHostToFarmAfterWeddings.
         if (Game1.weddingsToday is { Count: > 0 })
         {
             return;


### PR DESCRIPTION
Fixes the scheduled-E2E failure `PacingProbeTests.Debris_SettlesWallClock_AtReducedTps` ("Probe debris reported no chunks."), root-caused to the wedding automation stranding the host in its FarmHouse bed — off the Farm park spot the pacing probes' spawn geometry assumes.

- `AlwaysOn`: `WarpHostToFarmAfterWeddings` (was `WarpHostHomeAfterWeddings`) now warps the host to the standard Farm park spot after the day's last ceremony — the same target `HideHostActivity` uses on every day start — instead of relocating it into the level-0 FarmHouse and snapping it to the bed. From the bed, the probe spawn offsets land outside the 12×12 interior and vanilla deletes the entities on their first update tick.
- `WeddingTests`: the post-ceremony gate now asserts the host ends parked on the Farm (`HostCurrentLocation == "Farm"`); the previous gate asserted the FarmHouse relocation, pinning the buggy behavior.
- `/test/pacing_probe_spawn`: fail-fast bounds guard — a probe spawn point outside the host location's map returns an error naming the host's location/position instead of surfacing as an empty state read seconds later.
- `PacingProbeTests`: documents the host-position contract; the debris "no chunks" assertion message now explains the likely cause.
- `WeddingStateResponse.HostCurrentLocation` doc updated to the Farm-park expectation.
- Retires the implemented plan `.claude/plans/bugs/tests-wedding-samedaytwoweddings-speedup.md`.

Verification:
- Deterministic red repro on the pre-fix base (wedding scenario, then probes leasing the same pool server): Debris fails with exactly "Probe debris reported no chunks.", server log `[PacingProbe] Debris: debrisAtRest=0/0 count=0` — matching the CI artifacts.
- Same scenario on the fix: 5/5 green twice; server log shows the host parked on the Farm before the probes and `[PacingProbe] Debris: debrisAtRest=1/1 count=1`.
- Full local suite: 167 passed, 0 failed (6 pre-existing explicit skips).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Wedding hosts now reliably finish at the Farm’s standard parking spot after the final ceremony.
  - Improved wedding transitions and cleanup help prevent incorrect warping and lingering visual effects.
  - Pacing probes now validate spawn locations before running, reducing invalid test scenarios.

- **Tests**
  - Updated wedding and pacing validation to confirm the correct post-wedding Farm location.
  - Added clearer diagnostics, including host position details, when test setup or spawn geometry is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->