### PR TITLE
ci: SDK-scope the NuGet cache, pin the SDK for Renovate, fix the cache janitor

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -26,8 +26,8 @@ jobs:
           # creation, NOT last access: a restore-keys prefix fallback keeps re-reading
           # a stale cache, bumping its last_accessed_at indefinitely, so a last-accessed
           # filter never evicts such a zombie (GitHub's own eviction is last-accessed
-          # too, which is how the loophole persists). created_at is immutable, so no
-          # cache outlives two weeks regardless of access pattern.
+          # too, which is how the loophole persists). created_at is immutable, so each
+          # weekly run evicts every cache past 14 days, regardless of access pattern.
           CUTOFF=$(date -d '14 days ago' -Iseconds)
 
           STALE_CACHES=$(gh api repos/$REPO/actions/caches --paginate \

--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -22,11 +22,16 @@ jobs:
         run: |
           echo "Cleaning up stale caches..."
 
-          # Get caches older than 14 days
+          # Delete every cache created more than 14 days ago. Age is measured by
+          # creation, NOT last access: a restore-keys prefix fallback keeps re-reading
+          # a stale cache, bumping its last_accessed_at indefinitely, so a last-accessed
+          # filter never evicts such a zombie (GitHub's own eviction is last-accessed
+          # too, which is how the loophole persists). created_at is immutable, so no
+          # cache outlives two weeks regardless of access pattern.
           CUTOFF=$(date -d '14 days ago' -Iseconds)
 
           STALE_CACHES=$(gh api repos/$REPO/actions/caches --paginate \
-            --jq ".actions_caches[] | select(.last_accessed_at < \"$CUTOFF\") | .id")
+            --jq ".actions_caches[] | select(.created_at < \"$CUTOFF\") | .id")
 
           if [ -z "$STALE_CACHES" ]; then
             echo "No stale caches found"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -489,12 +489,13 @@ jobs:
             });
 
       # The coordinator is a net10.0 app that runs HERE on the runner (the mod
-      # builds inside Docker; the runner does not). .NET 10 is GA, so the default
-      # quality channel resolves a stable SDK — no preview pin needed.
+      # builds inside Docker; the runner does not). The SDK is pinned exactly
+      # (Renovate-managed) so every run uses the same SDK rather than whatever
+      # Microsoft shipped that day.
       - name: Setup .NET 10.0
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: '10.0.400'
 
       # Build the test-UI SPA so the runner can assemble the offline web report
       # (test-web) from it after the run. The runner's report path (ReportGenerator,

--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -211,16 +211,21 @@ jobs:
           ref: ${{ github.event.merge_group.head_sha }}
 
       - name: Setup .NET
+        id: dotnet
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "10.0.400"
 
+      # Key the cache by the resolved SDK version so a new SDK band always restores
+      # from scratch instead of inheriting another band's package extraction via a
+      # restore-keys prefix fallback. restore-keys is scoped to the same SDK for the
+      # same reason.
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-tools-${{ hashFiles('.config/dotnet-tools.json', 'tests/JunimoServer.Tests/*.csproj', 'tests/JunimoServer.TestRunner/*.csproj') }}
-          restore-keys: ${{ runner.os }}-nuget-tools-
+          key: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-${{ hashFiles('.config/dotnet-tools.json', 'tests/JunimoServer.Tests/*.csproj', 'tests/JunimoServer.TestRunner/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-
 
       - name: Restore .NET tools
         run: dotnet tool restore

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -250,16 +250,21 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup .NET
+        id: dotnet
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
-          dotnet-version: "10.0.x"
+          dotnet-version: "10.0.400"
 
+      # Key the cache by the resolved SDK version so a new SDK band always restores
+      # from scratch instead of inheriting another band's package extraction via a
+      # restore-keys prefix fallback. restore-keys is scoped to the same SDK for the
+      # same reason.
       - name: Cache NuGet packages
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-tools-${{ hashFiles('.config/dotnet-tools.json', 'tests/JunimoServer.Tests/*.csproj', 'tests/JunimoServer.TestRunner/*.csproj') }}
-          restore-keys: ${{ runner.os }}-nuget-tools-
+          key: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-${{ hashFiles('.config/dotnet-tools.json', 'tests/JunimoServer.Tests/*.csproj', 'tests/JunimoServer.TestRunner/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-
 
       - name: Restore .NET tools
         run: dotnet tool restore

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -415,7 +415,7 @@ The pipeline uses the same `docker-compose.yml` from the repository, ensuring co
 
 [Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/cleanup-caches.yml)
 
-GitHub Actions caches can accumulate over time. This pipeline removes caches that haven't been accessed in 14 days.
+GitHub Actions caches can accumulate over time. This pipeline removes every cache created more than 14 days ago. Age is measured by creation rather than last access on purpose: GitHub evicts by last access, and a `restore-keys` prefix fallback keeps re-reading a stale cache — bumping its last-accessed time indefinitely — so a stale entry could otherwise outlive its usefulness forever.
 
 ### When It Runs
 

--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,13 @@
             "groupName": "github-actions"
         },
         {
+            "description": "dotnet-sdk — the .NET SDK version pinned via dotnet-version in .github/workflows/*.yml (the custom.regex manager below). Standalone, not folded into the docker or github-actions groups, so an SDK bump lands as one visible PR that runs full CI before automerge — the point of pinning the SDK instead of floating on 10.0.x. Must come after the docker group rule (last-match-wins) so it overrides that rule's custom.regex match, which would otherwise misroute the bump to deps/docker.",
+            "matchManagers": ["custom.regex"],
+            "matchPackageNames": ["dotnet-sdk"],
+            "semanticCommitScope": "deps/dotnet-sdk",
+            "groupName": "dotnet-sdk"
+        },
+        {
             "description": "PIN — test-client mod-builder .NET 6 must match the game's runtime. Scoped to tag 6.0 in this file only; the 10.0 stages here and in docker/Dockerfile stay updatable.",
             "matchManagers": ["dockerfile"],
             "matchFileNames": ["docker/Dockerfile.test-client"],
@@ -236,6 +243,15 @@
             "datasourceTemplate": "github-releases",
             "extractVersionTemplate": "^v(?<version>.+)$",
             "versioningTemplate": "deb"
+        },
+        {
+            "customType": "regex",
+            "description": "dotnet-sdk — the pinned dotnet-version in .github/workflows/*.yml. Matches both quote styles and captures only a concrete version (e.g. 10.0.400), never a floating 10.0.x. datasource dotnet-version resolves depName dotnet-sdk against Microsoft's SDK release index; it has no default versioning, so semver is set explicitly (SDK versions order correctly under it, and config:recommended's ignoreUnstable keeps previews out).",
+            "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+            "matchStrings": ["dotnet-version:\\s*[\"'](?<currentValue>\\d+\\.\\d+\\.\\d+)[\"']"],
+            "depNameTemplate": "dotnet-sdk",
+            "datasourceTemplate": "dotnet-version",
+            "versioningTemplate": "semver"
         }
     ]
 }


### PR DESCRIPTION
## Why

The `Validate Formatting` job failed with `Restore operation failed.` whenever a new SDK feature
band shipped. Root cause chain: the NuGet cache key omitted the SDK version, so `restore-keys`
resurrected a different band's package extraction; a self-perpetuating stale cache (GitHub evicts
by last access, and the fallback kept re-reading the zombie so it never aged out); and a floating
`dotnet-version: "10.0.x"` adopted every new band untested. Interim fix was manual `gh cache delete`.

## Changes

- **SDK-scope the NuGet cache** (`validate-pr.yml`, `validate-merge-group.yml`): give `Setup .NET`
  an `id`, key `~/.nuget/packages` by `steps.dotnet.outputs.dotnet-version`, and scope
  `restore-keys` to the same SDK — a new band always restores from scratch instead of inheriting
  another band's extraction (the direct cause of the incident).
- **Pin the SDK, let Renovate bump it** (`validate-pr.yml`, `validate-merge-group.yml`,
  `e2e-tests.yml`, `renovate.json`): pin `dotnet-version` to an exact `10.0.400`, and add a Renovate
  `custom.regex` manager (`dotnet-version` datasource, `dotnet-sdk`, `semver`) routed to a standalone
  PR. A new SDK then lands as one visible bump PR that runs full CI before automerge, rather than
  ambiently on every open PR. `e2e-tests.yml` is pinned too so its runner-side net10.0 coordinator
  gets the same determinism.
- **Fix the cache janitor** (`cleanup-caches.yml`): age caches by `created_at` instead of
  `last_accessed_at`. A `restore-keys` fallback keeps re-reading a stale cache, bumping its
  last-accessed time indefinitely, so the old filter — and GitHub's own last-accessed eviction —
  could never evict such a zombie. `created_at` is immutable, so nothing outlives two weeks.
- **Docs** (`ci-cd.md`): update the Cleanup Caches description to match the `created_at` semantics.

Together a bad SDK release can neither break existing PRs (pin) nor poison the cache when its bump
PR runs (SDK-scoped key), and no cache of any kind outlives two weeks (janitor).

## Verification

- **Renovate dry-run**: `dotnet-sdk` extracts from all three workflow files (both quote styles),
  resolves against Microsoft's release index at `10.0.400` with `versioning: semver`; a forced
  older pin produced a standalone `renovate/dotnet-sdk` bump PR (`10.0.100 -> 10.0.400`).
  `renovate-config-validator` passes.
- **Janitor preflight** against the live 143-cache population: the new `created_at` filter deletes
  exactly one 2-month-old cache (created Jun 15, last-accessed the same day I checked); the old
  `last_accessed_at` filter deletes zero — the zombie made visible.
- **Cache key**: verified `setup-dotnet` resolves its `dotnet-version` output to exactly `10.0.400`
  under an exact pin with no `global.json`, so the key is genuinely SDK-scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale cache cleanup by consistently using cache creation time with the existing 14-day cutoff.
  * Standardized formatting and end-to-end checks on a fixed .NET SDK version for more predictable results.
  * Updated dependency caching to use the resolved SDK version.

* **Documentation**
  * Clarified how cache age is determined during cleanup.

* **Chores**
  * Added automated tracking for .NET SDK updates in dependency maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->