### PR TITLE
fix(ci): opt fork-head checkouts back in after actions/checkout v7

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -135,6 +135,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Fork head under pull_request_target — safe because this job is gated on `authorize`.
+          allow-unsafe-pr-checkout: true
 
       # The index is OS-agnostic, so this catches CRLF regardless of the contributor's
       # core.autocrlf. .gitattributes (* text=auto eol=lf) makes LF the committed normal form;
@@ -164,6 +166,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Fork head under pull_request_target — safe because this job is gated on `authorize`.
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Docker Buildx
         id: buildx
@@ -248,6 +252,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          # Fork head under pull_request_target — safe because this job is gated on `authorize`.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup .NET
         id: dotnet
@@ -306,6 +312,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+          # Fork head under pull_request_target — safe because this job is gated on `authorize`.
+          allow-unsafe-pr-checkout: true
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0


### PR DESCRIPTION
### Description

`actions/checkout` v7.0.1 now refuses to check out fork PR head code under `pull_request_target` by default (opt-in via `allow-unsafe-pr-checkout`). This turned every fork PR red at four required checks:

- Validate JS/TS
- Validate Build
- Validate Formatting
- Validate Line Endings

### Change

- Set `allow-unsafe-pr-checkout: true` on the four fork-head checkout steps in `validate-pr.yml`.
- All four are already gated on the `authorize` approval job, so this restores the pre-v7 behavior without weakening the fork-PR trust model.
- Base-repo-only checkouts (title, commits) don't take fork head and are left unchanged.

### Scope

Audited all `pull_request_target` workflows; only `validate-pr.yml` needed changes:
- `codeql.yml` — triggers on `pull_request`, not `pull_request_target`.
- `e2e-tests.yml` — triggers on `workflow_dispatch`/`schedule`/`issue_comment`, not `pull_request_target`.
- `label-pr.yml` — `pull_request_target` but has no checkout.

Since the workflow definition comes from the base branch under `pull_request_target`, this takes effect for in-flight fork PRs without them needing to rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated validation for contributions submitted from external branches.
  - Build, formatting, JavaScript, and line-ending checks now run more reliably during review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->