### PR TITLE
feat(chat): one-line help and hide admin commands from non-admins

### DIFF
--- a/docs/admins/operations/commands.md
+++ b/docs/admins/operations/commands.md
@@ -172,7 +172,7 @@ host-visibility
 
 ## Chat Commands
 
-Players and admins use chat commands in-game. Type in the chat box (press `T` or `/`).
+Players and admins use chat commands in-game. Type in the chat box (press `T` or `/`). Admin-only commands are hidden from non-admins in the `!help` list.
 
 ### General Commands (All Players)
 
@@ -218,9 +218,9 @@ For password-protected servers:
 
 See [Password Protection](/features/password-protection/) for full lobby customization.
 
-### Owner Commands
+### Irreversible Commands
 
-These require server owner (first player/host):
+These require admin role:
 
 | Command | Description |
 |---------|-------------|

--- a/docs/features/server-mechanics.md
+++ b/docs/features/server-mechanics.md
@@ -61,7 +61,7 @@ To prevent griefing, the server locks player storage:
 
 - Host automatically joins festivals
 - Players participate normally
-- If stuck, use the `!event` command to force-start
+- If stuck, an admin can use the `!event` command to force-start
 
 For the full handling model and a per-festival reference, see [Festival Handling](/developers/architecture/festival-handling) in the developer docs.
 

--- a/mod/JunimoServer/ModEntry.cs
+++ b/mod/JunimoServer/ModEntry.cs
@@ -338,26 +338,20 @@ internal class ModEntry : Mod
         CabinCommand.Register(Helper, chatCommandsService, cabinService, persistentOptions);
         RoleCommands.Register(Helper, chatCommandsService, roleService);
         BanCommand.Register(Helper, chatCommandsService, roleService);
-        KickCommand.Register(Helper, chatCommandsService, roleService);
+        KickCommand.Register(Helper, chatCommandsService);
         ListAdminsCommand.Register(Helper, chatCommandsService, roleService);
-        ListBansCommand.Register(Helper, chatCommandsService, roleService);
-        UnbanCommand.Register(Helper, chatCommandsService, roleService);
-        ChangeWalletCommand.Register(Helper, chatCommandsService, roleService);
-        JojaCommand.Register(Helper, chatCommandsService, roleService, alwaysOnConfig);
+        ListBansCommand.Register(Helper, chatCommandsService);
+        UnbanCommand.Register(Helper, chatCommandsService);
+        ChangeWalletCommand.Register(Helper, chatCommandsService);
+        JojaCommand.Register(Helper, chatCommandsService, alwaysOnConfig);
         ConsoleCommand.Register(Helper, chatCommandsService, roleService);
         InviteCodeCommand.Register(Helper, Monitor, chatCommandsService);
         ServerCommand.Register(Helper, Monitor, chatCommandsService);
 
         // Password protection commands
         LoginCommand.Register(Helper, Monitor, chatCommandsService, passwordProtectionService);
-        AuthStatusCommand.Register(
-            Helper,
-            Monitor,
-            chatCommandsService,
-            roleService,
-            passwordProtectionService
-        );
-        LobbyCommands.Register(Helper, Monitor, chatCommandsService, roleService, lobbyService);
+        AuthStatusCommand.Register(Helper, Monitor, chatCommandsService, passwordProtectionService);
+        LobbyCommands.Register(Helper, Monitor, chatCommandsService, lobbyService);
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -84,8 +84,9 @@ public class AlwaysOnServerFestivals
 
         chatCommandService.RegisterCommand(
             "event",
-            "Tries to start the current festival's event.",
-            StartEventCommand
+            "Starts the current festival's event.",
+            StartEventCommand,
+            requiresAdmin: true
         );
     }
 

--- a/mod/JunimoServer/Services/ChatCommands/ChatCommand.cs
+++ b/mod/JunimoServer/Services/ChatCommands/ChatCommand.cs
@@ -8,15 +8,28 @@ public class ChatCommand
     public string Description;
     public Action<string[], ReceivedMessage> Action;
 
+    /// <summary>
+    /// When true, only admins may run the command and it is hidden from non-admins in the
+    /// <c>!help</c> listing. Both the access check and the listing filter are enforced
+    /// centrally in <see cref="ChatCommandsService"/>, so commands don't repeat the check.
+    /// </summary>
+    public bool RequiresAdmin;
+
     public string CommandUsage
     {
         get { return $"!{Name}: {Description}"; }
     }
 
-    public ChatCommand(string name, string description, Action<string[], ReceivedMessage> action)
+    public ChatCommand(
+        string name,
+        string description,
+        Action<string[], ReceivedMessage> action,
+        bool requiresAdmin = false
+    )
     {
         Name = name;
         Description = description;
         Action = action;
+        RequiresAdmin = requiresAdmin;
     }
 }

--- a/mod/JunimoServer/Services/ChatCommands/ChatCommandAPI.cs
+++ b/mod/JunimoServer/Services/ChatCommands/ChatCommandAPI.cs
@@ -7,7 +7,8 @@ public interface IChatCommandApi
     public void RegisterCommand(
         string name,
         string description,
-        Action<string[], ReceivedMessage> action
+        Action<string[], ReceivedMessage> action,
+        bool requiresAdmin = false
     );
     public void RegisterCommand(ChatCommand command);
 }

--- a/mod/JunimoServer/Services/ChatCommands/ChatCommands.cs
+++ b/mod/JunimoServer/Services/ChatCommands/ChatCommands.cs
@@ -21,6 +21,7 @@ public class ChatCommandsService : ModService, IChatCommandApi
     private readonly IMonitor _monitor;
     private readonly IModHelper _helper;
     private readonly ApiService _apiService;
+    private readonly RoleService _roleService;
 
     private readonly List<ChatCommand> _registeredCommands = new List<ChatCommand>();
 
@@ -37,6 +38,7 @@ public class ChatCommandsService : ModService, IChatCommandApi
         _monitor = monitor;
         _helper = helper;
         _apiService = apiService;
+        _roleService = roleService;
 
         // Enable cheat/debug commands work (https://stardewvalleywiki.com/Modding:Console_commands#Debug_commands)
         Program.enableCheats = true;
@@ -118,26 +120,30 @@ public class ChatCommandsService : ModService, IChatCommandApi
 
     private void HelpCommand(string[] args, ReceivedMessage msg)
     {
+        // Hide admin-only commands from non-admins so their help stays uncluttered.
+        var visible = _registeredCommands.Where(command => CanPlayerUse(command, msg.SourceFarmer));
+
         if (args.Length > 0)
         {
             // Show help for specific commands passed as args
-            foreach (
-                var command in _registeredCommands.Where(command =>
-                    args.Contains(command.Name, StringComparer.OrdinalIgnoreCase)
-                )
-            )
-            {
-                _helper.SendPrivateMessage(msg.SourceFarmer, command.CommandUsage);
-            }
+            visible = visible.Where(command =>
+                args.Contains(command.Name, StringComparer.OrdinalIgnoreCase)
+            );
         }
-        else
+
+        foreach (var command in visible)
         {
-            // Show help for all commands
-            foreach (var command in _registeredCommands)
-            {
-                _helper.SendPrivateMessage(msg.SourceFarmer, command.CommandUsage);
-            }
+            _helper.SendPrivateMessage(msg.SourceFarmer, command.CommandUsage);
         }
+    }
+
+    /// <summary>
+    /// Whether a player may run — and see in <c>!help</c> — the given command. Admin-only
+    /// commands require the player to be an admin; all others are open.
+    /// </summary>
+    private bool CanPlayerUse(ChatCommand command, long playerId)
+    {
+        return !command.RequiresAdmin || _roleService.IsPlayerAdmin(playerId);
     }
 
     private void OnChatMessage(ReceivedMessage receivedMessage)
@@ -177,6 +183,16 @@ public class ChatCommandsService : ModService, IChatCommandApi
             )
             {
                 _monitor.Log($"[ChatCommands] Found command: {command.Name}", LogLevel.Trace);
+
+                if (!CanPlayerUse(command, receivedMessage.SourceFarmer))
+                {
+                    _helper.SendPrivateMessage(
+                        receivedMessage.SourceFarmer,
+                        "You are not an admin."
+                    );
+                    continue;
+                }
+
                 command.Action(args, receivedMessage);
             }
         }
@@ -257,10 +273,11 @@ public class ChatCommandsService : ModService, IChatCommandApi
     public void RegisterCommand(
         string name,
         string description,
-        Action<string[], ReceivedMessage> action
+        Action<string[], ReceivedMessage> action,
+        bool requiresAdmin = false
     )
     {
-        _registeredCommands.Add(new ChatCommand(name, description, action));
+        _registeredCommands.Add(new ChatCommand(name, description, action, requiresAdmin));
     }
 
     public void RegisterCommand(ChatCommand command)

--- a/mod/JunimoServer/Services/Commands/AuthStatusCommand.cs
+++ b/mod/JunimoServer/Services/Commands/AuthStatusCommand.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using JunimoServer.Services.ChatCommands;
 using JunimoServer.Services.PasswordProtection;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -18,25 +17,14 @@ public class AuthStatusCommand
         IModHelper helper,
         IMonitor monitor,
         ChatCommandsService chatCommandsService,
-        RoleService roleService,
         PasswordProtectionService passwordProtectionService
     )
     {
         chatCommandsService.RegisterCommand(
             "authstatus",
-            "(Admin) View authentication status of all players.",
+            "Shows player auth status.",
             (args, msg) =>
             {
-                // Check if player is admin
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(
-                        msg.SourceFarmer,
-                        "You must be an admin to use this command."
-                    );
-                    return;
-                }
-
                 // Check if password protection is enabled
                 if (!passwordProtectionService.IsEnabled)
                 {
@@ -71,7 +59,8 @@ public class AuthStatusCommand
                         $"{status} {farmer.Name} ({userName})"
                     );
                 }
-            }
+            },
+            requiresAdmin: true
         );
 
         monitor.Log("[AuthStatusCommand] Registered !authstatus command", LogLevel.Trace);

--- a/mod/JunimoServer/Services/Commands/BanCommand.cs
+++ b/mod/JunimoServer/Services/Commands/BanCommand.cs
@@ -16,14 +16,9 @@ public class BanCommand
     {
         chatCommandsService.RegisterCommand(
             "ban",
-            "\"farmerName|userName\" to ban the player.",
+            "Ban <player> from the server.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
                 if (args.Length != 1 || (args.Length == 1 && args[0] == ""))
                 {
                     helper.SendPrivateMessage(
@@ -53,7 +48,8 @@ public class BanCommand
 
                 Game1.server.ban(targetFarmer.UniqueMultiplayerID);
                 helper.SendPrivateMessage(msg.SourceFarmer, "Banned: " + targetFarmer.Name);
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -20,7 +20,7 @@ public static class CabinCommand
     {
         chatCommandsService.RegisterCommand(
             "cabin",
-            "Moves your cabin to the right of your player.\nThis will clear basic debris to make space.\nUse '!cabin reset' to send your cabin back to the shared stack.",
+            "Moves or resets your cabin (!cabin reset).",
             (args, msg) =>
             {
                 if (cabinService.options.IsFarmHouseStack)

--- a/mod/JunimoServer/Services/Commands/ChangeWalletCommand.cs
+++ b/mod/JunimoServer/Services/Commands/ChangeWalletCommand.cs
@@ -1,6 +1,5 @@
 using System;
 using JunimoServer.Services.ChatCommands;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -9,23 +8,13 @@ namespace JunimoServer.Services.Commands;
 
 public class ChangeWalletCommand
 {
-    public static void Register(
-        IModHelper helper,
-        ChatCommandsService chatCommandsService,
-        RoleService roleService
-    )
+    public static void Register(IModHelper helper, ChatCommandsService chatCommandsService)
     {
         chatCommandsService.RegisterCommand(
             "changewallet",
-            "Type \"!changewallet shared\" or \"!changewallet separate\" to switch wallet mode at the end of the day.",
+            "Set shared or separate wallets.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
-
                 bool wantSeparate;
                 if (
                     args.Length == 1
@@ -113,7 +102,8 @@ public class ChangeWalletCommand
                         wantSeparate ? "SeparateWallets" : "MergeWallets",
                         actorName
                     );
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/InviteCodeCommand.cs
+++ b/mod/JunimoServer/Services/Commands/InviteCodeCommand.cs
@@ -22,7 +22,7 @@ public class InviteCodeCommand
         // Register chat command
         chatCommandsService.RegisterCommand(
             "invitecode",
-            "Displays the current server invite code.",
+            "Shows the server invite code.",
             (args, msg) =>
             {
                 if (Game1.server == null)
@@ -46,7 +46,7 @@ public class InviteCodeCommand
         // Register console command
         helper.ConsoleCommands.Register(
             "invitecode",
-            "Displays the current server invite code.",
+            "Shows the server invite code.",
             InviteCodeConsoleCommand
         );
     }

--- a/mod/JunimoServer/Services/Commands/JojaCommand.cs
+++ b/mod/JunimoServer/Services/Commands/JojaCommand.cs
@@ -1,6 +1,5 @@
 using JunimoServer.Services.AlwaysOn;
 using JunimoServer.Services.ChatCommands;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 
@@ -11,21 +10,14 @@ public static class JojaCommand
     public static void Register(
         IModHelper helper,
         ChatCommandsService chatCommandsService,
-        RoleService roleService,
         AlwaysOnConfig alwaysOnConfig
     )
     {
         chatCommandsService.RegisterCommand(
             "joja",
-            "Type \"!joja IRREVERSIBLY_ENABLE_JOJA_RUN\" to enable joja and disable the standard community center forever.",
+            "Permanently enable the Joja route.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "Only admins can enable Joja.");
-                    return;
-                }
-
                 if (
                     args.Length != 1
                     || (args.Length == 1 && args[0] != "IRREVERSIBLY_ENABLE_JOJA_RUN")
@@ -40,7 +32,8 @@ public static class JojaCommand
 
                 alwaysOnConfig.IsCommunityCenterRun = false;
                 helper.SendPublicMessage("Joja run permanently enabled!");
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/KickCommand.cs
+++ b/mod/JunimoServer/Services/Commands/KickCommand.cs
@@ -1,5 +1,4 @@
 using JunimoServer.Services.ChatCommands;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -8,22 +7,13 @@ namespace JunimoServer.Services.Commands;
 
 public class KickCommand
 {
-    public static void Register(
-        IModHelper helper,
-        ChatCommandsService chatCommandsService,
-        RoleService roleService
-    )
+    public static void Register(IModHelper helper, ChatCommandsService chatCommandsService)
     {
         chatCommandsService.RegisterCommand(
             "kick",
-            "\"farmerName|userName\" to kick the player.",
+            "Kick <player> from the server.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
                 if (args.Length != 1 || (args.Length == 1 && args[0] == ""))
                 {
                     helper.SendPrivateMessage(
@@ -53,7 +43,8 @@ public class KickCommand
 
                 Game1.server.kick(targetFarmer.UniqueMultiplayerID);
                 helper.SendPrivateMessage(msg.SourceFarmer, "Kicked: " + targetFarmer.Name);
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/ListAdminsCommand.cs
+++ b/mod/JunimoServer/Services/Commands/ListAdminsCommand.cs
@@ -15,15 +15,9 @@ public class ListAdminsCommand
     {
         chatCommandsService.RegisterCommand(
             "listadmins",
-            "list bans",
+            "Lists server admins.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
-
                 helper.SendPrivateMessage(msg.SourceFarmer, "Admins:");
 
                 foreach (var farmerId in roleService.GetAdmins())
@@ -32,7 +26,8 @@ public class ListAdminsCommand
                     var userName = helper.GetFarmerUserNameById(farmerId);
                     helper.SendPrivateMessage(msg.SourceFarmer, $"{farmerName} | {userName}");
                 }
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/ListBansCommand.cs
+++ b/mod/JunimoServer/Services/Commands/ListBansCommand.cs
@@ -1,5 +1,4 @@
 using JunimoServer.Services.ChatCommands;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -8,23 +7,13 @@ namespace JunimoServer.Services.Commands;
 
 public class ListBansCommand
 {
-    public static void Register(
-        IModHelper helper,
-        ChatCommandsService chatCommandsService,
-        RoleService roleService
-    )
+    public static void Register(IModHelper helper, ChatCommandsService chatCommandsService)
     {
         chatCommandsService.RegisterCommand(
             "listbans",
-            "list bans",
+            "Lists banned players.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
-
                 if (Game1.bannedUsers.Count == 0)
                 {
                     helper.SendPrivateMessage(msg.SourceFarmer, "There are 0 banned users.");
@@ -37,7 +26,8 @@ public class ListBansCommand
                 {
                     helper.SendPrivateMessage(msg.SourceFarmer, $"{k} | {v} ");
                 }
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/LobbyCommands.cs
+++ b/mod/JunimoServer/Services/Commands/LobbyCommands.cs
@@ -1,7 +1,6 @@
 using System.Linq;
 using JunimoServer.Services.ChatCommands;
 using JunimoServer.Services.Lobby;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -18,25 +17,15 @@ public static class LobbyCommands
         IModHelper helper,
         IMonitor monitor,
         ChatCommandsService chatCommandsService,
-        RoleService roleService,
         LobbyService lobbyService
     )
     {
         // !lobby - Show help
         chatCommandsService.RegisterCommand(
             "lobby",
-            "(Admin) Manage lobby layouts. Use !lobby help for details.",
+            "Manage lobby layouts (see !lobby help).",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(
-                        msg.SourceFarmer,
-                        "You must be an admin to use lobby commands."
-                    );
-                    return;
-                }
-
                 if (args.Length == 0 || args[0].ToLower() == "help")
                 {
                     ShowHelp(helper, msg.SourceFarmer);
@@ -97,7 +86,8 @@ public static class LobbyCommands
                         );
                         break;
                 }
-            }
+            },
+            requiresAdmin: true
         );
 
         monitor.Log("[LobbyCommands] Registered !lobby command", LogLevel.Trace);

--- a/mod/JunimoServer/Services/Commands/LoginCommand.cs
+++ b/mod/JunimoServer/Services/Commands/LoginCommand.cs
@@ -20,7 +20,7 @@ public class LoginCommand
     {
         chatCommandsService.RegisterCommand(
             "login",
-            "<password> - Authenticate with the server password.",
+            "Log in with the server password.",
             (args, msg) =>
             {
                 // Check if password protection is enabled

--- a/mod/JunimoServer/Services/Commands/RoleCommands.cs
+++ b/mod/JunimoServer/Services/Commands/RoleCommands.cs
@@ -15,14 +15,9 @@ public static class RoleCommands
     {
         chatCommandsService.RegisterCommand(
             "admin",
-            "\"farmerName|userName\" to assign admin status to the player.",
+            "Grant <player> admin status.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
                 if (args.Length != 1 || (args.Length == 1 && args[0] == ""))
                 {
                     helper.SendPrivateMessage(
@@ -49,20 +44,15 @@ public static class RoleCommands
                     msg.SourceFarmer,
                     "Assigned Admin to: " + farmerToAdmin.Name
                 );
-            }
+            },
+            requiresAdmin: true
         );
 
         chatCommandsService.RegisterCommand(
             "unadmin",
-            "\"farmerName|userName\" to take away admin status from the player.",
+            "Remove <player>'s admin status.",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
-
                 if (args.Length != 1 || (args.Length == 1 && args[0] == ""))
                 {
                     helper.SendPrivateMessage(
@@ -98,7 +88,8 @@ public static class RoleCommands
                     msg.SourceFarmer,
                     "Took away admin from: " + farmerToUnadmin.Name
                 );
-            }
+            },
+            requiresAdmin: true
         );
     }
 }

--- a/mod/JunimoServer/Services/Commands/UnbanCommand.cs
+++ b/mod/JunimoServer/Services/Commands/UnbanCommand.cs
@@ -1,5 +1,4 @@
 using JunimoServer.Services.ChatCommands;
-using JunimoServer.Services.Roles;
 using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewValley;
@@ -8,22 +7,13 @@ namespace JunimoServer.Services.Commands;
 
 public class UnbanCommand
 {
-    public static void Register(
-        IModHelper helper,
-        ChatCommandsService chatCommandsService,
-        RoleService roleService
-    )
+    public static void Register(IModHelper helper, ChatCommandsService chatCommandsService)
     {
         chatCommandsService.RegisterCommand(
             "unban",
-            "\"id|userName\" to unban the player. Use !listban to find ID.",
+            "Unban <player> (see !listbans).",
             (args, msg) =>
             {
-                if (!roleService.IsPlayerAdmin(msg.SourceFarmer))
-                {
-                    helper.SendPrivateMessage(msg.SourceFarmer, "You are not an admin.");
-                    return;
-                }
                 if (args.Length != 1 || (args.Length == 1 && args[0] == ""))
                 {
                     helper.SendPrivateMessage(
@@ -54,7 +44,8 @@ public class UnbanCommand
                 }
                 Game1.bannedUsers.Remove(unbanKey);
                 helper.SendPrivateMessage(msg.SourceFarmer, $"Unbanned: {unbanKey} | {unbanVal}");
-            }
+            },
+            requiresAdmin: true
         );
     }
 }


### PR DESCRIPTION
Follow-up to the chat-command pagination work (#533): tidy the `!help` output and stop admin commands from cluttering non-admin players.

## Changes

- **One-line descriptions** — every chat command now has a single-line description so `!help` no longer wraps (the `cabin`, `admin`, `unadmin`, `changewallet`, and `joja` blurbs were the multi-line offenders).
- **Admin commands hidden from non-admins** — new `RequiresAdmin` flag on `ChatCommand`, enforced centrally in `ChatCommandsService.CanPlayerUse`: admin-only commands are filtered out of `!help` for non-admins **and** rejected before their action runs. This replaces the repeated per-command `IsPlayerAdmin` checks and drops the now-unused `RoleService` params from the commands that only used them for that guard.
- **`!event` gated to admin** — it was documented as admin-only but had never been gated in code; now it matches its documented, server-wide effect.
- **Fixed `!listadmins` description** — it read "list bans".
- **Docs synced** — command reference now matches the code (admin categorization, `!joja` "owner"→admin role, and a note that admin commands are hidden from non-admins in `!help`).

## Notes

- The single-line fit was sized against the ChatBox wrap width; not verified with a live in-game render.
- Enforcement stays server-side and unchanged in identity terms — the central check uses the same `msg.SourceFarmer` the per-command guards used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin-only commands are now restricted to administrators and hidden from non-admins in `!help`.
  * `!event` can be used by admins to start a stuck festival event.
  * Renamed the command for listing server bans to `listadmins`, which lists server administrators.

* **Documentation**
  * Clarified administrator requirements for irreversible commands, festival controls, and command visibility.

* **Improvements**
  * Updated several command descriptions for clearer, more concise guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->