### PR TITLE
fix: stop the Stardew Valley Fair deadlocking after grange judging (#537)

### DIFF
--- a/docs/developers/architecture/festival-handling.md
+++ b/docs/developers/architecture/festival-handling.md
@@ -29,7 +29,7 @@ Two shapes:
 - **Main event** — the host warps in, runs a countdown, and starts a host-triggered event (egg hunt, grange judging, soup tasting, etc.).
 - **Leave-only** — no host-triggered event; the host just waits for the `festivalEnd` ready-check (or the timeout). Spirit's Eve and the Feast of Winter Star are the only two.
 
-Only the **Stardew Valley Fair** auto-ends on its own once the countdown finishes — grange judging *is* the whole festival, so there is nothing left to do. Every other festival, main-event or leave-only, ends on the `festivalEnd` ready-check or the timeout backstop.
+No festival auto-ends on its own. Every festival, main-event or leave-only — the **Stardew Valley Fair** included — ends on the `festivalEnd` ready-check (a player votes to leave, or the last player leaves) or on the timeout backstop. This mirrors the game's own `DedicatedServer`, which ends festivals only via `CheckOthersReady("festivalEnd")` or the no-players path and never auto-ends the Fair.
 
 | Festival | Date | Shape | Countdown (default) | Timeout (default) |
 |----------|------|-------|--------------------|-------------------|
@@ -37,7 +37,7 @@ Only the **Stardew Valley Fair** auto-ends on its own once the countdown finishe
 | Flower Dance | Spring 24 | Main event | 5 min | ~33 min |
 | Luau | Summer 11 | Main event (adds iridium starfruit to the soup) | 5 min | ~33 min |
 | Dance of the Moonlight Jellies | Summer 28 | Main event | 5 min | ~33 min |
-| Stardew Valley Fair | Fall 16 | Main event, **auto-ends after countdown** | 5 min | ~33 min |
+| Stardew Valley Fair | Fall 16 | Main event | 5 min | ~33 min |
 | Spirit's Eve | Fall 27 | Leave-only | — | ~33 min |
 | Festival of Ice | Winter 8 | Main event | 5 min | ~33 min |
 | Feast of the Winter Star | Winter 25 | Leave-only | — | ~33 min |

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -492,13 +492,10 @@ public class AlwaysOnServerFestivals
             return;
         }
 
-        // Both graceful ends below go through TryStartEndFestivalDialogue, which no-ops while a host
-        // menu is open (its own activeClickableMenu == null guard) — yet EndFestival latches
-        // _startedFestivalEnd unconditionally, which would re-strand the festival with no exit. The
-        // one host menu that appears mid-festival is the grange results DialogueBox after judging;
-        // HandleDialogueBox clears it on its next once-per-second pass (~12s at SERVER_TPS=5), so gate
-        // both ends on no open menu and let the leave fire cleanly on a later tick. (The wall-clock
-        // timeout backstop is unaffected — it force-ends regardless of any menu.)
+        // TryStartEndFestivalDialogue (both graceful ends) no-ops while a host menu is open, but
+        // EndFestival latches _startedFestivalEnd unconditionally — so ending here while the grange
+        // results box is open would strand the festival. Gate on no menu; HandleDialogueBox clears
+        // that box within ~12s. The wall-clock backstop force-ends regardless of any menu.
         var noHostMenu = Game1.activeClickableMenu is null;
 
         // No online players left at the festival: end it so the host isn't stranded. Mirrors

--- a/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
+++ b/mod/JunimoServer/Services/AlwaysOnServer/AlwaysOnFestivals.cs
@@ -34,8 +34,6 @@ public class AlwaysOnServerFestivals
         public Func<int> CountdownSeconds;
         public string AnnounceText;
         public Action OnAnnounce; // e.g. add the iridium starfruit to the Luau soup
-        public bool AutoEndAfterCountdown; // host ends the festival once the countdown elapses (Fair)
-        public string EndLogText; // logged when AutoEndAfterCountdown fires
 
         // Wall-clock backstop: end the festival and warp everyone home once this elapses
         // (from entry or after the main event)
@@ -143,10 +141,8 @@ public class AlwaysOnServerFestivals
                 HasMainEvent = true,
                 CountdownSeconds = () => Config.GrangeDisplayCountdownSeconds,
                 AnnounceText = "The Grange Judging will begin in {0:0.#} minutes.",
-                AutoEndAfterCountdown = true,
                 TimeoutStart = TimeoutStart.OnEntry,
                 TimeoutSeconds = () => Config.FairTimeOutSeconds,
-                EndLogText = "Grange display finished, triggering festival end",
             },
             new FestivalSpec
             {
@@ -379,8 +375,8 @@ public class AlwaysOnServerFestivals
     }
 
     /// <summary>
-    /// Announce a countdown, start the host-triggered main event when it elapses,
-    /// then (for the Fair) auto-end. !event short-circuits the countdown.
+    /// Announce a countdown, then start the host-triggered main event when it elapses.
+    /// !event short-circuits the countdown.
     /// </summary>
     private void RunMainEventCountdown(FestivalSpec spec)
     {
@@ -419,8 +415,8 @@ public class AlwaysOnServerFestivals
 
         if (elapsed >= countdownSeconds)
         {
-            // Kick off the main event first, then start its timeout / auto-end — the ordering
-            // here is what guarantees the event is triggered before the backstop begins.
+            // Kick off the main event first, then start its timeout — the ordering here is what
+            // guarantees the event is triggered before the backstop begins.
             if (!_started)
             {
                 var festivalHost = GetFestivalHost();
@@ -434,11 +430,6 @@ public class AlwaysOnServerFestivals
             if (spec.TimeoutStart == TimeoutStart.AfterMainEvent)
             {
                 RunFestivalTimeout(spec);
-            }
-
-            if (spec.AutoEndAfterCountdown && !_startedFestivalEnd)
-            {
-                EndFestival(spec.EndLogText, force: false);
             }
         }
     }
@@ -501,12 +492,21 @@ public class AlwaysOnServerFestivals
             return;
         }
 
+        // Both graceful ends below go through TryStartEndFestivalDialogue, which no-ops while a host
+        // menu is open (its own activeClickableMenu == null guard) — yet EndFestival latches
+        // _startedFestivalEnd unconditionally, which would re-strand the festival with no exit. The
+        // one host menu that appears mid-festival is the grange results DialogueBox after judging;
+        // HandleDialogueBox clears it on its next once-per-second pass (~12s at SERVER_TPS=5), so gate
+        // both ends on no open menu and let the leave fire cleanly on a later tick. (The wall-clock
+        // timeout backstop is unaffected — it force-ends regardless of any menu.)
+        var noHostMenu = Game1.activeClickableMenu is null;
+
         // No online players left at the festival: end it so the host isn't stranded. Mirrors
         // DedicatedServer.Tick's onlineIds.Count == 0 branch (DedicatedServer.cs:294-308), which
         // ends via TryStartEndFestivalDialogue (force: false) — with no one else online the host's
         // own festivalEnd ready satisfies the check and the festival ends gracefully. Counts
         // online non-disconnecting players, NOT otherFarmers.Count (see OnlineFarmers).
-        if (OnlineFarmers.CountOthers() == 0)
+        if (OnlineFarmers.CountOthers() == 0 && noHostMenu)
         {
             EndFestival(
                 "No players remaining at festival, ending and sending host home",
@@ -526,7 +526,7 @@ public class AlwaysOnServerFestivals
             );
         }
 
-        if (CheckOthersReady("festivalEnd"))
+        if (CheckOthersReady("festivalEnd") && noHostMenu)
         {
             EndFestival(
                 "Other players ready to leave festival, triggering end dialogue",

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -197,19 +197,10 @@ public class TestFestivalStateResponse
     /// <summary>Current in-game time (HHMM). Jumps to the festival's reset cutoff once it ends.</summary>
     public int TimeOfDay { get; set; }
 
-    /// <summary>
-    /// Count of iridium-quality starfruit (item 268, quality 3) in the Luau soup
-    /// (<c>Game1.player.team.luauIngredients</c>). The mod's OnAnnounce adds exactly one; the #372
-    /// double-add regression would make this 2. Only meaningful during the Luau (0 otherwise).
-    /// </summary>
     public int LuauIridiumStarfruitCount { get; set; }
 }
 
-/// <summary>
-/// Response from POST /test/host_menu (test-only). Opens or closes an inert host menu
-/// (<c>Game1.activeClickableMenu</c>) to exercise the festival leave-end gate, and reports the
-/// resulting menu-open state.
-/// </summary>
+/// <summary>Response from POST /test/host_menu (test-only). Reports whether a host menu is open.</summary>
 public class TestHostMenuResponse
 {
     public bool Success { get; set; }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -196,6 +196,27 @@ public class TestFestivalStateResponse
 
     /// <summary>Current in-game time (HHMM). Jumps to the festival's reset cutoff once it ends.</summary>
     public int TimeOfDay { get; set; }
+
+    /// <summary>
+    /// Count of iridium-quality starfruit (item 268, quality 3) in the Luau soup
+    /// (<c>Game1.player.team.luauIngredients</c>). The mod's OnAnnounce adds exactly one; the #372
+    /// double-add regression would make this 2. Only meaningful during the Luau (0 otherwise).
+    /// </summary>
+    public int LuauIridiumStarfruitCount { get; set; }
+}
+
+/// <summary>
+/// Response from POST /test/host_menu (test-only). Opens or closes an inert host menu
+/// (<c>Game1.activeClickableMenu</c>) to exercise the festival leave-end gate, and reports the
+/// resulting menu-open state.
+/// </summary>
+public class TestHostMenuResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>Whether a host menu is open after the requested operation.</summary>
+    public bool MenuOpen { get; set; }
 }
 
 /// <summary>

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -301,8 +301,6 @@ public partial class ApiService
                 result.FestivalEndReady = Game1.netReady.GetNumberReady("festivalEnd");
                 result.FestivalEndRequired = Game1.netReady.GetNumberRequired("festivalEnd");
                 result.TimeOfDay = Game1.timeOfDay;
-                // Iridium-quality starfruit (item 268, quality 3) in the Luau soup. The mod's
-                // OnAnnounce adds exactly one; the #372 double-add regression would make this 2.
                 result.LuauIridiumStarfruitCount = Game1.player.team.luauIngredients.Count(i =>
                     i is { ParentSheetIndex: 268, Quality: 3 }
                 );
@@ -822,14 +820,8 @@ public partial class ApiService
         HttpListenerRequest request
     )
     {
-        // ?open=true|false. Reproduces the state the grange results DialogueBox creates on the host —
-        // a non-null Game1.activeClickableMenu — so a test can hold HandleFestivalLeave's leave-end
-        // gate (activeClickableMenu is null) closed deterministically across a client's leave vote.
-        // A bare IClickableMenu is used because its parameterless constructor is a no-op and no host
-        // handler clears it (HandleDialogueBox only clears DialogueBox; the naming/minigame/level-up/
-        // shipping handlers key on their own types), so it persists until this endpoint closes it —
-        // unlike the real grange DialogueBox, which HandleDialogueBox dismisses on its ~12s pass. The
-        // gate keys on activeClickableMenu being null, not its type, so any menu exercises it the same.
+        // ?open=true|false. Sets an inert menu that no host handler auto-clears, holding
+        // HandleFestivalLeave's leave-end gate (activeClickableMenu is null) closed until closed here.
         var open = string.Equals(
             request.QueryString["open"],
             "true",
@@ -856,12 +848,7 @@ public partial class ApiService
         return result;
     }
 
-    /// <summary>
-    /// A concrete, inert <see cref="StardewValley.Menus.IClickableMenu"/> for the leave-end gate test:
-    /// the base type is abstract, and both its parameterless constructor and its <c>update</c> are
-    /// no-ops, so this holds <c>Game1.activeClickableMenu</c> non-null with zero side effects and never
-    /// self-closes. Set/cleared only by <c>/test/host_menu</c>.
-    /// </summary>
+    /// <summary>Inert menu holding Game1.activeClickableMenu non-null with no side effects, for /test/host_menu.</summary>
     private sealed class TestHoldMenu : StardewValley.Menus.IClickableMenu { }
 
     [ApiEndpoint(

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -167,6 +167,9 @@ public partial class ApiService
                             await HandlePostTestSetIpConnectionsAsync(request)
                         );
                         return;
+                    case "/test/host_menu":
+                        await WriteJsonAsync(response, await HandlePostTestHostMenuAsync(request));
+                        return;
                     case "/test/break_npc_sprite":
                         await WriteJsonAsync(
                             response,
@@ -298,6 +301,11 @@ public partial class ApiService
                 result.FestivalEndReady = Game1.netReady.GetNumberReady("festivalEnd");
                 result.FestivalEndRequired = Game1.netReady.GetNumberRequired("festivalEnd");
                 result.TimeOfDay = Game1.timeOfDay;
+                // Iridium-quality starfruit (item 268, quality 3) in the Luau soup. The mod's
+                // OnAnnounce adds exactly one; the #372 double-add regression would make this 2.
+                result.LuauIridiumStarfruitCount = Game1.player.team.luauIngredients.Count(i =>
+                    i is { ParentSheetIndex: 268, Quality: 3 }
+                );
                 result.Success = true;
             });
         }
@@ -802,6 +810,59 @@ public partial class ApiService
 
         return result;
     }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/host_menu",
+        Summary = "Open or close an inert host menu to exercise the festival leave-end gate (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestHostMenuResponse), 200)]
+    private async Task<TestHostMenuResponse> HandlePostTestHostMenuAsync(
+        HttpListenerRequest request
+    )
+    {
+        // ?open=true|false. Reproduces the state the grange results DialogueBox creates on the host —
+        // a non-null Game1.activeClickableMenu — so a test can hold HandleFestivalLeave's leave-end
+        // gate (activeClickableMenu is null) closed deterministically across a client's leave vote.
+        // A bare IClickableMenu is used because its parameterless constructor is a no-op and no host
+        // handler clears it (HandleDialogueBox only clears DialogueBox; the naming/minigame/level-up/
+        // shipping handlers key on their own types), so it persists until this endpoint closes it —
+        // unlike the real grange DialogueBox, which HandleDialogueBox dismisses on its ~12s pass. The
+        // gate keys on activeClickableMenu being null, not its type, so any menu exercises it the same.
+        var open = string.Equals(
+            request.QueryString["open"],
+            "true",
+            StringComparison.OrdinalIgnoreCase
+        );
+
+        var result = new TestHostMenuResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                Game1.activeClickableMenu = open ? new TestHoldMenu() : null;
+                result.MenuOpen = Game1.activeClickableMenu != null;
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) — surface via response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// A concrete, inert <see cref="StardewValley.Menus.IClickableMenu"/> for the leave-end gate test:
+    /// the base type is abstract, and both its parameterless constructor and its <c>update</c> are
+    /// no-ops, so this holds <c>Game1.activeClickableMenu</c> non-null with zero side effects and never
+    /// self-closes. Set/cleared only by <c>/test/host_menu</c>.
+    /// </summary>
+    private sealed class TestHoldMenu : StardewValley.Menus.IClickableMenu { }
 
     [ApiEndpoint(
         "POST",

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -600,6 +600,11 @@ public class TestFestivalStateResponse
 
     [JsonPropertyName("timeOfDay")]
     public int TimeOfDay { get; set; }
+
+    /// <summary>Iridium-quality starfruit (item 268, quality 3) in the Luau soup. The mod adds one;
+    /// #372's double-add regression would make this 2. Only meaningful during the Luau.</summary>
+    [JsonPropertyName("luauIridiumStarfruitCount")]
+    public int LuauIridiumStarfruitCount { get; set; }
 }
 
 /// <summary>
@@ -1048,6 +1053,20 @@ public class TestSetIpConnectionsResponse
     /// <summary>The applied state of Game1.options.ipConnectionsEnabled.</summary>
     [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }
+}
+
+/// <summary>Response from /test/host_menu (test-only). Mirrors the server-side DTO.</summary>
+public class TestHostMenuResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>Whether a host menu is open after the requested operation.</summary>
+    [JsonPropertyName("menuOpen")]
+    public bool MenuOpen { get; set; }
 }
 
 /// <summary>Body for /test/import_save (test-only). Mirrors the server-side DTO.</summary>
@@ -2380,6 +2399,22 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestSetIpConnectionsResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: open or close an inert host menu (Game1.activeClickableMenu), reproducing the grange
+    /// results DialogueBox state so a test can hold HandleFestivalLeave's leave-end gate closed across
+    /// a client's leave vote. POST /test/host_menu?open=...
+    /// </summary>
+    public async Task<TestHostMenuResponse?> SetHostMenu(bool open, CancellationToken ct = default)
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            $"/test/host_menu?open={(open ? "true" : "false")}",
+            ct
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestHostMenuResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -601,8 +601,6 @@ public class TestFestivalStateResponse
     [JsonPropertyName("timeOfDay")]
     public int TimeOfDay { get; set; }
 
-    /// <summary>Iridium-quality starfruit (item 268, quality 3) in the Luau soup. The mod adds one;
-    /// #372's double-add regression would make this 2. Only meaningful during the Luau.</summary>
     [JsonPropertyName("luauIridiumStarfruitCount")]
     public int LuauIridiumStarfruitCount { get; set; }
 }
@@ -2402,9 +2400,8 @@ public class ServerApiClient : IDisposable
     }
 
     /// <summary>
-    /// Test-only: open or close an inert host menu (Game1.activeClickableMenu), reproducing the grange
-    /// results DialogueBox state so a test can hold HandleFestivalLeave's leave-end gate closed across
-    /// a client's leave vote. POST /test/host_menu?open=...
+    /// Test-only: open or close an inert host menu (Game1.activeClickableMenu) to exercise the
+    /// festival leave-end gate. POST /test/host_menu?open=...
     /// </summary>
     public async Task<TestHostMenuResponse?> SetHostMenu(bool open, CancellationToken ct = default)
     {

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -73,14 +73,13 @@ public class FestivalTests : TestBase
     private const int EggDay = 13;
     private const int EggBeforeDay = 12;
 
-    // Stardew Valley Fair: Fall 16, main-event, in Town. Test A (the #537 gate). Window Town/900 1500.
+    // Stardew Valley Fair: Fall 16, main-event, in Town.
     private const string FairSeason = "fall";
     private const int FairDay = 16;
     private const int FairBeforeDay = 15;
     private static readonly (int Open, int Close) FairWindow = (900, 1500);
 
-    // Luau: Summer 11, main-event (adds an iridium starfruit to the soup), at the Beach. Test B
-    // (folds in #372). Window Beach/900 1400 — the Luau is on the Beach, not in Town.
+    // Luau: Summer 11, main-event (adds an iridium starfruit to the soup), at the Beach.
     private const string LuauSeason = "summer";
     private const int LuauDay = 11;
     private const int LuauBeforeDay = 10;
@@ -98,11 +97,9 @@ public class FestivalTests : TestBase
     // larger than the old window, far below the SpiritsEveTimeOutSeconds wall-clock backstop.
     private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
 
-    // The Fair's leave can be briefly deferred: HandleFestivalLeave holds off ending while the grange
-    // results DialogueBox is open on the host, and HandleDialogueBox clears that box only on its
-    // once-per-second pass (~12s at SERVER_TPS=5). Allow comfortably more than that cadence for the
-    // end to land — NetworkSyncTimeout (10s) would flake if the box happens to be open when the leave
-    // vote arrives. Only a ceiling: the common (box-already-clear) case ends within ~1s.
+    // The Fair's leave can be briefly deferred while the grange results box is open (HandleDialogueBox
+    // clears it within ~12s), so allow more than NetworkSyncTimeout (10s). A ceiling only — the common
+    // (box-already-clear) case ends within ~1s.
     private static readonly TimeSpan FairLeaveEndTimeout = TimeSpan.FromSeconds(20);
 
     /// <summary>
@@ -369,19 +366,11 @@ public class FestivalTests : TestBase
     }
 
     /// <summary>
-    /// Test A (the #537 gate): the Stardew Valley Fair does not strand the festival after grange
-    /// judging, and a connected player can still leave it.
-    ///
-    /// <para>
-    /// Pre-fix, the Fair carried <c>AutoEndAfterCountdown</c>: when the grange countdown elapsed the
-    /// host both started judging AND called <c>EndFestival(force: false)</c>. With a player present
-    /// that marked only the host <c>festivalEnd</c>-ready and force-opened a ready-check no one could
-    /// satisfy, while latching <c>_startedFestivalEnd</c> so no other exit could ever fire — the
-    /// festival hung forever ("Grange display finished, triggering festival end", then silence).
-    /// Step 1 removes the auto-end so the Fair ends like every other main-event festival; Step 2's
-    /// menu-gated leave keeps the leave working even if the grange results dialogue is briefly open
-    /// on the host when the player votes.
-    /// </para>
+    /// The Stardew Valley Fair does not strand the festival after grange judging, and a connected
+    /// player can still leave it. Pre-fix the Fair auto-ended after the countdown — latching
+    /// <c>_startedFestivalEnd</c> against a host-only <c>festivalEnd</c> ready-check no one could
+    /// satisfy — and hung forever. The auto-end is gone; the leave also survives a briefly-open
+    /// grange results menu on the host.
     /// </summary>
     [Fact]
     public async Task Fair_DoesNotStrandFestival_AndLeavesCleanly()
@@ -399,10 +388,8 @@ public class FestivalTests : TestBase
             ct
         );
 
-        // The host announces the grange countdown within ~1s of the festival becoming active.
-        // Waiting for it confirms we entered the real main-event festival before skipping the
-        // countdown (and, per the runtime gate, the container log is checked for this announce with
-        // NO "Grange display finished, triggering festival end" line following it).
+        // Wait for the grange countdown announce to confirm we entered the main-event festival before
+        // skipping the countdown.
         var announce = await GameClient.Chat.WaitForMessageContainingAsync(
             new[] { "Grange Judging", "!event" },
             timeout: TestTimings.ChatCommandTimeout
@@ -414,9 +401,7 @@ public class FestivalTests : TestBase
         Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
 
         // Primary regression assertion: after judging fires, the festival must stay active with the
-        // host's festivalEnd ready NEVER set. Pre-fix the auto-end set FestivalEndReady >= 1 and
-        // force-opened the host ready-check — the exact deadlock. Poll the settle window and fail the
-        // moment the festival ends early or a host festivalEnd ready appears.
+        // host's festivalEnd ready never set. Fail the moment it ends early or a host ready appears.
         var stranded = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_Festival_FairNoAutoEnd,
             async () =>
@@ -430,9 +415,7 @@ public class FestivalTests : TestBase
         Assert.False(
             stranded,
             "The Fair auto-ended after the grange countdown (festival inactive or FestivalEndReady "
-                + ">= 1 within the settle window). Pre-fix, AutoEndAfterCountdown did exactly this — "
-                + "marking only the host festivalEnd-ready and latching _startedFestivalEnd — which "
-                + "deadlocked the festival. Step 1 removed the auto-end."
+                + ">= 1 within the settle window) — it must stay active with no host festivalEnd ready."
         );
 
         var midState = await ServerApi.GetFestivalState(ct);
@@ -443,13 +426,11 @@ public class FestivalTests : TestBase
         );
         Assert.True(
             midState.FestivalEndReady == 0,
-            $"No festivalEnd ready should be set after judging; got {midState.FestivalEndReady} "
-                + "(pre-fix the auto-end set the host's own festivalEnd ready and opened the ready-check)."
+            $"No festivalEnd ready should be set after judging; got {midState.FestivalEndReady}."
         );
 
         // End-to-end gate: a connected player can leave normally, proving _startedFestivalEnd was
-        // never prematurely latched. Step 2 makes this deterministic even if the grange results
-        // dialogue is transiently open on the host when the leave vote lands.
+        // never prematurely latched (the menu gate keeps this working even if the grange box is open).
         var leave = await GameClient.Actions.LeaveFestival();
         Assert.NotNull(leave);
         Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
@@ -467,33 +448,19 @@ public class FestivalTests : TestBase
         Assert.True(
             ended,
             "The Fair should end after the connected player votes to leave — a latched "
-                + "_startedFestivalEnd (the pre-fix auto-end, or an unguarded force:false end while the "
-                + "grange results dialogue was open) would make HandleFestivalLeave early-return and "
-                + "ignore the leave vote."
+                + "_startedFestivalEnd would make HandleFestivalLeave early-return and ignore the vote."
         );
         LogSuccess("Fair stayed active after judging (no auto-end) and ended cleanly on leave");
     }
 
     /// <summary>
-    /// Test C (the Step 2 gate): a leave vote that lands while a host menu is open must be deferred —
-    /// not latch <c>_startedFestivalEnd</c> — and must fire once the menu clears.
-    ///
-    /// <para>
-    /// Removing the auto-end (Step 1) newly exposes the grange results <c>DialogueBox</c> on the host
-    /// after judging. <c>TryStartEndFestivalDialogue</c> no-ops while any menu is open, but
-    /// <c>EndFestival</c> latches <c>_startedFestivalEnd</c> unconditionally — so an unguarded
-    /// <c>force:false</c> end during that window would re-strand the festival with no exit (the #537
-    /// deadlock, now reachable via the results box). Step 2 gates both graceful ends on no open host
-    /// menu.
-    /// </para>
-    ///
-    /// <para>
-    /// The gate keys on <c>Game1.activeClickableMenu is null</c>, not the menu's type, so this holds an
-    /// inert host menu open across the leave vote — a deterministic stand-in for the grange box, whose
-    /// real open/close timing on a render-suppressed host is nondeterministic. Test A covers the
-    /// judging/no-auto-end path; this isolates the menu-open deferral. The last assertion is the
-    /// discriminator: pre-fix, the vote latches on the open menu and the festival never ends.
-    /// </para>
+    /// A leave vote that lands while a host menu is open must be deferred — not latch
+    /// <c>_startedFestivalEnd</c> — and must fire once the menu clears. <c>TryStartEndFestivalDialogue</c>
+    /// no-ops while a menu is open but <c>EndFestival</c> latches unconditionally, so an unguarded end
+    /// during that window would strand the festival. Holds an inert host menu open across the vote — a
+    /// deterministic stand-in for the transient grange results box, since the gate keys on
+    /// <c>Game1.activeClickableMenu is null</c>, not the menu type. The final assertion is the
+    /// discriminator: without the gate the vote latches on the open menu and the festival never ends.
     /// </summary>
     [Fact]
     public async Task Fair_DefersLeaveWhileHostMenuOpen_ThenEndsWhenCleared()
@@ -511,11 +478,9 @@ public class FestivalTests : TestBase
             ct
         );
 
-        // Open a host menu on the active (idle-countdown) Fair, reproducing the state the grange
-        // results DialogueBox creates — a non-null Game1.activeClickableMenu. No host handler clears an
-        // inert menu, so it stays open until we close it below, holding the leave-end gate closed
-        // deterministically across the vote. (No !event: on the idle countdown no grange event runs to
-        // open a dialogue over it, and the leave path runs every tick regardless of the countdown.)
+        // Open an inert host menu on the active (idle-countdown) Fair. Nothing clears it, so it holds
+        // the leave-end gate closed until we close it below. (No !event needed: the leave path runs
+        // every tick regardless of the countdown.)
         var opened = await ServerApi.SetHostMenu(open: true, ct);
         Assert.True(
             opened?.Success == true && opened.MenuOpen,
@@ -542,8 +507,7 @@ public class FestivalTests : TestBase
         Assert.True(voteSynced, "The client's festivalEnd vote should replicate to the host.");
 
         // Deferral: with the vote present but a host menu open, the Fair must NOT end across the settle
-        // window — HandleFestivalLeave holds off, never latching _startedFestivalEnd. (The menu stays
-        // open the whole window: nothing clears an inert menu, and we only close it below.)
+        // window — HandleFestivalLeave holds off, never latching _startedFestivalEnd.
         var endedWhileMenuOpen = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_Festival_FairDeferredHold,
             async () =>
@@ -560,9 +524,7 @@ public class FestivalTests : TestBase
                 + "force-ended or latched."
         );
 
-        // Release: close the host menu. The deferred leave must now fire and end the Fair. Pre-fix, the
-        // force:false end latched _startedFestivalEnd while the menu was open, so HandleFestivalLeave
-        // early-returns forever and the festival never ends here — the #537 strand via the results box.
+        // Release: close the host menu. The deferred leave must now fire and end the Fair.
         var closed = await ServerApi.SetHostMenu(open: false, ct);
         Assert.True(
             closed?.Success == true && !closed.MenuOpen,
@@ -582,8 +544,7 @@ public class FestivalTests : TestBase
         Assert.True(
             ended,
             "After the host menu cleared, the deferred leave should end the Fair. A latched "
-                + "_startedFestivalEnd (the pre-fix unconditional latch on the force:false end while a "
-                + "host menu was open) would make HandleFestivalLeave early-return and strand it."
+                + "_startedFestivalEnd would make HandleFestivalLeave early-return and strand it."
         );
         LogSuccess(
             "Fair deferred the leave while a host menu was open, then ended cleanly once it cleared"
@@ -591,16 +552,11 @@ public class FestivalTests : TestBase
     }
 
     /// <summary>
-    /// Test B (folds in the #372 verification): the Luau adds the iridium starfruit to the soup
-    /// exactly once, even when <c>!event</c> fast-forwards the countdown after the on-entry announce.
-    ///
-    /// <para>
-    /// #372: the iridium starfruit was added twice when <c>!event</c> was used mid-countdown. It is
-    /// already fixed in the tree — the <c>!event</c> fast-forward guards its <c>OnAnnounce</c> with
-    /// <c>if (!_announced)</c> — but nothing locked it in. This test is that lock: enter the Luau (the
-    /// on-entry announce adds the starfruit once), then <c>!event</c> (the announce-then-!event
-    /// ordering #372 reproduces under), and assert the soup still holds exactly one iridium starfruit.
-    /// </para>
+    /// The Luau adds the iridium starfruit to the soup exactly once, even when <c>!event</c>
+    /// fast-forwards the countdown after the on-entry announce. The <c>!event</c> fast-forward guards
+    /// its <c>OnAnnounce</c> with <c>if (!_announced)</c>; this test locks that in — enter the Luau (the
+    /// on-entry announce adds the starfruit once), then <c>!event</c>, and assert the soup still holds
+    /// exactly one.
     /// </summary>
     [Fact]
     public async Task Luau_AddsIridiumStarfruitExactlyOnce()
@@ -618,10 +574,8 @@ public class FestivalTests : TestBase
             ct
         );
 
-        // The on-entry announce adds the starfruit once (OnAnnounce = AddIridiumStarfruitToSoup) and
-        // is broadcast as the "Soup Tasting" countdown message. Waiting for it guarantees the single
-        // on-entry add has run before we send !event — the exact announce-then-!event ordering #372
-        // reproduces under.
+        // The on-entry announce (OnAnnounce = AddIridiumStarfruitToSoup) adds the starfruit once and is
+        // broadcast as the "Soup Tasting" message. Waiting for it guarantees the add ran before !event.
         var announce = await GameClient.Chat.WaitForMessageContainingAsync(
             new[] { "Soup Tasting", "!event" },
             timeout: TestTimings.ChatCommandTimeout
@@ -644,8 +598,8 @@ public class FestivalTests : TestBase
             "The Luau on-entry announce should add exactly one iridium starfruit to the soup."
         );
 
-        // Fast-forward the countdown. Pre-#363 this re-ran OnAnnounce and added a SECOND starfruit;
-        // the if (!_announced) guard now skips it. The main event fires in the same pass.
+        // Fast-forward the countdown. Without the if (!_announced) guard this re-runs OnAnnounce and
+        // adds a second starfruit. The main event fires in the same pass.
         var sent = await GameClient.Chat.Send("!event");
         Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
 
@@ -663,9 +617,8 @@ public class FestivalTests : TestBase
         );
         Assert.False(
             doubleAdded,
-            "The Luau soup held more than one iridium starfruit after !event — the #372 double-add. "
-                + "The !event fast-forward must guard OnAnnounce with if (!_announced) so the starfruit "
-                + "is added exactly once per festival."
+            "The Luau soup held more than one iridium starfruit after !event — the !event fast-forward "
+                + "must guard OnAnnounce with if (!_announced) so the starfruit is added exactly once."
         );
 
         var finalState = await ServerApi.GetFestivalState(ct);

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -487,68 +487,80 @@ public class FestivalTests : TestBase
             $"Failed to open the host menu for the deferral scenario: {opened?.Error}"
         );
 
-        // The connected player votes to leave WHILE the host menu is open.
-        var leave = await GameClient.Actions.LeaveFestival();
-        Assert.NotNull(leave);
-        Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
+        // Wrap the rest in try/finally: the open menu is shared host state on this shared-class
+        // server, so it must be cleared even if an assertion fails or the test is cancelled — a
+        // leaked menu would hold the next festival test's leave-end gate closed.
+        try
+        {
+            // The connected player votes to leave WHILE the host menu is open.
+            var leave = await GameClient.Actions.LeaveFestival();
+            Assert.NotNull(leave);
+            Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
 
-        // Confirm the vote replicated to the host, so the deferral asserted next is genuinely "vote
-        // present but held", not "vote not yet arrived".
-        var voteSynced = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_Festival_FairLeaveVoteSynced,
-            async () =>
-            {
-                var state = await ServerApi.GetFestivalState(ct);
-                return state?.FestivalEndReady >= 1;
-            },
-            timeout: TestTimings.NetworkSyncTimeout,
-            cancellationToken: ct
-        );
-        Assert.True(voteSynced, "The client's festivalEnd vote should replicate to the host.");
+            // Confirm the vote replicated to the host, so the deferral asserted next is genuinely "vote
+            // present but held", not "vote not yet arrived".
+            var voteSynced = await PollingHelper.WaitUntilAsync(
+                WaitName.Polling_Festival_FairLeaveVoteSynced,
+                async () =>
+                {
+                    var state = await ServerApi.GetFestivalState(ct);
+                    return state?.FestivalEndReady >= 1;
+                },
+                timeout: TestTimings.NetworkSyncTimeout,
+                cancellationToken: ct
+            );
+            Assert.True(voteSynced, "The client's festivalEnd vote should replicate to the host.");
 
-        // Deferral: with the vote present but a host menu open, the Fair must NOT end across the settle
-        // window — HandleFestivalLeave holds off, never latching _startedFestivalEnd.
-        var endedWhileMenuOpen = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_Festival_FairDeferredHold,
-            async () =>
-            {
-                var state = await ServerApi.GetFestivalState(ct);
-                return state?.IsFestivalActive != true;
-            },
-            timeout: FestivalSettleWindow,
-            cancellationToken: ct
-        );
-        Assert.False(
-            endedWhileMenuOpen,
-            "While a host menu was open, the Fair must not end — the leave vote must be deferred, not "
-                + "force-ended or latched."
-        );
+            // Deferral: with the vote present but a host menu open, the Fair must NOT end across the
+            // settle window — HandleFestivalLeave holds off, never latching _startedFestivalEnd.
+            var endedWhileMenuOpen = await PollingHelper.WaitUntilAsync(
+                WaitName.Polling_Festival_FairDeferredHold,
+                async () =>
+                {
+                    var state = await ServerApi.GetFestivalState(ct);
+                    return state?.IsFestivalActive != true;
+                },
+                timeout: FestivalSettleWindow,
+                cancellationToken: ct
+            );
+            Assert.False(
+                endedWhileMenuOpen,
+                "While a host menu was open, the Fair must not end — the leave vote must be deferred, "
+                    + "not force-ended or latched."
+            );
 
-        // Release: close the host menu. The deferred leave must now fire and end the Fair.
-        var closed = await ServerApi.SetHostMenu(open: false, ct);
-        Assert.True(
-            closed?.Success == true && !closed.MenuOpen,
-            $"Failed to close the host menu: {closed?.Error}"
-        );
+            // Release: close the host menu. The deferred leave must now fire and end the Fair.
+            var closed = await ServerApi.SetHostMenu(open: false, ct);
+            Assert.True(
+                closed?.Success == true && !closed.MenuOpen,
+                $"Failed to close the host menu: {closed?.Error}"
+            );
 
-        var ended = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_Festival_FairEndedAfterMenuCleared,
-            async () =>
-            {
-                var state = await ServerApi.GetFestivalState(ct);
-                return state?.IsFestivalActive == false;
-            },
-            timeout: TestTimings.NetworkSyncTimeout,
-            cancellationToken: ct
-        );
-        Assert.True(
-            ended,
-            "After the host menu cleared, the deferred leave should end the Fair. A latched "
-                + "_startedFestivalEnd would make HandleFestivalLeave early-return and strand it."
-        );
-        LogSuccess(
-            "Fair deferred the leave while a host menu was open, then ended cleanly once it cleared"
-        );
+            var ended = await PollingHelper.WaitUntilAsync(
+                WaitName.Polling_Festival_FairEndedAfterMenuCleared,
+                async () =>
+                {
+                    var state = await ServerApi.GetFestivalState(ct);
+                    return state?.IsFestivalActive == false;
+                },
+                timeout: TestTimings.NetworkSyncTimeout,
+                cancellationToken: ct
+            );
+            Assert.True(
+                ended,
+                "After the host menu cleared, the deferred leave should end the Fair. A latched "
+                    + "_startedFestivalEnd would make HandleFestivalLeave early-return and strand it."
+            );
+            LogSuccess(
+                "Fair deferred the leave while a host menu was open, then ended cleanly once it cleared"
+            );
+        }
+        finally
+        {
+            // Non-cancellable so cleanup still runs if ct was cancelled. Idempotent on the happy path
+            // (the menu is already closed above).
+            await ServerApi.SetHostMenu(open: false, CancellationToken.None);
+        }
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -565,10 +565,9 @@ public class FestivalTests : TestBase
 
     /// <summary>
     /// The Luau adds the iridium starfruit to the soup exactly once, even when <c>!event</c>
-    /// fast-forwards the countdown after the on-entry announce. The <c>!event</c> fast-forward guards
-    /// its <c>OnAnnounce</c> with <c>if (!_announced)</c>; this test locks that in — enter the Luau (the
-    /// on-entry announce adds the starfruit once), then <c>!event</c>, and assert the soup still holds
-    /// exactly one.
+    /// fast-forwards the countdown after the on-entry announce. This test locks that in — enter the
+    /// Luau (the on-entry announce adds the starfruit once), then <c>!event</c>, and assert the soup
+    /// still holds exactly one.
     /// </summary>
     [Fact]
     public async Task Luau_AddsIridiumStarfruitExactlyOnce()
@@ -610,8 +609,8 @@ public class FestivalTests : TestBase
             "The Luau on-entry announce should add exactly one iridium starfruit to the soup."
         );
 
-        // Fast-forward the countdown. Without the if (!_announced) guard this re-runs OnAnnounce and
-        // adds a second starfruit. The main event fires in the same pass.
+        // Fast-forward the countdown — this must not re-add the starfruit. The main event fires in the
+        // same pass.
         var sent = await GameClient.Chat.Send("!event");
         Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
 
@@ -629,8 +628,8 @@ public class FestivalTests : TestBase
         );
         Assert.False(
             doubleAdded,
-            "The Luau soup held more than one iridium starfruit after !event — the !event fast-forward "
-                + "must guard OnAnnounce with if (!_announced) so the starfruit is added exactly once."
+            "The Luau soup held more than one iridium starfruit after !event — it must be added exactly "
+                + "once per festival, even when !event fast-forwards the countdown."
         );
 
         var finalState = await ServerApi.GetFestivalState(ct);

--- a/tests/JunimoServer.Tests/FestivalTests.cs
+++ b/tests/JunimoServer.Tests/FestivalTests.cs
@@ -73,15 +73,37 @@ public class FestivalTests : TestBase
     private const int EggDay = 13;
     private const int EggBeforeDay = 12;
 
-    // Per-map warp-in tiles (the engine's own area-warp tiles, Game1.cs:13204/13212).
+    // Stardew Valley Fair: Fall 16, main-event, in Town. Test A (the #537 gate). Window Town/900 1500.
+    private const string FairSeason = "fall";
+    private const int FairDay = 16;
+    private const int FairBeforeDay = 15;
+    private static readonly (int Open, int Close) FairWindow = (900, 1500);
+
+    // Luau: Summer 11, main-event (adds an iridium starfruit to the soup), at the Beach. Test B
+    // (folds in #372). Window Beach/900 1400 — the Luau is on the Beach, not in Town.
+    private const string LuauSeason = "summer";
+    private const int LuauDay = 11;
+    private const int LuauBeforeDay = 10;
+    private static readonly (int Open, int Close) LuauWindow = (900, 1400);
+    private const string LuauLocation = "Beach";
+
+    // Per-map warp-in tiles (the engine's own area-warp tiles, Game1.cs:13204/13212/13216).
     // warpFarmer's festival-entry guard keys on the location NAME matching whereIsTodaysFest,
     // not the tile, so any in-bounds tile on the festival map triggers entry.
     private static readonly (int X, int Y) TownEntryTile = (35, 35);
     private static readonly (int X, int Y) ForestEntryTile = (34, 13);
+    private static readonly (int X, int Y) BeachEntryTile = (34, 10);
 
     // How long a festival must stay active to prove the immediate auto-end is gone. Comfortably
     // larger than the old window, far below the SpiritsEveTimeOutSeconds wall-clock backstop.
     private static readonly TimeSpan FestivalSettleWindow = TimeSpan.FromSeconds(6);
+
+    // The Fair's leave can be briefly deferred: HandleFestivalLeave holds off ending while the grange
+    // results DialogueBox is open on the host, and HandleDialogueBox clears that box only on its
+    // once-per-second pass (~12s at SERVER_TPS=5). Allow comfortably more than that cadence for the
+    // end to land — NetworkSyncTimeout (10s) would flake if the box happens to be open when the leave
+    // vote arrives. Only a ceiling: the common (box-already-clear) case ends within ~1s.
+    private static readonly TimeSpan FairLeaveEndTimeout = TimeSpan.FromSeconds(20);
 
     /// <summary>
     /// Test 1 (the regression gate): Spirit's Eve does NOT auto-end immediately.
@@ -344,6 +366,317 @@ public class FestivalTests : TestBase
                 + "!event must start the main event in place, not end the festival."
         );
         LogSuccess("Egg Festival accepted the !event countdown skip and kept running");
+    }
+
+    /// <summary>
+    /// Test A (the #537 gate): the Stardew Valley Fair does not strand the festival after grange
+    /// judging, and a connected player can still leave it.
+    ///
+    /// <para>
+    /// Pre-fix, the Fair carried <c>AutoEndAfterCountdown</c>: when the grange countdown elapsed the
+    /// host both started judging AND called <c>EndFestival(force: false)</c>. With a player present
+    /// that marked only the host <c>festivalEnd</c>-ready and force-opened a ready-check no one could
+    /// satisfy, while latching <c>_startedFestivalEnd</c> so no other exit could ever fire — the
+    /// festival hung forever ("Grange display finished, triggering festival end", then silence).
+    /// Step 1 removes the auto-end so the Fair ends like every other main-event festival; Step 2's
+    /// menu-gated leave keeps the leave working even if the grange results dialogue is briefly open
+    /// on the host when the player votes.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Fair_DoesNotStrandFestival_AndLeavesCleanly()
+    {
+        var ct = TestCt;
+
+        await EnterFestivalAsync(
+            FairSeason,
+            FairBeforeDay,
+            FairDay,
+            FairWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestFair",
+            ct
+        );
+
+        // The host announces the grange countdown within ~1s of the festival becoming active.
+        // Waiting for it confirms we entered the real main-event festival before skipping the
+        // countdown (and, per the runtime gate, the container log is checked for this announce with
+        // NO "Grange display finished, triggering festival end" line following it).
+        var announce = await GameClient.Chat.WaitForMessageContainingAsync(
+            new[] { "Grange Judging", "!event" },
+            timeout: TestTimings.ChatCommandTimeout
+        );
+        Assert.NotNull(announce);
+
+        // Skip the 5-minute countdown so grange judging fires immediately (mirrors the Egg test).
+        var sent = await GameClient.Chat.Send("!event");
+        Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
+
+        // Primary regression assertion: after judging fires, the festival must stay active with the
+        // host's festivalEnd ready NEVER set. Pre-fix the auto-end set FestivalEndReady >= 1 and
+        // force-opened the host ready-check — the exact deadlock. Poll the settle window and fail the
+        // moment the festival ends early or a host festivalEnd ready appears.
+        var stranded = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_FairNoAutoEnd,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive != true || state.FestivalEndReady >= 1;
+            },
+            timeout: FestivalSettleWindow,
+            cancellationToken: ct
+        );
+        Assert.False(
+            stranded,
+            "The Fair auto-ended after the grange countdown (festival inactive or FestivalEndReady "
+                + ">= 1 within the settle window). Pre-fix, AutoEndAfterCountdown did exactly this — "
+                + "marking only the host festivalEnd-ready and latching _startedFestivalEnd — which "
+                + "deadlocked the festival. Step 1 removed the auto-end."
+        );
+
+        var midState = await ServerApi.GetFestivalState(ct);
+        Assert.NotNull(midState);
+        Assert.True(
+            midState.IsFestivalActive,
+            "The Fair should still be active after grange judging (it ends only on player-leave/timeout)."
+        );
+        Assert.True(
+            midState.FestivalEndReady == 0,
+            $"No festivalEnd ready should be set after judging; got {midState.FestivalEndReady} "
+                + "(pre-fix the auto-end set the host's own festivalEnd ready and opened the ready-check)."
+        );
+
+        // End-to-end gate: a connected player can leave normally, proving _startedFestivalEnd was
+        // never prematurely latched. Step 2 makes this deterministic even if the grange results
+        // dialogue is transiently open on the host when the leave vote lands.
+        var leave = await GameClient.Actions.LeaveFestival();
+        Assert.NotNull(leave);
+        Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
+
+        var ended = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_FairEndedOnLeave,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == false;
+            },
+            timeout: FairLeaveEndTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ended,
+            "The Fair should end after the connected player votes to leave — a latched "
+                + "_startedFestivalEnd (the pre-fix auto-end, or an unguarded force:false end while the "
+                + "grange results dialogue was open) would make HandleFestivalLeave early-return and "
+                + "ignore the leave vote."
+        );
+        LogSuccess("Fair stayed active after judging (no auto-end) and ended cleanly on leave");
+    }
+
+    /// <summary>
+    /// Test C (the Step 2 gate): a leave vote that lands while a host menu is open must be deferred —
+    /// not latch <c>_startedFestivalEnd</c> — and must fire once the menu clears.
+    ///
+    /// <para>
+    /// Removing the auto-end (Step 1) newly exposes the grange results <c>DialogueBox</c> on the host
+    /// after judging. <c>TryStartEndFestivalDialogue</c> no-ops while any menu is open, but
+    /// <c>EndFestival</c> latches <c>_startedFestivalEnd</c> unconditionally — so an unguarded
+    /// <c>force:false</c> end during that window would re-strand the festival with no exit (the #537
+    /// deadlock, now reachable via the results box). Step 2 gates both graceful ends on no open host
+    /// menu.
+    /// </para>
+    ///
+    /// <para>
+    /// The gate keys on <c>Game1.activeClickableMenu is null</c>, not the menu's type, so this holds an
+    /// inert host menu open across the leave vote — a deterministic stand-in for the grange box, whose
+    /// real open/close timing on a render-suppressed host is nondeterministic. Test A covers the
+    /// judging/no-auto-end path; this isolates the menu-open deferral. The last assertion is the
+    /// discriminator: pre-fix, the vote latches on the open menu and the festival never ends.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Fair_DefersLeaveWhileHostMenuOpen_ThenEndsWhenCleared()
+    {
+        var ct = TestCt;
+
+        await EnterFestivalAsync(
+            FairSeason,
+            FairBeforeDay,
+            FairDay,
+            FairWindow,
+            "Town",
+            TownEntryTile,
+            namePrefix: "FestFairMenu",
+            ct
+        );
+
+        // Open a host menu on the active (idle-countdown) Fair, reproducing the state the grange
+        // results DialogueBox creates — a non-null Game1.activeClickableMenu. No host handler clears an
+        // inert menu, so it stays open until we close it below, holding the leave-end gate closed
+        // deterministically across the vote. (No !event: on the idle countdown no grange event runs to
+        // open a dialogue over it, and the leave path runs every tick regardless of the countdown.)
+        var opened = await ServerApi.SetHostMenu(open: true, ct);
+        Assert.True(
+            opened?.Success == true && opened.MenuOpen,
+            $"Failed to open the host menu for the deferral scenario: {opened?.Error}"
+        );
+
+        // The connected player votes to leave WHILE the host menu is open.
+        var leave = await GameClient.Actions.LeaveFestival();
+        Assert.NotNull(leave);
+        Assert.True(leave.Success, $"leave_festival action failed: {leave.Error}");
+
+        // Confirm the vote replicated to the host, so the deferral asserted next is genuinely "vote
+        // present but held", not "vote not yet arrived".
+        var voteSynced = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_FairLeaveVoteSynced,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.FestivalEndReady >= 1;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(voteSynced, "The client's festivalEnd vote should replicate to the host.");
+
+        // Deferral: with the vote present but a host menu open, the Fair must NOT end across the settle
+        // window — HandleFestivalLeave holds off, never latching _startedFestivalEnd. (The menu stays
+        // open the whole window: nothing clears an inert menu, and we only close it below.)
+        var endedWhileMenuOpen = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_FairDeferredHold,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive != true;
+            },
+            timeout: FestivalSettleWindow,
+            cancellationToken: ct
+        );
+        Assert.False(
+            endedWhileMenuOpen,
+            "While a host menu was open, the Fair must not end — the leave vote must be deferred, not "
+                + "force-ended or latched."
+        );
+
+        // Release: close the host menu. The deferred leave must now fire and end the Fair. Pre-fix, the
+        // force:false end latched _startedFestivalEnd while the menu was open, so HandleFestivalLeave
+        // early-returns forever and the festival never ends here — the #537 strand via the results box.
+        var closed = await ServerApi.SetHostMenu(open: false, ct);
+        Assert.True(
+            closed?.Success == true && !closed.MenuOpen,
+            $"Failed to close the host menu: {closed?.Error}"
+        );
+
+        var ended = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_FairEndedAfterMenuCleared,
+            async () =>
+            {
+                var state = await ServerApi.GetFestivalState(ct);
+                return state?.IsFestivalActive == false;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            ended,
+            "After the host menu cleared, the deferred leave should end the Fair. A latched "
+                + "_startedFestivalEnd (the pre-fix unconditional latch on the force:false end while a "
+                + "host menu was open) would make HandleFestivalLeave early-return and strand it."
+        );
+        LogSuccess(
+            "Fair deferred the leave while a host menu was open, then ended cleanly once it cleared"
+        );
+    }
+
+    /// <summary>
+    /// Test B (folds in the #372 verification): the Luau adds the iridium starfruit to the soup
+    /// exactly once, even when <c>!event</c> fast-forwards the countdown after the on-entry announce.
+    ///
+    /// <para>
+    /// #372: the iridium starfruit was added twice when <c>!event</c> was used mid-countdown. It is
+    /// already fixed in the tree — the <c>!event</c> fast-forward guards its <c>OnAnnounce</c> with
+    /// <c>if (!_announced)</c> — but nothing locked it in. This test is that lock: enter the Luau (the
+    /// on-entry announce adds the starfruit once), then <c>!event</c> (the announce-then-!event
+    /// ordering #372 reproduces under), and assert the soup still holds exactly one iridium starfruit.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public async Task Luau_AddsIridiumStarfruitExactlyOnce()
+    {
+        var ct = TestCt;
+
+        await EnterFestivalAsync(
+            LuauSeason,
+            LuauBeforeDay,
+            LuauDay,
+            LuauWindow,
+            LuauLocation,
+            BeachEntryTile,
+            namePrefix: "FestLuau",
+            ct
+        );
+
+        // The on-entry announce adds the starfruit once (OnAnnounce = AddIridiumStarfruitToSoup) and
+        // is broadcast as the "Soup Tasting" countdown message. Waiting for it guarantees the single
+        // on-entry add has run before we send !event — the exact announce-then-!event ordering #372
+        // reproduces under.
+        var announce = await GameClient.Chat.WaitForMessageContainingAsync(
+            new[] { "Soup Tasting", "!event" },
+            timeout: TestTimings.ChatCommandTimeout
+        );
+        Assert.NotNull(announce);
+
+        // Confirm the on-entry add is observable as exactly one before fast-forwarding.
+        var addedOnce = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_LuauStarfruitAdded,
+            async () =>
+            {
+                var s = await ServerApi.GetFestivalState(ct);
+                return s?.LuauIridiumStarfruitCount == 1;
+            },
+            timeout: TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            addedOnce,
+            "The Luau on-entry announce should add exactly one iridium starfruit to the soup."
+        );
+
+        // Fast-forward the countdown. Pre-#363 this re-ran OnAnnounce and added a SECOND starfruit;
+        // the if (!_announced) guard now skips it. The main event fires in the same pass.
+        var sent = await GameClient.Chat.Send("!event");
+        Assert.True(sent?.Success == true, $"Sending !event failed: {sent?.Error}");
+
+        // Assert the count never exceeds one across the settle window. A regressed guard adds the
+        // second starfruit in the same tick !event is consumed, so it is caught on the first poll.
+        var doubleAdded = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_Festival_LuauStarfruitStaysOne,
+            async () =>
+            {
+                var s = await ServerApi.GetFestivalState(ct);
+                return s?.LuauIridiumStarfruitCount is > 1;
+            },
+            timeout: FestivalSettleWindow,
+            cancellationToken: ct
+        );
+        Assert.False(
+            doubleAdded,
+            "The Luau soup held more than one iridium starfruit after !event — the #372 double-add. "
+                + "The !event fast-forward must guard OnAnnounce with if (!_announced) so the starfruit "
+                + "is added exactly once per festival."
+        );
+
+        var finalState = await ServerApi.GetFestivalState(ct);
+        Assert.NotNull(finalState);
+        Assert.True(finalState.Success, $"festival_state read failed: {finalState.Error}");
+        Assert.True(
+            finalState.LuauIridiumStarfruitCount == 1,
+            "Expected exactly one iridium starfruit in the Luau soup after !event; got "
+                + $"{finalState.LuauIridiumStarfruitCount}."
+        );
+        LogSuccess("Luau added the iridium starfruit exactly once across the !event fast-forward");
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -184,7 +184,7 @@ public enum WaitName
     Polling_CabinPlacement_Moved,
     Polling_CabinPlacement_Rejected,
 
-    // FestivalTests.cs (8)
+    // FestivalTests.cs (15)
     Polling_Festival_DayConfirmed,
     Polling_Festival_ClientWindowSynced,
     Polling_Festival_BecameActive,
@@ -193,6 +193,13 @@ public enum WaitName
     Polling_Festival_EndedNoPlayers,
     Polling_Festival_NextFestivalEndedOnLeave,
     Polling_Festival_MainEventStillActive,
+    Polling_Festival_FairNoAutoEnd,
+    Polling_Festival_FairEndedOnLeave,
+    Polling_Festival_LuauStarfruitAdded,
+    Polling_Festival_LuauStarfruitStaysOne,
+    Polling_Festival_FairLeaveVoteSynced,
+    Polling_Festival_FairDeferredHold,
+    Polling_Festival_FairEndedAfterMenuCleared,
 
     // WeddingTests.cs (5)
     Polling_Wedding_EngagementReplicated,


### PR DESCRIPTION
Closes #537. Also folds in a regression test that locks in #372 (Luau double-starfruit, code-fixed earlier in #363).

## The bug (#537)

The Stardew Valley Fair carried `AutoEndAfterCountdown`: when the grange-display countdown elapsed, the host started grange judging **and**, on the same pass, called `EndFestival(force: false)`. With a player present, that marked only the host `festivalEnd`-ready and opened a ready-check no one could satisfy, while latching `_startedFestivalEnd` so no other exit (player-leave, timeout backstop, reset-cutoff) could fire. The Fair hung forever after `Grange display finished, triggering festival end`; only a server restart recovered.

## The fix

- **Remove the Fair's auto-end** (`AutoEndAfterCountdown`/`EndLogText`) so it ends like every other main-event festival — the `festivalEnd` player-leave ready-check or the ~33 min wall-clock backstop. This mirrors vanilla `DedicatedServer`, which ends festivals only via `CheckOthersReady("festivalEnd")` or the no-players path and never auto-ends the Fair.
- **Menu-gate the two graceful ends in `HandleFestivalLeave`.** Removing the auto-end newly exposes the grange results `DialogueBox` on the host. `TryStartEndFestivalDialogue` no-ops while a menu is open, but `EndFestival` latches `_startedFestivalEnd` unconditionally — which would re-strand the festival with no exit. Both `force: false` ends are now gated on no open host menu; the box is cleared within ~12s and the leave fires cleanly on a later tick. The wall-clock timeout backstop is unaffected (it force-ends regardless of any menu).

## #372 lock-in

- Add a test-only `LuauIridiumStarfruitCount` to `/test/festival_state` (surfaced on `ServerApiClient.GetFestivalState`) and a regression test asserting the Luau adds the iridium starfruit to the soup exactly once across an `!event` fast-forward.

## Tests

- `Fair_DoesNotStrandFestival_AndLeavesCleanly` — the Fair stays active after grange judging with no host `festivalEnd` ready set, then ends cleanly when a connected player votes to leave (Step 1 gate).
- `Fair_DefersLeaveWhileHostMenuOpen_ThenEndsWhenCleared` — a leave vote that lands while a host menu is open is **deferred** (festival stays active, not latched), then fires and ends the Fair once the menu clears (Step 2 gate). It drives a test-only `POST /test/host_menu` endpoint that holds an inert `IClickableMenu` open — a deterministic stand-in for the transient grange results box (the gate keys on `activeClickableMenu is null`, not the menu's type). Without Step 2 the vote latches `_startedFestivalEnd` on the open menu and the festival never ends, so the final assertion fails.
- `Luau_AddsIridiumStarfruitExactlyOnce` — the soup holds exactly one iridium starfruit through the announce-then-`!event` ordering #372 reproduces under.

## Docs

- `festival-handling.md`: rewrite the auto-end paragraph and update the Fair's table row.

## Verification

- Static: mod + tests build clean.
- The fix plus the Luau and no-auto-end Fair tests were green in a prior `FILTER=FestivalTests` run (6/6), with the server log confirming the Fair enters, grange judging fires, `festivalEnd` stays 0 (no auto-end, no `Grange display finished` line), and the leave completes; the Luau adds the starfruit exactly once.
- The new menu-deferral gate (`Fair_DefersLeaveWhileHostMenuOpen_ThenEndsWhenCleared`) and its `/test/host_menu` endpoint are **static-only so far** — an E2E re-run (full `FestivalTests`, plus a gate-revert run to confirm the new test fails without Step 2) is still pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Festivals now end reliably through standard exit checks or timeout handling.
  * The Stardew Valley Fair no longer ends automatically when its countdown reaches zero.
  * Fair completion is safely deferred while the host menu is open.

* **New Features**
  * Added controls for opening and closing the host menu.
  * Festival status now reports iridium-quality starfruit added during the Luau.

* **Tests**
  * Added coverage for Fair exits, host-menu behavior, and Luau starfruit handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->