### PR TITLE
fix(api): use a relative OpenAPI spec URL in the docs page

### DIFF
--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -5318,9 +5318,6 @@ public partial class ApiService : ModService
 
     private string GetScalarHtml()
     {
-        // The spec URL must be relative: data-url is fetched by the viewer's browser, so an
-        // absolute localhost URL only works when the browser runs on the server itself and
-        // breaks LAN/reverse-proxy access (plus mixed content when proxied over HTTPS).
         return @"<!DOCTYPE html>
 <html>
 <head>

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -5318,7 +5318,10 @@ public partial class ApiService : ModService
 
     private string GetScalarHtml()
     {
-        return $@"<!DOCTYPE html>
+        // The spec URL must be relative: data-url is fetched by the viewer's browser, so an
+        // absolute localhost URL only works when the browser runs on the server itself and
+        // breaks LAN/reverse-proxy access (plus mixed content when proxied over HTTPS).
+        return @"<!DOCTYPE html>
 <html>
 <head>
     <title>Stardew Dedicated Server API</title>
@@ -5326,7 +5329,7 @@ public partial class ApiService : ModService
     <meta name=""viewport"" content=""width=device-width, initial-scale=1"" />
 </head>
 <body>
-    <script id=""api-reference"" data-url=""http://localhost:{Env.ApiPort}/swagger/v1/swagger.json""></script>
+    <script id=""api-reference"" data-url=""/swagger/v1/swagger.json""></script>
     <script src=""https://cdn.jsdelivr.net/npm/@scalar/api-reference""></script>
 </body>
 </html>";


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #568

### 📚 Description

The `/docs` page embedded `data-url="http://localhost:<API_PORT>/swagger/v1/swagger.json"`. Since `data-url` is fetched by the **viewer's browser**, that absolute URL only resolves when the browser runs on the server machine itself: from any other machine — or behind a reverse proxy — Scalar shows *"Document 'api-1' could not be loaded"*, and when the page is proxied over HTTPS the `http://` fetch is additionally blocked as mixed content.

This makes the URL relative (`/swagger/v1/swagger.json`), so it resolves against whatever origin served the page — localhost, a LAN IP, or a proxy hostname alike. The spec endpoint is already served by the same listener, so no other change is needed; the now-interpolation-free string also drops its `$`.

Verified by serving the identical HTML (relative URL) in front of an otherwise unmodified server through an HTTPS reverse proxy: the docs page loads and renders the full spec, where the absolute URL failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* **Bug Fixes**
  * Improved API documentation access across different hosts and connection setups.
  * The API reference viewer now uses the current server location, helping it load correctly when accessed through LAN connections, reverse proxies, or HTTPS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->