### PR TITLE
ci: fix retry action template-validation error

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -26,7 +26,7 @@ runs:
         set -uo pipefail
         attempt=1
         # `run` is passed via env, never interpolated into the script, so a command
-        # containing quotes or `${{ }}`-like text can't break out of the loop.
+        # containing quotes or expression-like text can't break out of the loop.
         until bash -e -o pipefail -c "$RETRY_RUN"; do
           status=$?
           if (( attempt >= RETRY_MAX_ATTEMPTS )); then


### PR DESCRIPTION
## Why

#551 shipped a comment in the `retry` composite action's `run:` script containing the literal `${{ }}` token. GitHub interpolates `${{ }}` expressions inside a `run:` script at compose time, so it parsed the empty token as an expression and failed template validation for every job that loads the action:

```
Error: .../.github/actions/retry/action.yml (Line: 25, Col: 12): An expression was expected
```

## Fix

Reword the comment to drop the literal token (`` `${{ }}`-like `` → `expression-like`). The runtime injection-safety property is unchanged — `$RETRY_RUN` is expanded by bash at runtime, not by the template engine.