### PR TITLE
ci: switch the E2E command prefix from /run-tests-e2e to !run-tests-e2e

### DIFF
--- a/.claude/plans/features/tests-local-ci-runners.md
+++ b/.claude/plans/features/tests-local-ci-runners.md
@@ -165,7 +165,7 @@ is the human discipline for CI-vs-local). Disjoint `STEAM_ACCOUNTS` between the 
    - `workflow_dispatch` from master (trusted) — confirm the Tailscale step connects, the
      keyscan resolves the tailnet host, the SSH master comes up, images stream to the Mac,
      and the suite runs with `host_id=mac`.
-   - A same-repo PR `/run-tests-e2e <filter>` comment.
+   - A same-repo PR `!run-tests-e2e <filter>` comment.
    - Only with eyes-on review: a fork PR through the `fork-pr` approval.
 
 ## Open questions / risks

--- a/.claude/plans/features/tests-smart-diff-filter.md
+++ b/.claude/plans/features/tests-smart-diff-filter.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-The E2E suite has ~76 test methods across 29 classes; a full run is slow and serialized on one VPS. Today the only way to run a subset is a hand-typed `FILTER=` substring (`make test FILTER=...` locally; `/run-tests-e2e <filter>` comment or a dispatch input in CI). We want **automatic** selection: given a git diff, run only the tests the change could plausibly break.
+The E2E suite has ~76 test methods across 29 classes; a full run is slow and serialized on one VPS. Today the only way to run a subset is a hand-typed `FILTER=` substring (`make test FILTER=...` locally; `!run-tests-e2e <filter>` comment or a dispatch input in CI). We want **automatic** selection: given a git diff, run only the tests the change could plausibly break.
 
 **Why static mapping is out.** Tests are E2E black-box — every test asserts against the running server's HTTP API (`/cabins`, `/players`, `/farmhands`), so there is no compile-time call graph from a test to the mod service it exercises (per `tests-assert-via-http-api.md`). The mod is one-image-one-binary: any `mod/**` change rebuilds the whole image, so the import graph can't distinguish a CabinManager change from a CropSaver one. And Stardew mechanics are deeply coupled — a `GameLoader` save-flow change plausibly endangers cabins, farmhands, and save-import at once. No sound static map exists.
 

--- a/.github/scripts/e2e-pr-sticky.js
+++ b/.github/scripts/e2e-pr-sticky.js
@@ -206,7 +206,7 @@ function renderBody(state) {
         `- [ ] ${checkboxLabel}`,
         "",
         "<sub>Maintainers: tick the box to re-run with the same filter, or comment " +
-            "`/run-tests-e2e [filter]`.</sub>",
+            "`!run-tests-e2e [filter]`.</sub>",
     ];
 
     if (history.length) {
@@ -260,7 +260,7 @@ function statusToConclusion(status) {
  * either a prior attempt that never reached `completed` (a Checks API failure mid-run, a
  * job that died before its cleanup step) or — the gate runs outside the e2e concurrency
  * singleton — a run that is still live. Reuse it rather than creating a new row, so
- * re-running (the sticky's checkbox / repeated `/run-tests-e2e`) doesn't accumulate
+ * re-running (the sticky's checkbox / repeated `!run-tests-e2e`) doesn't accumulate
  * stale check-run entries on the PR's "Show all checks" list.
  * Returns the check_run id to thread through job outputs for the later update call.
  * @returns {Promise<number>} The reused or newly created check run's id.
@@ -369,7 +369,7 @@ async function upsertSticky({ github, owner, repo, issue_number, body, existing 
 const FILTER_ALLOWED = /^[A-Za-z0-9_.+=() -]*$/;
 
 /**
- * Parse a `/run-tests-e2e [filter]` PR comment into a command decision. Anchored to the
+ * Parse a `!run-tests-e2e [filter]` PR comment into a command decision. Anchored to the
  * FIRST line so a quoted or mid-text mention (e.g. in a paragraph) is ignored. The filter
  * is normalized (collapsed whitespace) and validated against {@link FILTER_ALLOWED}.
  * @param {string} body - The raw comment body.
@@ -380,9 +380,9 @@ const FILTER_ALLOWED = /^[A-Za-z0-9_.+=() -]*$/;
 function parseCommand(body) {
     // Split on CRLF or LF and strip any trailing \r — GitHub comment bodies often arrive
     // with \r\n, and JS `.` does not match \r, so a bare `\n` split would leave the regex
-    // unable to match `/run-tests-e2e Foo\r` (silently ignoring the command).
+    // unable to match `!run-tests-e2e Foo\r` (silently ignoring the command).
     const firstLine = (body || "").split(/\r?\n/, 1)[0].replace(/\r$/, "");
-    const m = firstLine.match(/^\/run-tests-e2e(?:\s+(.*))?$/);
+    const m = firstLine.match(/^!run-tests-e2e(?:\s+(.*))?$/);
     if (!m) {
         return { isCommand: false, filter: "", valid: false };
     }

--- a/.github/scripts/e2e-pr-sticky.test.js
+++ b/.github/scripts/e2e-pr-sticky.test.js
@@ -540,21 +540,21 @@ test("findSticky matches only comments carrying the marker", async () => {
 // --- command parsing (trigger interpretation) --------------------------------------
 
 test("parseCommand: anchored to the first line; a mid-text mention is ignored", () => {
-    assert.equal(helper.parseCommand("look at `/run-tests-e2e Foo`").isCommand, false);
-    assert.equal(helper.parseCommand("hey\n/run-tests-e2e Foo").isCommand, false); // not first line
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e Foo"), { isCommand: true, filter: "Foo", valid: true });
+    assert.equal(helper.parseCommand("look at `!run-tests-e2e Foo`").isCommand, false);
+    assert.equal(helper.parseCommand("hey\n!run-tests-e2e Foo").isCommand, false); // not first line
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e Foo"), { isCommand: true, filter: "Foo", valid: true });
 });
 
 test("parseCommand: CRLF line endings are handled (GitHub comments often arrive as \\r\\n)", () => {
     // JS `.` does not match \r, so a naive \n-split would leave a trailing \r and the command
     // would be silently ignored. Both no-arg and filtered forms must parse under CRLF.
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e\r\nsecond"), { isCommand: true, filter: "", valid: true });
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e MyClass\r\nsecond"), {
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e\r\nsecond"), { isCommand: true, filter: "", valid: true });
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e MyClass\r\nsecond"), {
         isCommand: true,
         filter: "MyClass",
         valid: true,
     });
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e MyClass\r"), {
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e MyClass\r"), {
         isCommand: true,
         filter: "MyClass",
         valid: true,
@@ -562,8 +562,8 @@ test("parseCommand: CRLF line endings are handled (GitHub comments often arrive 
 });
 
 test("parseCommand: no filter = full suite; extra whitespace collapses", () => {
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e"), { isCommand: true, filter: "", valid: true });
-    assert.deepEqual(helper.parseCommand("/run-tests-e2e   MyClass   Method  "), {
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e"), { isCommand: true, filter: "", valid: true });
+    assert.deepEqual(helper.parseCommand("!run-tests-e2e   MyClass   Method  "), {
         isCommand: true,
         filter: "MyClass Method",
         valid: true,
@@ -575,7 +575,7 @@ test("parseCommand: --abort-current is no longer special — it is just a litera
     // would run the FULL suite as if it had vanished). It is passed through verbatim as a
     // literal xUnit filter — valid characters, but it matches no test, so the run is an
     // explicit empty no-result rather than a surprise full-suite run.
-    const cmd = helper.parseCommand("/run-tests-e2e --abort-current");
+    const cmd = helper.parseCommand("!run-tests-e2e --abort-current");
     assert.equal(cmd.isCommand, true);
     assert.equal(cmd.filter, "--abort-current", "flag is preserved as the filter, not stripped");
     assert.equal(cmd.valid, true, "all-allowed-chars; harmless literal that matches nothing");

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,7 @@
 #   1. workflow_dispatch (Actions tab) — runs the full suite from a trusted branch; the
 #      optional `pr` input instead resolves that PR's HEAD (forks included, gated by
 #      `fork-pr`) and posts the same sticky as the comment path.
-#   2. `/run-tests-e2e [filter]` PR comment.
+#   2. `!run-tests-e2e [filter]` PR comment.
 #   3. the "Re-run E2E tests" checkbox in the bot's results comment (a click in the
 #      PR view; toggling it fires issue_comment: edited).
 #   4. schedule (nightly 08:00 UTC) — a full-suite run on master so the README E2E
@@ -75,7 +75,7 @@ on:
   # 06:00). Handled like workflow_dispatch in the gate (trusted, no PR context).
   schedule:
     - cron: '0 8 * * *'
-  # PR comments: `created` = the typed `/run-tests-e2e` command; `edited` = the re-run
+  # PR comments: `created` = the typed `!run-tests-e2e` command; `edited` = the re-run
   # checkbox in the bot's results comment being ticked. The `gate` job's `if:` narrows
   # this to PR comments that are actually our command or our sticky (see that job).
   issue_comment:
@@ -115,7 +115,7 @@ jobs:
        && github.event.sender.type != 'Bot'
        && (
             (github.event.action == 'created'
-               && startsWith(github.event.comment.body, '/run-tests-e2e'))
+               && startsWith(github.event.comment.body, '!run-tests-e2e'))
          || (github.event.action == 'edited'
                && contains(github.event.comment.body, '<!-- e2e-results -->'))
           ))
@@ -276,7 +276,7 @@ jobs:
             let filterValid = true;
             if (action === 'created') {
               const cmd = helper.parseCommand(body);
-              if (!cmd.isCommand) return noop('comment is not an anchored /run-tests-e2e command');
+              if (!cmd.isCommand) return noop('comment is not an anchored !run-tests-e2e command');
               filter = cmd.filter;
               filterValid = cmd.valid;
             } else {

--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ RUNNER_PROJECT := ./tests/JunimoServer.TestRunner
 #   make test FILTER="Login_WithCorrectPassword"
 #   make test FILTER="CabinStrategyNoneTests|CabinPositionPersistenceTests"
 #   make test (runs all tests)
-# Note: '|' works only for direct `make test`. The /run-tests-e2e PR-comment trigger
+# Note: '|' works only for direct `make test`. The !run-tests-e2e PR-comment trigger
 # rejects '|' (it would break the sticky-comment markdown table); use one pattern there.
 FILTER ?=
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -11,7 +11,7 @@ We use GitHub Actions for automated building, testing, and deployment.
 | [Validate PR](#validate-pr-pipeline) | Pull requests to `master` | Validates commits, builds, formatting, and line endings |
 | [Validate Merge Group](#merge-queue) | Merge queue (`merge_group`) | Re-validates each PR against the latest `master` before it merges |
 | [CodeQL](#codeql-pipeline) | Pull requests / push to `master` / weekly | Static security analysis (advisory) |
-| [E2E Tests](#e2e-tests-pipeline) | Manual (`workflow_dispatch`, a maintainer's `/run-tests-e2e` PR comment / re-run checkbox) or nightly schedule | Runs the Docker E2E suite on a remote VPS (never a required check) |
+| [E2E Tests](#e2e-tests-pipeline) | Manual (`workflow_dispatch`, a maintainer's `!run-tests-e2e` PR comment / re-run checkbox) or nightly schedule | Runs the Docker E2E suite on a remote VPS (never a required check) |
 | [Approve PR](#approve-pr-pipeline) | A maintainer's `!approve` PR comment | Records an approving review from `github-actions[bot]` so the required-approval rule is satisfiable on the maintainer's own PRs |
 | [Deploy Server](#deploy-server-pipeline) | After preview build / manual | Deploys server instances to VPS |
 | [Deploy Docs](#deploy-docs-pipeline) | After build / manual | Deploys documentation to GitHub Pages |
@@ -244,7 +244,7 @@ Runs the heavy Docker E2E suite. The coordinator (`JunimoServer.TestRunner`) run
 | Trigger | How |
 |---------|-----|
 | `workflow_dispatch` | Actions tab → **Run workflow** (full suite from a trusted branch; optional `filter`). |
-| `/run-tests-e2e [filter]` | A PR comment (the `issue_comment: created` event). Runs against the PR's HEAD. |
+| `!run-tests-e2e [filter]` | A PR comment (the `issue_comment: created` event). Runs against the PR's HEAD. |
 | **Re-run checkbox** | Ticking "🔁 Re-run E2E tests" in the bot's results comment (`issue_comment: edited`). |
 | **Nightly schedule** | Full-suite run on `master` (08:00 UTC) so the README E2E badge shows a recent real result. Never gates a merge. |
 

--- a/docs/developers/testing/e2e-testing.md
+++ b/docs/developers/testing/e2e-testing.md
@@ -182,7 +182,7 @@ VPS being down must not block the queue):
   `pr` input instead resolves that PR's HEAD and tests it, posting the same sticky comment
   as the comment path; fork PRs pause at the `fork-pr` approval (same as the comment path),
   and an empty `pr` runs the selected branch / master exactly as before.
-- **`/run-tests-e2e [filter]` PR comment** — runs against the PR's
+- **`!run-tests-e2e [filter]` PR comment** — runs against the PR's
   HEAD commit and posts results back to the PR (see below). `filter` is an xUnit
   class/method substring; omit it for the full suite.
 - **The "🔁 Re-run E2E tests" checkbox** in the bot's results comment — ticking it


### PR DESCRIPTION
Renames the E2E test-run PR comment command from `/run-tests-e2e` to `!run-tests-e2e`, so all repo PR-comment commands share the `!` prefix alongside `!approve` — visually distinct from GitHub's built-in `/` menu in comment fields.

## Changes

- **`.github/scripts/e2e-pr-sticky.js`**: `parseCommand` regex + doc comments + the sticky's rendered usage hint.
- **`.github/scripts/e2e-pr-sticky.test.js`**: command fixtures (all 40 tests pass).
- **`.github/workflows/e2e-tests.yml`**: the gate's `startsWith` pre-filter, header comment, noop message.
- **Docs/notes**: `ci-cd.md`, `e2e-testing.md`, the Makefile filter note, and the two plan documents citing the command.

No behavioural change beyond the prefix; old `/run-tests-e2e` comments in existing PR threads remain as plain text and no longer trigger runs.

## Verification

- `npm test`: 40/40 pass; workflow YAML parses; actionlint reports only pre-existing findings on untouched lines (`queue: max` unknown to its schema, three shellcheck notes in unchanged run scripts).
- Grep confirms zero `/run-tests-e2e` occurrences remain in tracked files.
