### PR TITLE
ci: pin formatting jobs to SDK 10.0.302

### DIFF
--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -213,7 +213,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "10.0.x"
+          # Pinned: `dotnet format` in SDK 10.0.400 fails workspace restore
+          # ("Restore operation failed", same class as dotnet/sdk#53383 on 10.0.200).
+          # Unpin to 10.0.x once a fixed 10.0.4xx patch ships.
+          dotnet-version: "10.0.302"
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -252,7 +252,10 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "10.0.x"
+          # Pinned: `dotnet format` in SDK 10.0.400 fails workspace restore
+          # ("Restore operation failed", same class as dotnet/sdk#53383 on 10.0.200).
+          # Unpin to 10.0.x once a fixed 10.0.4xx patch ships.
+          dotnet-version: "10.0.302"
 
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
- `dotnet format` in the freshly released SDK 10.0.400 fails workspace restore ("Restore operation failed", same class as dotnet/sdk#53383 on 10.0.200), breaking the Validate Formatting job on every PR
- Pin the two formatting jobs (validate-pr, validate-merge-group) to 10.0.302, the version the last green runs used; comment says to unpin once a fixed 10.0.4xx ships
- Note: these workflows run on `pull_request_target`, so the fix only takes effect once merged to master — this PR's own Validate Formatting check will still show the failure