### PR TITLE
ci: stamp shipped image versions onto closed issues

### DIFF
--- a/.github/actions/stamp-issue-versions/action.yml
+++ b/.github/actions/stamp-issue-versions/action.yml
@@ -61,21 +61,16 @@ runs:
         # build's own tag or a previous build of the same commit — taking it as base would empty
         # the range and permanently skip a failed run's issues. Re-walking an already-stamped
         # range is a no-op (first value wins, comments are marker-deduped).
-        AT_HEAD=$(git tag -l --points-at "$HEAD_OID" $TAG_MATCH)
         EXCLUDE_ARGS=()
-        for tag in $AT_HEAD; do EXCLUDE_ARGS+=(--exclude "$tag"); done
-        BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$HEAD_OID" 2>/dev/null || true)
-        if [ -n "$BASE" ]; then
-          BASE_OID=$(git rev-parse "$BASE^{commit}")
-        elif [ "$(git tag -l $TAG_MATCH)" = "$AT_HEAD" ]; then
-          # Every candidate tag (possibly none) points at HEAD: the true first build, or a
-          # rebuild of it — walk history to the root, the faithful retry of that first range.
-          BASE_OID=""
-        else
-          echo "::error::expected a base tag matching '$TAG_MATCH' below $HEAD_REF but none resolved"
+        for tag in $(git tag -l --points-at "$HEAD_OID" $TAG_MATCH); do
+          EXCLUDE_ARGS+=(--exclude "$tag")
+        done
+        BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$HEAD_OID" 2>/dev/null) || {
+          echo "::error::no base tag matching '$TAG_MATCH' strictly below $HEAD_REF"
           exit 1
-        fi
-        echo "HEAD=$HEAD_OID BASE=${BASE:-<root>} ($BASE_OID)"
+        }
+        BASE_OID=$(git rev-parse "$BASE^{commit}")
+        echo "HEAD=$HEAD_OID BASE=$BASE ($BASE_OID)"
         echo "head-oid=$HEAD_OID" >> "$GITHUB_OUTPUT"
         echo "base-oid=$BASE_OID" >> "$GITHUB_OUTPUT"
 

--- a/.github/actions/stamp-issue-versions/action.yml
+++ b/.github/actions/stamp-issue-versions/action.yml
@@ -58,6 +58,7 @@ runs:
         TAG_MATCH: ${{ inputs.tag-match }}
         EXCLUDE_TAG: ${{ inputs.exclude-tag }}
       run: |
+        set -f # tag globs must reach git verbatim, not expand against the working tree
         HEAD_OID=$(git rev-parse "$HEAD_REF^{commit}")
         MATCH_ARGS=()
         for glob in $TAG_MATCH; do MATCH_ARGS+=(--match "$glob"); done

--- a/.github/actions/stamp-issue-versions/action.yml
+++ b/.github/actions/stamp-issue-versions/action.yml
@@ -1,0 +1,99 @@
+name: Stamp Issue Versions
+description: >
+  Stamps the issues closed by the PRs in this build's commit range with the image version that
+  first contains their fix (org Issue Field, first value wins), and posts a "your fix shipped"
+  comment once per channel.
+
+inputs:
+  field-id:
+    description: Numeric id of the org issue field to write
+    required: true
+  field-name:
+    description: Expected name of that field — the first write is asserted against it to catch a stale id
+    required: true
+  value:
+    description: Version to stamp (e.g. 1.5.0 or 1.5.0-preview.3)
+    required: true
+  channel:
+    description: Comment channel, "preview" or "release"
+    required: true
+  head-ref:
+    description: Ref or SHA of the build's head commit
+    required: true
+  tag-match:
+    description: Space-separated `git describe --match` globs that select base-tag candidates
+    required: true
+  exclude-tag:
+    description: Tag to exclude from base resolution (this build's own tag)
+    required: false
+    default: ""
+  max-issues:
+    description: Abort if the range resolves more issues than this (guards a bad base tag)
+    required: false
+    default: "100"
+  dry-run:
+    description: Resolve and log everything but write nothing
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout full history
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up Bun
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+      with:
+        bun-version: 1.3.5
+
+    - name: Resolve commit range
+      id: range
+      shell: bash
+      env:
+        HEAD_REF: ${{ inputs.head-ref }}
+        TAG_MATCH: ${{ inputs.tag-match }}
+        EXCLUDE_TAG: ${{ inputs.exclude-tag }}
+      run: |
+        HEAD_OID=$(git rev-parse "$HEAD_REF^{commit}")
+        MATCH_ARGS=()
+        for glob in $TAG_MATCH; do MATCH_ARGS+=(--match "$glob"); done
+        EXCLUDE_ARGS=()
+        if [ -n "$EXCLUDE_TAG" ]; then EXCLUDE_ARGS+=(--exclude "$EXCLUDE_TAG"); fi
+        BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$HEAD_OID" 2>/dev/null || true)
+        if [ -n "$BASE" ]; then
+          BASE_OID=$(git rev-parse "$BASE^{commit}")
+        elif [ -z "$(git tag -l $TAG_MATCH)" ]; then
+          # True first release: no candidate tag exists anywhere, walk history to the root.
+          BASE_OID=""
+        else
+          echo "::error::expected a base tag matching '$TAG_MATCH' below $HEAD_REF but none resolved"
+          exit 1
+        fi
+        echo "HEAD=$HEAD_OID BASE=${BASE:-<root>} ($BASE_OID)"
+        echo "head-oid=$HEAD_OID" >> "$GITHUB_OUTPUT"
+        echo "base-oid=$BASE_OID" >> "$GITHUB_OUTPUT"
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: .github/scripts
+      run: bun install --frozen-lockfile
+
+    - name: Stamp issues
+      shell: bash
+      working-directory: .github/scripts
+      env:
+        GH_TOKEN: ${{ github.token }}
+        HEAD_OID: ${{ steps.range.outputs.head-oid }}
+        BASE_OID: ${{ steps.range.outputs.base-oid }}
+        FIELD_ID: ${{ inputs.field-id }}
+        EXPECTED_FIELD_NAME: ${{ inputs.field-name }}
+        VALUE: ${{ inputs.value }}
+        CHANNEL: ${{ inputs.channel }}
+        MAX_ISSUES: ${{ inputs.max-issues }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        OWNER="${GITHUB_REPOSITORY%%/*}" REPO="${GITHUB_REPOSITORY#*/}" bun run stamp-issue-versions.ts

--- a/.github/actions/stamp-issue-versions/action.yml
+++ b/.github/actions/stamp-issue-versions/action.yml
@@ -23,10 +23,6 @@ inputs:
   tag-match:
     description: Space-separated `git describe --match` globs that select base-tag candidates
     required: true
-  exclude-tag:
-    description: Tag to exclude from base resolution (this build's own tag)
-    required: false
-    default: ""
   max-issues:
     description: Abort if the range resolves more issues than this (guards a bad base tag)
     required: false
@@ -56,19 +52,24 @@ runs:
       env:
         HEAD_REF: ${{ inputs.head-ref }}
         TAG_MATCH: ${{ inputs.tag-match }}
-        EXCLUDE_TAG: ${{ inputs.exclude-tag }}
       run: |
         set -f # tag globs must reach git verbatim, not expand against the working tree
         HEAD_OID=$(git rev-parse "$HEAD_REF^{commit}")
         MATCH_ARGS=()
         for glob in $TAG_MATCH; do MATCH_ARGS+=(--match "$glob"); done
+        # The base must sit strictly below HEAD. A candidate tag pointing at HEAD itself is this
+        # build's own tag or a previous build of the same commit — taking it as base would empty
+        # the range and permanently skip a failed run's issues. Re-walking an already-stamped
+        # range is a no-op (first value wins, comments are marker-deduped).
+        AT_HEAD=$(git tag -l --points-at "$HEAD_OID" $TAG_MATCH)
         EXCLUDE_ARGS=()
-        if [ -n "$EXCLUDE_TAG" ]; then EXCLUDE_ARGS+=(--exclude "$EXCLUDE_TAG"); fi
+        for tag in $AT_HEAD; do EXCLUDE_ARGS+=(--exclude "$tag"); done
         BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$HEAD_OID" 2>/dev/null || true)
         if [ -n "$BASE" ]; then
           BASE_OID=$(git rev-parse "$BASE^{commit}")
-        elif [ -z "$(git tag -l $TAG_MATCH)" ]; then
-          # True first release: no candidate tag exists anywhere, walk history to the root.
+        elif [ "$(git tag -l $TAG_MATCH)" = "$AT_HEAD" ]; then
+          # Every candidate tag (possibly none) points at HEAD: the true first build, or a
+          # rebuild of it — walk history to the root, the faithful retry of that first range.
           BASE_OID=""
         else
           echo "::error::expected a base tag matching '$TAG_MATCH' below $HEAD_REF but none resolved"

--- a/.github/scripts/bun.lock
+++ b/.github/scripts/bun.lock
@@ -1,0 +1,53 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "sdvd-github-scripts",
+      "dependencies": {
+        "@octokit/rest": "22.0.1",
+      },
+    },
+  },
+  "packages": {
+    "@octokit/auth-token": ["@octokit/auth-token@6.0.0", "", {}, "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="],
+
+    "@octokit/core": ["@octokit/core@7.0.7", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.4", "@octokit/request": "^10.0.13", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.4", "", { "dependencies": { "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@9.0.4", "", { "dependencies": { "@octokit/request": "^10.0.13", "@octokit/types": "^17.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@28.0.0", "", {}, "sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@14.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@6.0.0", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@17.0.0", "", { "dependencies": { "@octokit/types": "^16.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw=="],
+
+    "@octokit/request": ["@octokit/request@10.0.15", "", { "dependencies": { "@octokit/endpoint": "^11.0.3", "@octokit/request-error": "^7.1.1", "@octokit/types": "^17.0.0", "content-type": "^3.0.0", "json-with-bigint": "^3.5.12", "universal-user-agent": "^7.0.2" } }, "sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.1", "", { "dependencies": { "@octokit/types": "^17.0.0" } }, "sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA=="],
+
+    "@octokit/rest": ["@octokit/rest@22.0.1", "", { "dependencies": { "@octokit/core": "^7.0.6", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/plugin-request-log": "^6.0.0", "@octokit/plugin-rest-endpoint-methods": "^17.0.0" } }, "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw=="],
+
+    "@octokit/types": ["@octokit/types@17.0.0", "", { "dependencies": { "@octokit/openapi-types": "^28.0.0" } }, "sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q=="],
+
+    "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
+
+    "content-type": ["content-type@3.0.0", "", {}, "sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw=="],
+
+    "json-with-bigint": ["json-with-bigint@3.5.12", "", {}, "sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "sdvd-github-scripts",
+    "private": true,
+    "type": "module",
+    "dependencies": {
+        "@octokit/rest": "22.0.1"
+    }
+}

--- a/.github/scripts/stamp-issue-versions.ts
+++ b/.github/scripts/stamp-issue-versions.ts
@@ -68,16 +68,16 @@ async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
             return await fn();
         } catch (error) {
             const status = (error as { status?: number }).status ?? 0;
+            const headers = (error as { response?: { headers?: Record<string, string> } }).response?.headers ?? {};
+            const retryAfterSec = Number.parseInt(headers["retry-after"] ?? "", 10);
+            // 403 is retryable only as rate limiting — primary (remaining=0) or secondary (retry-after).
             const rateLimited =
                 status === 429 ||
-                (status === 403 &&
-                    (error as { response?: { headers?: Record<string, string> } }).response?.headers?.[
-                        "x-ratelimit-remaining"
-                    ] === "0");
+                (status === 403 && (headers["x-ratelimit-remaining"] === "0" || !Number.isNaN(retryAfterSec)));
             if (attempt === maxAttempts || !(status >= 500 || rateLimited)) {
                 throw error;
             }
-            const delayMs = 2 ** attempt * 1000;
+            const delayMs = Number.isNaN(retryAfterSec) ? 2 ** attempt * 1000 : retryAfterSec * 1000;
             console.warn(`${label}: HTTP ${status}, retry ${attempt}/${maxAttempts - 1} in ${delayMs}ms`);
             await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
@@ -194,6 +194,9 @@ interface FieldValue {
     value: string;
 }
 
+/** A misconfigured FIELD_ID poisons every write — abort the whole run instead of per-issue skipping. */
+class FieldConfigError extends Error {}
+
 /** First-value-wins: returns false (skipped) when FIELD_ID already carries a value. */
 async function stampField(issueNumber: number): Promise<boolean> {
     const current = await withRetry(`get field values #${issueNumber}`, () =>
@@ -225,9 +228,10 @@ async function stampField(issueNumber: number): Promise<boolean> {
         .flat()
         .find((entry) => entry.issue_field_id === FIELD_ID);
     if (!echoed || echoed.issue_field_name !== EXPECTED_FIELD_NAME || echoed.data_type !== "text") {
-        throw new Error(
+        throw new FieldConfigError(
             `Field ${FIELD_ID} echoed back as "${echoed?.issue_field_name}" (${echoed?.data_type}), ` +
-                `expected text field "${EXPECTED_FIELD_NAME}" — check the field id`,
+                `expected text field "${EXPECTED_FIELD_NAME}" — stale field id, or the endpoint's response ` +
+                `shape changed (raw: ${JSON.stringify(response.data)})`,
         );
     }
     console.log(`#${issueNumber}: field set to "${VALUE}"`);
@@ -282,10 +286,24 @@ if (issues.length > MAX_ISSUES) {
 const stamped: number[] = [];
 const skipped: number[] = [];
 const commented: number[] = [];
+const failed: number[] = [];
 for (const issueNumber of issues) {
-    (await stampField(issueNumber)) ? stamped.push(issueNumber) : skipped.push(issueNumber);
-    if (await postComment(issueNumber)) {
-        commented.push(issueNumber);
+    try {
+        (await stampField(issueNumber)) ? stamped.push(issueNumber) : skipped.push(issueNumber);
+        if (await postComment(issueNumber)) {
+            commented.push(issueNumber);
+        }
+    } catch (error) {
+        if (error instanceof FieldConfigError) {
+            throw error;
+        }
+        // One broken issue (deleted, access-restricted, …) must not abandon the rest of the set.
+        failed.push(issueNumber);
+        console.error(`#${issueNumber}: ${error}`);
+    }
+    if (!DRY_RUN) {
+        // Pace the writes — GitHub's secondary rate limit targets rapid content creation.
+        await new Promise((resolve) => setTimeout(resolve, 1000));
     }
 }
 
@@ -298,4 +316,8 @@ writeStepSummary([
     `- Stamped: ${describe(stamped)}`,
     `- Already stamped (kept existing value): ${describe(skipped)}`,
     `- Commented: ${describe(commented)}`,
+    `- Failed: ${describe(failed)}`,
 ]);
+if (failed.length > 0) {
+    process.exit(1);
+}

--- a/.github/scripts/stamp-issue-versions.ts
+++ b/.github/scripts/stamp-issue-versions.ts
@@ -38,8 +38,7 @@ function requireEnv(name: string): string {
 const OWNER = requireEnv("OWNER");
 const REPO = requireEnv("REPO");
 const HEAD_OID = requireEnv("HEAD_OID");
-// Empty BASE_OID = no previous tag exists (true first release): walk history to the root.
-const BASE_OID = process.env.BASE_OID ?? "";
+const BASE_OID = requireEnv("BASE_OID");
 const FIELD_ID = Number.parseInt(requireEnv("FIELD_ID"), 10);
 const EXPECTED_FIELD_NAME = requireEnv("EXPECTED_FIELD_NAME");
 const VALUE = requireEnv("VALUE");
@@ -153,7 +152,7 @@ async function resolveIssues(): Promise<{ issues: number[]; commitCount: number 
         }
 
         for (const commit of history.nodes) {
-            if (BASE_OID !== "" && commit.oid === BASE_OID) {
+            if (commit.oid === BASE_OID) {
                 baseReached = true;
                 break;
             }
@@ -175,10 +174,7 @@ async function resolveIssues(): Promise<{ issues: number[]; commitCount: number 
 
         if (!baseReached) {
             if (!history.pageInfo.hasNextPage) {
-                if (BASE_OID !== "") {
-                    throw new Error(`BASE_OID ${BASE_OID} not found in the history of ${HEAD_OID}`);
-                }
-                break;
+                throw new Error(`BASE_OID ${BASE_OID} not found in the history of ${HEAD_OID}`);
             }
             cursor = history.pageInfo.endCursor;
         }
@@ -273,7 +269,7 @@ function writeStepSummary(lines: string[]): void {
 
 const { issues, commitCount } = await resolveIssues();
 console.log(
-    `Range ${BASE_OID === "" ? "<root>" : BASE_OID}..${HEAD_OID}: ` +
+    `Range ${BASE_OID}..${HEAD_OID}: ` +
         `${commitCount} commits, ${issues.length} closed issues${issues.length > 0 ? ` (#${issues.join(", #")})` : ""}`,
 );
 if (issues.length > MAX_ISSUES) {

--- a/.github/scripts/stamp-issue-versions.ts
+++ b/.github/scripts/stamp-issue-versions.ts
@@ -1,0 +1,304 @@
+// Stamps the issues shipped by a build with the image version that first contains their fix.
+//
+// Resolves the issues closed by the PRs in the commit range BASE_OID..HEAD_OID (via GitHub's own
+// PR↔issue linkage), writes VALUE into the org Issue Field FIELD_ID (first value wins), and posts
+// a human-readable "your fix shipped in <version>" comment once per channel (marker-deduped).
+// Run with Bun; invoked by .github/actions/stamp-issue-versions.
+import { appendFileSync } from "node:fs";
+import { Octokit } from "@octokit/rest";
+
+interface ChannelConfig {
+    floatingTag: string;
+    commentBody: (value: string, docsUrl: string) => string;
+}
+
+const DOCS_URL = "https://stardew-valley-dedicated-server.github.io/server/admins/operations/upgrading";
+
+const CHANNELS: Record<string, ChannelConfig> = {
+    preview: {
+        floatingTag: "preview",
+        commentBody: (value, docsUrl) =>
+            `🧪 A fix for this issue is available in a **preview build**. Set \`IMAGE_VERSION=${value}\` ` +
+            `(or \`IMAGE_VERSION=preview\` to always track the latest preview) and update — ` +
+            `see [how to run preview builds](${docsUrl}#using-preview-builds).`,
+    },
+    release: {
+        floatingTag: "latest",
+        commentBody: (value, docsUrl) =>
+            `🎉 This fix has been **released** in \`${value}\`. Set \`IMAGE_VERSION=${value}\` ` +
+            `(or \`IMAGE_VERSION=latest\` to track the latest stable) and update — see [how to update](${docsUrl}).`,
+    },
+};
+
+function requireEnv(name: string): string {
+    const value = process.env[name];
+    if (value === undefined || value === "") {
+        throw new Error(`Missing required env var ${name}`);
+    }
+    return value;
+}
+
+const OWNER = requireEnv("OWNER");
+const REPO = requireEnv("REPO");
+const HEAD_OID = requireEnv("HEAD_OID");
+// Empty BASE_OID = no previous tag exists (true first release): walk history to the root.
+const BASE_OID = process.env.BASE_OID ?? "";
+const FIELD_ID = Number.parseInt(requireEnv("FIELD_ID"), 10);
+const EXPECTED_FIELD_NAME = requireEnv("EXPECTED_FIELD_NAME");
+const VALUE = requireEnv("VALUE");
+const CHANNEL = requireEnv("CHANNEL");
+const MAX_ISSUES = Number.parseInt(requireEnv("MAX_ISSUES"), 10);
+const DRY_RUN = process.env.DRY_RUN === "true";
+
+if (!Number.isInteger(FIELD_ID) || FIELD_ID <= 0) {
+    throw new Error(`FIELD_ID must be a positive integer, got "${process.env.FIELD_ID}"`);
+}
+if (!Number.isInteger(MAX_ISSUES) || MAX_ISSUES <= 0) {
+    throw new Error(`MAX_ISSUES must be a positive integer, got "${process.env.MAX_ISSUES}"`);
+}
+const channel = CHANNELS[CHANNEL];
+if (!channel) {
+    throw new Error(`CHANNEL must be one of ${Object.keys(CHANNELS).join(", ")}, got "${CHANNEL}"`);
+}
+const COMMENT_MARKER = `<!-- image-version-stamp:${CHANNEL} -->`;
+
+const octokit = new Octokit({ auth: requireEnv("GH_TOKEN") });
+
+async function withRetry<T>(label: string, fn: () => Promise<T>): Promise<T> {
+    const maxAttempts = 4;
+    for (let attempt = 1; ; attempt++) {
+        try {
+            return await fn();
+        } catch (error) {
+            const status = (error as { status?: number }).status ?? 0;
+            const rateLimited =
+                status === 429 ||
+                (status === 403 &&
+                    (error as { response?: { headers?: Record<string, string> } }).response?.headers?.[
+                        "x-ratelimit-remaining"
+                    ] === "0");
+            if (attempt === maxAttempts || !(status >= 500 || rateLimited)) {
+                throw error;
+            }
+            const delayMs = 2 ** attempt * 1000;
+            console.warn(`${label}: HTTP ${status}, retry ${attempt}/${maxAttempts - 1} in ${delayMs}ms`);
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+        }
+    }
+}
+
+interface HistoryPage {
+    repository: {
+        object: {
+            history: {
+                nodes: Array<{
+                    oid: string;
+                    associatedPullRequests: {
+                        nodes: Array<{
+                            number: number;
+                            closingIssuesReferences: {
+                                nodes: Array<{ number: number; repository: { nameWithOwner: string } }>;
+                                pageInfo: { hasNextPage: boolean };
+                            };
+                        }>;
+                        pageInfo: { hasNextPage: boolean };
+                    };
+                }>;
+                pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            };
+        } | null;
+    };
+}
+
+const HISTORY_QUERY = `
+query ($owner: String!, $repo: String!, $headOid: GitObjectID!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+        object(oid: $headOid) {
+            ... on Commit {
+                history(first: 100, after: $cursor) {
+                    nodes {
+                        oid
+                        associatedPullRequests(first: 5) {
+                            nodes {
+                                number
+                                closingIssuesReferences(first: 50) {
+                                    nodes {
+                                        number
+                                        repository { nameWithOwner }
+                                    }
+                                    pageInfo { hasNextPage }
+                                }
+                            }
+                            pageInfo { hasNextPage }
+                        }
+                    }
+                    pageInfo { hasNextPage endCursor }
+                }
+            }
+        }
+    }
+}`;
+
+/** Walks HEAD_OID's history (exclusive of BASE_OID) and returns the closed same-repo issue numbers. */
+async function resolveIssues(): Promise<{ issues: number[]; commitCount: number }> {
+    const issues = new Set<number>();
+    let commitCount = 0;
+    let cursor: string | null = null;
+    let baseReached = false;
+
+    while (!baseReached) {
+        const page: HistoryPage = await withRetry("history query", () =>
+            octokit.graphql<HistoryPage>(HISTORY_QUERY, { owner: OWNER, repo: REPO, headOid: HEAD_OID, cursor }),
+        );
+        const history = page.repository.object?.history;
+        if (!history) {
+            throw new Error(`HEAD_OID ${HEAD_OID} is not a commit in ${OWNER}/${REPO}`);
+        }
+
+        for (const commit of history.nodes) {
+            if (BASE_OID !== "" && commit.oid === BASE_OID) {
+                baseReached = true;
+                break;
+            }
+            commitCount++;
+            if (commit.associatedPullRequests.pageInfo.hasNextPage) {
+                throw new Error(`Commit ${commit.oid} has more than 5 associated PRs — raise the page size`);
+            }
+            for (const pr of commit.associatedPullRequests.nodes) {
+                if (pr.closingIssuesReferences.pageInfo.hasNextPage) {
+                    throw new Error(`PR #${pr.number} closes more than 50 issues — raise the page size`);
+                }
+                for (const issue of pr.closingIssuesReferences.nodes) {
+                    if (issue.repository.nameWithOwner === `${OWNER}/${REPO}`) {
+                        issues.add(issue.number);
+                    }
+                }
+            }
+        }
+
+        if (!baseReached) {
+            if (!history.pageInfo.hasNextPage) {
+                if (BASE_OID !== "") {
+                    throw new Error(`BASE_OID ${BASE_OID} not found in the history of ${HEAD_OID}`);
+                }
+                break;
+            }
+            cursor = history.pageInfo.endCursor;
+        }
+    }
+
+    return { issues: [...issues].sort((a, b) => a - b), commitCount };
+}
+
+interface FieldValue {
+    issue_field_id: number;
+    issue_field_name: string;
+    data_type: string;
+    value: string;
+}
+
+/** First-value-wins: returns false (skipped) when FIELD_ID already carries a value. */
+async function stampField(issueNumber: number): Promise<boolean> {
+    const current = await withRetry(`get field values #${issueNumber}`, () =>
+        octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}/issue-field-values", {
+            owner: OWNER,
+            repo: REPO,
+            issue_number: issueNumber,
+        }),
+    );
+    const existing = (current.data as FieldValue[]).find((entry) => entry.issue_field_id === FIELD_ID);
+    if (existing) {
+        console.log(`#${issueNumber}: field already set to "${existing.value}", keeping it`);
+        return false;
+    }
+    if (DRY_RUN) {
+        console.log(`#${issueNumber}: [dry-run] would set field ${FIELD_ID} (${EXPECTED_FIELD_NAME}) = "${VALUE}"`);
+        return true;
+    }
+    const response = await withRetry(`set field #${issueNumber}`, () =>
+        octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/issue-field-values", {
+            owner: OWNER,
+            repo: REPO,
+            issue_number: issueNumber,
+            issue_field_values: [{ field_id: FIELD_ID, value: VALUE }],
+        }),
+    );
+    // Catch a stale or wrong FIELD_ID (field ids change when a field is deleted and recreated).
+    const echoed = [response.data as FieldValue | FieldValue[]]
+        .flat()
+        .find((entry) => entry.issue_field_id === FIELD_ID);
+    if (!echoed || echoed.issue_field_name !== EXPECTED_FIELD_NAME || echoed.data_type !== "text") {
+        throw new Error(
+            `Field ${FIELD_ID} echoed back as "${echoed?.issue_field_name}" (${echoed?.data_type}), ` +
+                `expected text field "${EXPECTED_FIELD_NAME}" — check the field id`,
+        );
+    }
+    console.log(`#${issueNumber}: field set to "${VALUE}"`);
+    return true;
+}
+
+/** Posts the channel comment unless one with this channel's marker already exists. */
+async function postComment(issueNumber: number): Promise<boolean> {
+    const comments = await withRetry(`list comments #${issueNumber}`, () =>
+        octokit.paginate(octokit.issues.listComments, {
+            owner: OWNER,
+            repo: REPO,
+            issue_number: issueNumber,
+            per_page: 100,
+        }),
+    );
+    if (comments.some((comment) => comment.body?.includes(COMMENT_MARKER))) {
+        console.log(`#${issueNumber}: ${CHANNEL} comment already present, skipping`);
+        return false;
+    }
+    const body = `${channel.commentBody(VALUE, DOCS_URL)}\n\n${COMMENT_MARKER}`;
+    if (DRY_RUN) {
+        console.log(`#${issueNumber}: [dry-run] would comment:\n${body}`);
+        return true;
+    }
+    await withRetry(`comment #${issueNumber}`, () =>
+        octokit.issues.createComment({ owner: OWNER, repo: REPO, issue_number: issueNumber, body }),
+    );
+    console.log(`#${issueNumber}: ${CHANNEL} comment posted`);
+    return true;
+}
+
+function writeStepSummary(lines: string[]): void {
+    const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+    if (summaryPath) {
+        appendFileSync(summaryPath, `${lines.join("\n")}\n`);
+    }
+}
+
+const { issues, commitCount } = await resolveIssues();
+console.log(
+    `Range ${BASE_OID === "" ? "<root>" : BASE_OID}..${HEAD_OID}: ` +
+        `${commitCount} commits, ${issues.length} closed issues${issues.length > 0 ? ` (#${issues.join(", #")})` : ""}`,
+);
+if (issues.length > MAX_ISSUES) {
+    throw new Error(
+        `Resolved ${issues.length} issues, exceeding MAX_ISSUES=${MAX_ISSUES} — ` +
+            `suspicious range (bad base tag?), refusing to stamp`,
+    );
+}
+
+const stamped: number[] = [];
+const skipped: number[] = [];
+const commented: number[] = [];
+for (const issueNumber of issues) {
+    (await stampField(issueNumber)) ? stamped.push(issueNumber) : skipped.push(issueNumber);
+    if (await postComment(issueNumber)) {
+        commented.push(issueNumber);
+    }
+}
+
+const describe = (list: number[]) => (list.length > 0 ? list.map((n) => `#${n}`).join(", ") : "none");
+writeStepSummary([
+    `### Issue version stamp (${CHANNEL})${DRY_RUN ? " — dry run" : ""}`,
+    "",
+    `**\`${EXPECTED_FIELD_NAME}\` = \`${VALUE}\`** over ${commitCount} commits`,
+    "",
+    `- Stamped: ${describe(stamped)}`,
+    `- Already stamped (kept existing value): ${describe(skipped)}`,
+    `- Commented: ${describe(commented)}`,
+]);

--- a/.github/scripts/stamp-issue-versions.ts
+++ b/.github/scripts/stamp-issue-versions.ts
@@ -8,7 +8,6 @@ import { appendFileSync } from "node:fs";
 import { Octokit } from "@octokit/rest";
 
 interface ChannelConfig {
-    floatingTag: string;
     commentBody: (value: string, docsUrl: string) => string;
 }
 
@@ -16,14 +15,12 @@ const DOCS_URL = "https://stardew-valley-dedicated-server.github.io/server/admin
 
 const CHANNELS: Record<string, ChannelConfig> = {
     preview: {
-        floatingTag: "preview",
         commentBody: (value, docsUrl) =>
             `🧪 A fix for this issue is available in a **preview build**. Set \`IMAGE_VERSION=${value}\` ` +
             `(or \`IMAGE_VERSION=preview\` to always track the latest preview) and update — ` +
             `see [how to run preview builds](${docsUrl}#using-preview-builds).`,
     },
     release: {
-        floatingTag: "latest",
         commentBody: (value, docsUrl) =>
             `🎉 This fix has been **released** in \`${value}\`. Set \`IMAGE_VERSION=${value}\` ` +
             `(or \`IMAGE_VERSION=latest\` to track the latest stable) and update — see [how to update](${docsUrl}).`,

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -251,6 +251,10 @@ jobs:
   stamp-issue-versions:
     name: Stamp Issue Versions
     needs: [calculate-version, build-server-preview]
+    # Deploy Server auto-deploys via workflow_run only when this workflow's conclusion is
+    # success, so a stamping failure must not fail the run — it still shows as a red job
+    # with an annotation, and the next preview build retries (stamping is idempotent).
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -268,10 +268,10 @@ jobs:
       - name: Stamp issues with preview version
         uses: ./.github/actions/stamp-issue-versions
         with:
-          # Org issue-field id for "IMAGE_VERSION Preview". Deleting and recreating a field
+          # Org issue-field id for "Preview version". Deleting and recreating a field
           # changes its id — this input must then be updated.
           field-id: "45970008"
-          field-name: IMAGE_VERSION Preview
+          field-name: Preview version
           value: ${{ needs.calculate-version.outputs.preview_version }}
           channel: preview
           head-ref: ${{ github.sha }}

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -275,10 +275,9 @@ jobs:
           value: ${{ needs.calculate-version.outputs.preview_version }}
           channel: preview
           head-ref: ${{ github.sha }}
-          # Base = the nearest earlier build of either channel, excluding the tracking tag
-          # build-server-preview just pushed for this run (it points at this very commit).
+          # Base = the nearest earlier build of either channel on a previous commit (the action
+          # ignores tags on this commit itself, including this run's own tracking tag).
           tag-match: sdvd-server-v* preview-[0-9]*
-          exclude-tag: preview-${{ needs.calculate-version.outputs.next_version }}.${{ needs.calculate-version.outputs.preview_number }}
 
   build-steam-service-preview:
     name: Build Steam Service Preview

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -248,6 +248,34 @@ jobs:
               }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
           fi
 
+  stamp-issue-versions:
+    name: Stamp Issue Versions
+    needs: [calculate-version, build-server-preview]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Stamp issues with preview version
+        uses: ./.github/actions/stamp-issue-versions
+        with:
+          # Org issue-field id for "IMAGE_VERSION Preview". Deleting and recreating a field
+          # changes its id — this input must then be updated.
+          field-id: "45970008"
+          field-name: IMAGE_VERSION Preview
+          value: ${{ needs.calculate-version.outputs.preview_version }}
+          channel: preview
+          head-ref: ${{ github.sha }}
+          # Base = the nearest earlier build of either channel, excluding the tracking tag
+          # build-server-preview just pushed for this run (it points at this very commit).
+          tag-match: sdvd-server-v* preview-[0-9]*
+          exclude-tag: preview-${{ needs.calculate-version.outputs.next_version }}.${{ needs.calculate-version.outputs.preview_number }}
+
   build-steam-service-preview:
     name: Build Steam Service Preview
     needs: calculate-version

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -131,6 +131,36 @@ jobs:
               }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
           fi
 
+  stamp-issue-versions:
+    name: Stamp Issue Versions
+    needs: [release-please, build-and-publish]
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Stamp issues with release version
+        uses: ./.github/actions/stamp-issue-versions
+        with:
+          # Org issue-field id for "IMAGE_VERSION Release". Deleting and recreating a field
+          # changes its id — this input must then be updated.
+          # TODO: the field does not exist yet (creating it needs an org admin) — create the
+          # Text field "IMAGE_VERSION Release" and replace 0 with its numeric id; until then
+          # this job fails fast without touching any issue.
+          field-id: "0"
+          field-name: IMAGE_VERSION Release
+          value: ${{ needs.release-please.outputs.version }}
+          channel: release
+          head-ref: ${{ needs.release-please.outputs.tag_name }}
+          tag-match: sdvd-server-v*
+          exclude-tag: ${{ needs.release-please.outputs.tag_name }}
+
   build-and-publish-steam-service:
     name: Build Steam Service
     needs: release-please

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -148,13 +148,13 @@ jobs:
       - name: Stamp issues with release version
         uses: ./.github/actions/stamp-issue-versions
         with:
-          # Org issue-field id for "IMAGE_VERSION Release". Deleting and recreating a field
+          # Org issue-field id for "Release version". Deleting and recreating a field
           # changes its id — this input must then be updated.
           # TODO: the field does not exist yet (creating it needs an org admin) — create the
-          # Text field "IMAGE_VERSION Release" and replace 0 with its numeric id; until then
+          # Text field "Release version" and replace 0 with its numeric id; until then
           # this job fails fast without touching any issue.
           field-id: "0"
-          field-name: IMAGE_VERSION Release
+          field-name: Release version
           value: ${{ needs.release-please.outputs.version }}
           channel: release
           head-ref: ${{ needs.release-please.outputs.tag_name }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -150,10 +150,7 @@ jobs:
         with:
           # Org issue-field id for "Release version". Deleting and recreating a field
           # changes its id — this input must then be updated.
-          # TODO: the field does not exist yet (creating it needs an org admin) — create the
-          # Text field "Release version" and replace 0 with its numeric id; until then
-          # this job fails fast without touching any issue.
-          field-id: "0"
+          field-id: "45984818"
           field-name: Release version
           value: ${{ needs.release-please.outputs.version }}
           channel: release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -156,7 +156,6 @@ jobs:
           channel: release
           head-ref: ${{ needs.release-please.outputs.tag_name }}
           tag-match: sdvd-server-v*
-          exclude-tag: ${{ needs.release-please.outputs.tag_name }}
 
   build-and-publish-steam-service:
     name: Build Steam Service

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -107,6 +107,19 @@ Day 4: Merge Release PR → v1.2.0 released
 
 The Release PR automatically updates as you merge more commits; the preview counter `N` increments on each preview build for the same target version, whether that build was dispatched manually or auto-triggered on push.
 
+## Issue Version Stamping
+
+Both build pipelines end with a **Stamp Issue Versions** job ([composite action](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/actions/stamp-issue-versions), [script](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/scripts/stamp-issue-versions.ts)). It resolves every issue closed by the PRs in the build's commit range (from GitHub's own PR↔issue linkage, not commit-subject parsing), then records on each issue which built image first shipped its fix:
+
+- **Two org Issue Fields** — `IMAGE_VERSION Preview` and `IMAGE_VERSION Release`. Each field independently records the **first** version of its channel that contained the fix; later builds never overwrite an existing value. A release without a prior preview simply leaves the preview field empty.
+- **One comment per channel** — a human-readable note telling the reporter the exact `IMAGE_VERSION` to set (and the rolling `preview` / `latest` alternative), linking the upgrade docs. Deduped by a hidden marker, so re-runs never post twice.
+
+The commit range is `previous build's tag → this build's head`: a release covers everything since the previous release; a preview covers only what's new since the last build of either channel. The job is idempotent — re-running a failed build changes nothing already stamped — and a stamping failure never affects the pushed image or deploy.
+
+::: warning Field ids are hardcoded
+The workflows reference the org issue fields by **numeric id**. Deleting and recreating a field gives it a new id — the `field-id` inputs in `build-release.yml` / `build-preview.yml` must then be updated. The script asserts the field's name and type on its first write, so a stale id fails loudly instead of stamping the wrong field.
+:::
+
 ## Cleanup Preview Tags
 
 [Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/cleanup-preview-tags.yml)

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -111,7 +111,7 @@ The Release PR automatically updates as you merge more commits; the preview coun
 
 Both build pipelines end with a **Stamp Issue Versions** job ([composite action](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/actions/stamp-issue-versions), [script](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/scripts/stamp-issue-versions.ts)). It resolves every issue closed by the PRs in the build's commit range (from GitHub's own PR↔issue linkage, not commit-subject parsing), then records on each issue which built image first shipped its fix:
 
-- **Two org Issue Fields** — `IMAGE_VERSION Preview` and `IMAGE_VERSION Release`. Each field independently records the **first** version of its channel that contained the fix; later builds never overwrite an existing value. A release without a prior preview simply leaves the preview field empty.
+- **Two org Issue Fields** — `Preview version` and `Release version`. Each field independently records the **first** version of its channel that contained the fix; later builds never overwrite an existing value. A release without a prior preview simply leaves the preview field empty.
 - **One comment per channel** — a human-readable note telling the reporter the exact `IMAGE_VERSION` to set (and the rolling `preview` / `latest` alternative), linking the upgrade docs. Deduped by a hidden marker, so re-runs never post twice.
 
 The commit range is `previous build's tag → this build's head`: a release covers everything since the previous release; a preview covers only what's new since the last build of either channel. The job is idempotent — re-running a failed build changes nothing already stamped — and a stamping failure never affects the pushed image or deploy.


### PR DESCRIPTION
Stamps every issue closed by the PRs contained in a build with the image version that first shipped its fix, and tells the reporter in a comment.

- `.github/scripts/stamp-issue-versions.ts` (Bun + Octokit): walks the build's commit range via GraphQL using GitHub's own PR↔issue linkage, writes the org issue field (**first value wins** — later builds never overwrite), and posts one marker-deduped comment per channel pointing at the exact `IMAGE_VERSION` to set plus the upgrade docs
- `.github/actions/stamp-issue-versions/action.yml`: composite action resolving the base tag with `git describe` (release: previous release tag; preview: nearest earlier build of either channel, excluding this run's own tracking tag; first release ever walks to root), then runs the script
- Stamp jobs appended to `build-release.yml` and `build-preview.yml` (`issues: write`); the preview job is `continue-on-error` because Deploy Server's `workflow_run` auto-deploy gates on the workflow conclusion
- Resilience: retry with `Retry-After`/secondary-rate-limit handling, 1s write pacing, per-issue failure isolation (config errors still abort before any wrong write), `MAX_ISSUES` guard, dry-run mode, step summary
- Fields `Preview version` (45970008) / `Release version` (45984818) are referenced by hardcoded id; deleting and recreating a field changes its id, and the script asserts name+type on first write so a stale id fails loudly
- Docs: new "Issue Version Stamping" section in `docs/developers/contributing/ci-cd.md`

Verified: dry runs over real history (v1.4.0..v1.4.1, v1.4.1..master resolving 15 issues incl. #537 via PR #550, preview.126..127 incremental split), live-probed GET/POST response shapes, base-tag resolution tested for all four scenarios, actionlint + biome clean.

Post-merge verification: dispatch Build Preview once with a throwaway linked issue to exercise live commenting end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically records the first released or preview version containing each fixed issue.
  * Adds channel-specific “your fix shipped” comments while preventing duplicates.
  * Supports dry runs, issue limits, retries, and clear failure reporting.
  * Processes issues linked to pull requests included in each build.

* **Documentation**
  * Documented issue version stamping behavior across release and preview pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->