### PR TITLE
fix(ci): make docs deploy recovery durable via an R2 live snapshot

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,8 +60,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      # Try to download from current workflow run first
-      # This works when called from build-release.yml/build-preview.yml which run build-docs first
+      # Each half is sourced in order: this run's artifact → its primary build workflow →
+      # a prior manual rebuild. Present in this run when invoked by build-release.yml /
+      # build-preview.yml, which run build-docs first.
       - name: Download latest docs (current run)
         id: current-latest
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -78,8 +79,7 @@ jobs:
           path: dist/preview
         continue-on-error: true
 
-      # If not found in current run, fetch from previous workflow runs
-      # Try build-release.yml first (primary source for latest docs)
+      # Primary source for latest: the last build-release.yml run.
       - name: Download latest docs (from release workflow)
         id: release-latest
         if: steps.current-latest.outcome != 'success'
@@ -92,7 +92,7 @@ jobs:
           allow_forks: false
         continue-on-error: true
 
-      # Fallback: check deploy-docs.yml for manually rebuilt latest docs
+      # Last resort: a manually-rebuilt artifact from a prior deploy-docs.yml run.
       - name: Download latest docs (from manual rebuild)
         if: steps.current-latest.outcome != 'success' && steps.release-latest.outcome != 'success'
         uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
@@ -103,7 +103,7 @@ jobs:
           if_no_artifact_found: warn
           allow_forks: false
 
-      # Try build-preview.yml first (primary source for preview docs)
+      # Primary source for preview: the last build-preview.yml run.
       - name: Download preview docs (from build-preview workflow)
         id: build-preview-artifact
         if: steps.current-preview.outcome != 'success'
@@ -116,7 +116,7 @@ jobs:
           allow_forks: false
         continue-on-error: true
 
-      # Fallback: check deploy-docs.yml for manually rebuilt preview docs
+      # Last resort: a manually-rebuilt artifact from a prior deploy-docs.yml run.
       - name: Download preview docs (from manual rebuild)
         if: steps.current-preview.outcome != 'success' && steps.build-preview-artifact.outcome != 'success'
         uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -162,7 +162,21 @@ jobs:
           fi
           if aws s3 sync "s3://${R2_BUCKET}/" live/site/ \
                --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress; then
-            echo "restore_status=ok" >> "$GITHUB_OUTPUT"
+            # The persist step writes a `.snapshot-complete` marker LAST, after a full mirror.
+            # Its absence beside non-empty content means the previous persist was interrupted
+            # mid-sync (aws s3 sync isn't atomic), so the snapshot is partial — treat that as a
+            # read failure so a single-half run refuses rather than deploying a truncated half.
+            # An empty bucket (never seeded) has no marker but nothing to be partial about: ok.
+            if [ -z "$(ls -A live/site 2>/dev/null)" ]; then
+              echo "restore_status=ok" >> "$GITHUB_OUTPUT"
+            elif [ -f live/site/.snapshot-complete ]; then
+              echo "restore_status=ok" >> "$GITHUB_OUTPUT"
+            else
+              echo "::warning::R2 snapshot has content but no completion marker — previous persist was interrupted; a partial deploy will be refused."
+              echo "restore_status=failed" >> "$GITHUB_OUTPUT"
+            fi
+            # Never let the marker leak into the merged/deployed site.
+            rm -f live/site/.snapshot-complete
           else
             echo "::warning::R2 live-snapshot read failed — a partial deploy will be refused by the decide step below."
             echo "restore_status=failed" >> "$GITHUB_OUTPUT"
@@ -214,10 +228,21 @@ jobs:
           echo "preview_src=$PREVIEW_SRC" >> "$GITHUB_OUTPUT"
 
           # deploy-pages replaces the whole site, so a half we can't obtain must not be
-          # published — that would wipe it live. A missing half is only safe to treat as
-          # genuinely-absent when the snapshot read succeeded or was config-skipped; a restore
-          # *failure* leaves us blind, so refuse (retry) rather than risk wiping a live half.
-          # A full-rebuild run never reaches these branches, so an R2 outage can't block it.
+          # published — that would wipe it live. A half is safe to ship only when it's built
+          # this run, restored intact, or confirmed genuinely absent by a successful read (ok);
+          # a failed/partial/skipped read leaves us blind and refuses below. A full-rebuild run
+          # never reaches these branches, so an R2 outage can't block it.
+
+          # A failed/partial restore can still leave live/site with SOME content, so a half can
+          # read as `live` off an incomplete snapshot. Deploying it would publish a truncated
+          # half and --delete the live files that didn't restore. Refuse whenever any half we'd
+          # ship was sourced from a restore we couldn't trust.
+          if [ "${RESTORE_STATUS:-}" = failed ] && { [ "$LATEST_SRC" = live ] || [ "$PREVIEW_SRC" = live ]; }; then
+            echo "::error::R2 snapshot restore was incomplete — a restored half may be truncated."
+            echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe a live half."
+            exit 1
+          fi
+
           if [ "$LATEST_SRC" = none ]; then
             if [ "${RESTORE_STATUS:-}" = failed ]; then
               echo "::error::Latest half not built this run and the R2 snapshot read failed (see warning above)."
@@ -229,12 +254,17 @@ jobs:
             exit 1
           fi
           if [ "$PREVIEW_SRC" = none ]; then
-            if [ "${RESTORE_STATUS:-}" = failed ]; then
-              echo "::error::Preview half not built this run and the R2 snapshot read failed (see warning above)."
-              echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe the live preview."
+            # Deploying LATEST ONLY wipes any preview the live site currently has, so it's only
+            # safe when we've positively CONFIRMED the live site has no preview. Only a
+            # successful restore (ok) confirms that — the snapshot is byte-exact with live via
+            # --delete. A failed read or an unconfigured/skipped restore leaves us blind, so
+            # refuse rather than risk wiping a live preview.
+            if [ "${RESTORE_STATUS:-}" != ok ]; then
+              echo "::error::Preview half not built this run and its absence from the live site is unconfirmed (restore: ${RESTORE_STATUS:-unknown})."
+              echo "::error::Refusing to deploy LATEST ONLY — that could wipe a live preview. Retry once R2 is reachable, or re-run with rebuild_preview=true."
               exit 1
             fi
-            echo "::warning::Deploying LATEST ONLY — dist/preview/ absent this deploy."
+            echo "::warning::Deploying LATEST ONLY — preview genuinely absent from the confirmed R2 snapshot."
           fi
 
       - name: Setup Pages
@@ -279,11 +309,21 @@ jobs:
             echo "::warning::aws CLI not found on runner — live snapshot NOT persisted."
             exit 0
           fi
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          # Clear the completion marker BEFORE mirroring so the snapshot is marked incomplete
+          # for the whole write window: if this step is interrupted mid-sync, no marker remains
+          # and the next restore treats the partial snapshot as unusable instead of deploying it.
+          aws s3 rm "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1 || true
           if aws s3 sync dist/ "s3://${R2_BUCKET}/" \
-               --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress --delete; then
-            echo "Live snapshot updated in R2."
+               --endpoint-url "$endpoint" --no-progress --delete; then
+            # Mirror succeeded — write the marker LAST to certify the snapshot is complete.
+            if printf 'ok' | aws s3 cp - "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1; then
+              echo "Live snapshot updated in R2."
+            else
+              echo "::warning::Snapshot mirrored but completion marker write failed — the next partial deploy will refuse until the next successful persist."
+            fi
           else
-            echo "::warning::Failed to persist live snapshot to R2 — the next partial deploy may recover from a stale snapshot."
+            echo "::warning::Failed to persist live snapshot to R2 — the next partial deploy will refuse (no completion marker) until the next successful persist."
           fi
 
       - name: Build summary

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -145,8 +145,8 @@ jobs:
         run: |
           # No `-e`: a sync error must NOT abort the step. A full-rebuild run (both halves
           # built this run) doesn't need the snapshot and must still deploy even if R2 is
-          # down. The decide step reads restore_status to tell a genuine miss (ok/skipped,
-          # so the half truly isn't live) from a read failure (failed, so we're blind).
+          # down. The decide step reads restore_status: `ok` = snapshot read and reflects
+          # live; `skipped`/`failed` = unconfirmed, so a single-half run refuses.
           set -uo pipefail
           mkdir -p live/site
           if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
@@ -162,14 +162,11 @@ jobs:
           fi
           if aws s3 sync "s3://${R2_BUCKET}/" live/site/ \
                --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress; then
-            # The persist step writes a `.snapshot-complete` marker LAST, after a full mirror.
-            # Its absence beside non-empty content means the previous persist was interrupted
-            # mid-sync (aws s3 sync isn't atomic), so the snapshot is partial — treat that as a
-            # read failure so a single-half run refuses rather than deploying a truncated half.
-            # An empty bucket (never seeded) has no marker but nothing to be partial about: ok.
-            if [ -z "$(ls -A live/site 2>/dev/null)" ]; then
-              echo "restore_status=ok" >> "$GITHUB_OUTPUT"
-            elif [ -f live/site/.snapshot-complete ]; then
+            # Persist writes a `.snapshot-complete` marker last, after a full mirror. Content
+            # without the marker means persist was interrupted mid-sync (aws s3 sync isn't
+            # atomic), so the snapshot is partial — treat it as a failed read so a single-half
+            # run refuses. An empty bucket (never seeded) has no marker but nothing partial: ok.
+            if [ -z "$(ls -A live/site 2>/dev/null)" ] || [ -f live/site/.snapshot-complete ]; then
               echo "restore_status=ok" >> "$GITHUB_OUTPUT"
             else
               echo "::warning::R2 snapshot has content but no completion marker — previous persist was interrupted; a partial deploy will be refused."
@@ -229,14 +226,11 @@ jobs:
 
           # deploy-pages replaces the whole site, so a half we can't obtain must not be
           # published — that would wipe it live. A half is safe to ship only when it's built
-          # this run, restored intact, or confirmed genuinely absent by a successful read (ok);
-          # a failed/partial/skipped read leaves us blind and refuses below. A full-rebuild run
-          # never reaches these branches, so an R2 outage can't block it.
+          # this run, restored intact, or confirmed absent by a successful read (ok). A
+          # full-rebuild run never reaches these branches, so an R2 outage can't block it.
 
-          # A failed/partial restore can still leave live/site with SOME content, so a half can
-          # read as `live` off an incomplete snapshot. Deploying it would publish a truncated
-          # half and --delete the live files that didn't restore. Refuse whenever any half we'd
-          # ship was sourced from a restore we couldn't trust.
+          # A failed restore can still leave partial content, so a half may read as `live` off
+          # a truncated snapshot. Deploying it would --delete the live files that didn't restore.
           if [ "${RESTORE_STATUS:-}" = failed ] && { [ "$LATEST_SRC" = live ] || [ "$PREVIEW_SRC" = live ]; }; then
             echo "::error::R2 snapshot restore was incomplete — a restored half may be truncated."
             echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe a live half."
@@ -289,8 +283,8 @@ jobs:
       - name: Persist live snapshot to R2
         if: success()
         # The deploy already published; a snapshot-write failure must not red the run or
-        # suppress the summary/notification below. It leaves the previous snapshot in place
-        # (identical for any half unchanged this run), so recovery barely degrades.
+        # suppress the summary/notification below. It clears the completion marker, so the
+        # next single-half run refuses (retry) instead of recovering from a partial snapshot.
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -316,7 +310,7 @@ jobs:
           aws s3 rm "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1 || true
           if aws s3 sync dist/ "s3://${R2_BUCKET}/" \
                --endpoint-url "$endpoint" --no-progress --delete; then
-            # Mirror succeeded — write the marker LAST to certify the snapshot is complete.
+            # Mirror succeeded — write the marker last to certify the snapshot is complete.
             if printf 'ok' | aws s3 cp - "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1; then
               echo "Live snapshot updated in R2."
             else

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -128,29 +128,55 @@ jobs:
           allow_forks: false
 
       # deploy-pages replaces the WHOLE site, so a half not rebuilt this run is restored from
-      # the currently-live site (the last github-pages artifact deploy-docs uploaded). The next
-      # step extracts the inner artifact.tar; ignore = tolerate it being absent/expired.
-      - name: Download live site snapshot
-        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
-        with:
-          workflow: deploy-docs.yml
-          # Only runs on the default branch actually deploy to live Pages — a dispatch
-          # on a feature branch can leave a github-pages artifact that was never deployed.
-          branch: ${{ github.event.repository.default_branch }}
-          name: github-pages
-          path: live
-          if_no_artifact_found: ignore
-          allow_forks: false
+      # the currently-live site. That snapshot lives in R2 (durable, no lifecycle rule),
+      # mirrored by "Persist live snapshot to R2" after every successful deploy.
+      # Unconfigured R2 is tolerated: live/site stays empty and a full-build run still deploys;
+      # only a partial deploy then hits the guard below.
+      - name: Restore live snapshot from R2
+        id: restore
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          # Bucket kept as a var, not a secret: the name has a hyphen and GitHub's secret
+          # masker would turn every `-` in the whole log into *** (see e2e-tests.yml).
+          R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
+        run: |
+          # No `-e`: a sync error must NOT abort the step. A full-rebuild run (both halves
+          # built this run) doesn't need the snapshot and must still deploy even if R2 is
+          # down. The decide step reads restore_status to tell a genuine miss (ok/skipped,
+          # so the half truly isn't live) from a read failure (failed, so we're blind).
+          set -uo pipefail
+          mkdir -p live/site
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
+             || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
+            echo "::warning::R2 not configured — skipping live-snapshot restore."
+            echo "restore_status=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "::warning::aws CLI not found on runner — skipping live-snapshot restore."
+            echo "restore_status=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if aws s3 sync "s3://${R2_BUCKET}/" live/site/ \
+               --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress; then
+            echo "restore_status=ok" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::R2 live-snapshot read failed — a partial deploy will be refused by the decide step below."
+            echo "restore_status=failed" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Restore missing halves and decide deploy
         id: check
+        env:
+          RESTORE_STATUS: ${{ steps.restore.outputs.restore_status }}
         run: |
           set -euo pipefail
 
-          # Extract the live snapshot (upload-pages-artifact tars uncompressed: tar -cvf).
-          if [ -f live/artifact.tar ]; then
-            mkdir -p live/site && tar -xf live/artifact.tar -C live/site
-          fi
+          # live/site holds the last deployed site, restored from R2 by the step above
+          # (empty if R2 was unconfigured or the restore skipped).
 
           # A dir counts as having content only if it holds at least one entry.
           has_root() { [ -d dist ] && [ -n "$(ls -A dist 2>/dev/null | grep -v '^preview$')" ]; }
@@ -187,33 +213,78 @@ jobs:
           echo "latest_src=$LATEST_SRC" >> "$GITHUB_OUTPUT"
           echo "preview_src=$PREVIEW_SRC" >> "$GITHUB_OUTPUT"
 
-          # Latest (site root) is required: deploy-pages replaces the whole site, so deploying
-          # without it would wipe the live root. If it's neither built this run nor recoverable
-          # from the live snapshot (artifact expired after >14d quiet), fail loudly rather than
-          # publish an empty root — re-run with rebuild_latest=true to repopulate it.
+          # deploy-pages replaces the whole site, so a half we can't obtain must not be
+          # published — that would wipe it live. A missing half is only safe to treat as
+          # genuinely-absent when the snapshot read succeeded or was config-skipped; a restore
+          # *failure* leaves us blind, so refuse (retry) rather than risk wiping a live half.
+          # A full-rebuild run never reaches these branches, so an R2 outage can't block it.
           if [ "$LATEST_SRC" = none ]; then
-            echo "::error::Latest docs missing and not recoverable from the live site (artifact likely expired)."
-            echo "::error::Refusing to deploy — that would wipe the live root. Re-run with rebuild_latest=true."
+            if [ "${RESTORE_STATUS:-}" = failed ]; then
+              echo "::error::Latest half not built this run and the R2 snapshot read failed (see warning above)."
+              echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe the live root."
+            else
+              echo "::error::Latest docs missing and absent from the R2 live snapshot (empty bucket or R2 unconfigured)."
+              echo "::error::Refusing to deploy — that would wipe the live root. Re-run with rebuild_latest=true."
+            fi
             exit 1
           fi
           if [ "$PREVIEW_SRC" = none ]; then
+            if [ "${RESTORE_STATUS:-}" = failed ]; then
+              echo "::error::Preview half not built this run and the R2 snapshot read failed (see warning above)."
+              echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe the live preview."
+              exit 1
+            fi
             echo "::warning::Deploying LATEST ONLY — dist/preview/ absent this deploy."
           fi
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
-      # The backfill above re-downloads this artifact, so it must outlive a deploy gap.
-      # Default 1d is too short; 14d matches the docs-latest / docs-preview window.
+      # Consumed by deploy-pages within this run; durable cross-run recovery is R2, not this
+      # artifact, so default retention is fine.
       - name: Upload merged artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: dist
-          retention-days: 14
 
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      # Mirror the just-deployed site to R2 (durable, no lifecycle rule) so the next run can
+      # restore whichever half it doesn't rebuild. Gated on success() alone: deploy-pages
+      # succeeds only when it actually published to live Pages (the github-pages environment's
+      # protection rules decide which refs may), so the snapshot always equals what's live —
+      # this fires for both default-branch and release-tag deploys. --delete keeps it byte-exact.
+      - name: Persist live snapshot to R2
+        if: success()
+        # The deploy already published; a snapshot-write failure must not red the run or
+        # suppress the summary/notification below. It leaves the previous snapshot in place
+        # (identical for any half unchanged this run), so recovery barely degrades.
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
+        run: |
+          set -uo pipefail
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
+             || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
+            echo "::warning::R2 not configured — live snapshot NOT persisted. Recovery on the next partial deploy will fail until this is set."
+            exit 0
+          fi
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "::warning::aws CLI not found on runner — live snapshot NOT persisted."
+            exit 0
+          fi
+          if aws s3 sync dist/ "s3://${R2_BUCKET}/" \
+               --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress --delete; then
+            echo "Live snapshot updated in R2."
+          else
+            echo "::warning::Failed to persist live snapshot to R2 — the next partial deploy may recover from a stale snapshot."
+          fi
 
       - name: Build summary
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -139,7 +139,7 @@ jobs:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           # Bucket kept as a var, not a secret: the name has a hyphen and GitHub's secret
           # masker would turn every `-` in the whole log into *** (see e2e-tests.yml).
-          R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
+          R2_BUCKET: ${{ vars.R2_BUCKET_DOCS }}
         run: |
           # restore_status, read by the decide step: skipped (R2 off) | ok (snapshot reflects
           # live, empty bucket included) | failed (read error, or a partial snapshot missing its
@@ -255,7 +255,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
+          R2_BUCKET: ${{ vars.R2_BUCKET_DOCS }}
         run: |
           set -uo pipefail
           endpoint="https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -127,11 +127,9 @@ jobs:
           if_no_artifact_found: warn
           allow_forks: false
 
-      # deploy-pages replaces the WHOLE site, so a half not rebuilt this run is restored from
-      # the currently-live site. That snapshot lives in R2 (durable, no lifecycle rule),
-      # mirrored by "Persist live snapshot to R2" after every successful deploy.
-      # Unconfigured R2 is tolerated: live/site stays empty and a full-build run still deploys;
-      # only a partial deploy then hits the guard below.
+      # A half not rebuilt this run is restored from the currently-live site, snapshotted in R2
+      # (durable, no lifecycle rule) by "Persist live snapshot to R2". Unconfigured R2 is
+      # tolerated: live/site stays empty, so only a single-half deploy refuses (in the decide step).
       - name: Restore live snapshot from R2
         id: restore
         env:
@@ -143,41 +141,25 @@ jobs:
           # masker would turn every `-` in the whole log into *** (see e2e-tests.yml).
           R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
         run: |
-          # No `-e`: a sync error must NOT abort the step. A full-rebuild run (both halves
-          # built this run) doesn't need the snapshot and must still deploy even if R2 is
-          # down. The decide step reads restore_status: `ok` = snapshot read and reflects
-          # live; `skipped`/`failed` = unconfirmed, so a single-half run refuses.
+          # restore_status, read by the decide step: skipped (R2 off) | ok (snapshot reflects
+          # live, empty bucket included) | failed (read error, or a partial snapshot missing its
+          # .snapshot-complete marker). A single-half deploy ships only a confirmed (ok) half.
           set -uo pipefail
           mkdir -p live/site
-          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
-             || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
-            echo "::warning::R2 not configured — skipping live-snapshot restore."
-            echo "restore_status=skipped" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if ! command -v aws >/dev/null 2>&1; then
-            echo "::warning::aws CLI not found on runner — skipping live-snapshot restore."
-            echo "restore_status=skipped" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if aws s3 sync "s3://${R2_BUCKET}/" live/site/ \
-               --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com" --no-progress; then
-            # Persist writes a `.snapshot-complete` marker last, after a full mirror. Content
-            # without the marker means persist was interrupted mid-sync (aws s3 sync isn't
-            # atomic), so the snapshot is partial — treat it as a failed read so a single-half
-            # run refuses. An empty bucket (never seeded) has no marker but nothing partial: ok.
-            if [ -z "$(ls -A live/site 2>/dev/null)" ] || [ -f live/site/.snapshot-complete ]; then
-              echo "restore_status=ok" >> "$GITHUB_OUTPUT"
-            else
-              echo "::warning::R2 snapshot has content but no completion marker — previous persist was interrupted; a partial deploy will be refused."
-              echo "restore_status=failed" >> "$GITHUB_OUTPUT"
-            fi
-            # Never let the marker leak into the merged/deployed site.
-            rm -f live/site/.snapshot-complete
+          endpoint="https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com"
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
+            echo "::warning::R2 not configured — skipping snapshot restore."; status=skipped
+          elif ! command -v aws >/dev/null 2>&1; then
+            echo "::warning::aws CLI not found — skipping snapshot restore."; status=skipped
+          elif ! aws s3 sync "s3://${R2_BUCKET}/" live/site/ --endpoint-url "$endpoint" --no-progress; then
+            echo "::warning::R2 snapshot read failed — a single-half deploy will refuse."; status=failed
+          elif [ -n "$(ls -A live/site 2>/dev/null)" ] && [ ! -f live/site/.snapshot-complete ]; then
+            echo "::warning::R2 snapshot has no completion marker (persist was interrupted) — a single-half deploy will refuse."; status=failed
           else
-            echo "::warning::R2 live-snapshot read failed — a partial deploy will be refused by the decide step below."
-            echo "restore_status=failed" >> "$GITHUB_OUTPUT"
+            status=ok
           fi
+          rm -f live/site/.snapshot-complete   # never let the marker leak into the deployed site
+          echo "restore_status=$status" >> "$GITHUB_OUTPUT"
 
       - name: Restore missing halves and decide deploy
         id: check
@@ -186,15 +168,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # live/site holds the last deployed site, restored from R2 by the step above
-          # (empty if R2 was unconfigured or the restore skipped).
-
-          # A dir counts as having content only if it holds at least one entry.
+          # Assemble dist/: for each half keep what this run built, else restore it from
+          # live/site (the R2 snapshot), else none. Latest = site root; preview = dist/preview.
+          # has_* treat a dir as content only if it holds an entry.
           has_root() { [ -d dist ] && [ -n "$(ls -A dist 2>/dev/null | grep -v '^preview$')" ]; }
           has_dir()  { [ -d "$1" ] && [ -n "$(ls -A "$1" 2>/dev/null)" ]; }
 
-          # Latest = site root (everything except preview/); preview = dist/preview/.
-          # Each half: keep what this run built, else restore it from the live snapshot, else none.
           if has_root; then
             LATEST_SRC=this-run
           elif has_dir live/site; then
@@ -220,45 +199,34 @@ jobs:
             PREVIEW_SRC=none
           fi
 
-          echo "latest=$LATEST_SRC preview=$PREVIEW_SRC"
           echo "latest_src=$LATEST_SRC" >> "$GITHUB_OUTPUT"
           echo "preview_src=$PREVIEW_SRC" >> "$GITHUB_OUTPUT"
 
-          # deploy-pages replaces the whole site, so a half we can't obtain must not be
-          # published — that would wipe it live. A half is safe to ship only when it's built
-          # this run, restored intact, or confirmed absent by a successful read (ok). A
-          # full-rebuild run never reaches these branches, so an R2 outage can't block it.
+          # deploy-pages replaces the whole site, so never publish a half we can't fully obtain —
+          # that wipes it live. Ship a half only if built this run, restored intact, or confirmed
+          # absent (ok). Full rebuilds never reach these guards, so an R2 outage can't block them.
 
-          # A failed restore can still leave partial content, so a half may read as `live` off
-          # a truncated snapshot. Deploying it would --delete the live files that didn't restore.
+          # Failed restore can leave partial content, so a `live` half may be truncated.
           if [ "${RESTORE_STATUS:-}" = failed ] && { [ "$LATEST_SRC" = live ] || [ "$PREVIEW_SRC" = live ]; }; then
-            echo "::error::R2 snapshot restore was incomplete — a restored half may be truncated."
-            echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe a live half."
+            echo "::error::R2 restore was incomplete — a restored half may be truncated. Retry once R2 is reachable."
             exit 1
           fi
-
           if [ "$LATEST_SRC" = none ]; then
             if [ "${RESTORE_STATUS:-}" = failed ]; then
-              echo "::error::Latest half not built this run and the R2 snapshot read failed (see warning above)."
-              echo "::error::Refusing to deploy — retry once R2 is reachable rather than wipe the live root."
+              echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable."
             else
-              echo "::error::Latest docs missing and absent from the R2 live snapshot (empty bucket or R2 unconfigured)."
-              echo "::error::Refusing to deploy — that would wipe the live root. Re-run with rebuild_latest=true."
+              echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true."
             fi
             exit 1
           fi
           if [ "$PREVIEW_SRC" = none ]; then
-            # Deploying LATEST ONLY wipes any preview the live site currently has, so it's only
-            # safe when we've positively CONFIRMED the live site has no preview. Only a
-            # successful restore (ok) confirms that — the snapshot is byte-exact with live via
-            # --delete. A failed read or an unconfigured/skipped restore leaves us blind, so
-            # refuse rather than risk wiping a live preview.
+            # LATEST-ONLY wipes any live preview, so ship it only when a successful read (ok)
+            # confirmed the snapshot — hence live — has no preview.
             if [ "${RESTORE_STATUS:-}" != ok ]; then
-              echo "::error::Preview half not built this run and its absence from the live site is unconfirmed (restore: ${RESTORE_STATUS:-unknown})."
-              echo "::error::Refusing to deploy LATEST ONLY — that could wipe a live preview. Retry once R2 is reachable, or re-run with rebuild_preview=true."
+              echo "::error::Preview absence unconfirmed (restore: ${RESTORE_STATUS:-unknown}) — refusing LATEST-ONLY. Retry, or re-run with rebuild_preview=true."
               exit 1
             fi
-            echo "::warning::Deploying LATEST ONLY — preview genuinely absent from the confirmed R2 snapshot."
+            echo "::warning::Deploying LATEST-ONLY — preview confirmed absent from R2."
           fi
 
       - name: Setup Pages
@@ -275,16 +243,12 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 
-      # Mirror the just-deployed site to R2 (durable, no lifecycle rule) so the next run can
-      # restore whichever half it doesn't rebuild. Gated on success() alone: deploy-pages
-      # succeeds only when it actually published to live Pages (the github-pages environment's
-      # protection rules decide which refs may), so the snapshot always equals what's live —
-      # this fires for both default-branch and release-tag deploys. --delete keeps it byte-exact.
+      # Mirror the deployed site to R2 so the next run can restore the half it doesn't rebuild.
+      # success() ⇒ deploy-pages actually published (its github-pages env decides which refs may),
+      # so the snapshot always equals live — for both default-branch and release-tag deploys.
       - name: Persist live snapshot to R2
         if: success()
-        # The deploy already published; a snapshot-write failure must not red the run or
-        # suppress the summary/notification below. It clears the completion marker, so the
-        # next single-half run refuses (retry) instead of recovering from a partial snapshot.
+        # Best-effort: a snapshot-write failure must not red the deploy that already published.
         continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -294,36 +258,25 @@ jobs:
           R2_BUCKET: ${{ vars.DOCS_R2_BUCKET }}
         run: |
           set -uo pipefail
-          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] \
-             || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
-            echo "::warning::R2 not configured — live snapshot NOT persisted. Recovery on the next partial deploy will fail until this is set."
-            exit 0
+          endpoint="https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com"
+          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
+            echo "::warning::R2 not configured — snapshot not persisted; single-half deploys will refuse until it is."; exit 0
           fi
-          if ! command -v aws >/dev/null 2>&1; then
-            echo "::warning::aws CLI not found on runner — live snapshot NOT persisted."
-            exit 0
+          command -v aws >/dev/null 2>&1 || { echo "::warning::aws CLI not found — snapshot not persisted."; exit 0; }
+
+          # The .snapshot-complete marker certifies a full mirror. Clear it first so an interrupted
+          # sync leaves the snapshot uncertified; mirror; write it last. Bail if it can't be cleared
+          # — a surviving marker would certify a partial sync. (rm of a missing key exits 0: first seed.)
+          marker="s3://${R2_BUCKET}/.snapshot-complete"
+          if ! aws s3 rm "$marker" --endpoint-url "$endpoint" >/dev/null 2>&1; then
+            echo "::warning::Could not clear the R2 completion marker — keeping the last certified snapshot."; exit 0
           fi
-          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          # Clear the completion marker before mirroring so the snapshot reads as incomplete for
-          # the whole write window: an interrupted sync then leaves no marker and the next restore
-          # refuses. If the marker can't be cleared, skip the mirror — overwriting the snapshot
-          # while a stale marker survives would let an interrupted sync pass as complete. (rm of a
-          # missing marker returns 0, so the first-ever persist isn't blocked here.)
-          if ! aws s3 rm "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1; then
-            echo "::warning::Couldn't clear the R2 completion marker — leaving the last certified snapshot untouched."
-            exit 0
+          if ! aws s3 sync dist/ "s3://${R2_BUCKET}/" --endpoint-url "$endpoint" --no-progress --delete; then
+            echo "::warning::R2 mirror failed — next single-half deploy will refuse until the next persist."; exit 0
           fi
-          if aws s3 sync dist/ "s3://${R2_BUCKET}/" \
-               --endpoint-url "$endpoint" --no-progress --delete; then
-            # Mirror succeeded — write the marker last to certify the snapshot is complete.
-            if printf 'ok' | aws s3 cp - "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1; then
-              echo "Live snapshot updated in R2."
-            else
-              echo "::warning::Snapshot mirrored but completion marker write failed — the next partial deploy will refuse until the next successful persist."
-            fi
-          else
-            echo "::warning::Failed to persist live snapshot to R2 — the next partial deploy will refuse (no completion marker) until the next successful persist."
-          fi
+          printf 'ok' | aws s3 cp - "$marker" --endpoint-url "$endpoint" >/dev/null 2>&1 \
+            || echo "::warning::Mirror done but marker write failed — next single-half deploy will refuse until the next persist."
+          echo "Live snapshot updated in R2."
 
       - name: Build summary
         run: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -304,10 +304,15 @@ jobs:
             exit 0
           fi
           endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          # Clear the completion marker BEFORE mirroring so the snapshot is marked incomplete
-          # for the whole write window: if this step is interrupted mid-sync, no marker remains
-          # and the next restore treats the partial snapshot as unusable instead of deploying it.
-          aws s3 rm "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1 || true
+          # Clear the completion marker before mirroring so the snapshot reads as incomplete for
+          # the whole write window: an interrupted sync then leaves no marker and the next restore
+          # refuses. If the marker can't be cleared, skip the mirror — overwriting the snapshot
+          # while a stale marker survives would let an interrupted sync pass as complete. (rm of a
+          # missing marker returns 0, so the first-ever persist isn't blocked here.)
+          if ! aws s3 rm "s3://${R2_BUCKET}/.snapshot-complete" --endpoint-url "$endpoint" >/dev/null 2>&1; then
+            echo "::warning::Couldn't clear the R2 completion marker — leaving the last certified snapshot untouched."
+            exit 0
+          fi
           if aws s3 sync dist/ "s3://${R2_BUCKET}/" \
                --endpoint-url "$endpoint" --no-progress --delete; then
             # Mirror succeeded — write the marker last to certify the snapshot is complete.

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -308,7 +308,9 @@ Deploys the documentation site to GitHub Pages. Runs automatically after builds 
 
 The site has two halves — `latest` (site root) and `preview` (`/preview/`) — and `deploy-pages` replaces the whole site each run. A run that rebuilds only one half restores the other from a durable snapshot of the currently-live site kept in Cloudflare R2, so recovery never depends on an expiring artifact. After every successful deploy the merged site is mirrored back to R2 (`aws s3 sync … --delete`), best-effort — a snapshot-write failure warns but never fails the deploy.
 
-A full rebuild (both halves built that run) never needs the snapshot, so it deploys even if R2 is down. A single-half run refuses to deploy — rather than wipe the half it can't supply — when that half is genuinely absent from the snapshot (empty bucket or R2 unconfigured; re-run with `rebuild_latest=true` to seed) or when the snapshot read failed (retry once R2 is reachable).
+A full rebuild (both halves built that run) never needs the snapshot, so it deploys even if R2 is down. A single-half run only proceeds when the half it doesn't rebuild is *confirmed* — either restored intact from the snapshot, or confirmed genuinely absent by a successful snapshot read. Otherwise it refuses rather than wipe a live half: it refuses when the missing half is `latest` and absent from the snapshot (empty bucket or R2 unconfigured; re-run with `rebuild_latest=true` to seed), when the snapshot read failed or was only partially restored (retry once R2 is reachable), and when `preview` isn't rebuilt this run and its absence can't be confirmed — an unconfigured/skipped or failed restore can't prove the live site has no preview, so LATEST-ONLY is only deployed against a confirmed snapshot (re-run with `rebuild_preview=true` to force a preview, or seed R2 first).
+
+The snapshot's integrity is self-certifying: the persist step clears a `.snapshot-complete` marker before mirroring and rewrites it last, so an interrupted persist leaves no marker and the next restore treats that partial snapshot as unusable rather than deploying truncated content.
 
 ### Setup Requirements
 
@@ -321,7 +323,7 @@ Add to the **`github-pages`** GitHub Environment (Settings → Environments):
 | `R2_SECRET_ACCESS_KEY` | Secret | R2 token secret |
 | `DOCS_R2_BUCKET` | Variable | Name of a **dedicated** R2 bucket with **no lifecycle rule** (a per-age expiry would sweep the snapshot). Kept as a variable, not a secret — the name's hyphen would trip the secret masker. |
 
-The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys behave as described above.
+The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys refuse (the half they don't rebuild can't be confirmed), so configure R2 or re-run rebuilding both halves.
 
 ## Deploy Server Pipeline
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -321,7 +321,7 @@ Add to the **`github-pages`** GitHub Environment (Settings → Environments):
 | `R2_ACCOUNT_ID` | Secret | Cloudflare account ID (S3 endpoint host) |
 | `R2_ACCESS_KEY_ID` | Secret | R2 token key with object read/write on the docs bucket |
 | `R2_SECRET_ACCESS_KEY` | Secret | R2 token secret |
-| `DOCS_R2_BUCKET` | Variable | Name of a **dedicated** R2 bucket with **no lifecycle rule** (a per-age expiry would sweep the snapshot). Kept as a variable, not a secret — the name's hyphen would trip the secret masker. |
+| `R2_BUCKET_DOCS` | Variable | Name of a **dedicated** R2 bucket with **no lifecycle rule** (a per-age expiry would sweep the snapshot). Kept as a variable, not a secret — the name's hyphen would trip the secret masker. |
 
 The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys refuse (the half they don't rebuild can't be confirmed), so configure R2 or re-run rebuilding both halves.
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -306,6 +306,23 @@ GitHub forbids approving your own pull request, which with a single maintainer m
 
 Deploys the documentation site to GitHub Pages. Runs automatically after builds or can be triggered manually to rebuild from existing Docker images.
 
+The site has two halves — `latest` (site root) and `preview` (`/preview/`) — and `deploy-pages` replaces the whole site each run. A run that rebuilds only one half restores the other from a durable snapshot of the currently-live site kept in Cloudflare R2, so recovery never depends on an expiring artifact. After every successful deploy the merged site is mirrored back to R2 (`aws s3 sync … --delete`), best-effort — a snapshot-write failure warns but never fails the deploy.
+
+A full rebuild (both halves built that run) never needs the snapshot, so it deploys even if R2 is down. A single-half run refuses to deploy — rather than wipe the half it can't supply — when that half is genuinely absent from the snapshot (empty bucket or R2 unconfigured; re-run with `rebuild_latest=true` to seed) or when the snapshot read failed (retry once R2 is reachable).
+
+### Setup Requirements
+
+Add to the **`github-pages`** GitHub Environment (Settings → Environments):
+
+| Name | Kind | Description |
+|------|------|-------------|
+| `R2_ACCOUNT_ID` | Secret | Cloudflare account ID (S3 endpoint host) |
+| `R2_ACCESS_KEY_ID` | Secret | R2 token key with object read/write on the docs bucket |
+| `R2_SECRET_ACCESS_KEY` | Secret | R2 token secret |
+| `DOCS_R2_BUCKET` | Variable | Name of a **dedicated** R2 bucket with **no lifecycle rule** (a per-age expiry would sweep the snapshot). Kept as a variable, not a secret — the name's hyphen would trip the secret masker. |
+
+The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys behave as described above.
+
 ## Deploy Server Pipeline
 
 [Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/deploy-server.yml)


### PR DESCRIPTION
## Problem

`deploy-docs` recovered the half of the site it didn't rebuild this run from the previous run's `github-pages` artifact, which expires after 14 days. A quiet gap longer than that (or a partial deploy with no recent default-branch deploy) failed hard:

```
Error: Latest docs missing and not recoverable from the live site (artifact likely expired).
Error: Refusing to deploy — that would wipe the live root. Re-run with rebuild_latest=true.
```

The recovery source was inherently time-critical and expiring.

## Change

Recover from a durable **Cloudflare R2 snapshot** of the live site instead of an expiring artifact.

- **Restore** the live snapshot from R2 before deciding what to deploy. The restore step never aborts; it records `restore_status` = `ok` / `skipped` / `failed`, so:
  - a **full rebuild** (both halves built this run) deploys even if R2 is down — it never consults the snapshot;
  - a **partial run** whose snapshot read *failed* refuses to deploy with an accurate "retry once R2 is reachable" message (not the misleading `rebuild_latest` hint), so it never wipes a live half on a transient error;
  - a **partial run** whose missing half is genuinely absent (`ok`/`skipped`) gets the correct `rebuild_latest` / LATEST-ONLY guidance.
- **Persist** the merged site back to R2 after every successful deploy (`aws s3 sync … --delete`), `continue-on-error` so a snapshot-write blip never reds a live deploy or suppresses its summary/notification.
- Drop the 14-day `github-pages` artifact retention override — it is no longer a cross-run recovery source (no remaining consumer).
- Mirrors the proven `aws s3 sync`→R2 invocation already used by `e2e-tests.yml`.

## ⚠️ Operator setup required before merge

R2 config lives in the **`github-pages`** GitHub Environment (Settings → Environments):

| Name | Kind | Notes |
|------|------|-------|
| `R2_ACCOUNT_ID` | Secret | Cloudflare account ID (S3 endpoint host) |
| `R2_ACCESS_KEY_ID` | Secret | R2 token key with object read/write on the docs bucket |
| `R2_SECRET_ACCESS_KEY` | Secret | R2 token secret |
| `R2_BUCKET_DOCS` | Variable | A **dedicated** R2 bucket with **no lifecycle rule** |

- Use a bucket dedicated to the docs snapshot: the deploy mirrors with `--delete`, so a shared bucket would have its other contents deleted, and a shared retention rule could sweep the snapshot.
- **Seed once** after setup: run Deploy Docs with `rebuild_latest=true` (add `rebuild_preview=true` to seed preview too). After that, partial deploys self-recover.
- If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys behave as documented (missing `latest` fails; missing `preview` deploys latest-only).

## Validation

- Workflow YAML parses; all 10 `LATEST_SRC × PREVIEW_SRC × restore_status` combinations trace to the correct action and an accurate message.
- `aws s3 sync`→R2 confirmed green on the same `ubuntu-latest` runner image (e2e report publish, recent runs); region `auto` confirmed against R2.
- No remaining consumer of the removed `github-pages` cross-run artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation deployments by restoring missing site sections from durable snapshots.
  * Added safeguards to prevent incomplete or unsafe deployments when restoration cannot be verified.
  * Preserved both the latest and preview documentation sections during single-section rebuilds.

* **Documentation**
  * Documented the updated deployment process, recovery behavior, snapshot validation, and required configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

