### PR TITLE
fix(ci): restore release-bot identity and tidy Discord changelog format

### DIFF
--- a/.github/actions/build-changelog/action.yml
+++ b/.github/actions/build-changelog/action.yml
@@ -1,9 +1,9 @@
 name: Build Changelog
 description: >
   Builds Discord-ready changelog markdown for a build: every first-parent commit since the
-  previous build tag, grouped into release-please's sections and budgeted for an embed
-  description. Performs no checkout — the caller's checkout must have full history and tags
-  (fetch-depth: 0, fetch-tags: true).
+  previous build tag, as one "Changes" list ordered by release-please's type priority and
+  budgeted for an embed description. Performs no checkout — the caller's checkout must have
+  full history and tags (fetch-depth: 0, fetch-tags: true).
 
 inputs:
   head:

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -17,6 +17,18 @@ inputs:
     description: Optional URL the title links to
     required: false
     default: ""
+  username:
+    description: >
+      Webhook display name (the release/preview bot identity). Empty keeps the webhook's
+      Discord-configured name, so callers that post no identity (internal CI) are untouched.
+    required: false
+    default: ""
+  avatar-url:
+    description: >
+      Webhook avatar URL. Empty falls back to the project logo only when a username is set,
+      so identity-bearing posts get a face while other callers keep their webhook's avatar.
+    required: false
+    default: ""
   color:
     description: Embed color as a decimal number
     required: true
@@ -44,6 +56,8 @@ runs:
         WEBHOOK: ${{ inputs.webhook }}
         TITLE: ${{ inputs.title }}
         URL: ${{ inputs.url }}
+        USERNAME: ${{ inputs.username }}
+        AVATAR_URL: ${{ inputs.avatar-url }}
         COLOR: ${{ inputs.color }}
         DESCRIPTION: ${{ inputs.description }}
         FIELDS: ${{ inputs.fields }}
@@ -62,20 +76,31 @@ runs:
           >/dev/null 2>&1 <<< "$FIELDS" \
           || { echo "::error::discord-notify: fields must be a JSON array of {name, value} objects"; exit 1; }
 
+        # A caller that sets an identity (release/preview) but no avatar gets the project logo —
+        # the single canonical URL, served from the deployed docs site. Callers with no username
+        # (internal CI) keep their webhook's Discord-configured identity untouched.
+        if [ -n "$USERNAME" ] && [ -z "$AVATAR_URL" ]; then
+          AVATAR_URL="https://stardew-valley-dedicated-server.github.io/server/logo.png"
+        fi
+
         payload=$(jq -cn \
           --arg title "$TITLE" \
           --arg url "$URL" \
           --arg desc "$DESCRIPTION" \
+          --arg username "$USERNAME" \
+          --arg avatar "$AVATAR_URL" \
           --argjson color "$COLOR" \
           --argjson fields "$FIELDS" \
           '{
             embeds: [(
-              {title: $title, color: $color, timestamp: (now | todate)}
+              {title: $title, color: $color}
               + (if $url == "" then {} else {url: $url} end)
               + (if $desc == "" then {} else {description: $desc} end)
               + (if ($fields | length) == 0 then {} else {fields: $fields} end)
             )]
-          }')
+          }
+          + (if $username == "" then {} else {username: $username} end)
+          + (if $avatar == "" then {} else {avatar_url: $avatar} end)')
 
         # Discord API "Embed Limits": title 256, description 4096, field name 256 /
         # value 1024, 25 fields, 6000 characters across the embed. Fail loudly instead of

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -1,10 +1,10 @@
 name: Discord Notify
 description: >
-  Posts a single-embed message to a Discord webhook. Validates Discord's embed limits up
-  front and fails the step with a clear message instead of truncating; an empty webhook
-  input logs a skip and exits 0, so notifications degrade to silence when the secret is
-  absent. A failed post fails the step (curl --fail-with-body) — success-path callers set
-  continue-on-error so a Discord outage never reds a build or deploy that succeeded.
+  Posts one embed message to a Discord webhook. It checks Discord's size limits first and fails
+  the step with a clear message rather than posting something cut off. If the webhook input is
+  empty it just logs a note and exits 0, so notifications quietly stop when the secret isn't set.
+  If the post itself fails the step fails (curl --fail-with-body); callers on the success path set
+  continue-on-error, so a Discord outage never turns a passing build or deploy red.
 
 inputs:
   webhook:
@@ -19,14 +19,14 @@ inputs:
     default: ""
   username:
     description: >
-      Webhook display name (the release/preview bot identity). Empty keeps the webhook's
-      Discord-configured name, so callers that post no identity (internal CI) are untouched.
+      The name shown as the message author. Leave empty to keep whatever name the webhook is set
+      to in Discord — so callers that don't set a name (internal CI) are left alone.
     required: false
     default: ""
   avatar-url:
     description: >
-      Webhook avatar URL. Empty falls back to the project logo only when a username is set,
-      so identity-bearing posts get a face while other callers keep their webhook's avatar.
+      The avatar shown next to the name. If empty, we use the project logo, but only when a name is
+      also set — so the release/preview bot gets a picture while other callers keep their own avatar.
     required: false
     default: ""
   color:
@@ -76,9 +76,9 @@ runs:
           >/dev/null 2>&1 <<< "$FIELDS" \
           || { echo "::error::discord-notify: fields must be a JSON array of {name, value} objects"; exit 1; }
 
-        # A caller that sets an identity (release/preview) but no avatar gets the project logo —
-        # the single canonical URL, served from the deployed docs site. Callers with no username
-        # (internal CI) keep their webhook's Discord-configured identity untouched.
+        # If a caller sets a name (release/preview) but no avatar, fall back to the project logo.
+        # This is the one place that URL lives; it's served from the docs site. Callers with no name
+        # (internal CI) are left alone and keep the avatar their webhook is configured with.
         if [ -n "$USERNAME" ] && [ -z "$AVATAR_URL" ]; then
           AVATAR_URL="https://stardew-valley-dedicated-server.github.io/server/logo.png"
         fi
@@ -102,10 +102,9 @@ runs:
           + (if $username == "" then {} else {username: $username} end)
           + (if $avatar == "" then {} else {avatar_url: $avatar} end)')
 
-        # Discord API "Embed Limits": title 256, description 4096, field name 256 /
-        # value 1024, 25 fields, 6000 characters across the embed. Fail loudly instead of
-        # truncating — a clipped ops message is worse than a red step, and the changelog
-        # builder owns its own budget upstream.
+        # Discord's embed limits: title 256, description 4096, field name 256 / value 1024, 25 fields,
+        # and 6000 characters across the whole embed. We fail loudly rather than trim — a cut-off
+        # message is worse than a red step, and the changelog builder already keeps itself under budget.
         errors=$(jq -r '
           .embeds[0]
           | (.description // "") as $d

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -1,32 +1,31 @@
-// Builds the Discord changelog for a build: every first-parent commit in the build's range,
-// as one flat "Changes" list ordered by release-please's type priority, budgeted for a Discord
-// embed description. Used by .github/actions/build-changelog; the pure logic is exported for
-// `npm test`.
+// Turns a build's commit range into the changelog we post to Discord: one flat "Changes" list,
+// ordered the way release-please orders its release notes, trimmed to fit a Discord embed. Used
+// by .github/actions/build-changelog; the core function is exported so `npm test` can call it.
 //
-// CLI contract (the composite action wires this up): `git log --first-parent
-// --format='%H%x1f%s' BASE..HEAD` lines on stdin; BASE_TAG, HEAD_OID, REPO_URL env in;
-// markdown / count / visible-count / hidden-count / compare-url appended to $GITHUB_OUTPUT
-// (printed to stdout when GITHUB_OUTPUT is unset, for local runs).
+// How the action runs it: it pipes `git log --first-parent --format='%H%x1f%s' BASE..HEAD` in on
+// stdin and sets the BASE_TAG, HEAD_OID and REPO_URL env vars. We write markdown / count /
+// visible-count / hidden-count / compare-url to $GITHUB_OUTPUT (or print them to stdout locally).
 
-// The single "Changes" list heading. One flat list, no per-type sub-headers.
+// The heading above the list. One flat list, no per-type sub-headings.
 const HEADER = "**Changes**";
 
-// Visible commit types in the order release-please lists them, so a Discord post reads like
-// the GitHub release page. Hidden types fold into one "+N internal changes" line. Anything
-// else — unknown type or non-conventional subject — sorts after these visible types, listed
-// verbatim; a change is never dropped for a parse failure.
+// The commit types we list individually, in the order release-please uses, so a post reads like
+// the GitHub release page. The "hidden" types below are counted but not listed. Anything else (an
+// unknown type, or a subject that isn't a conventional commit) is listed after these, as-is — we
+// never drop a commit just because we couldn't parse it.
 const VISIBLE_TYPES = ["feat", "fix", "perf", "revert", "docs"];
 const HIDDEN_TYPES = new Set(["style", "chore", "refactor", "test", "build", "ci"]);
 
-// Code points, not UTF-16 units — leaves headroom under Discord's 4096-char description
-// limit for the caller's trailing "Use it" block, and under the 6000-char embed total.
+// We measure length in code points (what Discord counts), not JS string length. 3500 leaves room
+// under Discord's 4096-char description limit for the "Use it" block the caller appends, and under
+// the 6000-char limit for the whole embed.
 const BUDGET = 3500;
 
 const CONVENTIONAL_RE = /^([a-z]+)(\([^()]*\))?(!)?: \S/i;
 const PR_SUFFIX_RE = /\s*\(#(\d+)\)$/;
-// release-please's own release commit ("chore(master): release sdvd-server 1.4.1") is the
-// commit a release tag points at, so it sits inside its own range. It is release machinery,
-// not a change — excluded from every count so it can't pad "+N internal changes".
+// release-please's own "release" commit (e.g. "chore(master): release sdvd-server 1.4.1") is what
+// a release tag points at, so it falls inside its own range. It's release plumbing, not a real
+// change, so we drop it from every count — otherwise it would inflate the "+N internal changes" line.
 const RELEASE_COMMIT_RE = /^chore(\([^()]*\))?: release\b.*\d+\.\d+\.\d+/;
 
 /** @param {string} s @returns {number} length in code points (what Discord counts) */
@@ -35,10 +34,10 @@ function codePoints(s) {
 }
 
 /**
- * Backslash-escape Discord inline-markdown characters so a commit subject renders as
- * plain text. Brackets are escaped too: a subject containing `[label](url)` must render
- * literally, not as a masked link — commit subjects are contributor-controlled and these
- * posts go to public channels. (Embeds never ping, so @-mentions need no handling.)
+ * Escapes the characters Discord treats as markdown so a commit subject shows as plain text.
+ * We escape brackets too, so a subject like `[label](url)` shows literally instead of turning
+ * into a clickable link — subjects come from contributors and these posts are public. (Embeds
+ * never ping, so we don't need to handle @-mentions.)
  * @param {string} text
  * @returns {string}
  */
@@ -50,8 +49,8 @@ function escapeMarkdown(text) {
  * Classify one commit subject.
  * @param {string} subject - Raw `git log %s` subject line.
  * @returns {{text: string, type: string|null, breaking: boolean, pr: number|null}}
- *   `text` is the subject without its trailing `(#N)`; `type` is the lowercased
- *   conventional-commit type or null for a non-conventional subject.
+ *   `text` is the subject with its trailing `(#N)` removed; `type` is the lowercased
+ *   conventional-commit type, or null if the subject isn't a conventional commit.
  */
 function parseSubject(subject) {
     const prMatch = subject.match(PR_SUFFIX_RE);
@@ -66,7 +65,7 @@ function parseSubject(subject) {
     };
 }
 
-/** @returns {string} one `- …` bullet; ⚠ marks a breaking change, the PR link is appended. */
+/** @returns {string} one `- …` bullet. A breaking change gets a ⚠ prefix; the PR link goes on the end. */
 function renderEntry(entry, repoUrl) {
     const warn = entry.breaking ? "⚠ " : "";
     const link = entry.pr === null ? "" : ` · [#${entry.pr}](${repoUrl}/pull/${entry.pr})`;
@@ -78,8 +77,8 @@ function renderEntry(entry, repoUrl) {
  * @param {string[]} subjects - `git log %s` subjects, newest first (git log order).
  * @param {{repoUrl: string, baseTag: string, headOid: string}} opts
  * @returns {{markdown: string, count: number, visibleCount: number, hiddenCount: number, compareUrl: string}}
- *   `markdown` is at most BUDGET code points; over-budget ranges drop trailing entries and
- *   name the dropped count on the bottom line, cut at a line boundary.
+ *   `markdown` is never longer than BUDGET code points. If the full list wouldn't fit, we drop
+ *   entries from the end (always between whole lines) and say how many we dropped on the bottom line.
  */
 function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
     const compareUrl = `${repoUrl}/compare/${baseTag}...${headOid}`;
@@ -106,9 +105,9 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
         return { ...result, markdown: `No changes since \`${baseTag}\` · ${diffLink}` };
     }
 
-    // Bottom line: an optional "…and N more" truncation notice, the internal-changes count,
-    // and always the diff link — joined with " · " so it reads like the "· #PR" suffix on
-    // every entry above.
+    // The last line of the changelog. It holds up to three pieces, joined with " · ": an "…and N
+    // more" note when we had to drop entries, the "+N internal changes" count, and always the diff
+    // link. The " · " separator matches the "· #PR" that ends each entry above, so it all reads alike.
     const bottomLine = (droppedCount) => {
         const parts = [];
         if (droppedCount > 0) {
@@ -128,8 +127,9 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
         return { ...result, markdown: full };
     }
 
-    // Over budget: keep whole entry lines while the worst-case bottom line (the largest
-    // possible dropped count) still fits, then report how many were dropped.
+    // Too long to fit: add whole entry lines until we'd run out of room for the bottom line —
+    // measured at its longest, in case every remaining entry ends up dropped — then note how many
+    // we left off.
     const reserve = 1 + codePoints(bottomLine(visibleCount));
     let used = codePoints(HEADER);
     const kept = [];
@@ -168,8 +168,8 @@ function main() {
     const headOid = requireEnv("HEAD_OID");
     const repoUrl = requireEnv("REPO_URL");
 
-    // One `<sha>\x1f<subject>` line per commit; the sha guarantees a non-empty line per
-    // commit so the count stays right even for an empty subject.
+    // Each line is `<sha>\x1f<subject>`. We split on the \x1f, which guarantees one line per commit
+    // even when the subject is empty, so the commit count stays correct.
     const subjects = readFileSync(0, "utf8")
         .split("\n")
         .filter((line) => line.includes("\x1f"))

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -1,23 +1,21 @@
 // Builds the Discord changelog for a build: every first-parent commit in the build's range,
-// grouped into the same sections release-please uses, budgeted for a Discord embed description.
-// Used by .github/actions/build-changelog; the pure logic is exported for `npm test`.
+// as one flat "Changes" list ordered by release-please's type priority, budgeted for a Discord
+// embed description. Used by .github/actions/build-changelog; the pure logic is exported for
+// `npm test`.
 //
 // CLI contract (the composite action wires this up): `git log --first-parent
 // --format='%H%x1f%s' BASE..HEAD` lines on stdin; BASE_TAG, HEAD_OID, REPO_URL env in;
 // markdown / count / visible-count / hidden-count / compare-url appended to $GITHUB_OUTPUT
 // (printed to stdout when GITHUB_OUTPUT is unset, for local runs).
 
-// Section order and titles mirror release-please-config.json's changelog-sections, so a
-// Discord post reads like the GitHub release page. Types "hidden" there fold into one
-// "+N internal changes" line here. Anything else — unknown type or non-conventional
-// subject — lands under "Other" verbatim; a change is never dropped for a parse failure.
-const VISIBLE_SECTIONS = [
-    { type: "feat", title: "Features" },
-    { type: "fix", title: "Bug Fixes" },
-    { type: "perf", title: "Performance Improvements" },
-    { type: "revert", title: "Reverts" },
-    { type: "docs", title: "Documentation" },
-];
+// The single "Changes" list heading. One flat list, no per-type sub-headers.
+const HEADER = "**Changes**";
+
+// Visible commit types in the order release-please lists them, so a Discord post reads like
+// the GitHub release page. Hidden types fold into one "+N internal changes" line. Anything
+// else — unknown type or non-conventional subject — sorts after these visible types, listed
+// verbatim; a change is never dropped for a parse failure.
+const VISIBLE_TYPES = ["feat", "fix", "perf", "revert", "docs"];
 const HIDDEN_TYPES = new Set(["style", "chore", "refactor", "test", "build", "ci"]);
 
 // Code points, not UTF-16 units — leaves headroom under Discord's 4096-char description
@@ -75,26 +73,21 @@ function renderEntry(entry, repoUrl) {
     return `- ${warn}${escapeMarkdown(entry.text)}${link}`;
 }
 
-/** @returns {string} the "+N internal changes" summary line. */
-function internalNote(hiddenCount) {
-    return `+${hiddenCount} internal change${hiddenCount === 1 ? "" : "s"}`;
-}
-
 /**
  * Build the changelog markdown for a commit range.
  * @param {string[]} subjects - `git log %s` subjects, newest first (git log order).
  * @param {{repoUrl: string, baseTag: string, headOid: string}} opts
  * @returns {{markdown: string, count: number, visibleCount: number, hiddenCount: number, compareUrl: string}}
- *   `markdown` is at most BUDGET code points; over-budget ranges end with
- *   "…and N more — [full diff](…)" cut at a line boundary.
+ *   `markdown` is at most BUDGET code points; over-budget ranges drop trailing entries and
+ *   name the dropped count on the bottom line, cut at a line boundary.
  */
 function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
     const compareUrl = `${repoUrl}/compare/${baseTag}...${headOid}`;
-    const fullDiff = `[full diff](${compareUrl})`;
+    const diffLink = `[diff](${compareUrl})`;
 
     const changes = subjects.filter((s) => !RELEASE_COMMIT_RE.test(s));
-    const sections = VISIBLE_SECTIONS.map((s) => ({ ...s, entries: [] }));
-    const other = { title: "Other", entries: [] };
+    const visible = new Map(VISIBLE_TYPES.map((t) => [t, []]));
+    const other = [];
     let hiddenCount = 0;
     for (const subject of changes) {
         const entry = parseSubject(subject);
@@ -102,8 +95,7 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
             hiddenCount += 1;
             continue;
         }
-        const section = sections.find((s) => s.type === entry.type) ?? other;
-        section.entries.push(entry);
+        (visible.get(entry.type) ?? other).push(entry);
     }
 
     const count = changes.length;
@@ -111,56 +103,46 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
     const result = { count, visibleCount, hiddenCount, compareUrl };
 
     if (count === 0) {
-        return { ...result, markdown: `No changes since \`${baseTag}\` — ${fullDiff}` };
-    }
-    if (visibleCount === 0) {
-        return { ...result, markdown: `No user-facing changes (${internalNote(hiddenCount)}) — ${fullDiff}` };
+        return { ...result, markdown: `No changes since \`${baseTag}\` · ${diffLink}` };
     }
 
-    // Flat line list, tagged so truncation can count dropped changes and trim headers
-    // whose entries were all cut.
-    const lines = [];
-    for (const section of [...sections, other]) {
-        if (section.entries.length === 0) {
-            continue;
+    // Bottom line: an optional "…and N more" truncation notice, the internal-changes count,
+    // and always the diff link — joined with " · " so it reads like the "· #PR" suffix on
+    // every entry above.
+    const bottomLine = (droppedCount) => {
+        const parts = [];
+        if (droppedCount > 0) {
+            parts.push(`…and ${droppedCount} more`);
         }
-        if (lines.length > 0) {
-            lines.push({ text: "", isEntry: false });
+        if (hiddenCount > 0) {
+            parts.push(`+${hiddenCount} internal change${hiddenCount === 1 ? "" : "s"}`);
         }
-        lines.push({ text: `**${section.title}**`, isEntry: false });
-        for (const entry of section.entries) {
-            lines.push({ text: renderEntry(entry, repoUrl), isEntry: true });
-        }
-    }
-    const hiddenLine = hiddenCount > 0 ? internalNote(hiddenCount) : null;
-    const tailAfter = (body) => (hiddenLine === null ? body : `${body}\n\n${hiddenLine}`);
+        parts.push(diffLink);
+        return parts.join(" · ");
+    };
 
-    const full = tailAfter(lines.map((l) => l.text).join("\n"));
+    const entryLines = [...VISIBLE_TYPES.flatMap((t) => visible.get(t)), ...other].map((e) => renderEntry(e, repoUrl));
+
+    const full = [HEADER, ...entryLines, bottomLine(0)].join("\n");
     if (codePoints(full) <= BUDGET) {
         return { ...result, markdown: full };
     }
 
-    // Over budget: emit whole lines while the worst-case tail (notice with the largest
-    // possible N, plus the internal-changes line) still fits, then trim trailing headers
-    // and blanks so the cut lands after an entry.
-    const notice = (n) => `…and ${n} more — ${fullDiff}`;
-    const reserve =
-        codePoints(`\n${notice(visibleCount)}`) + (hiddenLine === null ? 0 : codePoints(`\n\n${hiddenLine}`));
+    // Over budget: keep whole entry lines while the worst-case bottom line (the largest
+    // possible dropped count) still fits, then report how many were dropped.
+    const reserve = 1 + codePoints(bottomLine(visibleCount));
+    let used = codePoints(HEADER);
     const kept = [];
-    let used = 0;
-    for (const line of lines) {
-        const cost = codePoints(line.text) + (kept.length > 0 ? 1 : 0);
-        if (used + cost > BUDGET - reserve) {
+    for (const line of entryLines) {
+        const cost = 1 + codePoints(line);
+        if (used + cost + reserve > BUDGET) {
             break;
         }
         kept.push(line);
         used += cost;
     }
-    while (kept.length > 0 && !kept[kept.length - 1].isEntry) {
-        kept.pop();
-    }
-    const dropped = visibleCount - kept.filter((l) => l.isEntry).length;
-    const markdown = tailAfter(`${kept.map((l) => l.text).join("\n")}\n${notice(dropped)}`);
+    const dropped = visibleCount - kept.length;
+    const markdown = [HEADER, ...kept, bottomLine(dropped)].join("\n");
     return { ...result, markdown };
 }
 

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -1,10 +1,10 @@
-// Tests for build-changelog.js — fixed subject lists in, exact markdown out. Run with
-// `npm test` (wired into the Validate JS/TS job). No dependencies: Node's built-in runner.
+// Tests for build-changelog.js — fixed lists of commit subjects in, exact markdown out. Run with
+// `npm test` (part of the Validate JS/TS job). No dependencies: Node's built-in test runner.
 //
-// These pin the Discord-facing contract: one flat "Changes" list ordered by release-please's
-// type priority, no change ever dropped (unparseable ⇒ listed after the visible types),
-// markdown characters in subjects escaped, a trailing diff link on every path, and the output
-// under the 3500-code-point budget with a line-boundary cut and an "…and N more" notice.
+// These lock in how the Discord post looks: one flat "Changes" list in release-please's type order,
+// nothing ever dropped (a subject we can't parse is listed after the known types), markdown special
+// characters escaped, a diff link on every result, and the whole thing kept under the 3500-code-point
+// budget — trimming between whole lines with an "…and N more" note when it's too long.
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -1,10 +1,10 @@
 // Tests for build-changelog.js — fixed subject lists in, exact markdown out. Run with
 // `npm test` (wired into the Validate JS/TS job). No dependencies: Node's built-in runner.
 //
-// These pin the Discord-facing contract: section grouping mirrors release-please's
-// changelog-sections, no change is ever dropped (unparseable ⇒ "Other"), markdown
-// characters in subjects are escaped, and the output stays under the 3500-code-point
-// budget with a line-boundary cut and an "…and N more" notice.
+// These pin the Discord-facing contract: one flat "Changes" list ordered by release-please's
+// type priority, no change ever dropped (unparseable ⇒ listed after the visible types),
+// markdown characters in subjects escaped, a trailing diff link on every path, and the output
+// under the 3500-code-point budget with a line-boundary cut and an "…and N more" notice.
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
@@ -17,7 +17,7 @@ const OPTS = {
 };
 const COMPARE = "https://github.com/o/r/compare/preview-1.5.0.1...deadbee";
 
-test("groups each visible type into its release-please section, in order", () => {
+test("lists visible types in release-please priority order under one Changes heading", () => {
     const result = buildChangelog(
         [
             "docs: explain cabins (#5)",
@@ -31,40 +31,32 @@ test("groups each visible type into its release-please section, in order", () =>
     assert.equal(
         result.markdown,
         [
-            "**Features**",
+            "**Changes**",
             "- feat: add the thing · [#1](https://github.com/o/r/pull/1)",
-            "",
-            "**Bug Fixes**",
             "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)",
-            "",
-            "**Performance Improvements**",
             "- perf: fewer allocations · [#3](https://github.com/o/r/pull/3)",
-            "",
-            "**Reverts**",
             "- revert: undo the thing · [#4](https://github.com/o/r/pull/4)",
-            "",
-            "**Documentation**",
             "- docs: explain cabins · [#5](https://github.com/o/r/pull/5)",
+            `[diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [5, 5, 0]);
 });
 
-test("hidden-only range folds into an internal-changes note with the compare link", () => {
+test("hidden-only range is just the Changes heading and the internal-changes bottom line", () => {
     const result = buildChangelog(["ci: bump action (#9)", "chore: tidy", "refactor: rename (#8)"], OPTS);
-    assert.equal(result.markdown, `No user-facing changes (+3 internal changes) — [full diff](${COMPARE})`);
+    assert.equal(result.markdown, ["**Changes**", `+3 internal changes · [diff](${COMPARE})`].join("\n"));
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 0, 3]);
 });
 
-test("mixed range lists visible sections and appends the internal-changes line", () => {
+test("mixed range lists visible entries and folds hidden ones into the bottom line", () => {
     const result = buildChangelog(["test: cover cabins (#3)", "fix(ci): quote globs (#2)", "chore: bump deps"], OPTS);
     assert.equal(
         result.markdown,
         [
-            "**Bug Fixes**",
+            "**Changes**",
             "- fix(ci): quote globs · [#2](https://github.com/o/r/pull/2)",
-            "",
-            "+2 internal changes",
+            `+2 internal changes · [diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 1, 2]);
@@ -72,34 +64,38 @@ test("mixed range lists visible sections and appends the internal-changes line",
 
 test("a single internal change uses the singular note", () => {
     const result = buildChangelog(["chore: bump deps"], OPTS);
-    assert.equal(result.markdown, `No user-facing changes (+1 internal change) — [full diff](${COMPARE})`);
+    assert.equal(result.markdown, ["**Changes**", `+1 internal change · [diff](${COMPARE})`].join("\n"));
 });
 
 test("a subject without (#N) is listed without a PR link", () => {
     const result = buildChangelog(["feat(tools): add request-correlation context"], OPTS);
-    assert.equal(result.markdown, ["**Features**", "- feat(tools): add request-correlation context"].join("\n"));
+    assert.equal(
+        result.markdown,
+        ["**Changes**", "- feat(tools): add request-correlation context", `[diff](${COMPARE})`].join("\n"),
+    );
 });
 
-test("a non-conventional subject lands under Other verbatim, never dropped", () => {
+test("a non-conventional subject is listed after the visible types, verbatim, never dropped", () => {
     const result = buildChangelog(["Update README badges (#7)", "feat: real feature (#6)"], OPTS);
     assert.equal(
         result.markdown,
         [
-            "**Features**",
+            "**Changes**",
             "- feat: real feature · [#6](https://github.com/o/r/pull/6)",
-            "",
-            "**Other**",
             "- Update README badges · [#7](https://github.com/o/r/pull/7)",
+            `[diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.equal(result.visibleCount, 2);
 });
 
-test("an unknown conventional type lands under Other", () => {
+test("an unknown conventional type is listed after the visible types", () => {
     const result = buildChangelog(["wip: half-done thing (#7)"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Other**", "- wip: half-done thing · [#7](https://github.com/o/r/pull/7)"].join("\n"),
+        ["**Changes**", "- wip: half-done thing · [#7](https://github.com/o/r/pull/7)", `[diff](${COMPARE})`].join(
+            "\n",
+        ),
     );
 });
 
@@ -107,7 +103,11 @@ test("feat!: gets the breaking-change warning marker", () => {
     const result = buildChangelog(["feat!: drop LAN transport (#10)"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Features**", "- ⚠ feat!: drop LAN transport · [#10](https://github.com/o/r/pull/10)"].join("\n"),
+        [
+            "**Changes**",
+            "- ⚠ feat!: drop LAN transport · [#10](https://github.com/o/r/pull/10)",
+            `[diff](${COMPARE})`,
+        ].join("\n"),
     );
 });
 
@@ -119,8 +119,9 @@ test("markdown special characters in subjects are escaped", () => {
     assert.equal(
         result.markdown,
         [
-            "**Bug Fixes**",
+            "**Changes**",
             "- fix: escape \\`code\\` and \\*stars\\* and \\_under\\_ and \\~tilde\\~ and \\|pipe\\| and \\\\slash",
+            `[diff](${COMPARE})`,
         ].join("\n"),
     );
 });
@@ -130,8 +131,9 @@ test("a subject with markdown link syntax cannot inject a masked link", () => {
     assert.equal(
         result.markdown,
         [
-            "**Features**",
+            "**Changes**",
             "- feat: \\[deployment guide\\](https://attacker.example) · [#13](https://github.com/o/r/pull/13)",
+            `[diff](${COMPARE})`,
         ].join("\n"),
     );
 });
@@ -140,7 +142,9 @@ test("a non-ASCII subject passes through and the budget counts code points", () 
     const result = buildChangelog(["feat: 🎉 支持中文标题 (#12)"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Features**", "- feat: 🎉 支持中文标题 · [#12](https://github.com/o/r/pull/12)"].join("\n"),
+        ["**Changes**", "- feat: 🎉 支持中文标题 · [#12](https://github.com/o/r/pull/12)", `[diff](${COMPARE})`].join(
+            "\n",
+        ),
     );
 });
 
@@ -154,13 +158,12 @@ test("an over-budget list is cut at a line boundary with an …and N more notice
     const markdown = result.markdown;
     assert.ok([...markdown].length <= BUDGET, `markdown is ${[...markdown].length} code points, budget is ${BUDGET}`);
     const lines = markdown.split("\n");
-    // Every kept entry is whole (cut at a line boundary), the notice names the dropped
-    // count, and the internal-changes line survives truncation.
+    assert.equal(lines[0], "**Changes**");
+    // Every kept entry is whole (cut at a line boundary); the bottom line names the dropped
+    // count, folds the internal change in, and carries the diff link.
     const keptEntries = lines.filter((l) => l.startsWith("- feat:")).length;
     assert.ok(keptEntries > 0 && keptEntries < 100);
-    const noticeLine = lines.find((l) => l.startsWith("…and "));
-    assert.equal(noticeLine, `…and ${100 - keptEntries} more — [full diff](${COMPARE})`);
-    assert.equal(lines[lines.length - 1], "+1 internal change");
+    assert.equal(lines[lines.length - 1], `…and ${100 - keptEntries} more · +1 internal change · [diff](${COMPARE})`);
     for (const line of lines.filter((l) => l.startsWith("- "))) {
         assert.match(line, /· \[#\d+\]\(https:\/\/github\.com\/o\/r\/pull\/\d+\)$/);
     }
@@ -173,9 +176,11 @@ test("release-please's release commit is excluded from every count", () => {
     );
     assert.equal(
         result.markdown,
-        ["**Bug Fixes**", "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)", "", "+1 internal change"].join(
-            "\n",
-        ),
+        [
+            "**Changes**",
+            "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)",
+            `+1 internal change · [diff](${COMPARE})`,
+        ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [2, 1, 1]);
     // A plain chore mentioning "release" without a version is NOT the release commit.
@@ -184,6 +189,6 @@ test("release-please's release commit is excluded from every count", () => {
 
 test("zero commits reports no changes since the base tag", () => {
     const result = buildChangelog([], OPTS);
-    assert.equal(result.markdown, `No changes since \`preview-1.5.0.1\` — [full diff](${COMPARE})`);
+    assert.equal(result.markdown, `No changes since \`preview-1.5.0.1\` · [diff](${COMPARE})`);
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [0, 0, 0]);
 });

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -194,14 +194,17 @@ jobs:
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_PREVIEW }}
-          title: Preview build ${{ needs.calculate-version.outputs.preview_version }}
-          url: ${{ steps.changelog.outputs.compare-url }}
+          # Bot identity: per-channel var → shared var → literal default. Empty avatar falls
+          # back to the project logo inside the action.
+          username: ${{ vars.DISCORD_BOT_USERNAME_PREVIEW || vars.DISCORD_BOT_USERNAME || 'Preview Bot' }}
+          avatar-url: ${{ vars.DISCORD_BOT_AVATAR_URL_PREVIEW || vars.DISCORD_BOT_AVATAR_URL }}
+          title: Preview ${{ needs.calculate-version.outputs.preview_version }}
           color: "16753920"
           description: |
             ${{ steps.changelog.outputs.markdown }}
 
             **Use it**
-            ```IMAGE_VERSION=${{ needs.calculate-version.outputs.preview_version }}``` (or `preview` for the newest)
+            ```IMAGE_VERSION=${{ needs.calculate-version.outputs.preview_version }}```
             ```docker compose pull && docker compose up -d```
 
       - name: Update preview tracking tag

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -194,8 +194,8 @@ jobs:
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_PREVIEW }}
-          # Bot identity: per-channel var → shared var → literal default. Empty avatar falls
-          # back to the project logo inside the action.
+          # Bot name: try the channel-specific variable, then the shared one, then this default.
+          # If no avatar variable is set, the action falls back to the project logo.
           username: ${{ vars.DISCORD_BOT_USERNAME_PREVIEW || vars.DISCORD_BOT_USERNAME || 'Preview Bot' }}
           avatar-url: ${{ vars.DISCORD_BOT_AVATAR_URL_PREVIEW || vars.DISCORD_BOT_AVATAR_URL }}
           title: Preview ${{ needs.calculate-version.outputs.preview_version }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -130,14 +130,17 @@ jobs:
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          # Bot identity: per-channel var → shared var → literal default. Empty avatar falls
+          # back to the project logo inside the action.
+          username: ${{ vars.DISCORD_BOT_USERNAME_RELEASES || vars.DISCORD_BOT_USERNAME || 'Release Bot' }}
+          avatar-url: ${{ vars.DISCORD_BOT_AVATAR_URL_RELEASES || vars.DISCORD_BOT_AVATAR_URL }}
           title: Release ${{ needs.release-please.outputs.version }}
-          url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.release-please.outputs.tag_name }}
           color: "5763719"
           description: |
             ${{ steps.changelog.outputs.markdown }}
 
             **Use it**
-            ```IMAGE_VERSION=${{ needs.release-please.outputs.version }}``` (or `latest` for the newest release)
+            ```IMAGE_VERSION=${{ needs.release-please.outputs.version }}```
             ```docker compose pull && docker compose up -d```
 
   stamp-issue-versions:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -130,8 +130,8 @@ jobs:
         uses: ./.github/actions/discord-notify
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
-          # Bot identity: per-channel var → shared var → literal default. Empty avatar falls
-          # back to the project logo inside the action.
+          # Bot name: try the channel-specific variable, then the shared one, then this default.
+          # If no avatar variable is set, the action falls back to the project logo.
           username: ${{ vars.DISCORD_BOT_USERNAME_RELEASES || vars.DISCORD_BOT_USERNAME || 'Release Bot' }}
           avatar-url: ${{ vars.DISCORD_BOT_AVATAR_URL_RELEASES || vars.DISCORD_BOT_AVATAR_URL }}
           title: Release ${{ needs.release-please.outputs.version }}

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -466,7 +466,7 @@ GitHub Actions caches can accumulate over time. This pipeline removes every cach
 
 CI posts to Discord in two clearly separated streams, all through the shared composite action `.github/actions/discord-notify`:
 
-- **Public release feeds**: `#releases` (stable releases) and `#releases-preview` (preview builds). Each post carries the full changelog since the previous build — every first-parent commit, grouped like the GitHub release page (built by `.github/actions/build-changelog` on top of `.github/scripts/build-changelog.js`) — plus the exact `IMAGE_VERSION=…` value to deploy it.
+- **Public release feeds**: `#releases` (stable releases) and `#releases-preview` (preview builds). Each post carries the full changelog since the previous build — every first-parent commit as one **Changes** list ordered like the GitHub release page, with hidden types folded into a trailing `+N internal changes` line and a `[diff]` link to the range (built by `.github/actions/build-changelog` on top of `.github/scripts/build-changelog.js`) — plus the exact `IMAGE_VERSION=…` value to deploy it.
 - **Internal CI feed** for maintainers: `#internal-ci` gets docs deploys (with the versions per half), server deploys (with the resolved image version and commit), and deploy failures.
 
 ### Secrets
@@ -480,6 +480,21 @@ One repository secret per channel, each holding a [Discord webhook URL](https://
 | `DISCORD_WEBHOOK_INTERNAL_CI` | `#internal-ci` | Deploy Documentation (`deploy-docs.yml`), Deploy Server (`deploy-server.yml`, success and failure) |
 
 A missing secret is not an error: the notify action logs "no webhook configured" and skips, so notifications silently stop while everything else runs unaffected. A malformed or over-limit payload fails the notify step loudly instead of truncating; success-path notify steps run with `continue-on-error`, so a Discord outage never reds a build or deploy that succeeded.
+
+### Bot identity (release feeds)
+
+The release and preview posts set the webhook's display name and avatar per message. Both are optional repository **variables** — unset means the defaults below apply, so it works out of the box:
+
+| Variable | Applies to | Default |
+|----------|-----------|---------|
+| `DISCORD_BOT_USERNAME` | both release feeds | `Release Bot` / `Preview Bot` (per channel) |
+| `DISCORD_BOT_USERNAME_RELEASES` | `#releases` only | falls back to `DISCORD_BOT_USERNAME` |
+| `DISCORD_BOT_USERNAME_PREVIEW` | `#releases-preview` only | falls back to `DISCORD_BOT_USERNAME` |
+| `DISCORD_BOT_AVATAR_URL` | both release feeds | the project logo |
+| `DISCORD_BOT_AVATAR_URL_RELEASES` | `#releases` only | falls back to `DISCORD_BOT_AVATAR_URL` |
+| `DISCORD_BOT_AVATAR_URL_PREVIEW` | `#releases-preview` only | falls back to `DISCORD_BOT_AVATAR_URL` |
+
+Resolution is per-channel var → shared var → default. The internal CI feed posts no identity, so `#internal-ci` keeps whatever name/avatar its webhook is configured with in Discord.
 
 ### Discord server setup
 


### PR DESCRIPTION
Restores the "Release Bot" name + avatar on the `#releases` / `#releases-preview` posts (lost when the webhooks were split), and cleans up the changelog formatting.

## Bot identity
- `discord-notify`: new optional `username` + `avatar-url` inputs, injected as the webhook's top-level `username`/`avatar_url`. Resolution in the workflows is **per-channel var → shared var → default**:
  - `DISCORD_BOT_USERNAME` / `DISCORD_BOT_USERNAME_RELEASES` / `DISCORD_BOT_USERNAME_PREVIEW`
  - `DISCORD_BOT_AVATAR_URL` / `DISCORD_BOT_AVATAR_URL_RELEASES` / `DISCORD_BOT_AVATAR_URL_PREVIEW`
- Works with zero config: defaults to `Release Bot` / `Preview Bot` and the project logo (`…github.io/server/logo.png`).
- The logo default is applied **only when a username is set**, so the internal-CI feed keeps whatever identity its webhook is configured with in Discord.

## Formatting
- Dropped the redundant embed **timestamp** (Discord already stamps the message).
- Changelog is now one flat **Changes** list in release-please type order (no per-type sub-headers), ending in a single `+N internal changes · [diff](…)` line — the `[diff]` link matches the `· #PR` suffix on every entry and is drillable to the full range.
- **Unlinked the embed title** (no more blue link) and renamed to `Release {v}` / `Preview {v}` (dropped "build"). Preview's title no longer duplicated the compare link now carried by `[diff]`.
- Dropped the `(or latest/preview…)` hint from the **Use it** block — the feed informs about the specific image, not documentation.

## Rendered example (release)
```
Release 1.4.1
**Changes**
- Add multiplayer chat relay · #123
- ⚠ Fix cabin allocation race · #124
+10 internal changes · [diff](…/compare/…)

**Use it**
​```IMAGE_VERSION=1.4.1​```
​```docker compose pull && docker compose up -d​```
```

## Notes
- The logo avatar URL must be publicly reachable for Discord to fetch it.
- Docs: `docs/developers/contributing/ci-cd.md` documents the new `DISCORD_BOT_*` variables and format.
- `build-changelog.test.js` updated for the flat format (14 tests pass).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discord notifications support configurable bot names and avatars with sensible fallbacks.
  * Preview and release messages now use streamlined titles and usage instructions.

* **Improvements**
  * Changelogs use one prioritized **Changes** list with internal-change and truncation notices.
  * Diff links are consistently included in changelog notifications.
  * Notification messages no longer include unnecessary release links or timestamps.

* **Documentation**
  * Updated CI/CD guidance for changelog formatting, Discord bot identities, and the current merge process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->