### PR TITLE
feat(discord-bot): own the status dashboard message per deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,9 @@ services:
       STATUS_DASHBOARD_REFRESH_RATE: "${STATUS_DASHBOARD_REFRESH_RATE:-}"
       # API key (must match server's API_KEY if set)
       API_KEY: "${API_KEY:-}"
+    volumes:
+      # Dashboard ownership state (persists the dashboard message across restarts)
+      - discord-bot-data:/data
 
     depends_on:
       - server
@@ -105,3 +108,4 @@ volumes:
   game-data:
   saves:
   settings:
+  discord-bot-data:

--- a/docker/modern/docker-compose.yml
+++ b/docker/modern/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       STATUS_DASHBOARD_CHANNEL_ID: "${STATUS_DASHBOARD_CHANNEL_ID:-}"
       STATUS_DASHBOARD_REFRESH_RATE: "${STATUS_DASHBOARD_REFRESH_RATE:-}"
       API_KEY: "${API_KEY:-}"
+    volumes:
+      # Dashboard ownership state (persists the dashboard message across restarts)
+      - discord-bot-data:/data
     depends_on:
       - server
     restart: on-failure
@@ -94,6 +97,7 @@ volumes:
   steam-session:
   game-data:
   saves:
+  discord-bot-data:
 
 secrets:
   steam_username:

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -78,6 +78,12 @@ STATUS_DASHBOARD_REFRESH_RATE=60
 
 The dashboard may share a channel with the chat relay.
 
+The dashboard message is owned by your deployment: the bot stamps an ownership id into the embed footer and persists it in the `discord-bot-data` volume (shipped in the compose file), so the same message survives restarts and server resets. If a second server posts its dashboard to the same channel, the bot detects the foreign dashboard, logs a warning, and leaves it untouched instead of overwriting it.
+
+::: warning One bot application per server
+The ownership id protects only the dashboard message. Presence and nickname are global to the bot user, so two servers sharing one bot token still overwrite each other's presence and nickname. Run one bot application per server.
+:::
+
 ## Bot Nickname
 
 | Configuration | Behavior |

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -80,8 +80,13 @@ The dashboard may share a channel with the chat relay.
 
 The dashboard message is owned by your deployment: the bot stamps an ownership id into the embed footer and persists it in the `discord-bot-data` volume (shipped in the compose file), so the same message survives restarts and server resets. If a second server posts its dashboard to the same channel, the bot detects the foreign dashboard, logs a warning, and leaves it untouched instead of overwriting it.
 
+Both guards depend on that volume:
+
+- If it is missing or unwritable, the bot logs a warning and falls back to editing any dashboard in the channel — in a shared channel it can then overwrite another deployment's dashboard.
+- If you delete it (`docker compose down -v`, `make clean`), the bot gets a new identity: it posts a fresh dashboard and warns about the old one instead of reusing it. Delete the old message by hand.
+
 ::: warning One bot application per server
-The ownership id protects only the dashboard message. Presence and nickname are global to the bot user, so two servers sharing one bot token still overwrite each other's presence and nickname. Run one bot application per server.
+The ownership id protects only the dashboard message. Presence is global to the bot user, and each deployment rewrites the bot's nickname in every Discord server it is in, so two game servers sharing one bot token still overwrite each other's presence and nickname. Run one bot application per server.
 :::
 
 ## Bot Nickname

--- a/tools/discord-bot/Dockerfile
+++ b/tools/discord-bot/Dockerfile
@@ -11,6 +11,11 @@ RUN bun install --frozen-lockfile --production
 # Copy source
 COPY src ./src
 
+# Dashboard ownership state lives in /data (named volume). A fresh volume
+# inherits the mountpoint's ownership from the image, so chown here is what
+# lets the non-root user write to it.
+RUN mkdir -p /data && chown bun:bun /data
+
 # Run as non-root user
 USER bun
 

--- a/tools/discord-bot/package.json
+++ b/tools/discord-bot/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "start": "bun run src/index.ts",
         "dev": "bun run --watch src/index.ts",
+        "test": "bun test",
         "lint": "biome check .",
         "lint:fix": "biome check --write --unsafe ."
     },

--- a/tools/discord-bot/src/dashboard.test.ts
+++ b/tools/discord-bot/src/dashboard.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import {
+    classifyDashboardEmbed,
+    DASHBOARD_TITLE,
+    type EmbedLike,
+    formatFooter,
+    isDashboardEmbed,
+    parseOwnerId,
+} from "./dashboard";
+
+const OWNER_ID = "3f2c8a1e-9b4d-4c6f-8a2e-1d5b7c9e0f3a";
+const OTHER_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+
+function dashboardEmbed(footerText: string | null): EmbedLike {
+    return {
+        title: DASHBOARD_TITLE,
+        footer: footerText === null ? null : { text: footerText },
+    };
+}
+
+describe("formatFooter", () => {
+    test("stamps the owner id when present", () => {
+        expect(formatFooter("30 seconds", OWNER_ID)).toBe(`Automatically updates every 30 seconds • id:${OWNER_ID}`);
+    });
+
+    test("omits the stamp in degraded mode", () => {
+        expect(formatFooter("2 minutes", null)).toBe("Automatically updates every 2 minutes");
+    });
+});
+
+describe("parseOwnerId", () => {
+    test("round-trips the id written by formatFooter", () => {
+        expect(parseOwnerId(formatFooter("30 seconds", OWNER_ID))).toBe(OWNER_ID);
+    });
+
+    test("returns null for an unstamped footer", () => {
+        expect(parseOwnerId(formatFooter("30 seconds", null))).toBeNull();
+    });
+
+    test("returns null for empty, null, and undefined input", () => {
+        expect(parseOwnerId("")).toBeNull();
+        expect(parseOwnerId(null)).toBeNull();
+        expect(parseOwnerId(undefined)).toBeNull();
+    });
+
+    test("returns null when the separator is present but the id is empty", () => {
+        expect(parseOwnerId("Automatically updates every 30 seconds • id:")).toBeNull();
+        expect(parseOwnerId("Automatically updates every 30 seconds • id:   ")).toBeNull();
+    });
+});
+
+describe("isDashboardEmbed", () => {
+    test("matches the dashboard title", () => {
+        expect(isDashboardEmbed(dashboardEmbed(null))).toBeTrue();
+    });
+
+    test("rejects other embeds and missing embeds", () => {
+        expect(isDashboardEmbed({ title: "Some other embed" })).toBeFalse();
+        expect(isDashboardEmbed({ title: null })).toBeFalse();
+        expect(isDashboardEmbed(null)).toBeFalse();
+        expect(isDashboardEmbed(undefined)).toBeFalse();
+    });
+});
+
+describe("classifyDashboardEmbed", () => {
+    test("non-dashboard content is unrelated", () => {
+        expect(classifyDashboardEmbed({ title: "Not a dashboard" }, OWNER_ID)).toBe("unrelated");
+        expect(classifyDashboardEmbed(undefined, OWNER_ID)).toBe("unrelated");
+    });
+
+    test("our stamp is mine", () => {
+        const embed = dashboardEmbed(formatFooter("30 seconds", OWNER_ID));
+        expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("mine");
+    });
+
+    test("an unstamped dashboard is legacy", () => {
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter("30 seconds", null)), OWNER_ID)).toBe("legacy");
+        expect(classifyDashboardEmbed(dashboardEmbed(null), OWNER_ID)).toBe("legacy");
+    });
+
+    test("another deployment's stamp is foreign", () => {
+        const embed = dashboardEmbed(formatFooter("30 seconds", OTHER_ID));
+        expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("foreign");
+    });
+
+    test("degraded mode adopts every dashboard by title, regardless of stamp", () => {
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter("30 seconds", OTHER_ID)), null)).toBe("mine");
+        expect(classifyDashboardEmbed(dashboardEmbed(null), null)).toBe("mine");
+    });
+
+    test("degraded mode still ignores non-dashboard content", () => {
+        expect(classifyDashboardEmbed({ title: "Not a dashboard" }, null)).toBe("unrelated");
+    });
+});

--- a/tools/discord-bot/src/dashboard.ts
+++ b/tools/discord-bot/src/dashboard.ts
@@ -42,7 +42,7 @@ export function isDashboardEmbed(embed: EmbedLike | null | undefined): boolean {
 
 /**
  * - `mine` — dashboard embed stamped with our owner id
- * - `legacy` — dashboard embed with no stamp (pre-upgrade dashboard; adopt and stamp)
+ * - `legacy` — dashboard embed with no ownership stamp (adopt and stamp)
  * - `foreign` — dashboard embed stamped by another deployment (never touch)
  * - `unrelated` — not a dashboard embed (chat relay line, command reply, ...)
  */
@@ -51,8 +51,8 @@ export type DashboardMessageKind = "mine" | "legacy" | "foreign" | "unrelated";
 /**
  * Classifies a bot-authored message's first embed against our owner id.
  * With `ownerId` null (degraded mode) adoption is title-based: every dashboard
- * embed classifies as `mine`, whether stamped, legacy, or unstamped — a restart
- * without persistence must still re-adopt its own message.
+ * embed classifies as `mine`, stamped or not — a restart without persistence
+ * must still re-adopt its own message.
  */
 export function classifyDashboardEmbed(
     embed: EmbedLike | null | undefined,

--- a/tools/discord-bot/src/dashboard.ts
+++ b/tools/discord-bot/src/dashboard.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure helpers for dashboard message ownership: footer stamping, owner-id parsing,
+ * and classifying channel messages during the adoption scan.
+ */
+
+export const DASHBOARD_TITLE = "🧑‍🌾 Stardew Valley Server Status Dashboard";
+
+const FOOTER_ID_SEPARATOR = " • id:";
+
+/** Minimal embed shape shared by discord.js `Embed` and test fixtures. */
+export interface EmbedLike {
+    title?: string | null;
+    footer?: { text?: string | null } | null;
+}
+
+/**
+ * Builds the dashboard footer text. When `ownerId` is null (degraded mode,
+ * persistence unavailable) no ownership stamp is included.
+ */
+export function formatFooter(refreshRateFormatted: string, ownerId: string | null): string {
+    const base = `Automatically updates every ${refreshRateFormatted}`;
+    return ownerId ? `${base}${FOOTER_ID_SEPARATOR}${ownerId}` : base;
+}
+
+/** Extracts the ownership stamp from a footer text, or null if none is present. */
+export function parseOwnerId(footerText: string | null | undefined): string | null {
+    if (!footerText) {
+        return null;
+    }
+    const index = footerText.lastIndexOf(FOOTER_ID_SEPARATOR);
+    if (index === -1) {
+        return null;
+    }
+    const id = footerText.slice(index + FOOTER_ID_SEPARATOR.length).trim();
+    return id.length > 0 ? id : null;
+}
+
+/** A message is a dashboard iff its first embed carries the dashboard title. */
+export function isDashboardEmbed(embed: EmbedLike | null | undefined): boolean {
+    return embed?.title === DASHBOARD_TITLE;
+}
+
+/**
+ * - `mine` — dashboard embed stamped with our owner id
+ * - `legacy` — dashboard embed with no stamp (pre-upgrade dashboard; adopt and stamp)
+ * - `foreign` — dashboard embed stamped by another deployment (never touch)
+ * - `unrelated` — not a dashboard embed (chat relay line, command reply, ...)
+ */
+export type DashboardMessageKind = "mine" | "legacy" | "foreign" | "unrelated";
+
+/**
+ * Classifies a bot-authored message's first embed against our owner id.
+ * With `ownerId` null (degraded mode) adoption is title-based: every dashboard
+ * embed classifies as `mine`, whether stamped, legacy, or unstamped — a restart
+ * without persistence must still re-adopt its own message.
+ */
+export function classifyDashboardEmbed(
+    embed: EmbedLike | null | undefined,
+    ownerId: string | null,
+): DashboardMessageKind {
+    if (!isDashboardEmbed(embed)) {
+        return "unrelated";
+    }
+    if (ownerId === null) {
+        return "mine";
+    }
+    const stamp = parseOwnerId(embed?.footer?.text);
+    if (stamp === null) {
+        return "legacy";
+    }
+    return stamp === ownerId ? "mine" : "foreign";
+}

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -1,14 +1,25 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import {
     ActivityType,
     Client,
     Colors,
+    DiscordAPIError,
     EmbedBuilder,
     Events,
     GatewayIntentBits,
     type Message,
     PermissionFlagsBits,
+    RESTJSONErrorCodes,
     type TextChannel,
 } from "discord.js";
+import {
+    classifyDashboardEmbed,
+    DASHBOARD_TITLE,
+    type DashboardMessageKind,
+    formatFooter,
+    parseOwnerId,
+} from "./dashboard";
 
 // Configuration from environment
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -23,7 +34,6 @@ const STATUS_DASHBOARD_REFRESH_RATE_FORMATTED =
         ? `${STATUS_DASHBOARD_REFRESH_RATE} seconds`
         : `${Math.round(STATUS_DASHBOARD_REFRESH_RATE / 60)} minutes`;
 const DISCORD_BOT_NICKNAME = process.env.DISCORD_BOT_NICKNAME;
-let targetMessageId: string | null = null;
 const COOLDOWN_DURATION_MS = 30000;
 const MAX_COMMANDS_PER_WINDOW = 10;
 const commandHistory = new Map<string, number[]>();
@@ -390,95 +400,269 @@ function isRateLimited(userId: string): boolean {
     return false;
 }
 
+// ============================================================================
+// STATUS DASHBOARD
+// ============================================================================
+// The dashboard message is owned by one deployment: a UUID generated on first
+// boot, persisted to the bot's volume, and stamped into the embed footer. The
+// stamp lets the bot re-adopt its own message across restarts and refuse to
+// touch a dashboard owned by another deployment sharing the channel.
+
+const DASHBOARD_STATE_FILE = "/data/dashboard-state.json";
+
+interface DashboardState {
+    // null only in degraded mode (persistence unavailable): no id is stamped
+    // and adoption falls back to title-based matching.
+    ownerId: string | null;
+    messageId: string | null;
+}
+
+const dashboardState: DashboardState = { ownerId: null, messageId: null };
+let dashboardStateWritable = false;
+let dashboardUpdateInFlight = false;
+const warnedForeignOwnerIds = new Set<string>();
+
+/**
+ * Loads (or initializes) the persisted dashboard state. A missing file is a
+ * normal first boot — the id is never recovered from channel contents, since
+ * that could steal a foreign deployment's dashboard.
+ */
+function loadDashboardState(): void {
+    let raw: string | null = null;
+    try {
+        raw = readFileSync(DASHBOARD_STATE_FILE, "utf8");
+    } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+            console.warn(`[Dashboard] Could not read ${DASHBOARD_STATE_FILE} (${error}) - treating as first boot.`);
+        }
+    }
+
+    if (raw !== null) {
+        try {
+            const parsed = JSON.parse(raw);
+            if (typeof parsed?.ownerId === "string" && parsed.ownerId.length > 0) {
+                dashboardState.ownerId = parsed.ownerId;
+                dashboardState.messageId = typeof parsed.messageId === "string" ? parsed.messageId : null;
+                dashboardStateWritable = true;
+                console.log(`[Dashboard] Ownership id: ${dashboardState.ownerId}`);
+                return;
+            }
+            console.warn(`[Dashboard] ${DASHBOARD_STATE_FILE} has no ownerId - treating as first boot.`);
+        } catch {
+            console.warn(`[Dashboard] ${DASHBOARD_STATE_FILE} is unparseable - treating as first boot.`);
+        }
+    }
+
+    dashboardState.ownerId = crypto.randomUUID();
+    dashboardState.messageId = null;
+    dashboardStateWritable = true;
+    persistDashboardState();
+    if (dashboardStateWritable) {
+        console.log(`[Dashboard] Ownership id created: ${dashboardState.ownerId}`);
+    }
+}
+
+/**
+ * Atomically persists the dashboard state (tmp file + rename). A failed write
+ * at any point drops the bot into degraded mode: the ownership guard is
+ * disabled and the footer is written without an id, so a later healthy boot
+ * can re-adopt the message via the legacy branch and re-stamp it.
+ */
+function persistDashboardState(): void {
+    if (!dashboardStateWritable) {
+        return;
+    }
+    try {
+        mkdirSync(dirname(DASHBOARD_STATE_FILE), { recursive: true });
+        const tmpFile = `${DASHBOARD_STATE_FILE}.tmp`;
+        writeFileSync(tmpFile, JSON.stringify(dashboardState));
+        renameSync(tmpFile, DASHBOARD_STATE_FILE);
+    } catch (error) {
+        dashboardStateWritable = false;
+        dashboardState.ownerId = null;
+        console.warn(
+            `[Dashboard] ⚠️ Cannot persist ${DASHBOARD_STATE_FILE} (${error}) - ownership guard disabled. ` +
+                "The dashboard still updates, but a second deployment sharing this channel is no longer detected. " +
+                "Check that the bot's /data volume is mounted and writable.",
+        );
+    }
+}
+
+function clearTrackedMessage(): void {
+    dashboardState.messageId = null;
+    persistDashboardState();
+}
+
+/** Builds the dashboard embed from the current server status. */
+async function buildDashboardEmbed(): Promise<EmbedBuilder> {
+    const status: ServerStatus | null = await fetchServerStatus();
+
+    const embed = new EmbedBuilder()
+        .setTitle(DASHBOARD_TITLE)
+        .setTimestamp()
+        .setFooter({ text: formatFooter(STATUS_DASHBOARD_REFRESH_RATE_FORMATTED, dashboardState.ownerId) });
+
+    if (!status?.isOnline) {
+        embed
+            .setColor(Colors.Red)
+            .setDescription(
+                "🔴 **The server is currently offline.**\n\n_No game data can be pulled right now. Check back later!_",
+            );
+    } else {
+        const seasonEmojis: Record<string, string> = {
+            spring: "🌸 Spring",
+            summer: "☀️ Summer",
+            fall: "🍂 Fall",
+            winter: "❄️ Winter",
+        };
+        const formattedSeason = seasonEmojis[status.season?.toLowerCase()] || status.season;
+
+        embed.setColor(Colors.Blue).addFields(
+            { name: "🏡 Farm Name", value: status.farmName || "Our Farm", inline: true },
+            { name: "🗺️ Farm Layout", value: getFarmTypeName(status.farmTypeKey), inline: true },
+            {
+                name: "📶 Server Status",
+                value: status.isReady ? "✅ Ready & Running" : "⏳ Saving / Loading",
+                inline: true,
+            },
+            {
+                name: "👥 Active Players",
+                value: `**${status.playerCount} / ${status.maxPlayers}** ${status.isPaused ? "_(Paused)_" : ""}`,
+                inline: true,
+            },
+            {
+                name: "📅 In-Game Date",
+                value: `Year ${status.year}, ${formattedSeason}, Day ${status.day}`,
+                inline: true,
+            },
+            { name: "⏰ Clock Time", value: formatStardewTime(status.timeOfDay), inline: true },
+            {
+                name: "🔑 Connection Code",
+                value: `\`${status.steamInviteCode || status.gogInviteCode || "None Available"}\``,
+                inline: false,
+            },
+        );
+    }
+
+    return embed;
+}
+
 // Auto-updating status dashboard
-async function updateLiveDashboard() {
+async function updateLiveDashboard(): Promise<void> {
     if (!STATUS_DASHBOARD_CHANNEL_ID) {
         return;
     }
-
+    if (dashboardUpdateInFlight) {
+        return;
+    }
+    dashboardUpdateInFlight = true;
     try {
-        const channel = (await client.channels.fetch(STATUS_DASHBOARD_CHANNEL_ID)) as TextChannel;
-        if (!channel?.isTextBased()) {
-            console.error("[Dashboard] Target channel not found or is not text-based.");
-            return;
-        }
+        await runDashboardUpdate(STATUS_DASHBOARD_CHANNEL_ID);
+    } catch (error) {
+        console.error(`[Dashboard] Loop execution failed: ${error}`);
+    } finally {
+        dashboardUpdateInFlight = false;
+    }
+}
 
-        const status: ServerStatus | null = await fetchServerStatus();
+async function runDashboardUpdate(channelId: string): Promise<void> {
+    const channel = (await client.channels.fetch(channelId)) as TextChannel;
+    if (!channel?.isTextBased()) {
+        console.error("[Dashboard] Target channel not found or is not text-based.");
+        return;
+    }
 
-        const embed = new EmbedBuilder()
-            .setTitle("🧑‍🌾 Stardew Valley Server Status Dashboard")
-            .setTimestamp()
-            .setFooter({ text: `Automatically updates every ${STATUS_DASHBOARD_REFRESH_RATE_FORMATTED}` });
+    const embed = await buildDashboardEmbed();
 
-        if (!status?.isOnline) {
-            embed
-                .setColor(Colors.Red)
-                .setDescription(
-                    "🔴 **The server is currently offline.**\n\n_No game data can be pulled right now. Check back later!_",
-                );
-        } else {
-            const seasonEmojis: Record<string, string> = {
-                spring: "🌸 Spring",
-                summer: "☀️ Summer",
-                fall: "🍂 Fall",
-                winter: "❄️ Winter",
-            };
-            const formattedSeason = seasonEmojis[status.season?.toLowerCase()] || status.season;
-
-            embed.setColor(Colors.Blue).addFields(
-                { name: "🏡 Farm Name", value: status.farmName || "Our Farm", inline: true },
-                { name: "🗺️ Farm Layout", value: getFarmTypeName(status.farmTypeKey), inline: true },
-                {
-                    name: "📶 Server Status",
-                    value: status.isReady ? "✅ Ready & Running" : "⏳ Saving / Loading",
-                    inline: true,
-                },
-                {
-                    name: "👥 Active Players",
-                    value: `**${status.playerCount} / ${status.maxPlayers}** ${status.isPaused ? "_(Paused)_" : ""}`,
-                    inline: true,
-                },
-                {
-                    name: "📅 In-Game Date",
-                    value: `Year ${status.year}, ${formattedSeason}, Day ${status.day}`,
-                    inline: true,
-                },
-                { name: "⏰ Clock Time", value: formatStardewTime(status.timeOfDay), inline: true },
-                {
-                    name: "🔑 Connection Code",
-                    value: `\`${status.steamInviteCode || status.gogInviteCode || "None Available"}\``,
-                    inline: false,
-                },
-            );
-        }
-
-        // Dispatch/edit
-        if (targetMessageId) {
-            try {
-                const existingMsg = await channel.messages.fetch(targetMessageId);
-                await existingMsg.edit({ content: "", embeds: [embed] });
-                console.log("[Dashboard] Live status display updated successfully.");
+    // Primary path: edit the tracked message.
+    if (dashboardState.messageId) {
+        let existing: Message | null = null;
+        try {
+            existing = await channel.messages.fetch(dashboardState.messageId);
+        } catch (error) {
+            if (error instanceof DiscordAPIError && error.code === RESTJSONErrorCodes.UnknownMessage) {
+                console.log("[Dashboard] Tracked message was deleted - scanning for a replacement.");
+                clearTrackedMessage();
+            } else {
+                // Transient failure (network, 5xx, rate limit, permissions): keep the id
+                // and retry next tick — falling through to the scan here is what would
+                // duplicate the dashboard.
+                console.error(`[Dashboard] Could not fetch tracked message (${error}) - retrying next tick.`);
                 return;
-            } catch (_err) {
-                console.log("[Dashboard] Saved message ID missing or deleted. Generating a replacement entry...");
             }
         }
 
-        // Fallback
-        const recentMessages = await channel.messages.fetch({ limit: 10 });
-        const botOldMessage = recentMessages.find((m) => m.author.id === client.user?.id);
-
-        if (botOldMessage) {
-            targetMessageId = botOldMessage.id;
-            await botOldMessage.edit({ content: "", embeds: [embed] });
-            console.log("[Dashboard] Recovered old message reference and applied edits.");
-        } else {
-            const newMsg = await channel.send({ embeds: [embed] });
-            targetMessageId = newMsg.id;
-            console.log("[Dashboard] Fresh status message initialized.");
+        if (existing) {
+            const kind = classifyDashboardEmbed(existing.embeds[0], dashboardState.ownerId);
+            if (kind === "mine" || kind === "legacy") {
+                await existing.edit({ content: "", embeds: [embed] });
+                console.log("[Dashboard] Live status display updated successfully.");
+                return;
+            }
+            console.warn("[Dashboard] Tracked message is not our dashboard anymore - scanning for a replacement.");
+            clearTrackedMessage();
         }
+    }
+
+    // Scan path: classify recent bot-authored messages and adopt our dashboard.
+    let recentMessages: Awaited<ReturnType<typeof channel.messages.fetch>>;
+    try {
+        recentMessages = await channel.messages.fetch({ limit: 50 });
     } catch (error) {
-        console.error(`[Dashboard] Loop execution failed: ${error}`);
+        console.error(`[Dashboard] Message scan failed (${error}) - retrying next tick.`);
+        return;
+    }
+
+    const ownDashboards: { message: Message; kind: DashboardMessageKind }[] = [];
+    for (const message of recentMessages.values()) {
+        if (message.author.id !== client.user?.id) {
+            continue;
+        }
+        const kind = classifyDashboardEmbed(message.embeds[0], dashboardState.ownerId);
+        if (kind === "mine" || kind === "legacy") {
+            ownDashboards.push({ message, kind });
+        } else if (kind === "foreign") {
+            const foreignId = parseOwnerId(message.embeds[0]?.footer?.text) ?? "unknown";
+            if (!warnedForeignOwnerIds.has(foreignId)) {
+                warnedForeignOwnerIds.add(foreignId);
+                console.warn(
+                    `[Dashboard] ⚠️ This channel has a dashboard owned by another deployment (id:${foreignId}) - ` +
+                        "leaving it untouched. Each server needs its own bot application and channel setup.",
+                );
+            }
+        }
+    }
+
+    // fetch() returns newest-first; prefer a stamped dashboard over a legacy one.
+    const adopted = ownDashboards.find((d) => d.kind === "mine") ?? ownDashboards.find((d) => d.kind === "legacy");
+
+    if (adopted) {
+        dashboardState.messageId = adopted.message.id;
+        persistDashboardState();
+        // The edit re-stamps: legacy dashboards get the id on adoption.
+        await adopted.message.edit({ content: "", embeds: [embed] });
+        console.log(`[Dashboard] Adopted existing ${adopted.kind} dashboard message.`);
+    } else {
+        const newMsg = await channel.send({ embeds: [embed] });
+        dashboardState.messageId = newMsg.id;
+        persistDashboardState();
+        console.log("[Dashboard] Fresh status message initialized.");
+    }
+
+    // Best-effort cleanup of our own surplus dashboards. Skipped in degraded mode,
+    // where "mine" is title-based and could match a foreign deployment's dashboard.
+    if (dashboardState.ownerId !== null) {
+        for (const { message } of ownDashboards) {
+            if (message.id === dashboardState.messageId) {
+                continue;
+            }
+            try {
+                await message.delete();
+                console.log("[Dashboard] Deleted a surplus dashboard message of ours.");
+            } catch (error) {
+                console.warn(`[Dashboard] Could not delete a surplus dashboard message: ${error}`);
+            }
+        }
     }
 }
 
@@ -810,6 +994,7 @@ client.once(Events.ClientReady, async () => {
     connectWebSocket();
 
     if (STATUS_DASHBOARD_CHANNEL_ID) {
+        loadDashboardState();
         await updateLiveDashboard();
         setInterval(updateLiveDashboard, STATUS_DASHBOARD_REFRESH_RATE * 1000);
     }

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -440,9 +440,13 @@ function loadDashboardState(): void {
     if (raw !== null) {
         try {
             const parsed = JSON.parse(raw);
-            if (typeof parsed?.ownerId === "string" && parsed.ownerId.length > 0) {
-                dashboardState.ownerId = parsed.ownerId;
-                dashboardState.messageId = typeof parsed.messageId === "string" ? parsed.messageId : null;
+            const ownerId = typeof parsed?.ownerId === "string" ? parsed.ownerId.trim() : "";
+            if (ownerId.length > 0) {
+                dashboardState.ownerId = ownerId;
+                // A non-snowflake messageId would fail the tracked fetch with a 400,
+                // which the transient-error branch retries forever - drop it instead.
+                dashboardState.messageId =
+                    typeof parsed.messageId === "string" && /^\d+$/.test(parsed.messageId) ? parsed.messageId : null;
                 dashboardStateWritable = true;
                 console.log(`[Dashboard] Ownership id: ${dashboardState.ownerId}`);
                 return;
@@ -578,7 +582,9 @@ async function runDashboardUpdate(channelId: string): Promise<void> {
     if (dashboardState.messageId) {
         let existing: Message | null = null;
         try {
-            existing = await channel.messages.fetch(dashboardState.messageId);
+            // force: bypass the message cache (populated by our own edits), or a
+            // deletion / foreign takeover of the tracked message is never seen.
+            existing = await channel.messages.fetch({ message: dashboardState.messageId, force: true });
         } catch (error) {
             if (error instanceof DiscordAPIError && error.code === RESTJSONErrorCodes.UnknownMessage) {
                 console.log("[Dashboard] Tracked message was deleted - scanning for a replacement.");

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -492,6 +492,7 @@ function persistDashboardState(): void {
     }
 }
 
+/** Forgets the tracked dashboard message so the next update rescans the channel. */
 function clearTrackedMessage(): void {
     dashboardState.messageId = null;
     persistDashboardState();
@@ -551,7 +552,7 @@ async function buildDashboardEmbed(): Promise<EmbedBuilder> {
     return embed;
 }
 
-// Auto-updating status dashboard
+/** Interval entry point: runs one dashboard update, skipping ticks that overlap. */
 async function updateLiveDashboard(): Promise<void> {
     if (!STATUS_DASHBOARD_CHANNEL_ID) {
         return;
@@ -569,6 +570,10 @@ async function updateLiveDashboard(): Promise<void> {
     }
 }
 
+/**
+ * Updates the dashboard: edits the tracked message when it is still ours,
+ * otherwise scans the channel to adopt our dashboard or posts a fresh one.
+ */
 async function runDashboardUpdate(channelId: string): Promise<void> {
     const channel = (await client.channels.fetch(channelId)) as TextChannel;
     if (!channel?.isTextBased()) {


### PR DESCRIPTION
Implements `.claude/plans/features/discord-dashboard-ownership.md`: the status dashboard message is now owned by one deployment instead of "any recent bot message", fixing dashboard ping-pong between servers, wrong-message adoption after restarts, and dead dashboards accumulating after resets.

## Changes

- Persist a per-deployment owner UUID and the dashboard message id to `/data/dashboard-state.json` (atomic tmp+rename; written only when the id is created or the message id changes), stamped into the embed footer as `id:<uuid>`
- Resolution order in `updateLiveDashboard`: edit the tracked message (force-fetched past the discord.js message cache, or deletions/foreign takeovers are never observed); on 10008 Unknown Message or a foreign takeover, clear and rescan; on transient errors keep the id and retry next tick so no duplicate is ever posted
- Scan (limit 50) classifies bot-authored messages as mine/legacy/foreign: legacy (pre-upgrade) dashboards are adopted and stamped in place, foreign dashboards get one warning per owner id and are never touched
- Degraded mode when `/data` is unwritable: unstamped footer, title-based adoption, one loud warning; a later healthy boot re-adopts via the legacy branch and re-stamps
- In-flight guard prevents overlapping interval ticks from double-posting
- Best-effort deletion of our own surplus dashboards beyond the adopted one (skipped in degraded mode, where "mine" is title-based and could match a foreign deployment's dashboard)
- Ship the `discord-bot-data` volume in both compose files; `chown bun:bun /data` in the Dockerfile so a fresh named volume is writable by the non-root user
- Extract pure helpers (`formatFooter`, `parseOwnerId`, `isDashboardEmbed`, `classifyDashboardEmbed`) to `dashboard.ts` with bun tests; harden state loading (trim ownerId, drop non-snowflake messageId)
- Document the ownership guard and the one-bot-application-per-server rule (presence/nickname are per-bot-user globals no stamp can protect)

## Verification

- 14 bun tests pass; `biome check` and `tsc --strict` clean; both compose files validate
- Image built and a fresh named volume at `/data` confirmed writable by the `bun` user
- Not exercised (needs a live Discord deployment): the plan's manual smokes — two bots sharing token+channel, restart re-adoption, delete-and-repost, read-only `/data` degraded boot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboard messages now retain ownership across bot restarts and server resets.
  - Multiple bot deployments can share a channel without overwriting dashboards owned by another deployment.
  - Existing dashboards are automatically recovered, while duplicate dashboards created by the same deployment are cleaned up.

- **Bug Fixes**
  - Prevents unrelated or foreign dashboard messages from being modified.
  - Adds fallback behavior when ownership persistence is unavailable.

- **Documentation**
  - Added guidance on dashboard ownership and recommended bot configuration for multiple servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->