### PR TITLE
feat(ci): split Discord notifications into release feeds and an internal CI stream

### DIFF
--- a/.github/actions/build-changelog/action.yml
+++ b/.github/actions/build-changelog/action.yml
@@ -1,0 +1,57 @@
+name: Build Changelog
+description: >
+  Builds Discord-ready changelog markdown for a build: every first-parent commit since the
+  previous build tag, grouped into release-please's sections and budgeted for an embed
+  description. Performs no checkout — the caller's checkout must have full history and tags
+  (fetch-depth: 0, fetch-tags: true).
+
+inputs:
+  head:
+    description: Commit-ish of the build's head (SHA or tag name)
+    required: true
+  tag-match:
+    description: Space-separated `git describe --match` globs that select base-tag candidates
+    required: true
+
+outputs:
+  markdown:
+    description: Changelog markdown (at most 3500 code points)
+    value: ${{ steps.changelog.outputs.markdown }}
+  count:
+    description: Commits in the range
+    value: ${{ steps.changelog.outputs.count }}
+  visible-count:
+    description: Commits listed individually (visible sections plus Other)
+    value: ${{ steps.changelog.outputs.visible-count }}
+  hidden-count:
+    description: Commits folded into the internal-changes line
+    value: ${{ steps.changelog.outputs.hidden-count }}
+  base-tag:
+    description: Tag the range starts from (the previous build)
+    value: ${{ steps.range.outputs.base-tag }}
+  compare-url:
+    description: GitHub compare URL for the range
+    value: ${{ steps.changelog.outputs.compare-url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve commit range
+      id: range
+      shell: bash
+      env:
+        HEAD_REF: ${{ inputs.head }}
+        TAG_MATCH: ${{ inputs.tag-match }}
+      run: '"$GITHUB_ACTION_PATH/../../scripts/resolve-build-range.sh"'
+
+    - name: Build changelog
+      id: changelog
+      shell: bash
+      env:
+        BASE_OID: ${{ steps.range.outputs.base-oid }}
+        HEAD_OID: ${{ steps.range.outputs.head-oid }}
+        BASE_TAG: ${{ steps.range.outputs.base-tag }}
+        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+      run: |
+        git log --first-parent --format='%H%x1f%s' "$BASE_OID..$HEAD_OID" \
+          | node "$GITHUB_ACTION_PATH/../../scripts/build-changelog.js"

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -108,4 +108,4 @@ runs:
           echo "$payload"
           exit 0
         fi
-        curl -sS --fail-with-body -H "Content-Type: application/json" -d "$payload" "$WEBHOOK"
+        curl -sS --fail-with-body --proto '=https' -H "Content-Type: application/json" -d "$payload" "$WEBHOOK"

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -1,0 +1,111 @@
+name: Discord Notify
+description: >
+  Posts a single-embed message to a Discord webhook. Validates Discord's embed limits up
+  front and fails the step with a clear message instead of truncating; an empty webhook
+  input logs a skip and exits 0, so notifications degrade to silence when the secret is
+  absent. A failed post fails the step (curl --fail-with-body) — success-path callers set
+  continue-on-error so a Discord outage never reds a build or deploy that succeeded.
+
+inputs:
+  webhook:
+    description: Discord webhook URL; empty means log "no webhook configured" and skip
+    required: true
+  title:
+    description: Embed title (at most 256 characters)
+    required: true
+  url:
+    description: Optional URL the title links to
+    required: false
+    default: ""
+  color:
+    description: Embed color as a decimal number
+    required: true
+  description:
+    description: Optional embed description, markdown (at most 4096 characters)
+    required: false
+    default: ""
+  fields:
+    description: >
+      Optional JSON array of {name, value, inline?} objects. Callers build it with
+      `jq -n --arg` so user-supplied text is never string-interpolated into JSON.
+    required: false
+    default: "[]"
+  dry-run:
+    description: Print the payload instead of posting (used by payload tests)
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Build and post embed
+      shell: bash
+      env:
+        WEBHOOK: ${{ inputs.webhook }}
+        TITLE: ${{ inputs.title }}
+        URL: ${{ inputs.url }}
+        COLOR: ${{ inputs.color }}
+        DESCRIPTION: ${{ inputs.description }}
+        FIELDS: ${{ inputs.fields }}
+        DRY_RUN: ${{ inputs.dry-run }}
+      run: |
+        set -euo pipefail
+
+        if [ "$DRY_RUN" != "true" ] && [ -z "$WEBHOOK" ]; then
+          echo "No webhook configured, skipping Discord notification."
+          exit 0
+        fi
+
+        [[ "$COLOR" =~ ^[0-9]+$ ]] || { echo "::error::discord-notify: color must be decimal, got '$COLOR'"; exit 1; }
+        [ -n "$TITLE" ] || { echo "::error::discord-notify: title must not be empty"; exit 1; }
+        jq -e 'type == "array" and all(.[]; (.name | type == "string") and (.value | type == "string"))' \
+          >/dev/null 2>&1 <<< "$FIELDS" \
+          || { echo "::error::discord-notify: fields must be a JSON array of {name, value} objects"; exit 1; }
+
+        payload=$(jq -cn \
+          --arg title "$TITLE" \
+          --arg url "$URL" \
+          --arg desc "$DESCRIPTION" \
+          --argjson color "$COLOR" \
+          --argjson fields "$FIELDS" \
+          '{
+            embeds: [(
+              {title: $title, color: $color, timestamp: (now | todate)}
+              + (if $url == "" then {} else {url: $url} end)
+              + (if $desc == "" then {} else {description: $desc} end)
+              + (if ($fields | length) == 0 then {} else {fields: $fields} end)
+            )]
+          }')
+
+        # Discord API "Embed Limits": title 256, description 4096, field name 256 /
+        # value 1024, 25 fields, 6000 characters across the embed. Fail loudly instead of
+        # truncating — a clipped ops message is worse than a red step, and the changelog
+        # builder owns its own budget upstream.
+        errors=$(jq -r '
+          .embeds[0]
+          | (.description // "") as $d
+          | (.fields // []) as $f
+          | [
+              (select((.title | length) > 256) | "title exceeds 256 characters"),
+              (select(($d | length) > 4096) | "description exceeds 4096 characters"),
+              (select(($f | length) > 25) | "more than 25 fields"),
+              ($f[] | select((.name | length) < 1 or (.name | length) > 256)
+                | "field name empty or over 256 characters"),
+              ($f[] | select((.value | length) < 1 or (.value | length) > 1024)
+                | "field value empty or over 1024 characters (field: \(.name))"),
+              (select(
+                ((.title | length) + ($d | length)
+                  + ([$f[] | (.name | length) + (.value | length)] | add // 0)) > 6000)
+                | "embed exceeds 6000 characters total")
+            ]
+          | join("; ")' <<< "$payload")
+        if [ -n "$errors" ]; then
+          echo "::error::discord-notify: embed over Discord limits: $errors"
+          exit 1
+        fi
+
+        if [ "$DRY_RUN" = "true" ]; then
+          echo "$payload"
+          exit 0
+        fi
+        curl -sS --fail-with-body -H "Content-Type: application/json" -d "$payload" "$WEBHOOK"

--- a/.github/actions/stamp-issue-versions/action.yml
+++ b/.github/actions/stamp-issue-versions/action.yml
@@ -52,27 +52,7 @@ runs:
       env:
         HEAD_REF: ${{ inputs.head-ref }}
         TAG_MATCH: ${{ inputs.tag-match }}
-      run: |
-        set -f # tag globs must reach git verbatim, not expand against the working tree
-        HEAD_OID=$(git rev-parse "$HEAD_REF^{commit}")
-        MATCH_ARGS=()
-        for glob in $TAG_MATCH; do MATCH_ARGS+=(--match "$glob"); done
-        # The base must sit strictly below HEAD. A candidate tag pointing at HEAD itself is this
-        # build's own tag or a previous build of the same commit — taking it as base would empty
-        # the range and permanently skip a failed run's issues. Re-walking an already-stamped
-        # range is a no-op (first value wins, comments are marker-deduped).
-        EXCLUDE_ARGS=()
-        for tag in $(git tag -l --points-at "$HEAD_OID" $TAG_MATCH); do
-          EXCLUDE_ARGS+=(--exclude "$tag")
-        done
-        BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" "${EXCLUDE_ARGS[@]}" "$HEAD_OID" 2>/dev/null) || {
-          echo "::error::no base tag matching '$TAG_MATCH' strictly below $HEAD_REF"
-          exit 1
-        }
-        BASE_OID=$(git rev-parse "$BASE^{commit}")
-        echo "HEAD=$HEAD_OID BASE=$BASE ($BASE_OID)"
-        echo "head-oid=$HEAD_OID" >> "$GITHUB_OUTPUT"
-        echo "base-oid=$BASE_OID" >> "$GITHUB_OUTPUT"
+      run: '"$GITHUB_ACTION_PATH/../../scripts/resolve-build-range.sh"'
 
     - name: Install dependencies
       shell: bash

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -38,13 +38,14 @@ function codePoints(s) {
 
 /**
  * Backslash-escape Discord inline-markdown characters so a commit subject renders as
- * plain text. `[`/`]` stay unescaped: subjects are emitted as plain text, never as link
- * text, so they cannot break the appended PR link.
+ * plain text. Brackets are escaped too: a subject containing `[label](url)` must render
+ * literally, not as a masked link — commit subjects are contributor-controlled and these
+ * posts go to public channels. (Embeds never ping, so @-mentions need no handling.)
  * @param {string} text
  * @returns {string}
  */
 function escapeMarkdown(text) {
-    return text.replace(/[\\`*_~|]/g, (c) => `\\${c}`);
+    return text.replace(/[\\`*_~|[\]]/g, (c) => `\\${c}`);
 }
 
 /**

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -1,0 +1,217 @@
+// Builds the Discord changelog for a build: every first-parent commit in the build's range,
+// grouped into the same sections release-please uses, budgeted for a Discord embed description.
+// Used by .github/actions/build-changelog; the pure logic is exported for `npm test`.
+//
+// CLI contract (the composite action wires this up): `git log --first-parent
+// --format='%H%x1f%s' BASE..HEAD` lines on stdin; BASE_TAG, HEAD_OID, REPO_URL env in;
+// markdown / count / visible-count / hidden-count / compare-url appended to $GITHUB_OUTPUT
+// (printed to stdout when GITHUB_OUTPUT is unset, for local runs).
+
+// Section order and titles mirror release-please-config.json's changelog-sections, so a
+// Discord post reads like the GitHub release page. Types "hidden" there fold into one
+// "+N internal changes" line here. Anything else — unknown type or non-conventional
+// subject — lands under "Other" verbatim; a change is never dropped for a parse failure.
+const VISIBLE_SECTIONS = [
+    { type: "feat", title: "Features" },
+    { type: "fix", title: "Bug Fixes" },
+    { type: "perf", title: "Performance Improvements" },
+    { type: "revert", title: "Reverts" },
+    { type: "docs", title: "Documentation" },
+];
+const HIDDEN_TYPES = new Set(["style", "chore", "refactor", "test", "build", "ci"]);
+
+// Code points, not UTF-16 units — leaves headroom under Discord's 4096-char description
+// limit for the caller's trailing "Use it" block, and under the 6000-char embed total.
+const BUDGET = 3500;
+
+const CONVENTIONAL_RE = /^([a-z]+)(\([^()]*\))?(!)?: \S/i;
+const PR_SUFFIX_RE = /\s*\(#(\d+)\)$/;
+// release-please's own release commit ("chore(master): release sdvd-server 1.4.1") is the
+// commit a release tag points at, so it sits inside its own range. It is release machinery,
+// not a change — excluded from every count so it can't pad "+N internal changes".
+const RELEASE_COMMIT_RE = /^chore(\([^()]*\))?: release\b.*\d+\.\d+\.\d+/;
+
+/** @param {string} s @returns {number} length in code points (what Discord counts) */
+function codePoints(s) {
+    return [...s].length;
+}
+
+/**
+ * Backslash-escape Discord inline-markdown characters so a commit subject renders as
+ * plain text. `[`/`]` stay unescaped: subjects are emitted as plain text, never as link
+ * text, so they cannot break the appended PR link.
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeMarkdown(text) {
+    return text.replace(/[\\`*_~|]/g, (c) => `\\${c}`);
+}
+
+/**
+ * Classify one commit subject.
+ * @param {string} subject - Raw `git log %s` subject line.
+ * @returns {{text: string, type: string|null, breaking: boolean, pr: number|null}}
+ *   `text` is the subject without its trailing `(#N)`; `type` is the lowercased
+ *   conventional-commit type or null for a non-conventional subject.
+ */
+function parseSubject(subject) {
+    const prMatch = subject.match(PR_SUFFIX_RE);
+    const pr = prMatch ? Number(prMatch[1]) : null;
+    const text = (prMatch ? subject.slice(0, prMatch.index) : subject).trim();
+    const conv = text.match(CONVENTIONAL_RE);
+    return {
+        text,
+        type: conv ? conv[1].toLowerCase() : null,
+        breaking: conv ? conv[3] === "!" || /\bBREAKING[ -]CHANGE\b/.test(text) : false,
+        pr,
+    };
+}
+
+/** @returns {string} one `- …` bullet; ⚠ marks a breaking change, the PR link is appended. */
+function renderEntry(entry, repoUrl) {
+    const warn = entry.breaking ? "⚠ " : "";
+    const link = entry.pr === null ? "" : ` · [#${entry.pr}](${repoUrl}/pull/${entry.pr})`;
+    return `- ${warn}${escapeMarkdown(entry.text)}${link}`;
+}
+
+/** @returns {string} the "+N internal changes" summary line. */
+function internalNote(hiddenCount) {
+    return `+${hiddenCount} internal change${hiddenCount === 1 ? "" : "s"}`;
+}
+
+/**
+ * Build the changelog markdown for a commit range.
+ * @param {string[]} subjects - `git log %s` subjects, newest first (git log order).
+ * @param {{repoUrl: string, baseTag: string, headOid: string}} opts
+ * @returns {{markdown: string, count: number, visibleCount: number, hiddenCount: number, compareUrl: string}}
+ *   `markdown` is at most BUDGET code points; over-budget ranges end with
+ *   "…and N more — [full diff](…)" cut at a line boundary.
+ */
+function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
+    const compareUrl = `${repoUrl}/compare/${baseTag}...${headOid}`;
+    const fullDiff = `[full diff](${compareUrl})`;
+
+    const changes = subjects.filter((s) => !RELEASE_COMMIT_RE.test(s));
+    const sections = VISIBLE_SECTIONS.map((s) => ({ ...s, entries: [] }));
+    const other = { title: "Other", entries: [] };
+    let hiddenCount = 0;
+    for (const subject of changes) {
+        const entry = parseSubject(subject);
+        if (entry.type !== null && HIDDEN_TYPES.has(entry.type)) {
+            hiddenCount += 1;
+            continue;
+        }
+        const section = sections.find((s) => s.type === entry.type) ?? other;
+        section.entries.push(entry);
+    }
+
+    const count = changes.length;
+    const visibleCount = count - hiddenCount;
+    const result = { count, visibleCount, hiddenCount, compareUrl };
+
+    if (count === 0) {
+        return { ...result, markdown: `No changes since \`${baseTag}\` — ${fullDiff}` };
+    }
+    if (visibleCount === 0) {
+        return { ...result, markdown: `No user-facing changes (${internalNote(hiddenCount)}) — ${fullDiff}` };
+    }
+
+    // Flat line list, tagged so truncation can count dropped changes and trim headers
+    // whose entries were all cut.
+    const lines = [];
+    for (const section of [...sections, other]) {
+        if (section.entries.length === 0) {
+            continue;
+        }
+        if (lines.length > 0) {
+            lines.push({ text: "", isEntry: false });
+        }
+        lines.push({ text: `**${section.title}**`, isEntry: false });
+        for (const entry of section.entries) {
+            lines.push({ text: renderEntry(entry, repoUrl), isEntry: true });
+        }
+    }
+    const hiddenLine = hiddenCount > 0 ? internalNote(hiddenCount) : null;
+    const tailAfter = (body) => (hiddenLine === null ? body : `${body}\n\n${hiddenLine}`);
+
+    const full = tailAfter(lines.map((l) => l.text).join("\n"));
+    if (codePoints(full) <= BUDGET) {
+        return { ...result, markdown: full };
+    }
+
+    // Over budget: emit whole lines while the worst-case tail (notice with the largest
+    // possible N, plus the internal-changes line) still fits, then trim trailing headers
+    // and blanks so the cut lands after an entry.
+    const notice = (n) => `…and ${n} more — ${fullDiff}`;
+    const reserve =
+        codePoints(`\n${notice(visibleCount)}`) + (hiddenLine === null ? 0 : codePoints(`\n\n${hiddenLine}`));
+    const kept = [];
+    let used = 0;
+    for (const line of lines) {
+        const cost = codePoints(line.text) + (kept.length > 0 ? 1 : 0);
+        if (used + cost > BUDGET - reserve) {
+            break;
+        }
+        kept.push(line);
+        used += cost;
+    }
+    while (kept.length > 0 && !kept[kept.length - 1].isEntry) {
+        kept.pop();
+    }
+    const dropped = visibleCount - kept.filter((l) => l.isEntry).length;
+    const markdown = tailAfter(`${kept.map((l) => l.text).join("\n")}\n${notice(dropped)}`);
+    return { ...result, markdown };
+}
+
+module.exports = { buildChangelog, parseSubject, escapeMarkdown, BUDGET };
+
+// --- CLI entry (composite-action wiring) ---------------------------------------------
+
+/** @param {string} name @returns {string} */
+function requireEnv(name) {
+    const value = process.env[name];
+    if (value === undefined || value === "") {
+        console.error(`::error::build-changelog.js: missing required env ${name}`);
+        process.exit(1);
+    }
+    return value;
+}
+
+function main() {
+    const { readFileSync, appendFileSync } = require("node:fs");
+    const { randomUUID } = require("node:crypto");
+
+    const baseTag = requireEnv("BASE_TAG");
+    const headOid = requireEnv("HEAD_OID");
+    const repoUrl = requireEnv("REPO_URL");
+
+    // One `<sha>\x1f<subject>` line per commit; the sha guarantees a non-empty line per
+    // commit so the count stays right even for an empty subject.
+    const subjects = readFileSync(0, "utf8")
+        .split("\n")
+        .filter((line) => line.includes("\x1f"))
+        .map((line) => line.slice(line.indexOf("\x1f") + 1));
+
+    const result = buildChangelog(subjects, { repoUrl, baseTag, headOid });
+    const delimiter = `EOF_${randomUUID()}`;
+    const output = [
+        `markdown<<${delimiter}`,
+        result.markdown,
+        delimiter,
+        `count=${result.count}`,
+        `visible-count=${result.visibleCount}`,
+        `hidden-count=${result.hiddenCount}`,
+        `compare-url=${result.compareUrl}`,
+        "",
+    ].join("\n");
+
+    if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(process.env.GITHUB_OUTPUT, output);
+    }
+    console.log(`${result.count} commits (${result.visibleCount} visible, ${result.hiddenCount} internal)`);
+    console.log(result.markdown);
+}
+
+if (require.main === module) {
+    main();
+}

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -1,0 +1,178 @@
+// Tests for build-changelog.js — fixed subject lists in, exact markdown out. Run with
+// `npm test` (wired into the Validate JS/TS job). No dependencies: Node's built-in runner.
+//
+// These pin the Discord-facing contract: section grouping mirrors release-please's
+// changelog-sections, no change is ever dropped (unparseable ⇒ "Other"), markdown
+// characters in subjects are escaped, and the output stays under the 3500-code-point
+// budget with a line-boundary cut and an "…and N more" notice.
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { buildChangelog, BUDGET } = require("./build-changelog.js");
+
+const OPTS = {
+    repoUrl: "https://github.com/o/r",
+    baseTag: "preview-1.5.0.1",
+    headOid: "deadbee",
+};
+const COMPARE = "https://github.com/o/r/compare/preview-1.5.0.1...deadbee";
+
+test("groups each visible type into its release-please section, in order", () => {
+    const result = buildChangelog(
+        [
+            "docs: explain cabins (#5)",
+            "revert: undo the thing (#4)",
+            "perf: fewer allocations (#3)",
+            "fix: stop the crash (#2)",
+            "feat: add the thing (#1)",
+        ],
+        OPTS,
+    );
+    assert.equal(
+        result.markdown,
+        [
+            "**Features**",
+            "- feat: add the thing · [#1](https://github.com/o/r/pull/1)",
+            "",
+            "**Bug Fixes**",
+            "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)",
+            "",
+            "**Performance Improvements**",
+            "- perf: fewer allocations · [#3](https://github.com/o/r/pull/3)",
+            "",
+            "**Reverts**",
+            "- revert: undo the thing · [#4](https://github.com/o/r/pull/4)",
+            "",
+            "**Documentation**",
+            "- docs: explain cabins · [#5](https://github.com/o/r/pull/5)",
+        ].join("\n"),
+    );
+    assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [5, 5, 0]);
+});
+
+test("hidden-only range folds into an internal-changes note with the compare link", () => {
+    const result = buildChangelog(["ci: bump action (#9)", "chore: tidy", "refactor: rename (#8)"], OPTS);
+    assert.equal(result.markdown, `No user-facing changes (+3 internal changes) — [full diff](${COMPARE})`);
+    assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 0, 3]);
+});
+
+test("mixed range lists visible sections and appends the internal-changes line", () => {
+    const result = buildChangelog(["test: cover cabins (#3)", "fix(ci): quote globs (#2)", "chore: bump deps"], OPTS);
+    assert.equal(
+        result.markdown,
+        [
+            "**Bug Fixes**",
+            "- fix(ci): quote globs · [#2](https://github.com/o/r/pull/2)",
+            "",
+            "+2 internal changes",
+        ].join("\n"),
+    );
+    assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 1, 2]);
+});
+
+test("a single internal change uses the singular note", () => {
+    const result = buildChangelog(["chore: bump deps"], OPTS);
+    assert.equal(result.markdown, `No user-facing changes (+1 internal change) — [full diff](${COMPARE})`);
+});
+
+test("a subject without (#N) is listed without a PR link", () => {
+    const result = buildChangelog(["feat(tools): add request-correlation context"], OPTS);
+    assert.equal(result.markdown, ["**Features**", "- feat(tools): add request-correlation context"].join("\n"));
+});
+
+test("a non-conventional subject lands under Other verbatim, never dropped", () => {
+    const result = buildChangelog(["Update README badges (#7)", "feat: real feature (#6)"], OPTS);
+    assert.equal(
+        result.markdown,
+        [
+            "**Features**",
+            "- feat: real feature · [#6](https://github.com/o/r/pull/6)",
+            "",
+            "**Other**",
+            "- Update README badges · [#7](https://github.com/o/r/pull/7)",
+        ].join("\n"),
+    );
+    assert.equal(result.visibleCount, 2);
+});
+
+test("an unknown conventional type lands under Other", () => {
+    const result = buildChangelog(["wip: half-done thing (#7)"], OPTS);
+    assert.equal(
+        result.markdown,
+        ["**Other**", "- wip: half-done thing · [#7](https://github.com/o/r/pull/7)"].join("\n"),
+    );
+});
+
+test("feat!: gets the breaking-change warning marker", () => {
+    const result = buildChangelog(["feat!: drop LAN transport (#10)"], OPTS);
+    assert.equal(
+        result.markdown,
+        ["**Features**", "- ⚠ feat!: drop LAN transport · [#10](https://github.com/o/r/pull/10)"].join("\n"),
+    );
+});
+
+test("markdown special characters in subjects are escaped", () => {
+    const result = buildChangelog(
+        ["fix: escape `code` and *stars* and _under_ and ~tilde~ and |pipe| and \\slash"],
+        OPTS,
+    );
+    assert.equal(
+        result.markdown,
+        [
+            "**Bug Fixes**",
+            "- fix: escape \\`code\\` and \\*stars\\* and \\_under\\_ and \\~tilde\\~ and \\|pipe\\| and \\\\slash",
+        ].join("\n"),
+    );
+});
+
+test("a non-ASCII subject passes through and the budget counts code points", () => {
+    const result = buildChangelog(["feat: 🎉 支持中文标题 (#12)"], OPTS);
+    assert.equal(
+        result.markdown,
+        ["**Features**", "- feat: 🎉 支持中文标题 · [#12](https://github.com/o/r/pull/12)"].join("\n"),
+    );
+});
+
+test("an over-budget list is cut at a line boundary with an …and N more notice", () => {
+    const subjects = [];
+    for (let i = 1; i <= 100; i++) {
+        subjects.push(`feat: a rather long feature subject line to inflate the budget quickly number ${i} (#${i})`);
+    }
+    subjects.push("chore: internal");
+    const result = buildChangelog(subjects, OPTS);
+    const markdown = result.markdown;
+    assert.ok([...markdown].length <= BUDGET, `markdown is ${[...markdown].length} code points, budget is ${BUDGET}`);
+    const lines = markdown.split("\n");
+    // Every kept entry is whole (cut at a line boundary), the notice names the dropped
+    // count, and the internal-changes line survives truncation.
+    const keptEntries = lines.filter((l) => l.startsWith("- feat:")).length;
+    assert.ok(keptEntries > 0 && keptEntries < 100);
+    const noticeLine = lines.find((l) => l.startsWith("…and "));
+    assert.equal(noticeLine, `…and ${100 - keptEntries} more — [full diff](${COMPARE})`);
+    assert.equal(lines[lines.length - 1], "+1 internal change");
+    for (const line of lines.filter((l) => l.startsWith("- "))) {
+        assert.match(line, /· \[#\d+\]\(https:\/\/github\.com\/o\/r\/pull\/\d+\)$/);
+    }
+});
+
+test("release-please's release commit is excluded from every count", () => {
+    const result = buildChangelog(
+        ["chore(master): release sdvd-server 1.4.1 (#97)", "fix: stop the crash (#2)", "chore: bump deps"],
+        OPTS,
+    );
+    assert.equal(
+        result.markdown,
+        ["**Bug Fixes**", "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)", "", "+1 internal change"].join(
+            "\n",
+        ),
+    );
+    assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [2, 1, 1]);
+    // A plain chore mentioning "release" without a version is NOT the release commit.
+    assert.equal(buildChangelog(["chore: release notes cleanup"], OPTS).hiddenCount, 1);
+});
+
+test("zero commits reports no changes since the base tag", () => {
+    const result = buildChangelog([], OPTS);
+    assert.equal(result.markdown, `No changes since \`preview-1.5.0.1\` — [full diff](${COMPARE})`);
+    assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [0, 0, 0]);
+});

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -125,6 +125,17 @@ test("markdown special characters in subjects are escaped", () => {
     );
 });
 
+test("a subject with markdown link syntax cannot inject a masked link", () => {
+    const result = buildChangelog(["feat: [deployment guide](https://attacker.example) (#13)"], OPTS);
+    assert.equal(
+        result.markdown,
+        [
+            "**Features**",
+            "- feat: \\[deployment guide\\](https://attacker.example) · [#13](https://github.com/o/r/pull/13)",
+        ].join("\n"),
+    );
+});
+
 test("a non-ASCII subject passes through and the budget counts code points", () => {
     const result = buildChangelog(["feat: 🎉 支持中文标题 (#12)"], OPTS);
     assert.equal(

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,7 +1,6 @@
 {
     "name": "sdvd-github-scripts",
     "private": true,
-    "type": "module",
     "dependencies": {
         "@octokit/rest": "22.0.1"
     }

--- a/.github/scripts/resolve-build-range.sh
+++ b/.github/scripts/resolve-build-range.sh
@@ -25,7 +25,10 @@ EXCLUDE_ARGS=()
 for tag in $(git tag -l --points-at "$HEAD_OID" $TAG_MATCH); do
   EXCLUDE_ARGS+=(--exclude "$tag")
 done
-BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} "$HEAD_OID" 2>/dev/null) || {
+# --first-parent keeps the base on the same chain `git log --first-parent` walks later, so a
+# matching tag on a merged side branch could never yield a skewed range. (No-op on this
+# repository's linear history — verified identical on all current build tags.)
+BASE=$(git describe --tags --abbrev=0 --first-parent "${MATCH_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} "$HEAD_OID" 2>/dev/null) || {
   echo "::error::no base tag matching '$TAG_MATCH' strictly below $HEAD_REF"
   exit 1
 }

--- a/.github/scripts/resolve-build-range.sh
+++ b/.github/scripts/resolve-build-range.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Resolves a build's commit range: the head commit down to the nearest matching tag strictly
+# below it. The single definition of "what shipped in this build", shared by the
+# stamp-issue-versions and build-changelog actions so issue stamping and the changelog can
+# never disagree on the range.
+#
+# Inputs (env):
+#   HEAD_REF  - commit-ish of the build's head (SHA or tag name)
+#   TAG_MATCH - space-separated `git describe --match` globs selecting base-tag candidates
+# Outputs (appended to $GITHUB_OUTPUT):
+#   head-oid, base-oid, base-tag
+#
+# Requires full history and tags in the current checkout (fetch-depth: 0, fetch-tags: true).
+set -euo pipefail
+set -f # tag globs must reach git verbatim, not expand against the working tree
+
+HEAD_OID=$(git rev-parse "$HEAD_REF^{commit}")
+MATCH_ARGS=()
+for glob in $TAG_MATCH; do MATCH_ARGS+=(--match "$glob"); done
+# The base must sit strictly below HEAD. A candidate tag pointing at HEAD itself is this
+# build's own tag or a previous build of the same commit — taking it as base would empty
+# the range. Both consumers tolerate re-walking an already-processed range (stamping is
+# first-value-wins and marker-deduped; the changelog post just repeats).
+EXCLUDE_ARGS=()
+for tag in $(git tag -l --points-at "$HEAD_OID" $TAG_MATCH); do
+  EXCLUDE_ARGS+=(--exclude "$tag")
+done
+BASE=$(git describe --tags --abbrev=0 "${MATCH_ARGS[@]}" ${EXCLUDE_ARGS[@]+"${EXCLUDE_ARGS[@]}"} "$HEAD_OID" 2>/dev/null) || {
+  echo "::error::no base tag matching '$TAG_MATCH' strictly below $HEAD_REF"
+  exit 1
+}
+BASE_OID=$(git rev-parse "$BASE^{commit}")
+echo "HEAD=$HEAD_OID BASE=$BASE ($BASE_OID)"
+{
+  echo "head-oid=$HEAD_OID"
+  echo "base-oid=$BASE_OID"
+  echo "base-tag=$BASE"
+} >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -119,6 +119,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history + tags for the changelog range (previous build tag → this commit).
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Update version in files (for Docker build only)
         run: |
@@ -169,6 +173,37 @@ jobs:
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
 
+      # Changelog + notification run BEFORE the tracking-tag push: with cancel-in-progress
+      # concurrency, a cancellation between "tag pushed" and "post sent" would move the next
+      # build's range past changes that were never announced. In this order a cancellation
+      # loses nothing (the tag didn't move, the next build re-covers the range).
+      # continue-on-error on both: notification machinery must never red a successful build
+      # or block the tag push / downstream deploy.
+      - name: Build changelog
+        id: changelog
+        continue-on-error: true
+        uses: ./.github/actions/build-changelog
+        with:
+          head: ${{ github.sha }}
+          # Everything since the previous build of either channel — same rule as issue stamping.
+          tag-match: sdvd-server-v* preview-[0-9]*
+
+      - name: Discord notification
+        if: steps.changelog.outcome == 'success'
+        continue-on-error: true
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_PREVIEW }}
+          title: Preview build ${{ needs.calculate-version.outputs.preview_version }}
+          url: ${{ steps.changelog.outputs.compare-url }}
+          color: "16753920"
+          description: |
+            ${{ steps.changelog.outputs.markdown }}
+
+            **Use it**
+            ```IMAGE_VERSION=${{ needs.calculate-version.outputs.preview_version }}``` (or `preview` for the newest)
+            ```docker compose pull && docker compose up -d```
+
       - name: Update preview tracking tag
         run: |
           git config user.name "github-actions[bot]"
@@ -195,58 +230,6 @@ jobs:
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
           echo "docker pull sdvd/server:preview" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-      - name: Get merged PR info
-        id: pr
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_JSON=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/pulls --jq '.[0] // empty')
-          if [ -n "$PR_JSON" ]; then
-            echo "number=$(echo "$PR_JSON" | jq -r '.number')" >> $GITHUB_OUTPUT
-            echo "title=$(echo "$PR_JSON" | jq -r '.title')" >> $GITHUB_OUTPUT
-            echo "url=$(echo "$PR_JSON" | jq -r '.html_url')" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Discord notification
-        if: success()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
-          PR_TITLE: ${{ steps.pr.outputs.title }}
-          PR_URL: ${{ steps.pr.outputs.url }}
-          PREVIEW_VERSION: ${{ needs.calculate-version.outputs.preview_version }}
-        run: |
-          if [ -n "$PR_NUMBER" ]; then
-            # Use jq to safely build JSON with user-provided content
-            jq -n \
-              --arg version "$PREVIEW_VERSION" \
-              --arg pr_num "$PR_NUMBER" \
-              --arg pr_title "$PR_TITLE" \
-              --arg pr_url "$PR_URL" \
-              '{
-                embeds: [{
-                  title: "Preview Build Published",
-                  color: 16753920,
-                  fields: [
-                    {name: "Version", value: "`\($version)`"},
-                    {name: "Changes", value: "[#\($pr_num) - \($pr_title)](\($pr_url))"}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          else
-            jq -n \
-              --arg version "$PREVIEW_VERSION" \
-              '{
-                embeds: [{
-                  title: "Preview Build Published",
-                  color: 16753920,
-                  fields: [
-                    {name: "Version", value: "`\($version)`"}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          fi
 
   stamp-issue-versions:
     name: Stamp Issue Versions
@@ -326,11 +309,13 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    needs: build-docs
+    needs: [build-docs, calculate-version]
     permissions:
       contents: read
       pages: write
       id-token: write
       actions: read
     uses: ./.github/workflows/deploy-docs.yml
+    with:
+      preview_version: ${{ needs.calculate-version.outputs.preview_version }}
     secrets: inherit

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -42,8 +42,13 @@ jobs:
       packages: write
 
     steps:
+      # github.sha IS the tagged release commit here (release-please tags before this job
+      # starts); full history + tags let the changelog resolve the previous release locally.
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -107,29 +112,33 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Release:** https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}" >> $GITHUB_STEP_SUMMARY
 
+      # continue-on-error on both notification steps: a range or Discord failure must never
+      # red a release build that already published its images.
+      - name: Build changelog
+        id: changelog
+        continue-on-error: true
+        uses: ./.github/actions/build-changelog
+        with:
+          head: ${{ needs.release-please.outputs.tag_name }}
+          # Everything since the previous release — the stable stream carries a complete
+          # changelog even when previews already announced parts of it.
+          tag-match: sdvd-server-v*
+
       - name: Discord notification
-        if: success()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
-          RELEASE_URL: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}
-        run: |
-          if [ -n "$DISCORD_WEBHOOK" ]; then
-            jq -n \
-              --arg tag "$TAG_NAME" \
-              --arg url "$RELEASE_URL" \
-              '{
-                embeds: [{
-                  title: "New Release Published",
-                  color: 5763719,
-                  fields: [
-                    {name: "Version", value: "`\($tag)`"},
-                    {name: "How to update", value: "```docker compose pull```"},
-                    {name: "Release Notes", value: "[View Release](\($url))"}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          fi
+        if: steps.changelog.outcome == 'success'
+        continue-on-error: true
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          title: Release ${{ needs.release-please.outputs.version }}
+          url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}
+          color: "5763719"
+          description: |
+            ${{ steps.changelog.outputs.markdown }}
+
+            **Use it**
+            ```IMAGE_VERSION=${{ needs.release-please.outputs.version }}``` (or `latest` for the newest release)
+            ```docker compose pull && docker compose up -d```
 
   stamp-issue-versions:
     name: Stamp Issue Versions
@@ -206,11 +215,13 @@ jobs:
 
   deploy-docs:
     name: Deploy Documentation
-    needs: build-docs
+    needs: [build-docs, release-please]
     permissions:
       contents: read
       pages: write
       id-token: write
       actions: read
     uses: ./.github/workflows/deploy-docs.yml
+    with:
+      latest_version: ${{ needs.release-please.outputs.version }}
     secrets: inherit

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,6 +2,15 @@ name: Deploy Documentation
 
 on:
   workflow_call:
+    inputs:
+      latest_version:
+        description: 'Version deployed to the latest half, shown in the internal-ci notification (e.g. 1.4.1)'
+        required: false
+        type: string
+      preview_version:
+        description: 'Version deployed to the preview half, shown in the internal-ci notification (e.g. 1.5.0-preview.127)'
+        required: false
+        type: string
   workflow_dispatch:
     inputs:
       rebuild_latest:
@@ -60,6 +69,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      # The Discord notify action must exist in the checked-out tree (`uses: ./…`); this job
+      # otherwise needs no checkout, so take just the action. Runs first: checkout cleans the
+      # workspace, which must not eat the downloaded artifacts below.
+      - name: Checkout notify action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions/discord-notify
+          sparse-checkout-cone-mode: false
+
       # Each half is sourced in order: this run's artifact → its primary build workflow →
       # a prior manual rebuild. Present in this run when invoked by build-release.yml /
       # build-preview.yml, which run build-docs first.
@@ -278,43 +296,56 @@ jobs:
             || echo "::warning::Mirror done but marker write failed — next single-half deploy will refuse until the next persist."
           echo "Live snapshot updated in R2."
 
-      - name: Build summary
+      - name: Build summary and notification fields
+        id: labels
+        env:
+          LATEST_SRC: ${{ steps.check.outputs.latest_src }}
+          PREVIEW_SRC: ${{ steps.check.outputs.preview_src }}
+          LATEST_VERSION: ${{ inputs.latest_version }}
+          PREVIEW_VERSION: ${{ inputs.preview_version }}
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
+          # Single label definition for both the job summary and the Discord fields.
+          # *_src: this-run (built now) | live (preserved from last deploy) | none (omitted —
+          # preview only). A deployed half is version-prefixed when the calling build workflow
+          # passed its version (a manual dispatch rebuild has none).
+          label() { # $1 = src, $2 = version
+            case "$1" in
+              this-run) if [ -n "$2" ]; then echo "$2 — deployed"; else echo "deployed"; fi ;;
+              live) echo "preserved" ;;
+              *) echo "not included" ;;
+            esac
+          }
+          LATEST_LABEL=$(label "$LATEST_SRC" "$LATEST_VERSION")
+          PREVIEW_LABEL=$(label "$PREVIEW_SRC" "$PREVIEW_VERSION")
+
           echo "### Documentation Deployed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Site URL:** ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Site URL:** $PAGE_URL" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Half | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
-          # *_src: this-run (built now) | live (preserved from last deploy) | none (omitted — preview only).
-          status() { case "$1" in this-run) echo "Deployed";; live) echo "Preserved from live site";; *) echo "Not included this deploy";; esac; }
-          echo "| Latest | $(status '${{ steps.check.outputs.latest_src }}') |" >> $GITHUB_STEP_SUMMARY
-          echo "| Preview | $(status '${{ steps.check.outputs.preview_src }}') |" >> $GITHUB_STEP_SUMMARY
+          echo "| Latest | $LATEST_LABEL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Preview | $PREVIEW_LABEL |" >> $GITHUB_STEP_SUMMARY
+
+          jq -cn \
+            --arg latest "$LATEST_LABEL" \
+            --arg preview "$PREVIEW_LABEL" \
+            --arg run "$RUN_URL" \
+            '[
+              {name: "Latest", value: $latest, inline: true},
+              {name: "Preview", value: $preview, inline: true},
+              {name: "Run", value: "[view run](\($run))"}
+            ]' | sed 's/^/fields=/' >> "$GITHUB_OUTPUT"
 
       - name: Discord notification
         if: success()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
-          LATEST_STATE: ${{ steps.check.outputs.latest_src }}
-          PREVIEW_STATE: ${{ steps.check.outputs.preview_src }}
-        run: |
-          if [ -n "$DISCORD_WEBHOOK" ]; then
-            # Same mapping as the job summary's status().
-            label() { case "$1" in this-run) echo "Deployed";; live) echo "Preserved from live site";; *) echo "Not included";; esac; }
-            jq -n \
-              --arg url "$PAGE_URL" \
-              --arg latest "$(label "$LATEST_STATE")" \
-              --arg preview "$(label "$PREVIEW_STATE")" \
-              '{
-                embeds: [{
-                  title: "Documentation Updated",
-                  color: 3447003,
-                  fields: [
-                    {name: "View Docs", value: "[stardew-valley-dedicated-server.github.io/server](\($url))"},
-                    {name: "Latest", value: $latest, inline: true},
-                    {name: "Preview", value: $preview, inline: true}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          fi
+        continue-on-error: true
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_INTERNAL_CI }}
+          title: Docs deployed
+          url: ${{ steps.deployment.outputs.page_url }}
+          color: "9807270"
+          fields: ${{ steps.labels.outputs.fields }}

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -82,8 +82,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # discord-notify must exist in the tree for the `uses: ./…` steps below.
           sparse-checkout: |
             docker-compose.yml
+            .github/actions/discord-notify
           sparse-checkout-cone-mode: false
 
       - name: Graceful shutdown preparation
@@ -162,6 +164,66 @@ jobs:
           source: "docker-compose.yml,.env"
           target: ~/srv/${{ matrix.environment }}
 
+      # Resolves what the alias (matrix.image_tag) actually points at, for the internal-ci
+      # notification: the image's revision label → the build tag on that commit → the
+      # IMAGE_VERSION operators would type. Reading the registry (not github.sha) is correct
+      # for all three triggers — workflow_run, release, workflow_dispatch. The alias could in
+      # principle move between this inspect and the VPS's `docker compose pull`, but that
+      # needs a full preview build to finish inside that window; accepted. This step must
+      # never fail the deploy: every lookup degrades to a short SHA or "unknown".
+      - name: Resolve deployed version
+        id: version
+        env:
+          TAG: ${{ matrix.image_tag }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          FALLBACK_SHA: ${{ github.sha }}
+        run: |
+          sha=$(docker buildx imagetools inspect "sdvd/server:$TAG" \
+            --format '{{index .Image.Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            # Also hit if the image ever goes multi-arch (.Image becomes a per-platform map;
+            # the template must switch to '{{json .Image}}' + jq on one platform then).
+            echo "::warning::no usable revision label on sdvd/server:$TAG (got '${sha:0:60}')"
+            sha=""
+          fi
+
+          # SHA → version via the build tags (both kinds are lightweight, so ls-remote lists
+          # the commit oid directly). When one commit carries both kinds, pick by the alias
+          # being deployed.
+          version=""
+          if [ -n "$sha" ]; then
+            tags=$(git ls-remote --tags origin 'preview-[0-9]*' 'sdvd-server-v*' 2>/dev/null \
+              | awk -v s="$sha" '$1 == s { sub("refs/tags/", "", $2); sub(/\^\{\}$/, "", $2); print $2 }' || true)
+            case "$TAG" in
+              latest) tag=$(grep -m1 '^sdvd-server-v' <<< "$tags" || true) ;;
+              *) tag=$(grep -m1 '^preview-' <<< "$tags" || true) ;;
+            esac
+            [ -n "$tag" ] || tag=$(head -n 1 <<< "$tags")
+            case "$tag" in
+              preview-*) rest=${tag#preview-}; version="${rest%.*}-preview.${rest##*.}" ;;
+              sdvd-server-v*) version=${tag#sdvd-server-v} ;;
+            esac
+          fi
+
+          if [ -n "$version" ]; then
+            version_value="\`$version\` (\`$TAG\`)"
+          elif [ -n "$sha" ]; then
+            version_value="\`${sha:0:7}\` (\`$TAG\`, no build tag on this commit)"
+          else
+            version_value="unknown (\`$TAG\`)"
+          fi
+          commit_sha=${sha:-$FALLBACK_SHA}
+          commit_value="[\`${commit_sha:0:7}\`]($REPO_URL/commit/$commit_sha)"
+
+          jq -cn --arg version "$version_value" --arg commit "$commit_value" \
+            '[
+              {name: "Version", value: $version, inline: true},
+              {name: "Commit", value: $commit, inline: true}
+            ]' | sed 's/^/fields=/' >> "$GITHUB_OUTPUT"
+          jq -cn --arg commit "$commit_value" \
+            '[{name: "Commit", value: $commit, inline: true}]' \
+            | sed 's/^/failure_fields=/' >> "$GITHUB_OUTPUT"
+
       - name: Pull and restart containers
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
@@ -228,44 +290,24 @@ jobs:
 
       - name: Discord notification
         if: success()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        run: |
-          if [ -n "$DISCORD_WEBHOOK" ]; then
-            jq -n \
-              --arg env "${{ matrix.environment }}" \
-              --arg tag "${{ matrix.image_tag }}" \
-              --arg commit "${GITHUB_SHA:0:7}" \
-              '{
-                embeds: [{
-                  title: "Server Deployed",
-                  color: 3066993,
-                  fields: [
-                    {name: "Environment", value: $env, inline: true},
-                    {name: "Image", value: ("`" + $tag + "`"), inline: true},
-                    {name: "Commit", value: ("`" + $commit + "`"), inline: true}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          fi
+        # A Discord outage must never red a deploy that succeeded.
+        continue-on-error: true
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_INTERNAL_CI }}
+          title: 'Server deployed: ${{ matrix.environment }}'
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          color: "9807270"
+          fields: ${{ steps.version.outputs.fields }}
 
       - name: Discord notification (failure)
         if: failure()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
-        run: |
-          if [ -n "$DISCORD_WEBHOOK" ]; then
-            jq -n \
-              --arg env "${{ matrix.environment }}" \
-              --arg commit "${GITHUB_SHA:0:7}" \
-              '{
-                embeds: [{
-                  title: "Deployment Failed",
-                  color: 15158332,
-                  fields: [
-                    {name: "Environment", value: $env, inline: true},
-                    {name: "Commit", value: ("`" + $commit + "`"), inline: true}
-                  ]
-                }]
-              }' | curl -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
-          fi
+        uses: ./.github/actions/discord-notify
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_INTERNAL_CI }}
+          title: 'Server deploy failed: ${{ matrix.environment }}'
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          color: "15158332"
+          # The resolve step hasn't run when the failure was earlier (checkout, .env, scp);
+          # fall back to the workflow's own commit.
+          fields: ${{ steps.version.outputs.failure_fields || format('[{{"name":"Commit","value":"[{0}]({1}/{2}/commit/{0})","inline":true}}]', github.sha, github.server_url, github.repository) }}

--- a/.github/workflows/validate-merge-group.yml
+++ b/.github/workflows/validate-merge-group.yml
@@ -275,3 +275,6 @@ jobs:
 
       - name: Check JS/TS formatting and lints
         run: npx biome ci --max-diagnostics=50 .
+
+      - name: Run workflow-script tests
+        run: npm test

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -328,3 +328,6 @@ jobs:
 
       - name: Check JS/TS formatting and lints
         run: npx biome ci --max-diagnostics=50 .
+
+      - name: Run workflow-script tests
+        run: npm test

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -472,6 +472,25 @@ GitHub Actions caches can accumulate over time. This pipeline removes every cach
 
 ## Discord Notifications
 
-Most pipelines try to send notifications to Discord when builds complete or deployments finish.
+CI posts to Discord in two clearly separated streams, all through the shared composite action `.github/actions/discord-notify`:
 
-To enable notifications, the `DISCORD_WEBHOOK_URL` repository secret needs to be set with a [Discord webhook URL](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks).
+- **Public release feeds**: `#releases` (stable releases) and `#releases-preview` (preview builds). Each post carries the full changelog since the previous build — every first-parent commit, grouped like the GitHub release page (built by `.github/actions/build-changelog` on top of `.github/scripts/build-changelog.js`) — plus the exact `IMAGE_VERSION=…` value to deploy it.
+- **Internal CI feed** for maintainers: `#internal-ci` gets docs deploys (with the versions per half), server deploys (with the resolved image version and commit), and deploy failures.
+
+### Secrets
+
+One repository secret per channel, each holding a [Discord webhook URL](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks):
+
+| Secret | Channel | Posted by |
+|--------|---------|-----------|
+| `DISCORD_WEBHOOK_PREVIEW` | `#releases-preview` | Build Preview (`build-preview.yml`) |
+| `DISCORD_WEBHOOK_RELEASES` | `#releases` | Build Release (`build-release.yml`) |
+| `DISCORD_WEBHOOK_INTERNAL_CI` | `#internal-ci` | Deploy Documentation (`deploy-docs.yml`), Deploy Server (`deploy-server.yml`, success and failure) |
+
+A missing secret is not an error: the notify action logs "no webhook configured" and skips, so notifications silently stop while everything else runs unaffected. A malformed or over-limit payload fails the notify step loudly instead of truncating; success-path notify steps run with `continue-on-error`, so a Discord outage never reds a build or deploy that succeeded.
+
+### Discord server setup
+
+`#releases` and `#releases-preview` are public **Announcement** channels (so other servers can Follow them; requires Community to be enabled); `#internal-ci` is a private text channel for the maintainer role. Each has one webhook (Channel Settings → Integrations → Webhooks) whose URL is stored in the matching secret above.
+
+Webhook posts are not auto-published to Follower servers (that would need a bot with `crosspost`); accepted until someone actually follows the channels.


### PR DESCRIPTION
## What

Replaces the four inline jq/curl Discord posts (one shared `DISCORD_WEBHOOK_URL`) with two public release feeds and one internal CI stream, with one consistent message shape:

- **`#releases`** (`DISCORD_WEBHOOK_RELEASES`): release posts with the full changelog since the previous release and the exact `IMAGE_VERSION=…` to deploy
- **`#releases-preview`** (`DISCORD_WEBHOOK_PREVIEW`): preview posts with every first-parent commit since the previous build of either channel
- **`#internal-ci`** (`DISCORD_WEBHOOK_INTERNAL_CI`): docs deploys (versions per half), server deploys (resolved image version + commit), deploy failures

## Changes

- New composite action `.github/actions/discord-notify`: validates all Discord embed limits and fails loudly instead of truncating; skips cleanly when the webhook secret is absent; `dry-run` for payload tests
- New composite action `.github/actions/build-changelog` + `.github/scripts/build-changelog.js` (+ tests): changelog grouped like release-please's sections, 3500-code-point budget with line-boundary truncation, unparseable subjects kept under "Other", release-please's own release commit excluded from counts
- `.github/scripts/resolve-build-range.sh`: range resolution extracted from `stamp-issue-versions` so stamping and the changelog share one definition of "what shipped" (byte-identical to the old step body on the last 3 preview tags, last 2 release tags, and master)
- `build-preview.yml`: changelog + notification now run **before** the tracking-tag push, so a cancelled run can never move the tag past unannounced changes; removed the single-PR "Get merged PR info" step
- `deploy-server.yml`: new "Resolve deployed version" step (image revision label → build tags → `IMAGE_VERSION`), correct for all three triggers, never fails the deploy
- `deploy-docs.yml`: optional `latest_version`/`preview_version` inputs; one shared label definition for the summary and the Discord fields
- Notification machinery never reds a successful build/deploy (`continue-on-error` on changelog + success-path notify steps)
- Fixed `npm test` (`.github/scripts/package.json` declared `type: module`, breaking the CommonJS test files under Node) and wired it into Validate JS/TS (PR + merge queue)
- Docs: rewrote the "Discord Notifications" section in `docs/developers/contributing/ci-cd.md`

## Heads-up for in-flight PRs

Validate JS/TS now runs `npm test`. Open PRs branched before this change will fail that step until they rebase (their heads still carry the broken `type: module`). Self-healing; no action beyond rebase.

## Rollout (after merge)

1. Secrets are already set; dispatch **Build Preview** once → expect exactly three posts: changelog in `#releases-preview`, docs + deploy posts in `#internal-ci`
2. Delete the old `DISCORD_WEBHOOK_URL` secret (no longer referenced anywhere)
3. Release path is exercised by the next real release (builder validated locally against real release history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added formatted, version-aware changelogs for preview and release notifications.
  - Improved deployment and documentation notifications with clearer status details and deployed version information.
  - Added support for preview, release, and internal CI notification channels.
  - Added dry-run and validation support for notification messages.

- **Bug Fixes**
  - Notification failures no longer interrupt successful deployments.
  - Changelogs now safely escape special formatting and remain within message limits.

- **Documentation**
  - Updated CI/CD guidance for notification channels, content, and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->