### PR TITLE
chore(hooks): recover degraded worktree states in the remove hook

### DIFF
--- a/.claude/hooks/worktree-remove.mjs
+++ b/.claude/hooks/worktree-remove.mjs
@@ -10,7 +10,11 @@ const git = (...args) =>
   execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] }).trim();
 
 const input = JSON.parse(fs.readFileSync(0, "utf8"));
-const mainCheckout = path.dirname(git("rev-parse", "--path-format=absolute", "--git-common-dir"));
+const commonDir = git("rev-parse", "--path-format=absolute", "--git-common-dir");
+const mainCheckout = path.dirname(commonDir);
+// Windows refuses to delete any process's current directory — make sure this
+// process never holds a cwd lock inside the worktree being removed.
+process.chdir(mainCheckout);
 const container = path.join(path.dirname(mainCheckout), "worktrees") + path.sep;
 const registered = new Set(
   git("worktree", "list", "--porcelain")
@@ -19,11 +23,28 @@ const registered = new Set(
     .map((l) => path.resolve(l.slice(9))),
 );
 
+// A directory git has already deregistered still proves it was a worktree of
+// THIS repo when its `.git` is a file whose gitdir points into our admin area
+// (.git/worktrees/<id>) — the safety bar for deleting anything the
+// registration check can't vouch for.
+const adminRoot = path.join(commonDir, "worktrees") + path.sep;
+const isWorktreeStub = (p) => {
+  try {
+    const dotGit = path.join(p, ".git");
+    if (!fs.statSync(dotGit).isFile()) return false;
+    const m = fs.readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.*)$/m);
+    return !!m && (path.resolve(p, m[1].trim()) + path.sep).startsWith(adminRoot);
+  } catch {
+    return false;
+  }
+};
+
 // The input field carrying the path is undocumented; try likely names first,
 // then any string value — but never ambient fields (`cwd` may be a live
-// worktree that is not the removal target). Only registered worktrees inside
-// the convention container qualify; anything else exits 1, leaving the
-// worktree in place.
+// worktree that is not the removal target). Only worktrees inside the
+// convention container qualify — registered ones, or deregistered leftovers
+// that isWorktreeStub can vouch for; anything else exits 1, leaving the
+// directory in place.
 const ambient = new Set(["cwd", "session_id", "transcript_path", "hook_event_name"]);
 const candidates = [
   input.worktree_path,
@@ -33,23 +54,43 @@ const candidates = [
 ].filter((v) => typeof v === "string" && v.trim());
 const target = candidates
   .map((v) => path.resolve(v.trim()))
-  .find((p) => (p + path.sep).startsWith(container) && p + path.sep !== container && registered.has(p));
+  .find(
+    (p) =>
+      (p + path.sep).startsWith(container) &&
+      p + path.sep !== container &&
+      (registered.has(p) || isWorktreeStub(p)),
+  );
 if (!target) {
-  console.error(`worktree-remove hook: no registered worktree inside ${container} in hook input: ${JSON.stringify(input)}`);
+  console.error(
+    `worktree-remove hook: no removable worktree inside ${container} in hook input: ${JSON.stringify(input)}` +
+      ` — if a leftover directory remains, delete it manually and run \`git worktree prune\`.`,
+  );
   process.exit(1);
 }
 
-try {
-  execFileSync("git", ["worktree", "remove", "--force", target], {
-    cwd: mainCheckout,
-    stdio: ["ignore", "ignore", "pipe"],
-  });
-} catch (e) {
-  const stderr = e.stderr?.toString() ?? "";
-  process.stderr.write(stderr);
-  // Deep node_modules paths can exceed Windows path limits; anything else is a
-  // real git failure and must not fall through to a blind recursive delete.
-  if (!/too long/i.test(stderr)) process.exit(1);
+const prune = () => execFileSync("git", ["worktree", "prune"], { cwd: mainCheckout, stdio: "ignore" });
+
+if (!registered.has(target)) {
+  // Deregistered but still on disk (a prior removal dropped the registration,
+  // then failed deleting the files): filesystem delete + prune stale admin dirs.
   fs.rmSync(target, { recursive: true, force: true, maxRetries: 3 });
-  execFileSync("git", ["worktree", "prune"], { cwd: mainCheckout, stdio: "ignore" });
+  prune();
+} else if (!fs.existsSync(target)) {
+  // Registered but already gone from disk: only the stale registration is left.
+  prune();
+} else {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", target], {
+      cwd: mainCheckout,
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+  } catch (e) {
+    const stderr = e.stderr?.toString() ?? "";
+    process.stderr.write(stderr);
+    // Deep node_modules paths can exceed Windows path limits; anything else is a
+    // real git failure and must not fall through to a blind recursive delete.
+    if (!/too long/i.test(stderr)) process.exit(1);
+    fs.rmSync(target, { recursive: true, force: true, maxRetries: 3 });
+    prune();
+  }
 }


### PR DESCRIPTION
Hardens `.claude/hooks/worktree-remove.mjs` against the degraded worktree states a half-failed removal leaves behind. Previously the hook acted only on **registered** worktrees, so once a removal attempt dropped the registration but failed to delete the files, the directory was stranded: the hook exited 1 on every retry and `git worktree remove` refused with "not a working tree", forcing manual filesystem cleanup.

## Changes

- **Deregistered + present**: filesystem delete + `git worktree prune`, gated on an intrinsic proof of ownership — the directory's `.git` must be a *file* whose `gitdir:` points into this repo's `.git/worktrees/` admin area. Plain directories (no stub) are still refused, so the loose input-field scanning can never blind-delete an arbitrary folder.
- **Registered + absent**: `git worktree prune` only (stale registration, nothing on disk).
- **Registered + present** (normal path): unchanged — `git worktree remove --force`, with the filesystem fallback still reserved for path-too-long failures.
- `process.chdir(mainCheckout)` before any removal, so the hook's own cwd can never hold the Windows directory lock on the target.
- The refusal message now names the manual recovery (`delete the directory, git worktree prune`).

## Verification

All five states exercised live against this repo with throwaway detached worktrees: normal removal, deregistered+present, registered+absent, plain unregistered directory (refused, left intact), and a path outside `../worktrees/` (refused). All pass; no residue in `git worktree list` or on disk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree removal for deregistered or missing worktree directories.
  * Added validation to prevent removing unrelated directories.
  * Automatically cleans up stale worktree metadata after removal.
  * Enhanced error messages with manual cleanup and pruning guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->