### PR TITLE
fix(crop-saver): pot wins the tile shared with an empty terrain HoeDirt

### DIFF
--- a/mod/JunimoServer/Services/CropSaver/CropSaverData.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaverData.cs
@@ -55,16 +55,19 @@ public class SaverCrop
             return null;
         }
 
+        // Pot wins the tile: a pot on an empty tilled tile shares the key with
+        // the crop-less terrain dirt beneath it, so resolve the pot's dirt
+        // first (see CropWatcher's terrain-loop skip for the invariant).
+        if (location.Objects.TryGetValue(cropLocationTile, out var obj) && obj is IndoorPot pot)
+        {
+            return pot.hoeDirt.Value;
+        }
+
         if (
             location.terrainFeatures.TryGetValue(cropLocationTile, out var tf) && tf is HoeDirt dirt
         )
         {
             return dirt;
-        }
-
-        if (location.Objects.TryGetValue(cropLocationTile, out var obj) && obj is IndoorPot pot)
-        {
-            return pot.hoeDirt.Value;
         }
 
         return null;

--- a/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
@@ -23,7 +23,12 @@ public class CropSaverOverrides
             return true;
         }
 
-        var managed = _cropSaverDataLoader.GetSaverCrop(dirt.Location.NameOrUniqueName, dirt.Tile);
+        // Pot crops are keyed under pot.TileLocation (the watcher can't rely on
+        // dirt.Tile at pot creation), so canonicalize via HoeDirt.Pot — the
+        // vanilla back-reference to the containing pot (see CropWatcher's
+        // terrain-loop skip for the shared pot-wins-the-tile rule).
+        var tile = dirt.Pot?.TileLocation ?? dirt.Tile;
+        var managed = _cropSaverDataLoader.GetSaverCrop(dirt.Location.NameOrUniqueName, tile);
         return managed == null;
     }
 

--- a/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropWatcher.cs
@@ -63,6 +63,23 @@ public class CropWatcher
                     continue;
                 }
 
+                // Pot wins the tile: a Garden Pot can be placed on an *empty*
+                // tilled tile (CanItemBePlacedHere rejects only dirt WITH a
+                // crop), so two HoeDirts can share one (location, tile) key.
+                // At most one of them can bear a crop — the pot blocks
+                // planting the dirt beneath it — so the pot loop below owns
+                // such tiles; visiting the empty terrain dirt too would
+                // overwrite the pot's hasCrop and evict its entry every scan.
+                // Same rule in SaverCrop.TryGetCoorespondingDirt and
+                // CropSaverOverrides.KillCrop_Prefix — keep the three in sync.
+                if (
+                    location.Objects.TryGetValue(dirt.Tile, out var objAtTile)
+                    && objAtTile is IndoorPot
+                )
+                {
+                    continue;
+                }
+
                 CheckTile(new CropLocation(location, dirt, locName, dirt.Tile));
             }
 

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -371,6 +371,15 @@ public class LocationWarpsResult
     public List<LocationWarpInfo> Warps { get; set; } = new();
 }
 
+public class TillTileResult
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+}
+
 public class PlantCropResult
 {
     [JsonPropertyName("success")]
@@ -822,6 +831,21 @@ public class ActionsClient
                 tileY,
                 width,
                 height,
+            }
+        );
+
+    /// <summary>
+    /// Till a tile into a terrain HoeDirt via the vanilla hoe path
+    /// (GameLocation.makeHoeDirt). POST /actions/till_tile
+    /// </summary>
+    public Task<TillTileResult?> TillTile(string locationName, int tileX, int tileY) =>
+        _client.PostAsync<TillTileResult>(
+            "/actions/till_tile",
+            new
+            {
+                locationName,
+                tileX,
+                tileY,
             }
         );
 

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -7,7 +7,7 @@ namespace JunimoServer.Tests;
 /// <summary>
 /// E2E coverage for CropSaver across Garden Pots.
 ///
-/// Three complementary tests, all load-bearing:
+/// Complementary tests, all load-bearing:
 /// <list type="bullet">
 /// <item><description>
 /// <see cref="GardenPotCrop_IsRegisteredWithCropSaverWatcher"/> exercises the
@@ -22,6 +22,13 @@ namespace JunimoServer.Tests;
 /// <c>dirt.Location.NameOrUniqueName</c> suppresses vanilla <c>Crop.Kill()</c>'s
 /// out-of-season kill. Also exercises <c>SaverCrop.TryGetCoorespondingDirt</c>'s
 /// <c>StardewValley.Objects.IndoorPot</c> branch.
+/// </description></item>
+/// <item><description>
+/// <see cref="GardenPotOnTilledTile_StaysManagedAcrossWatcherScans"/> exercises
+/// the pot-wins-the-tile rule: a pot placed on an empty tilled tile makes two
+/// HoeDirts share one (location, tile) key, and without the <c>CropWatcher</c>
+/// terrain-loop skip the empty terrain dirt evicts the pot crop's entry one
+/// scan after registration.
 /// </description></item>
 /// <item><description>
 /// <see cref="PotCropInImmuneLocation_SurvivesPastDateOfDeath_WhileOwnerOffline"/>
@@ -72,6 +79,8 @@ public class CropSaverTests : TestBase
     private const int TileA_Y = 21;
     private const int TileB_X = 64;
     private const int TileB_Y = 22;
+    private const int TileC_X = 64;
+    private const int TileC_Y = 23;
 
     /// <summary>
     /// Tile inside the farmhand's cabin interior for the immune-location test.
@@ -88,6 +97,94 @@ public class CropSaverTests : TestBase
         var ct = TestCt;
         await PlacePotAndPlantCauliflowerAsync(TileA_X, TileA_Y, ct);
         await AssertWatcherRegistersPotAsync("Farm", TileA_X, TileA_Y, ct);
+    }
+
+    [Fact]
+    public async Task GardenPotOnTilledTile_StaysManagedAcrossWatcherScans()
+    {
+        var ct = TestCt;
+
+        // Force Spring so Cauliflower is plantable (see PlacePotAndPlantCauliflowerAsync).
+        var springDate = await ServerApi.SetDate("spring", 1, year: 1, ct);
+        Assert.NotNull(springDate);
+        Assert.True(springDate.Success, $"SetDate(spring 1) failed: {springDate.Error}");
+
+        await Farmers.ConnectFastAsync(namePrefix: "PotTilled", ct: ct);
+
+        var warp = await GameClient.Actions.Warp("Farm", TileC_X, TileC_Y);
+        Assert.True(warp?.Success, $"Warp failed: {warp?.Error}");
+        var arrived = await GameClient.WaitForLocationAsync("^Farm$", TimeSpan.FromSeconds(10), ct);
+        Assert.NotNull(arrived);
+
+        // Clear the 3×3 neighborhood (weed-spawn immunity, see the sibling helper),
+        // then till the pot tile so it hosts a terrain HoeDirt, and place the pot
+        // WITHOUT clearObstacles — the tilled dirt must survive placement. Vanilla
+        // allows this: CanItemBePlacedHere rejects only dirt WITH a crop, so a pot
+        // on an empty tilled tile is a legal player-reachable state, and the tile
+        // then holds two HoeDirts sharing one (location, tile) key.
+        var cleared = await GameClient.Actions.ClearArea(
+            "Farm",
+            TileC_X - 1,
+            TileC_Y - 1,
+            width: 3,
+            height: 3
+        );
+        Assert.True(cleared?.Success == true, $"ClearArea failed: {cleared?.Error}");
+
+        var tilled = await GameClient.Actions.TillTile("Farm", TileC_X, TileC_Y);
+        Assert.True(tilled?.Success == true, $"TillTile failed: {tilled?.Error}");
+
+        var place = await GameClient.Actions.PlacePot(
+            "Farm",
+            TileC_X,
+            TileC_Y,
+            clearObstacles: false
+        );
+        Assert.True(place?.Success, $"PlacePot failed: {place?.Error}");
+
+        var plant = await GameClient.Actions.PlantCrop(CauliflowerSeedId, "Farm", TileC_X, TileC_Y);
+        Assert.True(plant?.Success, $"PlantCrop failed: {plant?.Error}");
+
+        await AssertWatcherRegistersPotAsync("Farm", TileC_X, TileC_Y, ct);
+
+        // The pre-fix failure mode is time-shaped: the watcher's terrain visit saw
+        // the empty terrain dirt's hasCrop=false AFTER the pot's true and evicted
+        // the entry one scan window later — IsManaged flipped false ~1 scan after
+        // registration and stayed false. Sample the snapshot across several scan
+        // windows (5-tick scan ≈ 1s at SERVER_TPS=5; 3s ≈ 3 scans) and require
+        // IsManaged to hold on every sample. Also pin the row count: the crop-less
+        // terrain dirt must not double-report the tile.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            var snapshot = await ServerApi.GetAllCrops(ct);
+            Assert.NotNull(snapshot);
+            var rows = snapshot
+                .Crops.Where(c =>
+                    c.LocationName == "Farm" && c.TileX == TileC_X && c.TileY == TileC_Y
+                )
+                .ToList();
+            Assert.True(
+                rows.Count == 1,
+                $"Expected exactly one crop row at Farm ({TileC_X},{TileC_Y}), got {rows.Count} — "
+                    + "0 means the pot crop vanished; 2 means the tile double-reported "
+                    + "(a crop grew in the terrain dirt under the pot)."
+            );
+            var potRow = rows[0];
+            Assert.True(
+                potRow.IsInPot,
+                "The only crop row at the shared tile must be the pot's — a terrain row "
+                    + "here means a crop landed in the dirt under the pot."
+            );
+            Assert.True(
+                potRow.IsManaged,
+                "Pot crop on a tilled tile must STAY managed across watcher scans. "
+                    + "Pre-fix: the empty terrain HoeDirt sharing the tile key evicted the "
+                    + "SaverCrop entry one scan after registration (watcher churn)."
+            );
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
+        }
     }
 
     [Fact]

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -489,8 +489,8 @@ public class CropSaverTests : TestBase
     }
 
     /// <summary>
-    /// Waits up to 5s for the host's CropWatcher (5-tick scan ≈ 333ms at
-    /// SERVER_TPS=15) to register the pot crop in CropSaverData. Polled via
+    /// Waits up to 5s for the host's CropWatcher (5-tick scan ≈ 1s at
+    /// SERVER_TPS=5) to register the pot crop in CropSaverData. Polled via
     /// the host-side /test/crops endpoint, which sets <c>IsManaged=true</c>
     /// when <c>CropSaverData</c> has a matching entry.
     /// </summary>

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -80,7 +80,7 @@ public class CropSaverTests : TestBase
     private const int TileB_X = 64;
     private const int TileB_Y = 22;
     private const int TileC_X = 64;
-    private const int TileC_Y = 23;
+    private const int TileC_Y = 24;
 
     /// <summary>
     /// Tile inside the farmhand's cabin interior for the immune-location test.

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -314,6 +314,51 @@ public class ActionsController
     }
 
     /// <summary>
+    /// Till a tile into a terrain HoeDirt via the vanilla hoe path
+    /// (<c>GameLocation.makeHoeDirt</c>), which checks the Diggable tile
+    /// property and collisions the way a real hoe swing does.
+    /// </summary>
+    public TillTileResult TillTile(string locationName, int tileX, int tileY)
+    {
+        if (!Context.IsWorldReady)
+        {
+            return new TillTileResult { Success = false, Error = "Not in a game world" };
+        }
+
+        if (Game1.player.currentLocation?.Name != locationName)
+        {
+            return new TillTileResult
+            {
+                Success = false,
+                Error =
+                    $"Player is on '{Game1.player.currentLocation?.Name}', not '{locationName}'",
+            };
+        }
+
+        var location = Game1.player.currentLocation;
+        var tile = new Vector2(tileX, tileY);
+
+        if (!location.makeHoeDirt(tile))
+        {
+            return new TillTileResult
+            {
+                Success = false,
+                Error =
+                    $"makeHoeDirt refused ({tileX},{tileY}) — tile not Diggable, blocked, "
+                    + "or already tilled",
+            };
+        }
+
+        return new TillTileResult
+        {
+            Success = true,
+            LocationName = locationName,
+            TileX = tileX,
+            TileY = tileY,
+        };
+    }
+
+    /// <summary>
     /// Plant a seed via <c>HoeDirt.plant</c>. The dirt may be a terrain HoeDirt or
     /// the inner HoeDirt of a Garden Pot at the same tile. <c>plant</c> requires
     /// <c>player.currentLocation == dirt.Location</c>.
@@ -338,14 +383,18 @@ public class ActionsController
         var location = Game1.player.currentLocation;
         var tile = new Vector2(tileX, tileY);
 
+        // Pot first: a Garden Pot on a tilled tile coexists with an empty
+        // terrain HoeDirt at the same key, and real interaction always reaches
+        // the pot (it occupies the tile) — mirrors CropSaver's
+        // pot-wins-the-tile rule so tests plant where a player would.
         HoeDirt? dirt = null;
-        if (location.terrainFeatures.TryGetValue(tile, out var tf) && tf is HoeDirt td)
-        {
-            dirt = td;
-        }
-        else if (location.Objects.TryGetValue(tile, out var obj) && obj is IndoorPot pot)
+        if (location.Objects.TryGetValue(tile, out var obj) && obj is IndoorPot pot)
         {
             dirt = pot.hoeDirt.Value;
+        }
+        else if (location.terrainFeatures.TryGetValue(tile, out var tf) && tf is HoeDirt td)
+        {
+            dirt = td;
         }
 
         if (dirt == null)
@@ -725,6 +774,22 @@ public class ClearAreaParams
     public int TileY { get; set; }
     public int Width { get; set; }
     public int Height { get; set; }
+}
+
+public class TillTileResult
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+    public string? LocationName { get; set; }
+    public int? TileX { get; set; }
+    public int? TileY { get; set; }
+}
+
+public class TillTileParams
+{
+    public string LocationName { get; set; } = "";
+    public int TileX { get; set; }
+    public int TileY { get; set; }
 }
 
 public class PlantCropResult

--- a/tests/test-client/HttpServer/ApiDefinitions.cs
+++ b/tests/test-client/HttpServer/ApiDefinitions.cs
@@ -343,6 +343,17 @@ public class ApiDefinitions
 
     [ApiEndpoint(
         "POST",
+        "/actions/till_tile",
+        Summary = "Till a tile",
+        Description = "Till a tile into a terrain HoeDirt via the vanilla hoe path (GameLocation.makeHoeDirt).",
+        Tag = "Actions"
+    )]
+    [ApiRequestBody(typeof(TillTileParams))]
+    [ApiResponse(typeof(TillTileResult), 200)]
+    private void TillTile() { }
+
+    [ApiEndpoint(
+        "POST",
         "/actions/plant_crop",
         Summary = "Plant a crop seed",
         Description = "Plant a seed in a HoeDirt or IndoorPot at the given tile.",

--- a/tests/test-client/ModEntry.cs
+++ b/tests/test-client/ModEntry.cs
@@ -720,6 +720,23 @@ public class ModEntry : Mod
             }
         );
 
+        // POST /actions/till_tile - Till a tile into a terrain HoeDirt via the vanilla hoe path
+        _server.Post(
+            "actions/till_tile",
+            req =>
+            {
+                var body = TestApiServer.ReadBody<TillTileParams>(req);
+                if (body == null)
+                {
+                    return new TillTileResult { Success = false, Error = "Missing body" };
+                }
+
+                return ExecuteOnGameThread(() =>
+                    _actionsController!.TillTile(body.LocationName, body.TileX, body.TileY)
+                );
+            }
+        );
+
         // POST /actions/plant_crop - Plant a seed in a HoeDirt or IndoorPot at the given tile
         _server.Post(
             "actions/plant_crop",


### PR DESCRIPTION
- A Garden Pot can legally sit on an empty tilled tile, giving two HoeDirts at one `(location, tile)` key: the watcher's terrain pass and pot pass then fight over the entry (`OnCropRemoved` fires every scan after the first), so the pot crop stays permanently unmanaged; `TryGetCoorespondingDirt` also resolved the empty terrain dirt and swept the entry.
- One "pot wins the tile" rule at all three readers: the CropWatcher terrain loop skips a dirt whose tile hosts an `IndoorPot` (allocation-free `TryGetValue` + type check), `TryGetCoorespondingDirt` resolves the pot's inner dirt first (mirroring vanilla `GetHoeDirtAtTile`'s pot-first order), and `KillCrop_Prefix` canonicalizes the lookup tile as `dirt.Pot?.TileLocation ?? dirt.Tile`.
- Rests on the vanilla invariant (verified): at most one crop-bearing dirt per tile — a pot can't be placed over a terrain crop, and terrain dirt under a pot can't be planted.
- New test-client action `/actions/till_tile` (vanilla `makeHoeDirt`, Diggable/collision checks intact); test-client `PlantCrop` dirt resolution flipped to pot-first to match real interaction (all existing call sites verified unaffected).
- New E2E `GardenPotOnTilledTile_StaysManagedAcrossWatcherScans`: pot on a tilled tile stays `IsManaged` across multiple watcher scans (pre-fix it flips false one scan after registration).

Part of the crop-saver-hardening series; merges after #557.