### PR TITLE
fix(tests): bound E2E run finalization on abort paths

### DIFF
--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -1199,10 +1199,14 @@ public class ServerContainer : IAsyncDisposable
                     }
                 }
             }
-            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            catch (OperationCanceledException)
             {
+                // Cancelled by ShutdownCoordinator.Token (Ctrl+C / Docker-down) or by the host
+                // ExtractLimiter's poison token (host disconnect, or the broker's stopOnFail
+                // limiter-cancel). No inner call in this block applies its own timeout, so an OCE
+                // here is always a teardown cancellation — not a retrieval failure to warn about.
                 _logCallback?.Invoke(
-                    $"[Recording] server-{_serverIndex} recording extraction cancelled (shutdown)"
+                    $"[Recording] server-{_serverIndex} recording extraction cancelled (teardown)"
                 );
             }
             catch (Exception ex)

--- a/tests/JunimoServer.Tests/Helpers/ContainerRecorder.cs
+++ b/tests/JunimoServer.Tests/Helpers/ContainerRecorder.cs
@@ -748,7 +748,7 @@ internal sealed class ContainerRecorder : IAsyncDisposable
         // flushes segments.csv (its documented post-condition — "all segments finalized on disk, ready for
         // clip extraction"), so a clip whose window touched the former active segment still finds it as a
         // finalized covering segment. Accepting Stopped matters because the deferred per-test clip extract
-        // (EnqueueBackgroundTask, runs immediately) can RACE the backgrounded server disposal's StopAsync;
+        // (EnqueueBackgroundRecordingTask, runs immediately) can RACE the backgrounded server disposal's StopAsync;
         // if the stop wins, the clip must still extract off the finalized segments. NotStarted/Failed have
         // no usable segments.
         if (_state != RecorderState.Recording && _state != RecorderState.Stopped)

--- a/tests/JunimoServer.Tests/Helpers/TestTimings.cs
+++ b/tests/JunimoServer.Tests/Helpers/TestTimings.cs
@@ -285,6 +285,32 @@ public static class TestTimings
 
     #endregion
 
+    #region Recording Extraction
+
+    /// <summary>
+    /// Per-finalization timeout for recording-clip extraction (one
+    /// RecordingOrchestrator.FinalizeAsync call: the failing test's synchronous
+    /// path or one deferred passing-test extraction). A typical per-test clip
+    /// extracts in ~10-30s (per-clip budget inside ContainerRecorder is
+    /// max(30, 5×durationSec)); under full-suite load with the extract limiter
+    /// contended, ~90-120s has been observed. 150s covers that tail without
+    /// truncating legitimate extractions.
+    /// </summary>
+    public static readonly TimeSpan RecordingFinalizeBackstop = TimeSpan.FromSeconds(150);
+
+    /// <summary>
+    /// Aggregate bound on draining deferred (passing-test) recording extractions
+    /// during broker disposal. On a clean run the drain completes well inside
+    /// this (extractions run concurrently up to the extract limiter); on abort
+    /// (stopOnFail / shutdown) the limiter is cancelled first so waiters fail
+    /// fast and the drain is near-instant. Expiry means an extraction ignored
+    /// both signals — the run proceeds to finalization and the stragglers hit
+    /// their own RecordingFinalizeBackstop or die with the process.
+    /// </summary>
+    public static readonly TimeSpan RecordingDrainBudget = TimeSpan.FromSeconds(90);
+
+    #endregion
+
     #region HTTP Client Timeouts
 
     /// <summary>

--- a/tests/JunimoServer.Tests/Infrastructure/Fixture/TestArtifactCollector.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/Fixture/TestArtifactCollector.cs
@@ -276,15 +276,15 @@ internal sealed class TestArtifactCollector
 
         if (canDefer)
         {
-            TestResourceBroker.Instance.EnqueueBackgroundTask(async () =>
+            TestResourceBroker.Instance.EnqueueBackgroundRecordingTask(async () =>
             {
-                // 300s safety net. Per-clip extraction has its own budget
-                // (max(30, 5*durationSec) inside ContainerRecorder) and the orchestrator
-                // runs clip extractions in parallel, so total wall time ≈ measurement +
-                // max(per-clip-budget). The cap exists because Docker.DotNet's defaultTimeout
-                // is Infinite and the broker's _backgroundDisposeTasks drain has no timeout
-                // either — without it, a stuck exec would block broker shutdown indefinitely.
-                using var recCts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+                // Ctrl+C / Docker-down cancels the extraction immediately via
+                // ShutdownCoordinator.Token; RecordingFinalizeBackstop bounds it on
+                // normal and stopOnFail runs, where that token stays live.
+                using var recCts = CancellationTokenSource.CreateLinkedTokenSource(
+                    ShutdownCoordinator.Token
+                );
+                recCts.CancelAfter(TestTimings.RecordingFinalizeBackstop);
                 try
                 {
                     await orchestrator.FinalizeAsync(
@@ -336,10 +336,14 @@ internal sealed class TestArtifactCollector
             return;
         }
 
-        // Same 300s safety net as the deferred path above. The failing test is waiting
-        // on this finalize before test_failed is emitted, so we want it to complete
-        // rather than abort half-way; per-clip budgets bound runaway extractions.
-        using var syncCts = new CancellationTokenSource(TimeSpan.FromSeconds(300));
+        // Same token structure as the deferred path above. The failing test is
+        // waiting on this finalize before test_failed is emitted, so it runs to
+        // completion within the backstop; only a Ctrl+C / Docker-down shutdown
+        // aborts it early.
+        using var syncCts = CancellationTokenSource.CreateLinkedTokenSource(
+            ShutdownCoordinator.Token
+        );
+        syncCts.CancelAfter(TestTimings.RecordingFinalizeBackstop);
         try
         {
             await orchestrator.FinalizeAsync(

--- a/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestResourceBroker.cs
@@ -76,29 +76,37 @@ public sealed class TestResourceBroker : IAsyncDisposable
             );
     }
 
-    // Server.DisposeAsync tasks kicked off in the background by
-    // TryEvictIdleServerForAsync so the waiting test can proceed without
-    // blocking on Docker stop-grace + recording extraction. Also receives
-    // deferred per-test recording extraction (TestBase.DisposeAsync, "all"
+    // Deferred per-test recording extractions (TestBase.DisposeAsync, "all"
     // mode passing tests) so ffmpeg work doesn't sit on the test critical
-    // path. Drained in DisposeAsync via Task.WhenAll so the broker doesn't
-    // exit with orphan containers or pending extractions.
-    private readonly ConcurrentQueue<Task> _backgroundDisposeTasks = new();
+    // path. Drained in DisposeAsync bounded by RecordingDrainBudget —
+    // extraction is best-effort and must never wedge run finalization.
+    private readonly ConcurrentQueue<Task> _backgroundRecordingTasks = new();
+
+    // Server.DisposeAsync tasks kicked off in the background by
+    // TryEvictIdleServerForAsync, the sibling sweep in ReleaseAsync, and
+    // BackgroundDisposeServer so the waiting test can proceed without
+    // blocking on Docker stop-grace + recording extraction. Drained
+    // unbounded in DisposeAsync — each disposal is internally bounded by
+    // Docker stop-grace and must complete so the broker doesn't exit with
+    // orphan containers.
+    private readonly ConcurrentQueue<Task> _backgroundServerDisposalTasks = new();
 
     /// <summary>
-    /// Enqueues a background task whose completion is awaited during broker
-    /// disposal. Used by <see cref="TestBase"/> to defer non-critical work
-    /// (per-test recording clip extraction in "all" mode passing tests) off
-    /// the test's <c>DisposeAsync</c> critical path. Wrapped in
-    /// <see cref="ExecutionContext.SuppressFlow"/> so the deferred work
+    /// Enqueues a deferred recording extraction, drained in <see cref="DisposeAsync"/>
+    /// bounded by <see cref="TestTimings.RecordingDrainBudget"/> and failed fast on
+    /// abort via the extract-limiter cancel — best-effort only; work that must
+    /// complete does not belong on this queue. Used by
+    /// <see cref="Fixture.TestArtifactCollector"/> to defer per-test clip extraction
+    /// ("all" mode passing tests) off the test's <c>DisposeAsync</c> critical path.
+    /// Wrapped in <see cref="ExecutionContext.SuppressFlow"/> so the deferred work
     /// doesn't carry the deferring test's <c>TestContext.Current</c> across
     /// later events emitted from inside the work itself.
     /// </summary>
-    public void EnqueueBackgroundTask(Func<Task> work)
+    public void EnqueueBackgroundRecordingTask(Func<Task> work)
     {
         using (ExecutionContext.SuppressFlow())
         {
-            _backgroundDisposeTasks.Enqueue(
+            _backgroundRecordingTasks.Enqueue(
                 Task.Run(async () =>
                 {
                     try
@@ -110,6 +118,44 @@ public sealed class TestResourceBroker : IAsyncDisposable
                         InfrastructureEventLog.Emit(
                             "background_task_failed",
                             new { source = "broker_background", error = ex.Message }
+                        );
+                    }
+                })
+            );
+        }
+    }
+
+    /// <summary>
+    /// Enqueues <paramref name="server"/>'s disposal (Docker stop-grace +
+    /// recording extraction) on a background task, drained unbounded in
+    /// <see cref="DisposeAsync"/> so containers always stop cleanly. Callers
+    /// must have already handled pool removal and slot release. Wrapped in
+    /// <see cref="ExecutionContext.SuppressFlow"/> so the disposal doesn't
+    /// inherit the initiating test's <c>TestContext.Current</c> and
+    /// misattribute recording_extracted / server_dispose_* events
+    /// (see .claude/rules/asynclocal-pitfalls.md).
+    /// </summary>
+    private void EnqueueBackgroundServerDisposal(string serverKey, ManagedServer server)
+    {
+        using (ExecutionContext.SuppressFlow())
+        {
+            _backgroundServerDisposalTasks.Enqueue(
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        await server.DisposeAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        InfrastructureEventLog.Emit(
+                            "server_dispose_background_failed",
+                            new
+                            {
+                                server = serverKey,
+                                instanceId = server.InstanceId,
+                                error = ex.Message,
+                            }
                         );
                     }
                 })
@@ -2009,36 +2055,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
             // runs in the background. Eviction guards above guarantee
             // RefCount == 0 and no pending/remaining demand, so nothing
             // else can reach this instance.
-            var capturedKey = key;
-            var capturedServer = server;
-            // SuppressFlow: this dispose runs in the background after the evicting
-            // test has finished. Inheriting that test's TestContext.Current
-            // misattributes recording_extracted / server_dispose_* events.
-            // See .claude/rules/asynclocal-pitfalls.md.
-            using (ExecutionContext.SuppressFlow())
-            {
-                _backgroundDisposeTasks.Enqueue(
-                    Task.Run(async () =>
-                    {
-                        try
-                        {
-                            await capturedServer.DisposeAsync();
-                        }
-                        catch (Exception ex)
-                        {
-                            InfrastructureEventLog.Emit(
-                                "server_dispose_background_failed",
-                                new
-                                {
-                                    server = capturedKey,
-                                    instanceId = capturedServer.InstanceId,
-                                    error = ex.Message,
-                                }
-                            );
-                        }
-                    })
-                );
-            }
+            EnqueueBackgroundServerDisposal(key, server);
             return; // Only need to free one slot on this host
         }
     }
@@ -2273,7 +2290,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
                 // work — pool removal, Steam-account release, slot release, and the
                 // server_disposed event emit — happens here so observers see the
                 // sibling leave the pool immediately. Drained in DisposeAsync via
-                // Task.WhenAll(_backgroundDisposeTasks). Mirrors the eviction path
+                // the server-disposal queue. Mirrors the eviction path
                 // (TryEvictIdleServerForAsync).
                 foreach (var sibling in _servers.GetAll(managed.Key))
                 {
@@ -2301,36 +2318,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
                             TestLog.Server($"sibling early slot release failed: {ex.Message}");
                         }
 
-                        var capturedKey = managed.Key;
-                        var capturedSibling = sibling;
-                        // SuppressFlow: this dispose runs in the background after the
-                        // last test has finished. Inheriting that test's
-                        // TestContext.Current misattributes recording_extracted and
-                        // server_dispose_* events. See .claude/rules/asynclocal-pitfalls.md.
-                        using (ExecutionContext.SuppressFlow())
-                        {
-                            _backgroundDisposeTasks.Enqueue(
-                                Task.Run(async () =>
-                                {
-                                    try
-                                    {
-                                        await capturedSibling.DisposeAsync();
-                                    }
-                                    catch (Exception ex)
-                                    {
-                                        InfrastructureEventLog.Emit(
-                                            "server_dispose_background_failed",
-                                            new
-                                            {
-                                                server = capturedKey,
-                                                instanceId = capturedSibling.InstanceId,
-                                                error = ex.Message,
-                                            }
-                                        );
-                                    }
-                                })
-                            );
-                        }
+                        EnqueueBackgroundServerDisposal(managed.Key, sibling);
                     }
                 }
 
@@ -2358,8 +2346,8 @@ public sealed class TestResourceBroker : IAsyncDisposable
     /// slot immediately; <see cref="ManagedServer.ReleaseSlotEarly"/> is idempotent so the backgrounded
     /// <see cref="ManagedServer.DisposeAsync"/>'s own slot release is a no-op. Same shape as the sibling
     /// sweep in <see cref="ReleaseAsync"/>. The caller must have already removed <paramref name="managed"/>
-    /// from <c>_servers</c> and emitted <c>server_disposed</c>. Drained at run end via
-    /// <c>Task.WhenAll(_backgroundDisposeTasks)</c> in <see cref="DisposeAsync"/>.
+    /// from <c>_servers</c> and emitted <c>server_disposed</c>. Drained at run end via the
+    /// server-disposal queue in <see cref="DisposeAsync"/>.
     /// </summary>
     private void BackgroundDisposeServer(ManagedServer managed)
     {
@@ -2372,7 +2360,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
             TestLog.Server($"early slot release failed: {ex.Message}");
         }
 
-        EnqueueBackgroundTask(() => managed.DisposeAsync().AsTask());
+        EnqueueBackgroundServerDisposal(managed.Key, managed);
     }
 
     /// <summary>
@@ -2454,17 +2442,20 @@ public sealed class TestResourceBroker : IAsyncDisposable
             _remainingDemand[key] = 0;
         }
 
-        // Kick off eviction of idle servers in the background to free
-        // environment slots and unblock any tests stuck at WaitForServerAvailableAsync
-        // (they'll see the cancelled token and bail out).
-        _ = EvictAllIdleServersAsync();
+        // Evict idle servers to free environment slots and unblock any tests
+        // stuck at WaitForServerAvailableAsync (they'll see the cancelled token
+        // and bail out). Pool removal is synchronous; container teardown runs
+        // on the tracked server-disposal queue.
+        EvictAllIdleServers();
     }
 
     /// <summary>
     /// Evicts all servers that have refs=0 and pendingDemand=0.
     /// Used by NotifyStopOnFail to free environment slots for deferred configs.
+    /// Disposals go through <see cref="EnqueueBackgroundServerDisposal"/> so
+    /// <see cref="DisposeAsync"/> awaits them before network teardown.
     /// </summary>
-    private async Task EvictAllIdleServersAsync()
+    private void EvictAllIdleServers()
     {
         // During shutdown, don't evict; let DisposeAsync handle ordering (clients first)
         if (ShutdownCoordinator.IsShuttingDown)
@@ -2500,14 +2491,7 @@ public sealed class TestResourceBroker : IAsyncDisposable
                     queue.Reset();
                 }
 
-                try
-                {
-                    await server.DisposeAsync();
-                }
-                catch (Exception ex)
-                {
-                    TestLog.Server($"{displayLabel} shutdown failed: {ex.Message}");
-                }
+                EnqueueBackgroundServerDisposal(key, server);
             }
         }
     }
@@ -2566,19 +2550,49 @@ public sealed class TestResourceBroker : IAsyncDisposable
         await Task.WhenAll(poolDisposeTasks);
         _clientPools.Clear();
 
-        // Await any background server disposals enqueued by
-        // TryEvictIdleServerForAsync. Placed after client-pool dispose
+        // On abort (stopOnFail or Ctrl+C/Docker-down), cancel each host's
+        // extract limiter so queued recording extractions fail fast instead of
+        // serialize-wedging finalization behind a saturated limiter. The
+        // failing test's own clip was already extracted synchronously in its
+        // TestLifecycle.FinalizeAsync, before broker disposal; what's cancelled
+        // here is the deferred passing-test backlog and full-recording pulls.
+        // Never called on a clean run, so passing tests extract fully.
+        if (_stopOnFailNotified || ShutdownCoordinator.IsShuttingDown)
+        {
+            foreach (var host in HostPool.Instance.Hosts)
+            {
+                host.ExtractLimiter.CancelPending();
+            }
+        }
+
+        // Await background server disposals (eviction, sibling sweep,
+        // BackgroundDisposeServer). Placed after client-pool dispose
         // (preserves the clients-before-servers ordering invariant
         // documented above) and before the _servers loop so the shutdown
         // log and cleanup finish in one pass. _runCts is already cancelled
         // above, so any in-flight eviction now takes the synchronous path.
+        // Unbounded: disposals release Docker slots and must complete to
+        // avoid container leaks; Docker stop-grace bounds each internally.
+        await Task.WhenAll(_backgroundServerDisposalTasks);
+
+        // Drain deferred recording extractions, bounded by RecordingDrainBudget.
+        // On abort the limiter cancel above makes waiters fail fast (each task
+        // swallows its own failure and emits skip events), so this completes
+        // near-instantly; expiry means an extraction ignored both its linked
+        // shutdown token and the limiter cancel.
         try
         {
-            await Task.WhenAll(_backgroundDisposeTasks);
+            await Task.WhenAll(_backgroundRecordingTasks)
+                .WaitAsync(TestTimings.RecordingDrainBudget);
         }
-        catch (Exception ex)
+        catch (TimeoutException)
         {
-            TestLog.Server($"Background server dispose(s) faulted during shutdown: {ex.Message}");
+            var pending = _backgroundRecordingTasks.Count(t => !t.IsCompleted);
+            TestLog.Server(
+                $"Recording drain timeout: {pending} extraction(s) still pending after "
+                    + $"{TestTimings.RecordingDrainBudget.TotalSeconds}s; proceeding to finalization "
+                    + "(stragglers are bounded by RecordingFinalizeBackstop or die with the process)"
+            );
         }
 
         // Parallelize server teardown. Heavy extraction work inside


### PR DESCRIPTION
## Problem

A full E2E run could wedge for minutes in the "running" state after a single test failed (StopOnFail) or on Ctrl+C. `runner.Run()` blocks until every in-flight test's `DisposeAsync` completes and `summary.json` is written in the `finally` after — so slow finalization wedges the whole run.

Root causes in `TestResourceBroker.DisposeAsync`:
- One background queue drained via **unbounded** `Task.WhenAll`, mixing best-effort recording extractions with must-complete server disposals.
- StopOnFail never released the serialized extract limiter, so queued extractions serialize-wedged.
- Recording finalize used a bare 300s CTS not linked to the abort signal.

## Changes

- Link recording finalize (deferred + sync paths) to `ShutdownCoordinator.Token` plus a `RecordingFinalizeBackstop`, replacing the bare 300s CTS.
- Cancel each host's extract limiter on any abort (stopOnFail or shutdown) so queued extractions fail fast instead of serialize-wedging.
- Split the drain into two queues: server disposals awaited **unbounded** (release Docker slots, avoid container leaks); recording extractions **bounded** by `RecordingDrainBudget`.
- Route `EvictAllIdleServers` disposals through the tracked queue so `DisposeAsync` awaits them instead of racing a fire-and-forget task.
- Log a limiter-cancelled server extraction as `cancelled (teardown)` rather than a misleading retrieval-error warning (the stopOnFail limiter-cancel fires the limiter poison token, not `ShutdownCoordinator.Token`).

## Verification

StopOnFail gate run (`PasswordProtectionTests`, recording on, injected failure after passing tests):
- Finalization bounded to **~50s** (failure → `summary.json`), vs the previous ~8-minute wedge.
- Failing test's screenshot **and** finalized `.mp4` (366 KB) captured — debug-capture priority preserved.
- 11 deferred clips drained, no drain-timeout; **zero leaked containers**; `summary.json` + `ctrf-report.json` written.

Not stress-tested: the limiter-cancel rescue under a genuinely saturated (~9-extraction) backlog — the verification run's backlog drained within budget. That path is validated by code inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability during recording finalization and test-environment shutdown.
  * Teardown cancellation is now handled consistently, reducing failures caused by interrupted cleanup.
  * Server and recording cleanup now complete in a more predictable order.

* **Maintenance**
  * Added dedicated timing safeguards for recording finalization and deferred cleanup.
  * Improved background task handling to prevent cleanup work from being left behind during shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->