### PR TITLE
feat(crop-saver): configurable lightning immunity for managed crops (default on)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,10 @@ VNC_PASSWORD=""
 # Force a new debug game on startup (default: false)
 # FORCE_NEW_DEBUG_GAME=false
 
+# Crops tracked by the crop saver survive lightning strikes (default: true).
+# Set false to restore vanilla lightning kills.
+# CROP_SAVER_LIGHTNING_IMMUNITY=true
+
 # Override verbose logging (default: config-file setting)
 # VERBOSE_LOGGING=false
 

--- a/mod/JunimoServer/Env.cs
+++ b/mod/JunimoServer/Env.cs
@@ -29,6 +29,17 @@ internal class Env
     public static readonly bool ForceNewDebugGame = ParseBool("FORCE_NEW_DEBUG_GAME", false);
 
     /// <summary>
+    /// When true (default), crops tracked by CropSaver survive lightning strikes:
+    /// CropSaverOverrides.KillCrop_Prefix suppresses the strike's Crop.Kill. Set false
+    /// to restore vanilla lightning kills for managed crops (the killed crop's tracking
+    /// entry is dropped so the corpse doesn't stay managed).
+    /// </summary>
+    public static readonly bool CropSaverLightningImmunity = ParseBool(
+        "CROP_SAVER_LIGHTNING_IMMUNITY",
+        true
+    );
+
+    /// <summary>
     /// Target game ticks per second. Lower values reduce CPU usage.
     /// Default: 60 (game default). Clamped to [1, 60]: above vanilla's fixed 60 every per-tick-constant
     /// gameplay path (movement, physics) runs faster than real time, and <c>TpsAgnosticPacing</c> can

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.Models.cs
@@ -153,6 +153,38 @@ public class TestSaverCropResponse
 }
 
 /// <summary>
+/// Body for POST /test/lightning_strike. Names the crop tile to strike (terrain
+/// HoeDirt, or a Garden Pot's inner dirt).
+/// </summary>
+public class TestLightningStrikeRequest
+{
+    public string? LocationName { get; set; }
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+}
+
+/// <summary>
+/// Response from POST /test/lightning_strike (test-only). Runs vanilla's lightning
+/// crop-strike (HoeDirt.performToolAction with lightning damage) on a chosen tile,
+/// inside the CropSaver lightning context — a deterministic stand-in for the
+/// RNG-gated Utility.performLightningUpdate.
+/// </summary>
+public class TestLightningStrikeResponse
+{
+    public bool Success { get; set; }
+    public string? Error { get; set; }
+
+    /// <summary>True if a crop was found at the requested (location, tile).</summary>
+    public bool Found { get; set; }
+
+    /// <summary>True if the crop is still alive after the strike (immunity suppressed the kill).</summary>
+    public bool CropAliveAfter { get; set; }
+
+    /// <summary>True if CropSaver still tracks the tile after the strike.</summary>
+    public bool IsManagedAfter { get; set; }
+}
+
+/// <summary>
 /// Response from POST /test/house_upgrade (test-only). Runs a vanilla debug house-upgrade
 /// command through parseDebugInput (exercising the HostFarmhouseUpgradeGuard Harmony prefix) and
 /// reports the host's resulting HouseUpgradeLevel, so a test can pin "the host farmhouse can't be

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -797,24 +797,13 @@ public partial class ApiService
                     return;
                 }
 
-                // Same dirt resolution as /test/crops: a terrain HoeDirt, or the inner
-                // dirt of a Garden Pot at the tile. Vanilla lightning only ever targets
-                // farm.terrainFeatures (Utility.performLightningUpdate), but the pot path
-                // exercises the identical Crop.Kill enforcement seam, and pots are the
-                // only crop container the E2E client harness can place.
-                HoeDirt? dirt = null;
-                if (
-                    location.terrainFeatures.TryGetValue(tile, out var feature)
-                    && feature is HoeDirt terrainDirt
-                )
-                {
-                    dirt = terrainDirt;
-                }
-                else if (location.Objects.TryGetValue(tile, out var obj) && obj is IndoorPot pot)
-                {
-                    dirt = pot.hoeDirt.Value;
-                }
-
+                // Resolve through CropSaver's own lookup (terrain HoeDirt, else a
+                // Garden Pot's inner dirt) so the probe can't drift from the tracker.
+                // Vanilla lightning only ever targets farm.terrainFeatures
+                // (Utility.performLightningUpdate), but the pot path exercises the
+                // identical Crop.Kill enforcement seam, and pots are the only crop
+                // container the E2E client harness can place.
+                var dirt = SaverCrop.TryGetDirtAt(location, tile);
                 if (dirt?.crop == null)
                 {
                     result.Error = $"No crop at {body.LocationName} ({body.TileX},{body.TileY})";

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -107,6 +107,12 @@ public partial class ApiService
                     case "/test/saver_crop":
                         await WriteJsonAsync(response, await HandlePostTestSaverCropAsync(request));
                         return;
+                    case "/test/lightning_strike":
+                        await WriteJsonAsync(
+                            response,
+                            await HandlePostTestLightningStrikeAsync(request)
+                        );
+                        return;
                     case "/test/house_upgrade":
                         await WriteJsonAsync(
                             response,
@@ -732,6 +738,122 @@ public partial class ApiService
                 OwnerId = saverCrop.ownerId,
             };
         });
+
+        return result;
+    }
+
+    [ApiEndpoint(
+        "POST",
+        "/test/lightning_strike",
+        Summary = "Run a deterministic lightning strike against the crop at a tile (test-only)",
+        Tag = "Test"
+    )]
+    [ApiResponse(typeof(TestLightningStrikeResponse), 200)]
+    private async Task<TestLightningStrikeResponse> HandlePostTestLightningStrikeAsync(
+        HttpListenerRequest request
+    )
+    {
+        TestLightningStrikeRequest? body = null;
+        try
+        {
+            using var reader = new System.IO.StreamReader(
+                request.InputStream,
+                request.ContentEncoding
+            );
+            var json = await reader.ReadToEndAsync();
+            if (!string.IsNullOrWhiteSpace(json))
+            {
+                body = JsonConvert.DeserializeObject<TestLightningStrikeRequest>(json);
+            }
+        }
+        catch (Exception ex)
+        {
+            return new TestLightningStrikeResponse
+            {
+                Success = false,
+                Error = $"Failed to parse body: {ex.Message}",
+            };
+        }
+
+        if (body == null || string.IsNullOrEmpty(body.LocationName))
+        {
+            return new TestLightningStrikeResponse
+            {
+                Success = false,
+                Error = "Missing 'locationName' in request body",
+            };
+        }
+
+        var tile = new Vector2(body.TileX, body.TileY);
+        var result = new TestLightningStrikeResponse();
+        try
+        {
+            await RunOnGameThreadAsync(() =>
+            {
+                var location = Game1.getLocationFromName(body.LocationName);
+                if (location == null)
+                {
+                    result.Error = $"Unknown location '{body.LocationName}'";
+                    return;
+                }
+
+                // Same dirt resolution as /test/crops: a terrain HoeDirt, or the inner
+                // dirt of a Garden Pot at the tile. Vanilla lightning only ever targets
+                // farm.terrainFeatures (Utility.performLightningUpdate), but the pot path
+                // exercises the identical Crop.Kill enforcement seam, and pots are the
+                // only crop container the E2E client harness can place.
+                HoeDirt? dirt = null;
+                if (
+                    location.terrainFeatures.TryGetValue(tile, out var feature)
+                    && feature is HoeDirt terrainDirt
+                )
+                {
+                    dirt = terrainDirt;
+                }
+                else if (location.Objects.TryGetValue(tile, out var obj) && obj is IndoorPot pot)
+                {
+                    dirt = pot.hoeDirt.Value;
+                }
+
+                if (dirt?.crop == null)
+                {
+                    result.Error = $"No crop at {body.LocationName} ({body.TileX},{body.TileY})";
+                    return;
+                }
+
+                result.Found = true;
+
+                // Reproduce the crop branch of vanilla Utility.performLightningUpdate —
+                // HoeDirt.performToolAction(null, 50, tile) → crop.Kill() — inside the
+                // same lightning context the Harmony patch establishes, so
+                // KillCrop_Prefix sees a real strike. Deliberately skipped vanilla
+                // side effects: the RNG target roll (this endpoint exists to bypass it)
+                // and the cosmetic lightningStrikeEvent flash; the destroyed-feature
+                // removal never applies here because HoeDirt.performToolAction returns
+                // false on the damage path. crop.dead is a NetBool, so the kill
+                // replicates to clients on its own.
+                CropSaverOverrides.LightningUpdate_Prefix();
+                try
+                {
+                    dirt.performToolAction(null, 50, tile);
+                }
+                finally
+                {
+                    CropSaverOverrides.LightningUpdate_Finalizer();
+                }
+
+                result.CropAliveAfter = !dirt.crop.dead.Value;
+                result.IsManagedAfter = CropSaverOverrides.IsManaged(body.LocationName, tile);
+                result.Success = true;
+            });
+        }
+        catch (Exception ex)
+        {
+            // Never LogLevel.Error here (test poison per .claude/rules/debugging.md) —
+            // surface via the response.
+            result.Success = false;
+            result.Error = ex.Message;
+        }
 
         return result;
     }

--- a/mod/JunimoServer/Services/CropSaver/CropSaver.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaver.cs
@@ -38,6 +38,22 @@ public class CropSaver : ModService
             )
         );
 
+        // Lightning-context flag around Utility.performLightningUpdate, so
+        // KillCrop_Prefix can distinguish a lightning kill (opt-out via
+        // CROP_SAVER_LIGHTNING_IMMUNITY=false) from other kill paths. The finalizer
+        // clears the flag even when the strike throws.
+        harmony.Patch(
+            original: AccessTools.Method(typeof(Utility), nameof(Utility.performLightningUpdate)),
+            prefix: new HarmonyMethod(
+                typeof(CropSaverOverrides),
+                nameof(CropSaverOverrides.LightningUpdate_Prefix)
+            ),
+            finalizer: new HarmonyMethod(
+                typeof(CropSaverOverrides),
+                nameof(CropSaverOverrides.LightningUpdate_Finalizer)
+            )
+        );
+
         helper.Events.GameLoop.Saving += OnSaving;
         helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
         helper.Events.GameLoop.DayEnding += OnDayEnd;

--- a/mod/JunimoServer/Services/CropSaver/CropSaverData.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaverData.cs
@@ -50,22 +50,25 @@ public class SaverCrop
     public HoeDirt TryGetCoorespondingDirt()
     {
         var location = Game1.getLocationFromName(cropLocationName);
-        if (location == null)
-        {
-            return null;
-        }
+        return location == null ? null : TryGetDirtAt(location, cropLocationTile);
+    }
 
-        // Pot wins the tile: a pot on an empty tilled tile shares the key with
-        // the crop-less terrain dirt beneath it, so resolve the pot's dirt
-        // first (see CropWatcher's terrain-loop skip for the invariant).
-        if (location.Objects.TryGetValue(cropLocationTile, out var obj) && obj is IndoorPot pot)
+    /// <summary>
+    /// CropSaver's canonical dirt resolution for a tile: a Garden Pot's inner dirt,
+    /// else a terrain HoeDirt. Pot wins the tile: a pot on an empty tilled tile
+    /// shares the key with the crop-less terrain dirt beneath it (see CropWatcher's
+    /// terrain-loop skip for the invariant). Test probes of the Crop.Kill seam
+    /// (e.g. /test/lightning_strike) resolve through this too, so they can't drift
+    /// from the tracker's own lookup.
+    /// </summary>
+    public static HoeDirt TryGetDirtAt(GameLocation location, Vector2 tile)
+    {
+        if (location.Objects.TryGetValue(tile, out var obj) && obj is IndoorPot pot)
         {
             return pot.hoeDirt.Value;
         }
 
-        if (
-            location.terrainFeatures.TryGetValue(cropLocationTile, out var tf) && tf is HoeDirt dirt
-        )
+        if (location.terrainFeatures.TryGetValue(tile, out var tf) && tf is HoeDirt dirt)
         {
             return dirt;
         }

--- a/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaverOverrides.cs
@@ -9,10 +9,32 @@ public class CropSaverOverrides
     private static IMonitor _monitor;
     private static CropSaverDataLoader _cropSaverDataLoader;
 
+    /// <summary>
+    /// True while Utility.performLightningUpdate is executing. Both lightning paths
+    /// (the live storm tick and the overnight batch) run on the game thread, so a
+    /// plain field suffices — no interlocking.
+    /// </summary>
+    private static bool _lightningUpdateInProgress;
+
     public static void Initialize(IMonitor monitor, CropSaverDataLoader cropSaverDataLoader)
     {
         _monitor = monitor;
         _cropSaverDataLoader = cropSaverDataLoader;
+    }
+
+    /// <summary>Harmony prefix on Utility.performLightningUpdate.</summary>
+    public static void LightningUpdate_Prefix()
+    {
+        _lightningUpdateInProgress = true;
+    }
+
+    /// <summary>
+    /// Harmony finalizer on Utility.performLightningUpdate — clears the flag even when
+    /// the strike throws, so an exception can't leave it stuck.
+    /// </summary>
+    public static void LightningUpdate_Finalizer()
+    {
+        _lightningUpdateInProgress = false;
     }
 
     public static bool KillCrop_Prefix(ref Crop __instance)
@@ -29,7 +51,22 @@ public class CropSaverOverrides
         // terrain-loop skip for the shared pot-wins-the-tile rule).
         var tile = dirt.Pot?.TileLocation ?? dirt.Tile;
         var managed = _cropSaverDataLoader.GetSaverCrop(dirt.Location.NameOrUniqueName, tile);
-        return managed == null;
+        if (managed == null)
+        {
+            return true;
+        }
+
+        if (_lightningUpdateInProgress && !Env.CropSaverLightningImmunity)
+        {
+            // Vanilla lightning kill re-enabled: let the kill through and drop the
+            // tracking entry — a dead crop still counts as trackable to the watcher
+            // (CropLocation.HasTrackableCrop), so without the removal the corpse
+            // would stay managed and OnDayEnd would keep prolonging it.
+            _cropSaverDataLoader.RemoveCrop(managed);
+            return true;
+        }
+
+        return false;
     }
 
     public static bool IsManaged(string locationName, Vector2 tile)

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1207,6 +1207,30 @@ public class TestSaverCropResponse
 }
 
 /// <summary>
+/// Response from /test/lightning_strike POST endpoint (test-only).
+/// </summary>
+public class TestLightningStrikeResponse
+{
+    [JsonPropertyName("success")]
+    public bool Success { get; set; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>True iff a crop was found at the requested (location, tile).</summary>
+    [JsonPropertyName("found")]
+    public bool Found { get; set; }
+
+    /// <summary>True iff the crop is still alive after the strike.</summary>
+    [JsonPropertyName("cropAliveAfter")]
+    public bool CropAliveAfter { get; set; }
+
+    /// <summary>True iff CropSaver still tracks the tile after the strike.</summary>
+    [JsonPropertyName("isManagedAfter")]
+    public bool IsManagedAfter { get; set; }
+}
+
+/// <summary>
 /// Response from /roles/admin POST endpoint.
 /// </summary>
 public class RoleGrantResponse
@@ -2636,6 +2660,38 @@ public class ServerApiClient : IDisposable
         );
         response.EnsureSuccessStatusCode();
         return await response.Content.ReadFromJsonAsync<TestSaverCropResponse>(ct);
+    }
+
+    /// <summary>
+    /// Test-only: run a deterministic lightning strike against the crop at a tile —
+    /// vanilla's crop-strike (<c>HoeDirt.performToolAction</c> with lightning damage)
+    /// inside the CropSaver lightning context, bypassing the RNG target roll of
+    /// <c>Utility.performLightningUpdate</c>.
+    /// POST /test/lightning_strike
+    /// </summary>
+    public async Task<TestLightningStrikeResponse?> LightningStrike(
+        string locationName,
+        int tileX,
+        int tileY,
+        CancellationToken ct = default
+    )
+    {
+        var response = await SendWithRetryAsync(
+            HttpMethod.Post,
+            "/test/lightning_strike",
+            ct,
+            () =>
+                JsonContent.Create(
+                    new
+                    {
+                        locationName,
+                        tileX,
+                        tileY,
+                    }
+                )
+        );
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<TestLightningStrikeResponse>(ct);
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -36,6 +36,15 @@ namespace JunimoServer.Tests;
 /// past its computed date of death through a real <c>OnDayEnd</c>, asserting the
 /// <c>IsCropSeasonImmune()</c> guard spares it — the greenhouse bug class.
 /// </description></item>
+/// <item><description>
+/// <see cref="ManagedCrop_SurvivesLightningStrike_ByDefault"/> exercises the
+/// lightning-immunity default: a deterministic <c>/test/lightning_strike</c>
+/// (vanilla's crop-strike inside the CropSaver lightning context) must be
+/// suppressed by <c>KillCrop_Prefix</c> for a managed crop when
+/// <c>CROP_SAVER_LIGHTNING_IMMUNITY</c> is unset. The disabled path (kill let
+/// through, tracking entry dropped) needs a server booted with the env var set
+/// to false, which the test harness cannot express per-class — not E2E-covered.
+/// </description></item>
 /// </list>
 /// </summary>
 // Exclusive serializes the methods (SharedClass alone runs them concurrently): all
@@ -81,6 +90,8 @@ public class CropSaverTests : TestBase
     private const int TileB_Y = 22;
     private const int TileC_X = 64;
     private const int TileC_Y = 24;
+    private const int TileD_X = 64;
+    private const int TileD_Y = 23;
 
     /// <summary>
     /// Tile inside the farmhand's cabin interior for the immune-location test.
@@ -185,6 +196,48 @@ public class CropSaverTests : TestBase
 
             await Task.Delay(TimeSpan.FromMilliseconds(500), ct);
         }
+    }
+
+    [Fact]
+    public async Task ManagedCrop_SurvivesLightningStrike_ByDefault()
+    {
+        var ct = TestCt;
+
+        await PlacePotAndPlantCauliflowerAsync(TileD_X, TileD_Y, ct);
+        await AssertWatcherRegistersPotAsync("Farm", TileD_X, TileD_Y, ct);
+
+        // Deterministic strike: /test/lightning_strike runs vanilla's crop-strike
+        // (HoeDirt.performToolAction with lightning damage → Crop.Kill) inside the
+        // CropSaver lightning context, bypassing performLightningUpdate's RNG target
+        // roll. With CROP_SAVER_LIGHTNING_IMMUNITY at its default (true),
+        // KillCrop_Prefix must suppress the kill for a managed crop.
+        var strike = await ServerApi.LightningStrike("Farm", TileD_X, TileD_Y, ct);
+        Assert.NotNull(strike);
+        Assert.True(strike.Success, $"Lightning strike failed: {strike.Error}");
+        Assert.True(strike.Found, "Strike must find the pot crop at the target tile");
+        Assert.True(
+            strike.CropAliveAfter,
+            "Managed crop must survive a lightning strike with immunity at its default (true). "
+                + "Dead means KillCrop_Prefix failed to suppress the lightning-context kill."
+        );
+        Assert.True(
+            strike.IsManagedAfter,
+            "Surviving crop must stay tracked by CropSaver — the entry is only dropped "
+                + "when a lightning kill is let through (immunity disabled)."
+        );
+
+        // Re-assert on the /test/crops snapshot so the survival check goes through the
+        // same read path the other tests gate on.
+        var crops = await ServerApi.GetAllCrops(ct);
+        Assert.NotNull(crops);
+        var row = crops.Crops.SingleOrDefault(c =>
+            c.IsInPot && c.LocationName == "Farm" && c.TileX == TileD_X && c.TileY == TileD_Y
+        );
+        Assert.NotNull(row);
+        Assert.True(
+            row.IsAlive,
+            "Snapshot must agree the managed crop is alive after the lightning strike"
+        );
     }
 
     [Fact]

--- a/tests/JunimoServer.Tests/CropSaverTests.cs
+++ b/tests/JunimoServer.Tests/CropSaverTests.cs
@@ -47,8 +47,8 @@ namespace JunimoServer.Tests;
 /// </description></item>
 /// </list>
 /// </summary>
-// Exclusive serializes the methods (SharedClass alone runs them concurrently): all
-// three mutate the global calendar and would clobber each other mid-transition.
+// Exclusive serializes the methods (SharedClass alone runs them concurrently): they
+// all mutate the global calendar and would clobber each other mid-transition.
 [TestServer(Isolation = IsolationMode.SharedClass, Exclusive = true)]
 public class CropSaverTests : TestBase
 {


### PR DESCRIPTION
- Since CropSaver registers essentially every crop and lightning kills route through `Crop.Kill`, the existing prefix made every crop on the server lightning-immune — an undocumented deviation from vanilla. This makes it an explicit, opt-out knob.
- New env knob `CROP_SAVER_LIGHTNING_IMMUNITY` (default `true`, documented in `.env.example`); default behavior is bit-for-bit unchanged.
- Lightning context is tracked by a static flag set/cleared by a Harmony prefix + finalizer on `Utility.performLightningUpdate` (finalizer so an exception mid-strike can't leave it stuck; game-thread-only, plain field). With the knob off, `KillCrop_Prefix` lets the kill through and removes the SaverCrop entry (a dead crop still counts as trackable, so the corpse would otherwise stay managed).
- New deterministic test endpoint `POST /test/lightning_strike`: runs vanilla's crop-strike branch (`HoeDirt.performToolAction(null, 50, tile)`) between the real patch methods on the game thread, resolving the dirt through `SaverCrop.TryGetDirtAt` — the same lookup CropSaver itself uses.
- New E2E `ManagedCrop_SurvivesLightningStrike_ByDefault` covers the default path.
- Coverage gap, stated explicitly: the knob-off path is not E2E-covered — `[TestServer]` has no per-class env overrides, and adding them means plumbing attribute → requirements → config hash → container env. Deferred.

Part of the crop-saver-hardening series; no ordering constraints.