### PR TITLE
docs(backup): list the discord-bot-data volume in the persistence table

### DIFF
--- a/docs/features/backup.md
+++ b/docs/features/backup.md
@@ -64,6 +64,7 @@ Your data lives in Docker volumes and bind mounts that persist across container 
 | Saves | `saves` volume | Save files |
 | Game data | `game-data` volume | Game files |
 | Steam session | `steam-session` volume | Steam tokens |
+| Discord dashboard | `discord-bot-data` volume | Dashboard ownership id ([details](/admins/configuration/discord#status-dashboard)) |
 | Settings | `.local-container/settings/` bind mount | Server configuration (`server-settings.json`) |
 
 ::: info Volume Names


### PR DESCRIPTION
- Adds the volume introduced in #590 to the Docker volume persistence table, linking to the ownership details in the Discord setup docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Discord dashboard data volume to the Docker persistence table.
  * Included a link to its configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->