### PR TITLE
chore(renovate): cap the xunit.v3 stack below 4.0 pending MTP-v2 migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -189,6 +189,17 @@
             "allowedVersions": "<18.0.0"
         },
         {
+            "description": "CAP — xunit.v3 stack below 4.0 (coordinated MTP-v2 major, deferred alongside the Test.Sdk 18 cap above). xunit.v3 (Tests) + xunit.v3.runner.utility (TestRunner) must move together — split majors fail restore (NU1107, mismatched xunit.v3.runner.common) — and 4.x drops AssemblyRunnerOptions.ParallelizeTestCollections, set in TestRunner/Program.cs. xunit.runner.visualstudio has no xunit.v3 dependency; capped only as a precaution (3.1.5 is the terminal 3.x, so nothing is forfeited). Lift all three together. versioning:semver — nuget silently no-ops allowedVersions on interleaved prereleases.",
+            "matchManagers": ["nuget"],
+            "matchFileNames": [
+                "tests/JunimoServer.Tests/JunimoServer.Tests.csproj",
+                "tests/JunimoServer.TestRunner/JunimoServer.TestRunner.csproj"
+            ],
+            "matchPackageNames": ["xunit.v3", "xunit.v3.runner.utility", "xunit.runner.visualstudio"],
+            "versioning": "semver",
+            "allowedVersions": "<4.0.0"
+        },
+        {
             "description": "CAP — SixLabors.ImageSharp below 4.0 in the E2E test project, pending a Six Labors license key in CI. 4.0 is the first release to enforce a build-time license key for direct package dependencies, so merging it breaks the build until the (free-to-apply for OSS) key is provisioned. Lift once the key is wired into the build. versioning:semver — the default nuget scheme can silently no-op allowedVersions for packages with interleaved prereleases.",
             "matchManagers": ["nuget"],
             "matchFileNames": [


### PR DESCRIPTION
## Why

Renovate opened #546 (`xunit.v3` → v4) and #547 (`xunit.v3.runner.utility` → v4). Each fails to restore with `NU1107` — bumped alone, the two projects pin incompatible `xunit.v3.runner.common` (4.0.0 vs 3.2.2). They're split because the trailing "every major standalone" rule overrides the `test-runner` group's lockstep for major bumps.

Deeper, `xunit.v3` 4.x is the **MTP-v2** line (it pulls `xunit.v3.mtp-v2`), which requires `Microsoft.NET.Test.Sdk` 18 and coverlet 10 — the coordinated migration the neighbouring Test.Sdk cap already defers. 4.x also drops `AssemblyRunnerOptions.ParallelizeTestCollections`, used in `tests/JunimoServer.TestRunner/Program.cs`. So this major must land deliberately, with its code change, not piecemeal via Renovate.

## Change

Add a CAP rule (`allowedVersions: <4.0.0` + `versioning: semver`, matching the existing cap style) over the three test-harness xunit packages:

- `xunit.v3` (Tests) + `xunit.v3.runner.utility` (TestRunner) — must move together or restore breaks (NU1107).
- `xunit.runner.visualstudio` (Tests) — has no `xunit.v3` dependency (loosely coupled, not part of the conflict), capped only as a precaution: it ships in the 4.0 wave and 3.1.5 is already the terminal 3.x, so nothing is forfeited.

3.x minor/patch still flow; lift all three together in the coordinated migration.

## Verification

Local `renovate --platform=local --dry-run=lookup`: with the cap, **no** `renovate/xunit.v3-4.x`, `renovate/xunit.v3.runner.utility-4.x`, or `renovate/xunit.runner.visualstudio-4.x` branch is proposed (the last one *was* proposed without the visualstudio entry). Config passes `renovate-config-validator`.

Once merged, Renovate stops offering these majors; #546/#547 can be closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated version controls for xUnit testing packages.
  * Coordinated updates for related xUnit packages while keeping them below version 4.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->