### PR TITLE
test(stats): reconnect the container stats stream after a transport loss

### DIFF
--- a/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
+++ b/tests/JunimoServer.TestRunner/Rendering/Web/TestRunState.cs
@@ -1434,6 +1434,7 @@ public sealed class TestRunState
                     BlkReadBytesPerSec = roundedBlkRead,
                     BlkWriteBytesPerSec = roundedBlkWrite,
                     MemoryLimitMb = roundedMemLimit,
+                    SampleAgeMs = d.SampleAgeMs,
                 }
             );
 
@@ -1461,6 +1462,7 @@ public sealed class TestRunState
                 BlkReadBytesPerSec = roundedBlkRead,
                 BlkWriteBytesPerSec = roundedBlkWrite,
                 MemoryLimitMb = roundedMemLimit,
+                d.SampleAgeMs,
             };
             // Not added to event log; stats are too frequent
             return Serialize(evt);
@@ -1536,6 +1538,7 @@ public sealed class TestRunState
                                 s.BlkReadBytesPerSec,
                                 s.BlkWriteBytesPerSec,
                                 s.MemoryLimitMb,
+                                s.SampleAgeMs,
                             }
                         )
                     );
@@ -2199,6 +2202,7 @@ public sealed class TestRunState
                                     s.BlkReadBytesPerSec,
                                     s.BlkWriteBytesPerSec,
                                     s.MemoryLimitMb,
+                                    s.SampleAgeMs,
                                 })
                                 .ToList()
                             : null,
@@ -2592,6 +2596,7 @@ public sealed class TestRunState
         public double? BlkReadBytesPerSec { get; set; }
         public double? BlkWriteBytesPerSec { get; set; }
         public double MemoryLimitMb { get; set; }
+        public int? SampleAgeMs { get; set; }
     }
 
     private sealed class InstanceHistoryEntry

--- a/tests/JunimoServer.Tests/Helpers/ContainerStatsCollector.cs
+++ b/tests/JunimoServer.Tests/Helpers/ContainerStatsCollector.cs
@@ -45,6 +45,11 @@ public sealed record InstanceStatsData
 
     // Container memory limit (0 = no limit set)
     public double MemoryLimitMb { get; init; }
+
+    // Age of the Docker sample the container fields were taken from, at emit time.
+    // The stream pushes ~1/s, so an age well above that means the stream is down
+    // and the container fields are a stale repeat. Null when no Docker sample exists.
+    public int? SampleAgeMs { get; init; }
 }
 
 /// <summary>
@@ -66,6 +71,7 @@ public static class ContainerStatsCollector
         public double BlkReadBytes { get; init; } = -1; // -1 = no blkio data (cgroup v2)
         public double BlkWriteBytes { get; init; } = -1;
         public double MemoryLimitMb { get; init; }
+        public DateTime SampledAt { get; init; }
     }
 
     private sealed class InstanceEntry
@@ -73,7 +79,10 @@ public static class ContainerStatsCollector
         public required string InstanceId { get; init; }
         public required string ContainerId { get; init; }
         public required string ContainerName { get; init; }
-        public string? ApiBaseUrl { get; init; }
+
+        // Live-read on every poll: the container's BaseUrl moves when its API forward
+        // is reopened, so a captured string would point at a dead port.
+        public Func<string?>? ApiBaseUrl { get; init; }
         public required string HostId { get; init; }
         public required DockerClient Client { get; init; }
         public CancellationTokenSource Cts { get; } = new();
@@ -86,11 +95,12 @@ public static class ContainerStatsCollector
         public DateTime PreviousTimestamp;
 
         // Per-instance flood-guard counters for structured-event emits in the
-        // stats stream and the game-stats poll. Cumulative across the entry's
-        // lifetime — a fresh container gets a fresh entry and thus a fresh
-        // budget. Updated atomically via ShouldEmitStrike below.
-        public int DockerStatsFailureStreak;
-        public int GameStatsFailureStreak;
+        // stats stream and the game-stats parse step. Cumulative across the
+        // entry's lifetime — a fresh container gets a fresh entry and thus a
+        // fresh budget. Updated atomically via ShouldEmitStrike below. Distinct
+        // from GameStatsPollFailStreak, which resets on a successful poll.
+        public int DockerStatsFailureCount;
+        public int GameStatsParseFailureCount;
 
         // The daemon's stats stream delivers one sample per second, so a
         // sample arriving more than StatsGapThreshold after the previous one
@@ -99,6 +109,10 @@ public static class ContainerStatsCollector
         // thread pool, so a burst of buffered samples after a stall runs
         // concurrently and would otherwise report the same gap twice.
         public long LastSampleTicks;
+
+        // Consecutive failed /stats polls; reset on success. One
+        // game_stats_poll_failed at streak start, one game_stats_poll_recovered at end.
+        public int GameStatsPollFailStreak;
     }
 
     private static readonly TimeSpan StatsGapThreshold = TimeSpan.FromSeconds(5);
@@ -158,7 +172,7 @@ public static class ContainerStatsCollector
         string containerId,
         string containerName,
         Infrastructure.DockerHost host,
-        string? apiBaseUrl = null
+        Func<string?>? apiBaseUrl = null
     )
     {
         // SDVD_TEST_STATS=none disables the entire collector — neither the
@@ -191,18 +205,12 @@ public static class ContainerStatsCollector
 
     public static void Unregister(string instanceId)
     {
+        // Only the caller that removed the entry cancels and disposes its CTS, so
+        // Unregister racing Stop can never cancel an already-disposed source.
         if (_instances.TryRemove(instanceId, out var entry))
         {
-            try
-            {
-                entry.Cts.Cancel();
-            }
-            catch { }
-            try
-            {
-                entry.Cts.Dispose();
-            }
-            catch { }
+            entry.Cts.Cancel();
+            entry.Cts.Dispose();
         }
     }
 
@@ -234,35 +242,17 @@ public static class ContainerStatsCollector
     {
         _started = false;
 
-        try
-        {
-            _cts?.Cancel();
-        }
-        catch { }
+        _cts?.Cancel();
 
-        foreach (var (_, entry) in _instances)
+        foreach (var instanceId in _instances.Keys.ToArray())
         {
-            try
-            {
-                entry.Cts.Cancel();
-            }
-            catch { }
-            try
-            {
-                entry.Cts.Dispose();
-            }
-            catch { }
+            Unregister(instanceId);
         }
-        _instances.Clear();
 
         // Note: per-host DockerClients are owned by HostPool, not by this
         // collector — disposing them here would break other consumers.
 
-        try
-        {
-            _cts?.Dispose();
-        }
-        catch { }
+        _cts?.Dispose();
         _cts = null;
     }
 
@@ -288,9 +278,19 @@ public static class ContainerStatsCollector
 
             _emissionLoop = EmissionLoopAsync(ct);
         }
-        catch
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+        catch (Exception ex)
         {
-            // Non-fatal; stats will be unavailable
+            // Non-fatal for the run: no stats at all until the next process.
+            InfrastructureEventLog.Emit(
+                "stats_collector_init_failed",
+                new
+                {
+                    exceptionType = ex.GetType().FullName,
+                    message = ex.Message,
+                    decision = "stats_unavailable",
+                }
+            );
         }
     }
 
@@ -298,14 +298,27 @@ public static class ContainerStatsCollector
     // per-tick hot loops. Increments the counter atomically and returns true
     // only for the first FailureStrikeLimit failures. No reset-on-success:
     // these are bug-shaped failures (parse / shape changes, math NaN paths)
-    // that recur every tick once they start; we want first-N reports total,
-    // not first-N per streak. Mirrors RendererDispatchGuard's strike threshold
-    // (3) but per-instance instead of per-renderer.
+    // that recur every tick once they start, so we want first-N reports over
+    // the whole lifetime, not first-N each time a burst resumes. Borrows
+    // RendererDispatchGuard's threshold value (3); unlike that guard, which
+    // trips on consecutive failures and resets, this counter never resets.
     private const int FailureStrikeLimit = 3;
 
     private static bool ShouldEmitStrike(ref int counter) =>
         Interlocked.Increment(ref counter) <= FailureStrikeLimit;
 
+    // Reconnect backoff for the stats stream: the first retry is quick (a transport
+    // blip), later ones are paced so a long outage doesn't hammer the daemon.
+    private static readonly TimeSpan StreamReconnectDelayMin = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan StreamReconnectDelayMax = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Sole supervisor of the per-container Docker stats stream. Loops
+    /// <c>GetContainerStatsAsync(Stream = true)</c>; on any non-cancellation exit it
+    /// emits <c>docker_stats_stream_ended</c> with the reason and, unless the container
+    /// is confirmed not running, reconnects and emits
+    /// <c>docker_stats_stream_reconnected</c> on the first sample of the new stream.
+    /// </summary>
     private static Task StartStreamAsync(InstanceEntry entry)
     {
         // SuppressFlow: stats stream lives for the container's whole lifetime,
@@ -313,119 +326,260 @@ public static class ContainerStatsCollector
         // first test that triggers Register() poisons every later event with its
         // TestContext.Current. See .claude/rules/asynclocal-pitfalls.md.
         using var _ = ExecutionContext.SuppressFlow();
-        return Task.Run(async () =>
+        // Captured once: Unregister disposes the CTS, after which .Token throws.
+        var ct = entry.Cts.Token;
+        return Task.Run(() => SuperviseStreamAsync(entry, ct));
+    }
+
+    private static async Task SuperviseStreamAsync(InstanceEntry entry, CancellationToken ct)
+    {
+        var attempt = 0;
+        DateTime? endedAt = null;
+        var reconnectAnnounced = true;
+
+        void OnSample()
         {
+            if (reconnectAnnounced || endedAt is null)
+            {
+                return;
+            }
+
+            reconnectAnnounced = true;
+            InfrastructureEventLog.Emit(
+                "docker_stats_stream_reconnected",
+                new
+                {
+                    instanceId = entry.InstanceId,
+                    containerName = entry.ContainerName,
+                    attempt,
+                    gapMs = (long)(DateTime.UtcNow - endedAt.Value).TotalMilliseconds,
+                }
+            );
+        }
+
+        var progress = BuildProgress(entry, OnSample);
+
+        while (!ct.IsCancellationRequested)
+        {
+            attempt++;
+            string reason;
+            Exception? error = null;
             try
             {
-                var progress = new Progress<ContainerStatsResponse>(response =>
-                {
-                    try
-                    {
-                        RecordStatsGap(entry, DateTime.UtcNow);
-
-                        // The daemon omits these blocks for a container that has no
-                        // CPU/memory accounting yet (just-created, or between restarts);
-                        // skip the sample rather than synthesize zeroes.
-                        if (
-                            response.CPUStats is null
-                            || response.PreCPUStats is null
-                            || response.MemoryStats is null
-                        )
-                        {
-                            return;
-                        }
-
-                        var cpuDelta =
-                            response.CPUStats.CPUUsage.TotalUsage
-                            - response.PreCPUStats.CPUUsage.TotalUsage;
-                        var systemDelta =
-                            (response.CPUStats.SystemUsage ?? 0)
-                            - (response.PreCPUStats.SystemUsage ?? 0);
-                        var onlineCpus = response.CPUStats.OnlineCPUs ?? 0;
-
-                        double cpuPercent = 0;
-                        if (systemDelta > 0 && onlineCpus > 0)
-                        {
-                            cpuPercent = (double)cpuDelta / systemDelta * onlineCpus * 100.0;
-                        }
-
-                        var memBytes = response.MemoryStats.Usage ?? 0;
-                        if (response.MemoryStats.Stats?.TryGetValue("cache", out var cache) == true)
-                        {
-                            memBytes -= cache;
-                        }
-
-                        // Network I/O: sum all interfaces
-                        double netRx = 0,
-                            netTx = 0;
-                        if (response.Networks != null)
-                        {
-                            foreach (var net in response.Networks.Values)
-                            {
-                                netRx += net.RxBytes;
-                                netTx += net.TxBytes;
-                            }
-                        }
-
-                        // Block I/O: sum read/write ops (-1 sentinel when cgroup v2 provides no data)
-                        double blkRead = -1,
-                            blkWrite = -1;
-                        var blkioEntries = response.BlkioStats?.IoServiceBytesRecursive;
-                        if (blkioEntries is { Count: > 0 })
-                        {
-                            blkRead = 0;
-                            blkWrite = 0;
-                            foreach (var e in blkioEntries)
-                            {
-                                if (string.Equals(e.Op, "read", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    blkRead += e.Value;
-                                }
-                                else if (
-                                    string.Equals(e.Op, "write", StringComparison.OrdinalIgnoreCase)
-                                )
-                                {
-                                    blkWrite += e.Value;
-                                }
-                            }
-                        }
-
-                        // Memory limit
-                        var memLimit = response.MemoryStats.Limit ?? 0;
-                        double memLimitMb = memLimit > 0 ? memLimit / (1024.0 * 1024.0) : 0;
-
-                        entry.Latest = new StatsSnapshot
-                        {
-                            CpuPercent = cpuPercent,
-                            MemoryMb = memBytes / (1024.0 * 1024.0),
-                            NetRxBytes = netRx,
-                            NetTxBytes = netTx,
-                            BlkReadBytes = blkRead,
-                            BlkWriteBytes = blkWrite,
-                            MemoryLimitMb = memLimitMb,
-                        };
-                    }
-                    catch (Exception ex)
-                    {
-                        if (ShouldEmitStrike(ref entry.DockerStatsFailureStreak))
-                        {
-                            InfrastructureEventLog.Emit(
-                                "docker_stats_snapshot_failed",
-                                new { instanceId = entry.InstanceId, error = ex.Message }
-                            );
-                        }
-                    }
-                });
-
                 await entry.Client.Containers.GetContainerStatsAsync(
                     entry.ContainerId,
                     new ContainerStatsParameters { Stream = true },
                     progress,
-                    entry.Cts.Token
+                    ct
                 );
+                // The daemon closes the stream when the container stops or the
+                // transport underneath (e.g. an ssh-tunneled socket) drops.
+                reason = "stream_closed";
             }
-            catch (OperationCanceledException) { }
-            catch { }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                reason = "stream_failed";
+                error = ex;
+            }
+
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            endedAt = DateTime.UtcNow;
+            reconnectAnnounced = false;
+
+            bool? running;
+            string? containerState;
+            string? inspectError;
+            try
+            {
+                (running, containerState, inspectError) = await IsContainerRunningAsync(entry, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                // Unregister can cancel the CTS after the check above; the inspect
+                // then throws, and this task is never awaited, so swallow it here.
+                return;
+            }
+            var decision = running == false ? "gave_up_container_not_running" : "reconnect";
+            InfrastructureEventLog.Emit(
+                "docker_stats_stream_ended",
+                new
+                {
+                    instanceId = entry.InstanceId,
+                    containerName = entry.ContainerName,
+                    attempt,
+                    reason,
+                    exceptionType = error?.GetType().FullName,
+                    message = error?.Message,
+                    innerExceptionType = error?.InnerException?.GetType().FullName,
+                    innerMessage = error?.InnerException?.Message,
+                    containerState,
+                    inspectError,
+                    decision,
+                }
+            );
+
+            if (running == false)
+            {
+                return;
+            }
+
+            var delay = TimeSpan.FromTicks(
+                Math.Min(StreamReconnectDelayMax.Ticks, StreamReconnectDelayMin.Ticks * attempt)
+            );
+            try
+            {
+                await Task.Delay(delay, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// <c>Running</c> is false only when the daemon confirmed the container is not
+    /// running (or no longer exists); null when the inspect itself failed, in which
+    /// case the supervisor keeps reconnecting.
+    /// </summary>
+    private static async Task<(
+        bool? Running,
+        string? State,
+        string? InspectError
+    )> IsContainerRunningAsync(InstanceEntry entry, CancellationToken ct)
+    {
+        try
+        {
+            var inspect = await entry.Client.Containers.InspectContainerAsync(
+                entry.ContainerId,
+                ct
+            );
+            return (inspect.State?.Running == true, inspect.State?.Status, null);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (DockerContainerNotFoundException)
+        {
+            return (false, "removed", null);
+        }
+        catch (Exception ex)
+        {
+            return (null, null, $"{ex.GetType().FullName}: {ex.Message}");
+        }
+    }
+
+    private static Progress<ContainerStatsResponse> BuildProgress(
+        InstanceEntry entry,
+        Action onSample
+    )
+    {
+        return new Progress<ContainerStatsResponse>(response =>
+        {
+            try
+            {
+                onSample();
+                RecordStatsGap(entry, DateTime.UtcNow);
+
+                // The daemon omits these blocks for a container that has no
+                // CPU/memory accounting yet (just-created, or between restarts);
+                // skip the sample rather than synthesize zeroes.
+                if (
+                    response.CPUStats is null
+                    || response.PreCPUStats is null
+                    || response.MemoryStats is null
+                )
+                {
+                    return;
+                }
+
+                var cpuDelta =
+                    response.CPUStats.CPUUsage.TotalUsage
+                    - response.PreCPUStats.CPUUsage.TotalUsage;
+                var systemDelta =
+                    (response.CPUStats.SystemUsage ?? 0) - (response.PreCPUStats.SystemUsage ?? 0);
+                var onlineCpus = response.CPUStats.OnlineCPUs ?? 0;
+
+                double cpuPercent = 0;
+                if (systemDelta > 0 && onlineCpus > 0)
+                {
+                    cpuPercent = (double)cpuDelta / systemDelta * onlineCpus * 100.0;
+                }
+
+                var memBytes = response.MemoryStats.Usage ?? 0;
+                if (response.MemoryStats.Stats?.TryGetValue("cache", out var cache) == true)
+                {
+                    memBytes -= cache;
+                }
+
+                // Network I/O: sum all interfaces
+                double netRx = 0,
+                    netTx = 0;
+                if (response.Networks != null)
+                {
+                    foreach (var net in response.Networks.Values)
+                    {
+                        netRx += net.RxBytes;
+                        netTx += net.TxBytes;
+                    }
+                }
+
+                // Block I/O: sum read/write ops (-1 sentinel when cgroup v2 provides no data)
+                double blkRead = -1,
+                    blkWrite = -1;
+                var blkioEntries = response.BlkioStats?.IoServiceBytesRecursive;
+                if (blkioEntries is { Count: > 0 })
+                {
+                    blkRead = 0;
+                    blkWrite = 0;
+                    foreach (var e in blkioEntries)
+                    {
+                        if (string.Equals(e.Op, "read", StringComparison.OrdinalIgnoreCase))
+                        {
+                            blkRead += e.Value;
+                        }
+                        else if (string.Equals(e.Op, "write", StringComparison.OrdinalIgnoreCase))
+                        {
+                            blkWrite += e.Value;
+                        }
+                    }
+                }
+
+                // Memory limit
+                var memLimit = response.MemoryStats.Limit ?? 0;
+                double memLimitMb = memLimit > 0 ? memLimit / (1024.0 * 1024.0) : 0;
+
+                entry.Latest = new StatsSnapshot
+                {
+                    SampledAt = DateTime.UtcNow,
+                    CpuPercent = cpuPercent,
+                    MemoryMb = memBytes / (1024.0 * 1024.0),
+                    NetRxBytes = netRx,
+                    NetTxBytes = netTx,
+                    BlkReadBytes = blkRead,
+                    BlkWriteBytes = blkWrite,
+                    MemoryLimitMb = memLimitMb,
+                };
+            }
+            catch (Exception ex)
+            {
+                if (ShouldEmitStrike(ref entry.DockerStatsFailureCount))
+                {
+                    InfrastructureEventLog.Emit(
+                        "docker_stats_snapshot_failed",
+                        new { instanceId = entry.InstanceId, error = ex.Message }
+                    );
+                }
+            }
         });
     }
 
@@ -445,26 +599,48 @@ public static class ContainerStatsCollector
 
                     var mappings = _instances.ToArray();
 
-                    // Poll game stats in parallel (best-effort, 3s timeout)
+                    // Poll game stats in parallel (3s timeout each)
                     var gameStatsTasks = mappings
                         .Where(m => m.Value.ApiBaseUrl != null)
                         .Select(async m =>
                         {
+                            var baseUrl = m.Value.ApiBaseUrl!();
+                            if (baseUrl == null)
+                            {
+                                return (m.Key, Stats: (GameStatsResponse?)null);
+                            }
                             try
                             {
-                                var json = await _statsHttp.GetStringAsync(
-                                    $"{m.Value.ApiBaseUrl}/stats",
-                                    ct
-                                );
+                                var json = await _statsHttp.GetStringAsync($"{baseUrl}/stats", ct);
                                 var gameStats = JsonSerializer.Deserialize<GameStatsResponse>(
                                     json,
                                     GameStatsJsonOptions
                                 );
+                                var failed = Interlocked.Exchange(
+                                    ref m.Value.GameStatsPollFailStreak,
+                                    0
+                                );
+                                if (failed > 0)
+                                {
+                                    InfrastructureEventLog.Emit(
+                                        "game_stats_poll_recovered",
+                                        new
+                                        {
+                                            instanceId = m.Key,
+                                            baseUrl,
+                                            failedPolls = failed,
+                                        }
+                                    );
+                                }
                                 return (m.Key, Stats: gameStats);
+                            }
+                            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                            {
+                                throw;
                             }
                             catch (JsonException ex)
                             {
-                                if (ShouldEmitStrike(ref m.Value.GameStatsFailureStreak))
+                                if (ShouldEmitStrike(ref m.Value.GameStatsParseFailureCount))
                                 {
                                     InfrastructureEventLog.Emit(
                                         "game_stats_parse_failed",
@@ -474,10 +650,26 @@ public static class ContainerStatsCollector
 
                                 return (m.Key, Stats: (GameStatsResponse?)null);
                             }
-                            catch
+                            catch (Exception ex)
                             {
-                                // HTTP-level failures (server starting up, brief disconnect) are
-                                // expected and not worth a structured event.
+                                // HTTP-level failure: server still starting, a transport blip,
+                                // or a stale forward. One event per streak names which.
+                                if (Interlocked.Increment(ref m.Value.GameStatsPollFailStreak) == 1)
+                                {
+                                    InfrastructureEventLog.Emit(
+                                        "game_stats_poll_failed",
+                                        new
+                                        {
+                                            instanceId = m.Key,
+                                            baseUrl,
+                                            exceptionType = ex.GetType().FullName,
+                                            message = ex.Message,
+                                            innerExceptionType = ex
+                                                .InnerException?.GetType()
+                                                .FullName,
+                                        }
+                                    );
+                                }
                                 return (m.Key, Stats: (GameStatsResponse?)null);
                             }
                         });
@@ -564,6 +756,10 @@ public static class ContainerStatsCollector
                             BlkReadBytesPerSec = blkReadRate,
                             BlkWriteBytesPerSec = blkWriteRate,
                             MemoryLimitMb = docker?.MemoryLimitMb ?? 0,
+                            SampleAgeMs =
+                                docker != null
+                                    ? (int)Math.Max(0, (now - docker.SampledAt).TotalMilliseconds)
+                                    : null,
                         };
 
                         SetupEventBus.EmitInstanceStats(instanceId, data, entry.HostId);
@@ -574,12 +770,28 @@ public static class ContainerStatsCollector
                         entry.PreviousTimestamp = now;
                     }
                 }
-                catch { }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    if (ShouldEmitStrike(ref _emissionFailureCount))
+                    {
+                        InfrastructureEventLog.Emit(
+                            "stats_emission_tick_failed",
+                            new { exceptionType = ex.GetType().FullName, message = ex.Message }
+                        );
+                    }
+                }
             }
         }
-        catch (OperationCanceledException) { }
-        catch { }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
     }
+
+    // Emission-loop tick failures are bug-shaped (see ShouldEmitStrike); loop-wide
+    // because one tick covers every instance.
+    private static int _emissionFailureCount;
 
     private sealed class GameStatsResponse
     {

--- a/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ClientPool.cs
@@ -775,7 +775,7 @@ internal sealed class ClientPool : IAsyncDisposable
                 client.Container.Id,
                 client.Container.Name,
                 _host,
-                client.BaseUrl
+                () => client.BaseUrl
             );
 
             return client;

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -923,7 +923,7 @@ internal sealed class ManagedServer : IAsyncDisposable
             Server.Container.Id,
             Server.Container.Name,
             Host,
-            Server.BaseUrl
+            () => Server.BaseUrl
         );
 
         SetupEventBus.EmitStep(

--- a/tests/JunimoServer.Tests/Schema/Events/InstanceEvents.cs
+++ b/tests/JunimoServer.Tests/Schema/Events/InstanceEvents.cs
@@ -123,7 +123,7 @@ public sealed record InstanceDisconnectedEvent(string InstanceId) : IRendererEve
 /// <summary>
 /// Container performance stats for an instance.
 /// Carries the full <see cref="InstanceStatsData"/> by reference; the
-/// <see cref="InstanceStatsEventConverter"/> flattens its 18 fields onto the
+/// <see cref="InstanceStatsEventConverter"/> flattens its 19 fields onto the
 /// wire alongside <c>instanceId</c> and <c>hostId</c>:
 /// <c>{ event, timestamp, instanceId, hostId, cpuPercent, memoryMb, … }</c>.
 /// </summary>
@@ -195,6 +195,7 @@ public sealed class InstanceStatsEventConverter : JsonConverter<InstanceStatsEve
             BlkReadBytesPerSec = GetOptDouble(root, "blkReadBytesPerSec"),
             BlkWriteBytesPerSec = GetOptDouble(root, "blkWriteBytesPerSec"),
             MemoryLimitMb = GetDouble(root, "memoryLimitMb"),
+            SampleAgeMs = GetOptInt(root, "sampleAgeMs"),
         };
 
         return new InstanceStatsEvent(instanceId, hostId, data) { Timestamp = timestamp };
@@ -232,6 +233,7 @@ public sealed class InstanceStatsEventConverter : JsonConverter<InstanceStatsEve
         WriteOptDouble(writer, "blkReadBytesPerSec", d.BlkReadBytesPerSec);
         WriteOptDouble(writer, "blkWriteBytesPerSec", d.BlkWriteBytesPerSec);
         writer.WriteNumber("memoryLimitMb", d.MemoryLimitMb);
+        WriteOptInt(writer, "sampleAgeMs", d.SampleAgeMs);
 
         writer.WriteEndObject();
     }

--- a/tests/test-ui/src/components/InstanceCard.vue
+++ b/tests/test-ui/src/components/InstanceCard.vue
@@ -30,6 +30,7 @@ const props = withDefaults(
             blkReadBytesPerSec: number | null;
             blkWriteBytesPerSec: number | null;
             memoryLimitMb: number;
+            sampleAgeMs: number | null;
         };
         setupSteps?: SetupStepSnapshot[];
         setupStatus?: "pending" | "running" | "completed" | "failed" | null;

--- a/tests/test-ui/src/components/InstanceInspect.vue
+++ b/tests/test-ui/src/components/InstanceInspect.vue
@@ -68,6 +68,7 @@ const props = withDefaults(
             blkReadBytesPerSec: number | null;
             blkWriteBytesPerSec: number | null;
             memoryLimitMb: number;
+            sampleAgeMs: number | null;
         };
         statsHistory: StatsSnapshotEntry[];
         instanceCount: number;

--- a/tests/test-ui/src/components/VncTile.vue
+++ b/tests/test-ui/src/components/VncTile.vue
@@ -12,6 +12,8 @@ import {
     queueTextClass as _queueText,
     tpsTextClass as _tpsText,
     formatMem,
+    isStaleSample,
+    staleSampleSuffix,
 } from "../utils/metrics";
 
 const props = withDefaults(
@@ -40,6 +42,7 @@ const props = withDefaults(
             blkReadBytesPerSec: number | null;
             blkWriteBytesPerSec: number | null;
             memoryLimitMb: number;
+            sampleAgeMs: number | null;
         };
         setupSteps?: SetupStepSnapshot[];
         setupStatus?: "pending" | "running" | "completed" | "failed" | null;
@@ -77,13 +80,27 @@ function fpsTextClass(): string {
     return _fpsText(props.stats);
 }
 function cpuTextClass(): string {
-    return _cpuText(props.stats, props.instanceCount!);
+    return _cpuText(props.stats, props.instanceCount ?? 1);
 }
 function memTextClass(): string {
-    return _memText(props.stats, props.instanceCount!);
+    return _memText(props.stats, props.instanceCount ?? 1);
 }
 function queueTextClass(): string {
     return _queueText(props.stats);
+}
+function staleClass(): string {
+    return isStaleSample(props.stats) ? "opacity-40" : "";
+}
+function staleSuffix(): string {
+    return staleSampleSuffix(props.stats);
+}
+// MEM shows game memory when available, else the container sample — only the
+// latter can go stale, so the staleness cue applies only in that fallback.
+function memStaleClass(): string {
+    return props.stats?.gameMemoryMb == null ? staleClass() : "";
+}
+function memStaleSuffix(): string {
+    return props.stats?.gameMemoryMb == null ? staleSuffix() : "";
 }
 function displayMem(): number | null {
     return _displayMem(props.stats);
@@ -216,12 +233,12 @@ onBeforeUnmount(() => {
                 :title="stats.fps != null ? `FPS: ${stats.fps.toFixed(1)}` : 'FPS: not available'">
             <span class="text-base-content/25">FPS:</span> {{ stats.fps != null ? Math.round(stats.fps) : '-' }}
           </span>
-          <span class="flex-none" :class="cpuTextClass()"
-                :title="stats ? `CPU: ${stats.cpuPercent.toFixed(1)}%` : 'CPU: not available'">
+          <span class="flex-none" :class="[cpuTextClass(), staleClass()]"
+                :title="`CPU: ${stats.cpuPercent.toFixed(1)}%${staleSuffix()}`">
             <span class="text-base-content/25">CPU:</span> {{ stats.cpuPercent.toFixed(0) }}%
           </span>
-          <span class="flex-none" :class="memTextClass()"
-                :title="displayMem() != null ? `Memory: ${displayMem()! >= 1024 ? (displayMem()! / 1024).toFixed(1) + ' GB' : Math.round(displayMem()!) + ' MB'}` : 'Memory: not available'">
+          <span class="flex-none" :class="[memTextClass(), memStaleClass()]"
+                :title="displayMem() != null ? `Memory: ${displayMem()! >= 1024 ? (displayMem()! / 1024).toFixed(1) + ' GB' : Math.round(displayMem()!) + ' MB'}${memStaleSuffix()}` : 'Memory: not available'">
             <span class="text-base-content/25">MEM:</span> {{ displayMem() != null ? formatMem(displayMem()!) : '-' }}
           </span>
           <span v-if="stats.pendingActions != null" class="flex-none" :class="queueTextClass()"

--- a/tests/test-ui/src/composables/useTestStore.ts
+++ b/tests/test-ui/src/composables/useTestStore.ts
@@ -81,6 +81,7 @@ export interface TestStore {
             blkReadBytesPerSec: number | null;
             blkWriteBytesPerSec: number | null;
             memoryLimitMb: number;
+            sampleAgeMs: number | null;
         }
     >;
     /** Stats history, keyed by instanceId. Unbounded; kept for the entire run. */
@@ -221,6 +222,7 @@ export function useTestStore(): TestStore {
                 blkReadBytesPerSec: number | null;
                 blkWriteBytesPerSec: number | null;
                 memoryLimitMb: number;
+                sampleAgeMs: number | null;
             }
         >(),
     );
@@ -1267,6 +1269,7 @@ export function useTestStore(): TestStore {
                     blkReadBytesPerSec: event.blkReadBytesPerSec ?? null,
                     blkWriteBytesPerSec: event.blkWriteBytesPerSec ?? null,
                     memoryLimitMb: event.memoryLimitMb ?? 0,
+                    sampleAgeMs: event.sampleAgeMs ?? null,
                 };
                 instanceStats.set(event.instanceId, statsEntry);
                 let history = instanceStatsHistory.get(event.instanceId);

--- a/tests/test-ui/src/types/events.ts
+++ b/tests/test-ui/src/types/events.ts
@@ -397,4 +397,6 @@ export interface InstanceStatsEvent {
     blkWriteBytesPerSec: number | null;
     /** Container memory limit in MB (0 = no limit set). */
     memoryLimitMb: number;
+    /** Age of the Docker sample behind the container fields at emit time. Null when there is none. */
+    sampleAgeMs: number | null;
 }

--- a/tests/test-ui/src/types/state.ts
+++ b/tests/test-ui/src/types/state.ts
@@ -106,6 +106,8 @@ export interface StatsSnapshotEntry {
     blkReadBytesPerSec: number | null;
     blkWriteBytesPerSec: number | null;
     memoryLimitMb: number;
+    /** Age of the Docker sample behind the container fields at emit time. Null when there is none. */
+    sampleAgeMs: number | null;
 }
 
 export interface InstanceHistoryEntry {

--- a/tests/test-ui/src/utils/metrics.ts
+++ b/tests/test-ui/src/utils/metrics.ts
@@ -56,6 +56,7 @@ interface MetricStats {
     pendingActions: number | null;
     gameThreadWaitMs: number | null;
     memoryLimitMb: number;
+    sampleAgeMs?: number | null;
 }
 
 /** TPS color class based on % of target. */
@@ -179,4 +180,23 @@ export function formatBytesPerSec(bps: number): string {
         return `${(bps / 1024).toFixed(1)} KB/s`;
     }
     return `${Math.round(bps)} B/s`;
+}
+
+/** Docker pushes a stats sample about once a second; an age past this means the stream is down
+ *  and the container fields (CPU, container memory, I/O) are a repeat of the last sample. */
+export const STALE_SAMPLE_MS = 2500;
+
+/** True when the container-side fields of `stats` come from a sample older than the stream interval. */
+export function isStaleSample(stats: MetricStats | undefined): boolean {
+    return stats?.sampleAgeMs != null && stats.sampleAgeMs > STALE_SAMPLE_MS;
+}
+
+/** Suffix for a metric tooltip whose value is a stale container sample; empty when fresh. */
+export function staleSampleSuffix(stats: MetricStats | undefined): string {
+    if (!isStaleSample(stats)) {
+        return "";
+    }
+    // isStaleSample guarantees sampleAgeMs is non-null here; ?? 0 keeps the type checker happy.
+    const ageMs = stats?.sampleAgeMs ?? 0;
+    return ` (stale: sample is ${(ageMs / 1000).toFixed(0)}s old)`;
 }


### PR DESCRIPTION
Independent (base `master`); can merge any time.

- Supervise `GetContainerStatsAsync` with reconnect on any non-cancellation exit; emit `docker_stats_stream_ended`/`docker_stats_stream_reconnected`; give up only on a daemon-confirmed non-running container.
- `ApiBaseUrl` becomes a `Func` reading the container's live `BaseUrl` at both `Register` sites (`ManagedServer`, `ClientPool`) so game-stats polls follow a reopened forward instead of a dead captured port.
- Emission carries `sampleAgeMs`; the UI greys samples older than the stream interval so a frozen `Latest` is never shown as fresh; game-stats failures emit `game_stats_poll_failed` (with `baseUrl`/`exceptionType`) instead of a silent null.
- End-to-end plumbing per the runner→UI contract: collector emit → runner event → JSONL → test-ui types/store → components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metrics freshness indicators for CPU and fallback memory values when samples are delayed.
  - Displays the age of container statistics in monitoring data and history.
  - Automatically reconnects interrupted statistics streams when possible.

- **Bug Fixes**
  - Refreshes server connection details after reconnection, improving continued statistics collection.
  - Improved handling and reporting of temporary statistics collection failures, including recovery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->