### PR TITLE
fix(crop-saver): guard null farmer location, align maturity estimate with engine

### DIFF
--- a/mod/JunimoServer/Services/CropSaver/CropSaver.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaver.cs
@@ -181,8 +181,15 @@ public class CropSaver : ModService
             return SDate.Now();
         }
 
+        // Mirrors Crop.newDay / HoeDirt.dayUpdate: an unwatered crop only loses a growth day
+        // when its data has NeedsWatering, and a paddy crop near water is force-watered
+        // (paddyWaterCheck) before newDay runs.
         var extraDayForUnwatered = 1;
-        if (dirt.state.Value == HoeDirt.watered)
+        if (
+            dirt.state.Value == HoeDirt.watered
+            || crop.GetData()?.NeedsWatering == false
+            || dirt.paddyWaterCheck(forceUpdate: true)
+        )
         {
             extraDayForUnwatered = 0;
         }

--- a/mod/JunimoServer/Services/CropSaver/CropSaver.cs
+++ b/mod/JunimoServer/Services/CropSaver/CropSaver.cs
@@ -182,13 +182,14 @@ public class CropSaver : ModService
         }
 
         // Mirrors Crop.newDay / HoeDirt.dayUpdate: an unwatered crop only loses a growth day
-        // when its data has NeedsWatering, and a paddy crop near water is force-watered
-        // (paddyWaterCheck) before newDay runs.
+        // when its data needs watering (missing data counts as needing it), and a paddy crop
+        // near water is force-watered (paddyWaterCheck) before newDay runs. paddyWaterCheck
+        // dereferences dirt.Location, so skip it for an anomalous location-less dirt.
         var extraDayForUnwatered = 1;
         if (
             dirt.state.Value == HoeDirt.watered
             || crop.GetData()?.NeedsWatering == false
-            || dirt.paddyWaterCheck(forceUpdate: true)
+            || (dirt.Location != null && dirt.paddyWaterCheck(forceUpdate: true))
         )
         {
             extraDayForUnwatered = 0;

--- a/mod/JunimoServer/Services/CropSaver/FarmerUtil.cs
+++ b/mod/JunimoServer/Services/CropSaver/FarmerUtil.cs
@@ -20,7 +20,10 @@ public static class FarmerUtil
                 continue;
             }
 
-            if (!farmer.currentLocation.Equals(location))
+            // currentLocation can be null for a just-approved farmhand: the server adds it to
+            // otherFarmers (GameServer.checkFarmhandRequest -> Multiplayer.addPlayer) before the
+            // client's first farmer delta binds a location.
+            if (farmer.currentLocation?.Equals(location) != true)
             {
                 continue;
             }


### PR DESCRIPTION
- `FarmerUtil.GetClosestFarmer` dereferenced `farmer.currentLocation` for every online farmer; the engine can yield location-less farmers during the join window (`Multiplayer.addPlayer` registers the farmhand before its location binds, and vanilla's own `FarmerCollection`/`FarmerTeam` null-guard the same read). Guarded with `farmer.currentLocation?.Equals(location) != true`, preserving exact match semantics for non-null locations.
- `CalculateEarliestPossibleFullyGrownDate` charged the +1 unwatered day to crops the engine grows regardless: `Crop.newDay` skips growth only when `data.NeedsWatering` is true (sole vanilla exception: Fiber Seeds), and `HoeDirt.dayUpdate` force-waters paddy crops near water via `paddyWaterCheck`. The estimator now mirrors both gates, making `OnDayEnd`'s branch-1 season-end cull faithful to the engine.
- `paddyWaterCheck` is only called when `dirt.Location` is non-null (CropSaver's kill sweep already treats location-less dirt as possible; the anomalous case keeps the conservative +1 penalty).

Part of the crop-saver-hardening series; no ordering constraints.