### PR TITLE
ci: harden dotnet format against transient NuGet restore failures

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,40 @@
+name: Retry a shell command
+description: Runs a shell command, retrying with linear backoff on failure.
+
+inputs:
+  run:
+    description: Shell command to execute. Runs under `bash -e -o pipefail`, so any line failing fails the attempt.
+    required: true
+  max-attempts:
+    description: Maximum number of attempts before giving up.
+    required: false
+    default: "3"
+  retry-delay-seconds:
+    description: Base delay between attempts; the wait grows linearly (delay, 2×delay, …) per attempt.
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        RETRY_RUN: ${{ inputs.run }}
+        RETRY_MAX_ATTEMPTS: ${{ inputs.max-attempts }}
+        RETRY_DELAY_SECONDS: ${{ inputs.retry-delay-seconds }}
+      run: |
+        set -uo pipefail
+        attempt=1
+        # `run` is passed via env, never interpolated into the script, so a command
+        # containing quotes or `${{ }}`-like text can't break out of the loop.
+        until bash -e -o pipefail -c "$RETRY_RUN"; do
+          status=$?
+          if (( attempt >= RETRY_MAX_ATTEMPTS )); then
+            echo "::error::Command failed after ${attempt} attempts (exit ${status})"
+            exit "${status}"
+          fi
+          wait=$(( RETRY_DELAY_SECONDS * attempt ))
+          echo "::warning::Attempt ${attempt}/${RETRY_MAX_ATTEMPTS} failed (exit ${status}); retrying in ${wait}s"
+          sleep "${wait}"
+          attempt=$(( attempt + 1 ))
+        done

--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -228,18 +228,29 @@ jobs:
           restore-keys: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-
 
       - name: Restore .NET tools
-        run: dotnet tool restore
+        uses: ./.github/actions/retry
+        with:
+          run: dotnet tool restore
 
       - name: Check C# formatting
         run: dotnet csharpier check .
+
+      # Restore explicitly with retry, then `dotnet format --no-restore`: format's own
+      # implicit restore isn't retried and hides NuGet errors as "Restore operation failed."
+      - name: Restore test projects
+        uses: ./.github/actions/retry
+        with:
+          run: |
+            dotnet restore tests/JunimoServer.Tests/JunimoServer.Tests.csproj
+            dotnet restore tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj
 
       # Analyzer style rules ride compilation, so they only gate where CI compiles
       # C#. The mod projects gate via the Docker image build (Validate Build); the
       # test projects compile game-free, so verify them here. Mirrors validate-pr.yml.
       - name: Check C# analyzer style rules (test projects)
         run: |
-          dotnet format style tests/JunimoServer.Tests/JunimoServer.Tests.csproj --severity error --verify-no-changes
-          dotnet format style tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj --severity error --verify-no-changes
+          dotnet format style tests/JunimoServer.Tests/JunimoServer.Tests.csproj --severity error --verify-no-changes --no-restore
+          dotnet format style tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj --severity error --verify-no-changes --no-restore
 
   validate-js:
     name: Validate JS/TS

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -267,10 +267,21 @@ jobs:
           restore-keys: ${{ runner.os }}-nuget-${{ steps.dotnet.outputs.dotnet-version }}-
 
       - name: Restore .NET tools
-        run: dotnet tool restore
+        uses: ./.github/actions/retry
+        with:
+          run: dotnet tool restore
 
       - name: Check C# formatting
         run: dotnet csharpier check .
+
+      # Restore explicitly with retry, then `dotnet format --no-restore`: format's own
+      # implicit restore isn't retried and hides NuGet errors as "Restore operation failed."
+      - name: Restore test projects
+        uses: ./.github/actions/retry
+        with:
+          run: |
+            dotnet restore tests/JunimoServer.Tests/JunimoServer.Tests.csproj
+            dotnet restore tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj
 
       # Analyzer style rules ride compilation, so they only gate where CI compiles
       # C#. The mod projects gate via the Docker image build (Validate Build); the
@@ -278,8 +289,8 @@ jobs:
       # (tests/test-client needs the game DLLs and only compiles inside its image.)
       - name: Check C# analyzer style rules (test projects)
         run: |
-          dotnet format style tests/JunimoServer.Tests/JunimoServer.Tests.csproj --severity error --verify-no-changes
-          dotnet format style tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj --severity error --verify-no-changes
+          dotnet format style tests/JunimoServer.Tests/JunimoServer.Tests.csproj --severity error --verify-no-changes --no-restore
+          dotnet format style tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj --severity error --verify-no-changes --no-restore
 
   validate-js:
     name: Validate JS/TS


### PR DESCRIPTION
## Why

The `Validate Formatting` job intermittently fails with an opaque `System.Exception: Restore operation failed.` (e.g. PRs #546, #547 — both cache-missed and died within ~2s of each other, the fingerprint of a shared nuget.org blip).

The job never restored the test projects itself — it let `dotnet format style` run its own implicit restore. On a NuGet cache miss that restore pulls the whole test-project dependency graph over the network with no retry, and `dotnet format` swallows NuGet's real error into the bare "Restore operation failed." message.

The earlier SDK-scoped-cache fix (#528) addressed a different mechanism (cross-SDK-band cache contamination) and doesn't cover this path. `NUGET_ENABLE_ENHANCED_HTTP_RETRY` is a no-op on .NET 10, so it isn't an option.

## Changes

- Add a local `retry` composite action (`.github/actions/retry`) — runs a shell command under `bash -e -o pipefail` with linear backoff. Shared home for transient-fault-tolerant CI steps.
- Restore the test projects explicitly with retry, then pass `--no-restore` to `dotnet format style` so it never runs the un-retried implicit restore. The explicit restore also surfaces NuGet's real error if one occurs.
- Wrap `dotnet tool restore` in the same retry.
- Applied identically to `validate-pr.yml` and `validate-merge-group.yml` (the two mirror format jobs).

## Verification

- Retry loop smoke-tested: success-first-try, fail-twice-then-succeed, always-fail (exhausts attempts), multi-line command with an early-failing line.
- End-to-end locally: `dotnet restore <test csproj>` then `dotnet format style … --no-restore` runs clean (exit 0), confirming `--no-restore` finds the restored assets.