### PR TITLE
fix(docker): pin tmux default-shell in attach-cli so panes survive nologin

### DIFF
--- a/docker/modern/rootfs/opt/bin/attach-cli
+++ b/docker/modern/rootfs/opt/bin/attach-cli
@@ -31,7 +31,9 @@ start_output_pane() {
     local session_name="$1"
     local log_file="$2"
 
-    tmux new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    # Pin default-shell so panes and #() jobs never inherit an account shell that can't run
+    # commands (the production baseimage writes /sbin/nologin for every account)
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
 }
 
 start_input_pane_split() {

--- a/docker/rootfs/opt/base/bin/attach-cli
+++ b/docker/rootfs/opt/base/bin/attach-cli
@@ -33,9 +33,12 @@ start_output_pane() {
     local session_name="$1"
     local log_file="$2"
 
+    # Pin default-shell before the first pane spawns: the baseimage writes /sbin/nologin as every
+    # account's shell, and tmux would adopt it (killing each pane and #() job instantly) since
+    # Debian 13's usr-merge makes that path resolvable
     # Using `stty` to prevent user input (focus is still possible, and needed for scrolling)
     # Using `sed` to replace black text with gray to make trace logs easier to read
-    tmux new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
 }
 
 # Add command input pane at bottom (exactly 2 lines - tmux minimum)


### PR DESCRIPTION
## Problem

On preview `1.5.0.126` (Debian 13, #516), `docker compose exec server attach-cli` fails with `no server running on /tmp/tmux-0/default` (×4) plus `no sessions`.

## Root cause

- The baseimage regenerates `/etc/passwd` on every boot with `/sbin/nologin` as every account's shell, including uid-0 `app`.
- On Debian 11 that path didn't exist, so tmux's `checkshell()` rejected it and fell back to `/bin/sh`.
- Debian 13 is usr-merged, so `/sbin/nologin` exists and is executable → tmux adopts it as `default-shell` → every string-command pane runs `nologin -c ...` and exits 1 instantly → session dies → tmux server exits → attach-cli's unsuppressed tmux calls print the errors.

## Fix

- Pin `default-shell /bin/sh` at tmux server start in `start_output_pane`, in both `docker/rootfs/opt/base/bin/attach-cli` and `docker/modern/rootfs/opt/bin/attach-cli`.
- attach-cli is the image's only tmux-server producer, so the setting covers both panes and the status-bar `#()` jobs; chosen over `ENV SHELL`, a global `/etc/tmux.conf`, or a passwd-fixing cont-init for locality.

## Verification

- Bind-mounted the patched script into `sdvd/server:1.5.0-preview.126` with a booted-style passwd (`app:x:0:0::/root:/sbin/nologin`): `default-shell` reports `/bin/sh`, the session stays alive, both panes report `pane_dead=0`.
- E2E test coverage lands in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved output session startup reliability by explicitly initializing the session environment and default shell.
  * Existing log tailing, input handling, and color display behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->