### PR TITLE
chore: add SPDX-License-Identifier to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: MIT
+
 MIT License
 
 Copyright (c) 2024 Stardew Valley Dedicated Server - Team and Contributors


### PR DESCRIPTION
- Add an `SPDX-License-Identifier: MIT` header as the first line of `LICENSE`.
- Makes the license machine-parsable by tooling such as Greptile.
- `MIT` is the canonical SPDX short identifier for the license text in the file; the single top-level tag covers both copyright blocks (identical MIT terms).