### PR TITLE
fix(crop-saver): key entries on NameOrUniqueName so interior crops resolve

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -13,8 +13,14 @@ namespace JunimoServer.Services.Api;
 /// </summary>
 public class TestCrop
 {
-    /// <summary>Internal location name where the crop lives (e.g. "Farm", "Greenhouse", "IslandWest").</summary>
+    /// <summary>Display location name (e.g. "Farm", "Greenhouse"). Shared by building
+    /// interiors — every cabin interior reads "Cabin".</summary>
     public string LocationName { get; set; } = "";
+
+    /// <summary>Unique location name (NameOrUniqueName, e.g. "Cabin{GUID}" for a cabin
+    /// interior; equals <see cref="LocationName"/> for root locations). This is the
+    /// CropSaver entry key — pass it as locationName to /test/saver_crop.</summary>
+    public string UniqueLocationName { get; set; } = "";
 
     /// <summary>Tile X coordinate (terrain HoeDirt tile, or pot's TileLocation).</summary>
     public int TileX { get; set; }
@@ -116,9 +122,11 @@ public class TestFarmEventResponse
 
 /// <summary>
 /// Body for POST /test/saver_crop. Mutates an existing CropSaver entry in
-/// place. Optional fields are skipped when null. Used by E2E tests to
-/// pre-arm extraDays past CropSaver.OnDayEnd's branch-1 floor without
-/// having to simulate many real day-transitions.
+/// place. LocationName must be the entry key — the unique location name
+/// (TestCrop.UniqueLocationName from /test/crops). Optional fields are
+/// skipped when null. Used by E2E tests to pre-arm extraDays past
+/// CropSaver.OnDayEnd's branch-1 floor without having to simulate many
+/// real day-transitions.
 /// </summary>
 public class TestSaverCropRequest
 {

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -214,9 +214,9 @@ public partial class ApiService
             {
                 Utility.ForEachLocation(location =>
                 {
-                    // CropSaver entries are keyed on NameOrUniqueName; the
-                    // response's LocationName stays the display Name so test
-                    // row addressing ("Cabin") keeps working.
+                    // LocationName carries the display Name for test row
+                    // addressing; UniqueLocationName and the IsManaged lookup
+                    // use NameOrUniqueName, the CropSaver entry key.
                     var displayName = location.Name;
                     var lookupName = location.NameOrUniqueName;
 
@@ -237,6 +237,7 @@ public partial class ApiService
                             new TestCrop
                             {
                                 LocationName = displayName,
+                                UniqueLocationName = lookupName,
                                 TileX = (int)dirt.Tile.X,
                                 TileY = (int)dirt.Tile.Y,
                                 IsAlive = !crop.dead.Value,
@@ -266,6 +267,7 @@ public partial class ApiService
                             new TestCrop
                             {
                                 LocationName = displayName,
+                                UniqueLocationName = lookupName,
                                 TileX = (int)pot.TileLocation.X,
                                 TileY = (int)pot.TileLocation.Y,
                                 IsAlive = !crop.dead.Value,
@@ -692,56 +694,7 @@ public partial class ApiService
         TestSaverCropResponse result = new();
         await RunOnGameThreadAsync(() =>
         {
-            // Entries are keyed on NameOrUniqueName. A direct hit covers root
-            // locations and callers passing the unique name; the fallback lets
-            // callers address a building interior by its display Name ("Cabin"),
-            // matching how /test/crops rows are addressed.
             var saverCrop = loader.GetSaverCrop(body.LocationName, tile);
-            if (saverCrop == null)
-            {
-                var ambiguous = false;
-                foreach (var candidate in loader.GetSaverCrops())
-                {
-                    if (candidate.cropLocationTile != tile)
-                    {
-                        continue;
-                    }
-
-                    var candidateLocation = Game1.getLocationFromName(candidate.cropLocationName);
-                    if (
-                        candidateLocation == null
-                        || !candidateLocation.Name.Equals(
-                            body.LocationName,
-                            StringComparison.OrdinalIgnoreCase
-                        )
-                    )
-                    {
-                        continue;
-                    }
-
-                    if (saverCrop != null)
-                    {
-                        ambiguous = true;
-                        break;
-                    }
-
-                    saverCrop = candidate;
-                }
-
-                if (ambiguous)
-                {
-                    result = new TestSaverCropResponse
-                    {
-                        Success = false,
-                        Found = false,
-                        Error =
-                            $"Multiple SaverCrop entries match {body.LocationName} "
-                            + $"({body.TileX},{body.TileY}); address by unique location name",
-                    };
-                    return;
-                }
-            }
-
             if (saverCrop == null)
             {
                 result = new TestSaverCropResponse
@@ -749,7 +702,9 @@ public partial class ApiService
                     Success = false,
                     Found = false,
                     Error =
-                        $"No SaverCrop entry at {body.LocationName} ({body.TileX},{body.TileY})",
+                        $"No SaverCrop entry at {body.LocationName} ({body.TileX},{body.TileY}). "
+                        + "Entries are keyed on the unique location name — pass "
+                        + "uniqueLocationName from the /test/crops row.",
                 };
                 return;
             }

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -214,7 +214,11 @@ public partial class ApiService
             {
                 Utility.ForEachLocation(location =>
                 {
-                    var locName = location.Name;
+                    // CropSaver entries are keyed on NameOrUniqueName; the
+                    // response's LocationName stays the display Name so test
+                    // row addressing ("Cabin") keeps working.
+                    var displayName = location.Name;
+                    var lookupName = location.NameOrUniqueName;
 
                     foreach (var feature in location.terrainFeatures.Values)
                     {
@@ -232,13 +236,13 @@ public partial class ApiService
                         crops.Add(
                             new TestCrop
                             {
-                                LocationName = locName,
+                                LocationName = displayName,
                                 TileX = (int)dirt.Tile.X,
                                 TileY = (int)dirt.Tile.Y,
                                 IsAlive = !crop.dead.Value,
                                 IsInPot = false,
                                 SeedItemId = crop.netSeedIndex.Value,
-                                IsManaged = CropSaverOverrides.IsManaged(locName, dirt.Tile),
+                                IsManaged = CropSaverOverrides.IsManaged(lookupName, dirt.Tile),
                                 IsSeasonImmune = location.IsCropSeasonImmune(),
                             }
                         );
@@ -261,13 +265,16 @@ public partial class ApiService
                         crops.Add(
                             new TestCrop
                             {
-                                LocationName = locName,
+                                LocationName = displayName,
                                 TileX = (int)pot.TileLocation.X,
                                 TileY = (int)pot.TileLocation.Y,
                                 IsAlive = !crop.dead.Value,
                                 IsInPot = true,
                                 SeedItemId = crop.netSeedIndex.Value,
-                                IsManaged = CropSaverOverrides.IsManaged(locName, pot.TileLocation),
+                                IsManaged = CropSaverOverrides.IsManaged(
+                                    lookupName,
+                                    pot.TileLocation
+                                ),
                                 IsSeasonImmune = location.IsCropSeasonImmune(),
                             }
                         );
@@ -685,7 +692,56 @@ public partial class ApiService
         TestSaverCropResponse result = new();
         await RunOnGameThreadAsync(() =>
         {
+            // Entries are keyed on NameOrUniqueName. A direct hit covers root
+            // locations and callers passing the unique name; the fallback lets
+            // callers address a building interior by its display Name ("Cabin"),
+            // matching how /test/crops rows are addressed.
             var saverCrop = loader.GetSaverCrop(body.LocationName, tile);
+            if (saverCrop == null)
+            {
+                var ambiguous = false;
+                foreach (var candidate in loader.GetSaverCrops())
+                {
+                    if (candidate.cropLocationTile != tile)
+                    {
+                        continue;
+                    }
+
+                    var candidateLocation = Game1.getLocationFromName(candidate.cropLocationName);
+                    if (
+                        candidateLocation == null
+                        || !candidateLocation.Name.Equals(
+                            body.LocationName,
+                            StringComparison.OrdinalIgnoreCase
+                        )
+                    )
+                    {
+                        continue;
+                    }
+
+                    if (saverCrop != null)
+                    {
+                        ambiguous = true;
+                        break;
+                    }
+
+                    saverCrop = candidate;
+                }
+
+                if (ambiguous)
+                {
+                    result = new TestSaverCropResponse
+                    {
+                        Success = false,
+                        Found = false,
+                        Error =
+                            $"Multiple SaverCrop entries match {body.LocationName} "
+                            + $"({body.TileX},{body.TileY}); address by unique location name",
+                    };
+                    return;
+                }
+            }
+
             if (saverCrop == null)
             {
                 result = new TestSaverCropResponse

--- a/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
@@ -23,7 +23,7 @@ public class CropSaverOverrides
             return true;
         }
 
-        var managed = _cropSaverDataLoader.GetSaverCrop(dirt.Location.Name, dirt.Tile);
+        var managed = _cropSaverDataLoader.GetSaverCrop(dirt.Location.NameOrUniqueName, dirt.Tile);
         return managed == null;
     }
 

--- a/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
@@ -52,7 +52,9 @@ public class CropWatcher
 
         Utility.ForEachLocation(location =>
         {
-            var locName = location.Name;
+            // NameOrUniqueName, not Name: building interiors share a Name
+            // ("Cabin") and only resolve back via their unique name.
+            var locName = location.NameOrUniqueName;
 
             foreach (var feature in location.terrainFeatures.Values)
             {

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -483,8 +483,14 @@ public class ClockSpeedResponse
 /// </summary>
 public class TestCrop
 {
+    /// <summary>Display location name (e.g. "Farm"; every cabin interior reads "Cabin").</summary>
     [JsonPropertyName("locationName")]
     public string LocationName { get; set; } = "";
+
+    /// <summary>Unique location name (NameOrUniqueName) — the CropSaver entry key; pass it
+    /// as locationName to <see cref="ServerApiClient.SetSaverCrop"/>.</summary>
+    [JsonPropertyName("uniqueLocationName")]
+    public string UniqueLocationName { get; set; } = "";
 
     [JsonPropertyName("tileX")]
     public int TileX { get; set; }
@@ -2581,9 +2587,12 @@ public class ServerApiClient : IDisposable
     /// <summary>
     /// Test-only: mutate an existing CropSaver tracking entry. Used by E2E
     /// tests to pre-arm <c>extraDays</c> past <c>OnDayEnd</c>'s
-    /// branch-1 floor without simulating many real day-transitions. All
-    /// optional parameters are skipped (left at their existing values) when
-    /// null. Returns <c>Found=false</c> if no SaverCrop exists at the tile.
+    /// branch-1 floor without simulating many real day-transitions.
+    /// <paramref name="locationName"/> must be the entry key — the unique
+    /// location name (<see cref="TestCrop.UniqueLocationName"/> from
+    /// /test/crops). All optional parameters are skipped (left at their
+    /// existing values) when null. Returns <c>Found=false</c> if no SaverCrop
+    /// exists at the (unique name, tile).
     /// POST /test/saver_crop
     /// </summary>
     public async Task<TestSaverCropResponse?> SetSaverCrop(

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -19,7 +19,7 @@ namespace JunimoServer.Tests;
 /// <see cref="GardenPotCrop_KillSuppressedOnSeasonTransition_WhileOwnerOffline"/>
 /// drives a real day-transition across a season boundary and asserts that
 /// <c>KillCrop_Prefix</c>'s switch from a hardcoded <c>"Farm"</c> lookup to
-/// <c>dirt.Location.Name</c> suppresses vanilla <c>Crop.Kill()</c>'s
+/// <c>dirt.Location.NameOrUniqueName</c> suppresses vanilla <c>Crop.Kill()</c>'s
 /// out-of-season kill. Also exercises <c>SaverCrop.TryGetCoorespondingDirt</c>'s
 /// <c>StardewValley.Objects.IndoorPot</c> branch.
 /// </description></item>
@@ -169,7 +169,7 @@ public class CropSaverTests : TestBase
         }
 
         // Crop.newDay ran on the host as part of the season-transition. With
-        // the prefix fix in place dirt.Location.Name resolves to "Farm" for
+        // the prefix fix in place dirt.Location.NameOrUniqueName resolves to "Farm" for
         // the pot's dirt and the SaverCrop lookup suppresses Kill(). Without
         // the fix, the pre-fix code's hardcoded "Farm" lookup would *also*
         // match here (because the pot IS on the Farm), but TryGetCoorespondingDirt
@@ -317,6 +317,14 @@ public class CropSaverTests : TestBase
             "Pumpkin in a Garden Pot inside a season-immune cabin interior must survive "
                 + "Fall 28 → Winter 1 past its computed date of death. Pre-fix: CropSaver.OnDayEnd "
                 + "had no immunity awareness and date-of-death-killed it — the greenhouse bug class."
+        );
+        Assert.True(
+            stillThere.IsManaged,
+            "CropSaver entry for the cabin pot must survive the Fall 28 → Winter 1 transition. "
+                + "IsManaged=false means the OnDayEnd orphan sweep evicted it: entries keyed on "
+                + "the shared display Name (\"Cabin\") never resolve via Game1.getLocationFromName, "
+                + "so the sweep saw dirt==null and deleted the entry — the immune-guard `continue` "
+                + "under test never ran."
         );
     }
 

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -253,9 +253,10 @@ public class CropSaverTests : TestBase
 
         // Stamp datePlanted = Fall 1 (death Fall 28) with extraDays left at 0, so the
         // upcoming Fall 28 → Winter 1 rollover would kill a seasonal crop. Only the
-        // immunity guard spares this one.
+        // immunity guard spares this one. SetSaverCrop addresses the entry by its key,
+        // the unique location name ("Cabin{GUID}") — not the display name "Cabin".
         var planted = await ServerApi.SetSaverCrop(
-            "Cabin",
+            potRow.UniqueLocationName,
             CabinTileX,
             CabinTileY,
             datePlanted: ("fall", 1, 1),


### PR DESCRIPTION
- CropSaver keyed entries on `location.Name`, which is `"Cabin"` for every cabin interior; `Game1.getLocationFromName` can never resolve that (interiors match only their unique name via the structure fallback), so every interior entry was evicted by `OnDayEnd`'s orphan sweep on the first night after planting.
- CropWatcher scan, `KillCrop_Prefix` lookup, and `/test/crops` `IsManaged` now key on `NameOrUniqueName`; the snapshot's `LocationName` stays the display name and rows additionally expose `UniqueLocationName` (the entry key).
- `/test/saver_crop` addresses entries by the exact entry key only; the cabin test passes the snapshot row's `UniqueLocationName` instead of `"Cabin"`.
- `PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline` now also asserts `IsManaged` after the season rollover, making the immune-guard scenario load-bearing (fails pre-fix: the sweep evicted the entry).
- No saved-data migration: legacy interior entries stored as `"Cabin"` already self-evict today; root-location entries are unaffected (`Name` equals `NameOrUniqueName` there).

Part of the crop-saver-hardening series. Merge order: this PR first, then #558, then #559 — the later two rebase onto the key convention this one establishes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crop test results now include a unique location name for accurately identifying individual locations.
  * Crop-saving requests now use the unique location name as the entry key.
* **Bug Fixes**
  * Improved crop tracking and management for locations with shared display names, including cabins.
  * Enhanced error guidance when an invalid crop location key is provided.
* **Tests**
  * Updated coverage to validate unique location handling across season changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->