### PR TITLE
chore(docker-modern): migration roadmap + build fix

### DIFF
--- a/.claude/plans/docker-modern/README.md
+++ b/.claude/plans/docker-modern/README.md
@@ -1,0 +1,78 @@
+# Plan: Modern Docker image to production — Debian glibc → shell-free → distroless
+
+## What this is
+
+A staged roadmap to take the experimental modern server image (`docker/modern/`) from
+its current Alpine/musl WIP state to a hardened, production-ready image. The work is split
+into three phases that ship independently and in order, with risk decreasing at each step.
+
+The modern image's value is its rendering/streaming/init modernization — SwiftShader + Mesa
+Zink instead of llvmpipe/LLVM, Xvfb + go2rtc WebRTC instead of TigerVNC, s6-overlay instead
+of the jlesage cinit base. None of that depends on musl. Musl was chosen for size, but it is
+also the single reason the image cannot do Steam Datagram Relay (SDR), and the reason it carries
+a family of compatibility shims. This roadmap keeps the modernization and drops the musl tax.
+
+## The three phases
+
+1. **Debian glibc base** (`phase-1-debian-glibc-base.md`) — rebase the runtime stage from
+   `alpine:edge` to `debian:13-slim`. This unlocks SDR (real `steamclient.so` works on glibc)
+   and lets the whole musl-workaround family be deleted. Also folds in the LLVM-size fix, a
+   real-client SDR check, and first-time test coverage. After this phase the modern image is
+   production-viable.
+
+2. **Remove shell dependencies** (`phase-2-remove-shell-dependencies/`) — a series of
+   independently-shippable changes that each remove a runtime dependency on a shell: move the
+   command path from the SMAPI stdin FIFO to the existing HTTP API, replace the SMAPI
+   download/install shell with a small C# tool, convert the s6 run-scripts from bash to execline,
+   and move boot-time glue and env validation out of shell. Done on the Debian base, where a
+   shell is still present to fall back on for debugging.
+
+3. **Distroless** (`phase-3-distroless.md`) — once nothing in the runtime path shells out,
+   swap the base to a distroless glibc image for maximum hardening (no shell, no package
+   manager in the runtime). This becomes a near-mechanical base swap plus copying the traced
+   library closure, gated by a checklist that phase 2 produces.
+
+## Why this order
+
+- **Phase 1 first** because SDR is required for production and only works on glibc. Until the
+  base is glibc, the image cannot ship. It is also the highest-value, lowest-risk single step:
+  it deletes more code (the shims) than it adds.
+- **Phase 2 is really "remove the shell while you still have one."** The FIFO→HTTP switch, the
+  SMAPI C# tool, and the execline conversions are exactly the shell dependencies that block
+  distroless. Doing them on Debian — where `docker exec sh` still works for debugging — is what
+  de-risks phase 3. Each change ships and is validated on its own.
+- **Phase 3 falls out** of phase 2. When the "nothing in the runtime path shells out" checklist
+  is empty, flipping the base is low-drama.
+
+## Entry gates
+
+- **Enter phase 2** after phase 1 ships: the modern image runs on Debian glibc, a real vanilla
+  Steam client has joined over SDR, and a smoke test guards it.
+- **Enter phase 3** when phase 2's checklist is clean — no runtime process invokes a shell, all
+  command input is over HTTP, SMAPI install is a binary, and the s6 run-scripts are execline.
+  Also an explicit sign-off that losing `docker exec sh` (debug via logs + HTTP API, or a
+  separate shell-having sidecar) is acceptable.
+
+## Facts that hold across all phases
+
+- **The `steam-auth` sidecar does not change.** It is already its own glibc container
+  (`tools/steam-service/`), separate from the game image. Only the main server image is in
+  motion here. The compose topology in `docker/modern/docker-compose.yml` stays the same shape.
+- **SDR works on glibc, proven at the SDK level.** With a glibc runtime, `libsteam_api.so` loads
+  the real `steamclient.so`, `SteamInternal_GameServer_Init` succeeds, and an anonymous
+  GameServer logon completes — the same path that crashes on musl inside Valve's own tier1
+  allocator. Real-client join validation is a phase-1 task.
+- **glibc version and the execstack requirement.** Debian 13 is glibc 2.41, which refuses to
+  `dlopen` executable-stack libraries; the repo already handles this with `ExecstackPatcher`
+  (`tools/steam-service/ExecstackPatcher.cs`), see `.claude/rules/glibc-execstack-dlopen.md`.
+  Keep the glibc line consistent between phase 1 and phase 3 so this handling doesn't toggle.
+- **Image size is dominated by payload, not the base.** Every candidate base is 7–9 MB. The
+  image is filled by the .NET runtime, the X/Mesa/graphics stack, and — today — a 183 MB LLVM
+  that the SwiftShader+Zink design is supposed to eliminate. The size and CVE wins are in the
+  payload (phase 1 LLVM cut, optional feature trimming), not the base choice.
+
+## Status
+
+Not started. The build currently succeeds on Alpine only after the two-line
+`JunimoServer.Shared` restore fix in `docker/modern/Dockerfile` (copy the Shared csproj for
+layer caching, drop `--no-restore`) — carry that fix into phase 1.

--- a/.claude/plans/docker-modern/phase-1-debian-glibc-base.md
+++ b/.claude/plans/docker-modern/phase-1-debian-glibc-base.md
@@ -1,0 +1,116 @@
+# Phase 1: Rebase the modern image to a Debian glibc base
+
+## Goal
+
+Move the modern image's runtime stage from `alpine:edge` to `debian:13-slim` so that Steam
+Datagram Relay works, and delete the family of musl compatibility shims that only exist because
+of Alpine. After this phase the modern image can actually be used in production: vanilla Steam
+clients can join over SDR, which they cannot on the musl image.
+
+This phase also folds in two things that are cheapest to do while the base layer is already being
+rewritten (the LLVM size cut) and one thing that must be true before anyone relies on the image
+(a real-client SDR check), plus first-time test coverage so phases 2 and 3 aren't refactoring a
+completely untested image.
+
+## Why glibc
+
+On musl, the real `steamclient.so` (Valve's proprietary, glibc-only blob) crashes inside its own
+tier1 memory allocator once the Steam engine threads spin up — so the image ships a stub
+(`docker/modern/rootfs/opt/lib/steamclient_stub.c`) that makes `GameServer.Init()` fail
+gracefully, leaving only Galaxy-invite joins. On glibc the same binary loads and logs on cleanly.
+SDR is required for production, so the base must be glibc. Musl is not required for anything.
+
+## Tasks
+
+### 1.1 — Rebase the runtime stage to `debian:13-slim`
+
+Change the final runtime stage in `docker/modern/Dockerfile` (the `FROM alpine:edge AS server`
+stage) to a Debian 13 slim base. Translate the `apk add` package set to the Debian equivalents:
+the X stack (Xvfb, openbox, the X client libraries), the Vulkan loader, the Mesa runtime
+libraries the custom Zink build needs, PipeWire, ffmpeg, ca-certificates, and the .NET runtime
+dependency `libicu` (SMAPI fails at startup without ICU — see
+`.claude/rules/image-runtime-deps-must-be-explicit.md`). Keep the SwiftShader and custom Mesa
+build stages as they are; they already build on Debian.
+
+Carry over the build fix already needed on Alpine: copy `mod/JunimoServer.Shared`'s csproj into
+the mod-builder stage for layer caching and drop the `--no-restore` on the mod build.
+
+Verify by booting the image far enough that the .NET/SMAPI process actually starts, not just
+container init.
+
+### 1.2 — Delete the musl workarounds
+
+With a glibc base, remove the shims that only exist for musl. Each is dead weight on glibc:
+
+- The steamclient stub and the shell logic that installs it on musl
+  (`docker/modern/rootfs/opt/lib/steamclient_stub.c`, and the musl branch of `init_steam_sdk` in
+  `docker/modern/rootfs/opt/bin/start-game.sh`). On glibc, link the real `steamclient.so` from the
+  game volume instead.
+- The pthread symbol shim (`docker/modern/rootfs/opt/lib/pthread_shim.c`) and its `LD_PRELOAD`.
+- `gcompat` and the shim-compile step in the Dockerfile.
+- The SMAPI `RunSynchronously` musl-deadlock Harmony patch described in
+  `.claude/rules/modern-docker.md` (the `SModHooks.StartTask` workaround) — it addresses a
+  musl-only ThreadPool behavior.
+- The musl detection and try/catch in `mod/JunimoServer/Services/AuthService/AuthService.cs` can
+  stay harmless, but its musl branch becomes dead; note it for cleanup.
+
+Update `.claude/rules/modern-docker.md` once these are gone — several of its invariants describe
+musl-only behavior that no longer applies. (Follow `.claude/rules/delete-the-plan-when-its-code-lands.md`
+for the plan itself when this work merges.)
+
+### 1.3 — Cut the stray 183 MB LLVM
+
+The modern image builds a custom Mesa Zink with `llvm=disabled`, specifically to avoid the ~183 MB
+LLVM that llvmpipe drags in. But the runtime package install also pulls a distro Mesa package
+(`mesa-gl` on Alpine) whose dependency chain reinstalls the full `llvm` library behind the custom
+build's back. The result is the image carrying the exact 183 MB the architecture was designed to
+remove — roughly a fifth of the image.
+
+On the Debian rebase, install only the minimal Mesa runtime libraries the custom Zink `.so` links
+against, and confirm no installed package pulls `llvm`. Verify the custom `zink_dri.so` is the
+driver actually loaded (not a distro llvmpipe), and that no `libLLVM` is present in the final image.
+This is a larger size win than the base change itself.
+
+### 1.4 — Keep ExecstackPatcher for glibc 2.41
+
+Debian 13 is glibc 2.41, which refuses to `dlopen` a library with an executable stack. The repo
+already solves this with `ExecstackPatcher` (`tools/steam-service/ExecstackPatcher.cs`); make sure
+the modern image runs it against the Steam libraries the way the production path does. Do not use
+the `glibc.rtld.execstack` tunable — per `.claude/rules/glibc-execstack-dlopen.md` it breaks .NET
+stack-bounds detection under emulated amd64. Note: the real `steamclient.so` in the current game
+volume already has a non-executable stack, but keep the patcher for whichever library in the chain
+needs it and for version drift.
+
+### 1.5 — Validate SDR with a real vanilla Steam client
+
+The SDK-level proof (that `GameServer.Init` and anonymous logon succeed on glibc) is necessary but
+not sufficient — it does not prove a player actually joins over the relay. Boot the rebased image
+and have a real, unmodified Steam client join the server through SDR (not Galaxy invite, not direct
+IP). This is the product-critical outcome the whole phase exists to unlock; treat it as the gate
+for calling phase 1 done. Confirm the join reached the server via SDR by inspecting the server log
+(`SteamGameServerService` logging the relay network status and the connection), not just by the
+client appearing connected.
+
+### 1.6 — Add smoke-test / CI coverage for the modern image
+
+The modern image is not built by the Makefile or CI, and Renovate excludes `docker/modern/` — which
+is why its SMAPI version has already drifted behind the production image. Phases 2 and 3 will
+refactor this image heavily; without a test it is a blind refactor.
+
+Add at least a smoke test: build the modern image and boot it far enough to confirm the server
+process starts, the HTTP health endpoint responds, and (ideally) a client can join. Wire it into CI
+so regressions across the later phases are caught. This does not need to be the full E2E suite —
+just enough signal that the image still works.
+
+## Definition of done
+
+- The modern image builds and runs on `debian:13-slim`.
+- All musl shims are gone from the tree and the image.
+- No `libLLVM` in the final image; the custom Zink driver is the one in use.
+- A real vanilla Steam client has joined over SDR, confirmed in the server log.
+- A smoke test guards the image in CI.
+
+## Not in this phase
+
+Shell removal (phase 2) and distroless (phase 3). Phase 1 keeps the existing shell-based
+`start-game.sh` and s6 bash run-scripts — it only changes the base and the Steam/graphics layers.

--- a/.claude/plans/docker-modern/phase-1-debian-glibc-base.md
+++ b/.claude/plans/docker-modern/phase-1-debian-glibc-base.md
@@ -29,8 +29,14 @@ stage) to a Debian 13 slim base. Translate the `apk add` package set to the Debi
 the X stack (Xvfb, openbox, the X client libraries), the Vulkan loader, the Mesa runtime
 libraries the custom Zink build needs, PipeWire, ffmpeg, ca-certificates, and the .NET runtime
 dependency `libicu` (SMAPI fails at startup without ICU — see
-`.claude/rules/image-runtime-deps-must-be-explicit.md`). Keep the SwiftShader and custom Mesa
-build stages as they are; they already build on Debian.
+`.claude/rules/image-runtime-deps-must-be-explicit.md`).
+
+The `swiftshader-builder` stage already uses a Debian (glibc) base, so its output runs on a glibc
+runtime unchanged. The `mesa-builder` stage, however, currently builds on `alpine:edge` (musl) — a
+musl-linked Mesa will not load in a glibc runtime, so this stage must also be rebased to a glibc base
+(or the Zink runtime libraries sourced from Debian packages). Keep this coordinated with task 1.3:
+whichever way Mesa is rebuilt, preserve `llvm=disabled` and make sure no distro Mesa package pulls
+LLVM back in.
 
 Carry over the build fix already needed on Alpine: copy `mod/JunimoServer.Shared`'s csproj into
 the mod-builder stage for layer caching and drop the `--no-restore` on the mod build.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
@@ -21,10 +21,13 @@ The whole interactive UI lives in `docker/modern/rootfs/opt/bin/attach-cli` (tmu
 
 ## What already exists to replace it
 
-The mod's HTTP API (`mod/JunimoServer/Services/Api/ApiService.cs`) already has the two hard pieces:
+The mod's HTTP API (`mod/JunimoServer/Services/Api/ApiService.cs`) already has the hard pieces for
+command *input*; command *output* streaming is the one piece that still needs building:
 
-- An authenticated **WebSocket at `/ws`** — a real-time channel (today it carries chat relay for
-  the Discord bot). This is the stream a CLI uses for live log/output.
+- An authenticated **WebSocket at `/ws`** — a real-time channel with auth already in place. Today it
+  only carries chat relay for the Discord bot (`BroadcastChatMessage` / `BroadcastToAllClients`); it
+  does **not** currently stream SMAPI console output or the server log. So the transport and auth
+  exist, but the output feed a CLI needs is new work (see "What to build" below).
 - A **`POST /test/console`** endpoint that injects a console command name + args through SMAPI's
   command manager (models in `mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs`).
   The tricky part — invoking a registered SMAPI console command from outside the console, with the
@@ -36,16 +39,21 @@ The mod's HTTP API (`mod/JunimoServer/Services/Api/ApiService.cs`) already has t
 1. **Promote console injection to a production endpoint.** Add an authenticated `POST /console`
    (or promote `/test/console` out of the test-only gate) that runs an arbitrary SMAPI console
    command. Keep it behind `API_KEY` auth like the rest of the API.
-2. **Point the CLI at HTTP.** Rework the interactive CLI to submit commands via `POST /console` and
-   stream output over `/ws`. This client no longer needs to live inside the server container — it
-   can be a separate sidecar, or a local tool run from a laptop. This lines up with the existing
-   `.claude/plans/features/cli-rewrite-v4.md`.
-3. **Replace `toggle-rendering.sh`** with a call to the API (a rendering endpoint likely already
+2. **Broadcast console/log output over `/ws`.** Today `/ws` only relays chat, so removing the FIFO
+   would leave operators with no command output. Add a broadcast of SMAPI console output and/or the
+   server log to WebSocket clients, so the CLI has something to display. The channel and auth already
+   exist (`BroadcastToAllClients`); the output feed is the new part, and it must land before the FIFO
+   is removed or the CLI has no output stream.
+3. **Point the CLI at HTTP.** Rework the interactive CLI to submit commands via `POST /console` and
+   stream output over the `/ws` broadcast from the previous step. This client no longer needs to live
+   inside the server container — it can be a separate sidecar, or a local tool run from a laptop. This
+   lines up with the existing `.claude/plans/features/cli-rewrite-v4.md`.
+4. **Replace `toggle-rendering.sh`** with a call to the API (a rendering endpoint likely already
    exists in `ApiService.cs`; use it, or add one).
-4. **Drop the FIFO wrapper at launch.** Once nothing writes commands to stdin, SMAPI can be exec'd
+5. **Drop the FIFO wrapper at launch.** Once nothing writes commands to stdin, SMAPI can be exec'd
    directly instead of through `script` + `tail -f FIFO`. This also removes two always-on processes
    plus a PTY.
-5. **Retire the shell CLI files** — `attach-cli`, `server-command-loop`, `toggle-rendering.sh`,
+6. **Retire the shell CLI files** — `attach-cli`, `server-command-loop`, `toggle-rendering.sh`,
    `mem-cpu.sh` — from the image once the client replaces them.
 
 ## Benefits this unlocks (beyond removing shell)

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
@@ -1,0 +1,75 @@
+# Task 2.1: Move the command path from the FIFO to HTTP
+
+## Goal
+
+Stop feeding server commands through the SMAPI stdin FIFO and the shell CLI that writes to it.
+Instead, drive commands over the mod's existing HTTP API, and turn the interactive CLI into a
+client that runs on demand — including against remote servers.
+
+## How commands work today
+
+The launch in `docker/modern/rootfs/opt/bin/start-game.sh` runs SMAPI with its stdin coming from a
+named pipe (`tail -f` on `/tmp/smapi-input` piped into SMAPI, wrapped in `script` to get a PTY for
+coloured output). Anything written to that FIFO becomes a SMAPI console command. Two shell pieces
+write to it:
+
+- `docker/modern/rootfs/opt/bin/server-command-loop` — the interactive REPL in the tmux bottom pane.
+- `docker/modern/rootfs/opt/bin/toggle-rendering.sh` — writes `rendering on/off/toggle`.
+
+The whole interactive UI lives in `docker/modern/rootfs/opt/bin/attach-cli` (tmux split-pane, the
+`mem-cpu.sh` status bar, the invite-code display).
+
+## What already exists to replace it
+
+The mod's HTTP API (`mod/JunimoServer/Services/Api/ApiService.cs`) already has the two hard pieces:
+
+- An authenticated **WebSocket at `/ws`** — a real-time channel (today it carries chat relay for
+  the Discord bot). This is the stream a CLI uses for live log/output.
+- A **`POST /test/console`** endpoint that injects a console command name + args through SMAPI's
+  command manager (models in `mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs`).
+  The tricky part — invoking a registered SMAPI console command from outside the console, with the
+  right threading — is already solved here (see `.claude/rules/smapi-api-surface.md` for why this
+  needs reflection into `SCore` → `CommandManager`, and that the callback runs off the game thread).
+
+## What to build
+
+1. **Promote console injection to a production endpoint.** Add an authenticated `POST /console`
+   (or promote `/test/console` out of the test-only gate) that runs an arbitrary SMAPI console
+   command. Keep it behind `API_KEY` auth like the rest of the API.
+2. **Point the CLI at HTTP.** Rework the interactive CLI to submit commands via `POST /console` and
+   stream output over `/ws`. This client no longer needs to live inside the server container — it
+   can be a separate sidecar, or a local tool run from a laptop. This lines up with the existing
+   `.claude/plans/features/cli-rewrite-v4.md`.
+3. **Replace `toggle-rendering.sh`** with a call to the API (a rendering endpoint likely already
+   exists in `ApiService.cs`; use it, or add one).
+4. **Drop the FIFO wrapper at launch.** Once nothing writes commands to stdin, SMAPI can be exec'd
+   directly instead of through `script` + `tail -f FIFO`. This also removes two always-on processes
+   plus a PTY.
+5. **Retire the shell CLI files** — `attach-cli`, `server-command-loop`, `toggle-rendering.sh`,
+   `mem-cpu.sh` — from the image once the client replaces them.
+
+## Benefits this unlocks (beyond removing shell)
+
+- **Runs only when used.** The persistent FIFO reader and PTY that ran for the server's whole life
+  go away; the CLI client's processes exist only while someone is using it. The overhead saving is
+  small and honest — those were cheap — but the decoupling is real.
+- **Runs locally against remote servers.** An HTTP + WebSocket client with an `API_KEY` is
+  location-independent: one CLI can manage any number of remote servers, switching by URL, with no
+  `docker exec` and no SSH into a container. The API already enforces `API_KEY`, so remote control
+  is already secured.
+
+## Caveat to design around
+
+SMAPI console commands write their output to the log/monitor, not as a return value. So
+`POST /console` returns "accepted", and the command's textual output arrives over `/ws` (or a log
+tail) — not as a tidy per-request HTTP response for arbitrary commands. This is the same input-pane
+/ output-pane split the tmux CLI already has, so it maps naturally; just don't design the client to
+expect the command output back in the POST response. The mod's own operations that already have
+dedicated REST endpoints do return structured responses — this caveat is only about arbitrary
+SMAPI-console passthrough.
+
+## Done when
+
+- An authenticated production endpoint injects SMAPI console commands.
+- The CLI submits over HTTP and streams over `/ws`, and works against a remote server.
+- The FIFO, the `script`/`tail` launch wrapper, and the shell CLI files are gone.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/02-smapi-bootstrap-tool.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/02-smapi-bootstrap-tool.md
@@ -1,0 +1,62 @@
+# Task 2.2: Replace the SMAPI download/install shell with a C# tool
+
+## Goal
+
+Replace the curl + unzip + shell that downloads and installs SMAPI at container startup with a
+small self-contained C# tool. Keep the download happening at runtime so SMAPI can be updated by
+changing the configured version and restarting — no image rebuild — but do it without a shell or
+external download utilities.
+
+## How it works today
+
+`init_smapi` in `docker/modern/rootfs/opt/bin/start-game.sh` uses `curl` to download the SMAPI
+installer zip from GitHub, `unzip` to extract it, and pipes `"2\n\n"` into the installer executable
+to answer its prompts. This is why the runtime image needs curl, unzip, and a shell — and it runs
+at startup specifically so SMAPI can update independently of the image.
+
+## Why a C# tool fits
+
+The repo already ships small self-contained .NET tools built this way — `tools/steam-service/`,
+`tools/dll-patcher/`, `tools/netdebug/`, `tools/diagnostics/` — published as trimmed single-file
+binaries. A SMAPI bootstrapper is the same pattern, and the runtime already has .NET, so it adds no
+new base dependency and slots into a shell-free image cleanly (s6/execline just execs the binary).
+
+The .NET base class library covers everything the shell did:
+
+- **Download** with `HttpClient` — it follows the GitHub release → storage redirect automatically.
+- **Extract** with `System.IO.Compression.ZipFile.ExtractToDirectory` — no `unzip`.
+- **Install** by starting the SMAPI installer executable (the `SMAPI.Installer` apphost the current
+  shell runs) with `Process.Start` and `RedirectStandardInput`, writing the same `"2\n\n"` the shell
+  pipes in.
+
+## What to build
+
+1. A new tool (for example `tools/smapi-bootstrap/`) that takes the target SMAPI version (from the
+   `SMAPI_VERSION` env, matching today's behaviour) and a game path, and performs download →
+   extract → install.
+2. Make it **idempotent**: skip if SMAPI is already installed at the expected version, the same way
+   `init_smapi` checks for the installed SMAPI executable today.
+3. Run it as a startup one-shot — an s6 oneshot service ordered before the game service, or the
+   mod's own pre-launch — so runtime updating is preserved.
+4. Remove `curl` and `unzip` from the runtime image once this and the other tasks no longer need
+   them. (Check other consumers first: the game-download and health paths.)
+
+## Gotcha to handle
+
+`System.IO.Compression.ZipFile` does not restore the Unix executable bit on extraction by default.
+The SMAPI and game executables need to be executable, so the tool must set the mode explicitly —
+`File.SetUnixFileMode` (available on modern .NET) on the relevant files, or apply the zip entry's
+`ExternalAttributes`. This is a small, known step, not a blocker. A C# tool can also do things the
+shell did loosely — verify a checksum, handle GitHub rate limits and redirects robustly.
+
+## Build-time vs runtime
+
+The same tool works either way. The production image bakes SMAPI at build; the modern image wants it
+at runtime for independent updates. Keep runtime here — the tool just runs at startup. If a future
+build-time bake is wanted, the identical binary can run in a build stage.
+
+## Done when
+
+- SMAPI download, extract, and install run through the C# tool with no shell, curl, or unzip.
+- Changing the configured SMAPI version and restarting updates SMAPI, no image rebuild.
+- Installed files have the correct executable permissions.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/03-s6-execline-conversion.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/03-s6-execline-conversion.md
@@ -1,0 +1,45 @@
+# Task 2.3: Convert the s6 run-scripts from bash to execline
+
+## Goal
+
+Rewrite the bodies of the s6-overlay service scripts so they no longer call bash. They already use
+execline as their interpreter; they just take a shortcut into `/bin/bash -c` for the actual logic.
+Removing that shortcut removes bash from the boot path.
+
+## What they look like today
+
+Each service under `docker/modern/rootfs/etc/s6-overlay/s6-rc.d/*/run` starts with the execline
+shebang (`#!/command/execlineb -P`) and then immediately runs `/bin/bash -c "..."`. The bash bodies
+are simple:
+
+- `xvfb/run` — exec Xvfb with the configured resolution.
+- `openbox/run` — poll `xdpyinfo` until the X server answers, then exec openbox.
+- `streaming/run` — poll `xdpyinfo`, then exec go2rtc.
+- `game/run` — poll `xdpyinfo`, then exec `start-game.sh`.
+- `pipewire/run` — already nearly execline (exports one variable, execs pipewire).
+- `init-runtime/up` — already execline.
+
+## What to do
+
+Rewrite the bash bodies in pure execline, which ships with s6-overlay and needs no shell:
+
+- The plain "exec this binary with these args" cases (xvfb, pipewire) are direct execline.
+- The "wait for X, then exec" cases (openbox, streaming, game) become either an execline retry loop
+  around the readiness check, or — better — an s6 readiness dependency so the dependent service only
+  starts once X is up, removing the poll entirely. Prefer the dependency approach where it fits the
+  s6-rc model; fall back to an execline loop where a poll is genuinely needed.
+
+The `game/run` script's target (`start-game.sh`) is itself shell today — task 2.2 removes its SMAPI
+install, and task 2.4 removes the rest of its boot glue, after which `game/run` execs the game (or a
+tiny init) directly rather than a bash script.
+
+## Note on readiness checks
+
+`xdpyinfo` is the readiness probe today. If the s6 dependency approach replaces the polling, confirm
+the X server genuinely signals readiness at the right point; otherwise keep a minimal execline poll.
+The goal is no bash, not necessarily no polling.
+
+## Done when
+
+- No `run` or `up` script under `docker/modern/rootfs/etc/s6-overlay/s6-rc.d/` calls `/bin/bash`.
+- Service startup ordering (X before the WM, streaming, and game) still holds.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/04-boot-glue-and-env-validation.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/04-boot-glue-and-env-validation.md
@@ -1,0 +1,55 @@
+# Task 2.4: Move the remaining boot glue and env validation out of shell
+
+## Goal
+
+Remove what's left of `docker/modern/rootfs/opt/bin/start-game.sh` after tasks 2.1 (FIFO→HTTP) and
+2.2 (SMAPI tool) have taken the command path and the SMAPI install out of it. What remains is
+one-time boot filesystem glue and an environment-validation gate — none of which fundamentally needs
+a shell.
+
+## What remains in start-game.sh
+
+After the earlier tasks, the shell functions still present are:
+
+- `validate_environment` — refuses to start if the API is enabled without an `API_KEY`, unless
+  `ALLOW_INSECURE_SETUP=true`.
+- `init_time_sync` — tries `hwclock`, then `ntpdate`, to avoid Galaxy P2P drift.
+- `init_stardew` — symlinks the game files from the shared volume into place, waiting in a loop if
+  the steam-auth sidecar hasn't produced them yet.
+- `init_steam_sdk` — places `steamclient.so` (the real one now, after phase 1) and writes
+  `steam_appid.txt`.
+- `init_mods` — copies mods into the mods path.
+- `init_permissions` — sets executable bits and ownership on the game files.
+- The launch itself — after task 2.1, exec the game/SMAPI directly.
+
+## Where each piece should go
+
+- **`validate_environment` → the mod.** This belongs in `mod/JunimoServer/Env.cs` (or a startup
+  check in the mod) as a fail-fast, so the rule lives in one place with the other env parsing rather
+  than duplicated in a shell script. Note `.claude/rules/preflight-check-vs-committed-config.md`:
+  test any new fail-fast against the committed compose config, not just the example.
+- **`init_time_sync` → drop or a tiny init.** Containers usually inherit the host clock; the
+  `SYS_TIME` capability plus `hwclock` handles drift. If kept, it's a one-shot, not part of the
+  serving path. `ntpdate` isn't installed anyway (a dead fallback today), so this is a good place to
+  simplify.
+- **`init_stardew`, `init_steam_sdk`, `init_mods`, `init_permissions` → build-time where static,
+  a tiny init where dynamic.** Mod copying and permissions can largely be baked at build. The
+  genuinely runtime part is linking the game files that the steam-auth sidecar produces at runtime,
+  and placing `steamclient.so` — a handful of filesystem operations. Options, in order of preference:
+  fold into the SMAPI bootstrap tool from task 2.2 (it already runs as a startup one-shot in .NET),
+  express as execline in the s6 init, or a small dedicated init binary. Pick one home; don't split
+  across several.
+
+## Guidance
+
+Prefer folding the dynamic filesystem glue into the existing startup one-shot (the SMAPI bootstrap
+tool) over creating a new mechanism — it already runs at the right time, in .NET, with filesystem
+access. That keeps the boot path to: one .NET one-shot for setup, then the game service. Once this
+task lands, `start-game.sh` is gone entirely.
+
+## Done when
+
+- `start-game.sh` no longer exists.
+- Env validation runs in the mod against the committed config.
+- Game-file linking and steamclient placement happen with no shell.
+- Time sync is either dropped or a shell-free one-shot.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/05-feature-trimming.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/05-feature-trimming.md
@@ -1,0 +1,49 @@
+# Task 2.5: Trim features that aren't needed (optional, reversible)
+
+## Goal
+
+Optionally drop runtime features that aren't required, each of which removes packages, image size,
+and CVE surface. These are independent, reversible decisions — none is a prerequisite for distroless,
+but each makes the final image smaller and cleaner. Decide each on its own merits.
+
+## Candidates
+
+### Screen streaming (go2rtc + ffmpeg)
+
+`go2rtc` and `ffmpeg` exist to stream the server's screen over WebRTC for remote viewing/debugging
+(`docker/modern/rootfs/etc/s6-overlay/s6-rc.d/streaming/run`, `docker/modern/rootfs/etc/go2rtc/config.yaml`).
+If watching the server's screen isn't needed in production, dropping both removes the go2rtc binary,
+ffmpeg, and ffmpeg's historically heavy CVE surface. The game still runs headless into Xvfb without
+them. Keep them only if remote screen-viewing is an actual requirement.
+
+### Audio (PipeWire)
+
+PipeWire provides a null audio sink (`docker/modern/rootfs/etc/s6-overlay/s6-rc.d/pipewire/run`). The
+game may try to open an audio device; if it tolerates a dummy driver (an SDL dummy-audio setting or
+no device) without crashing, PipeWire and its libraries can go. This one needs a boot test to confirm
+the game starts cleanly with no audio device before committing.
+
+### Debug tooling
+
+Any interactive debug tools carried for convenience (the tmux CLI is removed in task 2.1; check for
+others) are candidates to drop, especially since distroless removes the shell they'd rely on anyway.
+
+## What must stay
+
+The graphics path is not optional: Xvfb, the custom Mesa Zink build, SwiftShader, and the Vulkan
+loader. The game is a rendering engine and initializes a graphics device even though the server
+suppresses drawing — it needs an X display and a GL/Vulkan stack to start at all. openbox stays too:
+per `.claude/rules/modern-docker.md` a window manager is required, or a window resize during startup
+crashes the game with a null Farmer.
+
+## Guidance
+
+If a feature is dropped, do it cleanly — remove the s6 service, the packages, and the config — rather
+than leaving a disabled service in place. If a feature is genuinely uncertain, keep it and note why,
+rather than shipping a half-removed stub.
+
+## Done when
+
+- Each candidate has an explicit keep/drop decision.
+- Dropped features are fully removed (service, packages, config), and the image still boots and
+  serves.

--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/README.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/README.md
@@ -1,0 +1,49 @@
+# Phase 2: Remove runtime shell dependencies
+
+## Goal
+
+Remove every runtime dependency on a shell from the modern image, one shippable change at a time,
+while still on the Debian base where a shell is present to fall back on for debugging. When this
+phase is done, nothing in the running container invokes bash, coreutils, tmux, or the SMAPI stdin
+FIFO — which is exactly the precondition for going distroless in phase 3.
+
+## Why now, and why on Debian
+
+The shell in the modern image is wide but shallow. It lives almost entirely in two places: the
+interactive operator CLI (tmux split-pane, status bar, command REPL) and one-time boot glue in
+`start-game.sh`. Neither is in the actual request-serving path — once running, the server is Xvfb →
+openbox → SMAPI/.NET → the HTTP API, all binaries.
+
+Doing this work on the Debian base (phase 1's output) means each shell-removal change can be built,
+shipped, and validated with `docker exec sh` still available if something breaks. By the end, the
+shell is unused and phase 3 can remove it entirely.
+
+## The tasks (each independently shippable)
+
+1. `01-http-command-api.md` — replace the SMAPI stdin FIFO command path with the mod's HTTP API,
+   and move the interactive CLI out of the server container into a client that can also target
+   remote servers.
+2. `02-smapi-bootstrap-tool.md` — replace the curl+unzip+shell SMAPI download/install with a small
+   C# tool, preserving runtime download so SMAPI can update without an image rebuild.
+3. `03-s6-execline-conversion.md` — convert the s6 run-script bodies from bash to execline.
+4. `04-boot-glue-and-env-validation.md` — move the remaining one-time boot glue and the env-validation
+   gate out of shell (into the mod, into build-time, or into a tiny init step).
+5. `05-feature-trimming.md` — optional, reversible decisions to drop features that aren't needed
+   (screen streaming, audio), each of which also removes packages and CVE surface.
+
+## What makes this safe
+
+Two of the hardest-sounding pieces already exist in the mod's HTTP API
+(`mod/JunimoServer/Services/Api/ApiService.cs`): an authenticated WebSocket at `/ws` for real-time
+output, and a `POST /test/console` endpoint that already injects SMAPI console commands through the
+command manager. So the command-path work is mostly promoting and repurposing existing code, not
+building a new mechanism.
+
+## Checklist this phase produces (the phase-3 entry gate)
+
+- [ ] No runtime process reads the SMAPI stdin FIFO; command input is over HTTP.
+- [ ] SMAPI download/install is a binary, not curl+unzip+shell.
+- [ ] All s6 run-scripts are execline, with no `/bin/bash -c` bodies.
+- [ ] Boot glue (game-file linking, steamclient placement, permissions) needs no shell.
+- [ ] Env validation runs in the mod, not `start-game.sh`.
+- [ ] The interactive CLI runs as a client (local or remote), not inside the server container.

--- a/.claude/plans/docker-modern/phase-3-distroless.md
+++ b/.claude/plans/docker-modern/phase-3-distroless.md
@@ -1,0 +1,74 @@
+# Phase 3: Switch to a distroless base
+
+## Goal
+
+Once nothing in the runtime path invokes a shell (phase 2 complete), swap the runtime base to a
+distroless glibc image for maximum hardening: no shell and no package manager in the running
+container. By this point it is a near-mechanical base swap plus copying the traced library closure —
+not a rewrite.
+
+## Why distroless is a hardening choice, not a size or CVE win
+
+Measured on this workload, distroless barely moves size or CVE:
+
+- **Size is dominated by payload, not base.** Every base is 7–9 MB (distroless/cc ≈ 9 MB, Wolfi ≈ 7,
+  Debian slim ≈ 29). The image is filled by the .NET runtime (~67 MB), the X/Mesa/graphics stack,
+  and — until phase 1's LLVM cut — a 183 MB LLVM. The base swap saves single-digit MB.
+- **CVE is dominated by payload, not base.** Distroless/cc and Wolfi both scan clean at zero. The
+  CVEs in the final image come from .NET, Mesa, X, and ffmpeg — identical whichever base. Distroless
+  gives no CVE edge over a minimal glibc base.
+
+What distroless uniquely gives is **attack surface**: no shell, no package manager to exploit or to
+live-off-the-land with. That is the reason to do phase 3, and it's only reachable because phase 2
+removed the shell dependencies.
+
+## Entry gate (from phase 2)
+
+Do not start until all of these hold:
+
+- [ ] No runtime process reads the SMAPI stdin FIFO; command input is over HTTP.
+- [ ] SMAPI download/install is a binary, not curl+unzip+shell.
+- [ ] All s6 run-scripts are execline, no `/bin/bash -c` bodies.
+- [ ] Boot glue and env validation need no shell.
+- [ ] The interactive CLI runs as a client, not inside the server container.
+
+Plus an explicit sign-off that losing `docker exec sh` is acceptable (see below).
+
+## What to build
+
+1. **Pick the distroless variant: `cc`, not `base`.** The .NET runtime (`libcoreclr`) and
+   `steamclient.so` both need `libstdc++` and `libgcc`, which the `cc` variant includes and `base`
+   does not.
+2. **Keep the glibc line consistent with phase 1.** Phase 1 is Debian 13 / glibc 2.41 (which needs
+   `ExecstackPatcher`). Choose the distroless base to match that glibc line; if it lands on an older
+   glibc, the execstack handling behaviour shifts and you lose parity with what phases 1–2 validated.
+   Decide this consciously.
+3. **Multi-stage: assemble on a full glibc distro, copy the closure into distroless.** Build and
+   gather everything on a distro with packages (Debian, or Fedora which packages the X/Mesa/PipeWire
+   stack well), then `COPY` the traced runtime library closure — the game, SMAPI, .NET, Xvfb, Mesa
+   Zink, SwiftShader, the Vulkan loader, and their transitive `.so` dependencies — into the
+   distroless runtime stage. Trace the closure with `ldd` over every binary; a missing transitive
+   dependency fails at runtime, not build (see `.claude/rules/verify-edit-landed-in-artifact.md`).
+4. **Supervision stays s6-overlay.** s6 and execline are shell-free binaries and run fine in
+   distroless; phase 2 already converted the run-scripts to execline.
+
+## The ongoing cost to accept
+
+Distroless has no package manager, so the copied library set is maintained by hand — there is no
+`apt`/`apk upgrade` to refresh Mesa, .NET, or the X libraries when a CVE lands. That maintenance
+moves to rebuilding the builder stage and re-copying. This is the real tax of distroless for a
+dynamically-linked workload like this; weigh it against the hardening benefit.
+
+## The ops change to accept
+
+No shell means no `docker exec sh` into the running server. Debugging moves to logs and the HTTP API.
+If an interactive CLI is wanted, it runs as a separate shell-having sidecar (or a local tool) that
+talks to the server over HTTP and the shared log volume — the server container itself stays
+shell-free. Make this an explicit sign-off, not a phase-3 surprise.
+
+## Done when
+
+- The runtime image is distroless/cc (glibc matching phase 1).
+- The traced library closure is complete and the image boots, serves, and a client joins over SDR.
+- The smoke test from phase 1 still passes against the distroless image.
+- No shell or package manager is present in the runtime image.

--- a/docker/modern/Dockerfile
+++ b/docker/modern/Dockerfile
@@ -169,6 +169,7 @@ COPY --from=game-downloader /game /game
 # (.editorconfig: code-style rules enforced at build via EnforceCodeStyleInBuild)
 COPY ./Directory.Build.props ./CodeStyle.props ./.editorconfig /src/
 COPY ./mod/JunimoServer/JunimoServer.csproj /src/mod/JunimoServer/
+COPY ./mod/JunimoServer.Shared/JunimoServer.Shared.csproj /src/mod/JunimoServer.Shared/
 
 # Restore dependencies
 RUN --mount=type=cache,target=/root/.nuget/packages \
@@ -190,7 +191,6 @@ COPY ./mod /src/mod
 RUN --mount=type=cache,target=/root/.nuget/packages \
     dotnet build /src/mod/JunimoServer/JunimoServer.csproj \
     --configuration ${BUILD_CONFIGURATION} \
-    --no-restore \
     /p:GamePath=/game \
     -o /output/JunimoServer
 


### PR DESCRIPTION
## Summary

Groundwork for taking the experimental modern server image (`docker/modern/`) to production.

- **Migration roadmap** under `.claude/plans/docker-modern/` — a three-phase plan:
  1. **Debian glibc base** — rebase the runtime from Alpine/musl to `debian:13-slim`. This unlocks
     Steam Datagram Relay (the real `steamclient.so` works on glibc but crashes on musl) and lets the
     musl compatibility shims — the steamclient stub, pthread shim, gcompat, the `RunSynchronously`
     patch — be deleted. Folds in a 183 MB LLVM size cut and first-time CI smoke coverage.
  2. **Remove runtime shell dependencies** — move commands from the SMAPI stdin FIFO to the existing
     HTTP API (an authenticated `/ws` WebSocket and console-injection endpoint already exist), replace
     the SMAPI download/install shell with a C# tool (runtime update preserved), and convert the s6
     run-scripts from bash to execline. Done on Debian, where a shell is still available for debugging.
  3. **Distroless** — switch to a distroless glibc base for hardening once nothing in the runtime path
     shells out.
- **Build fix** — the modern Dockerfile predated the `JunimoServer.Shared` project split, so the mod
  build failed with `NETSDK1004`. Copy the Shared csproj into the mod-builder stage and drop
  `--no-restore`, matching the production Dockerfile.

## Notes

- The roadmap is investigation-backed: SDR was verified working at the SDK level on glibc
  (`GameServer.Init` + anonymous logon succeed), and the musl failure was traced to a crash inside
  Valve's own tier1 allocator threads.
- Image size and CVE surface are dominated by payload, not the base — every candidate base is 7–9 MB.
  The size/CVE wins are in the payload (the LLVM cut, optional feature trimming), which the plan
  reflects.
- The `steam-auth` sidecar and compose topology don't change; only the main image moves.
