### PR TITLE
feat(tools): add discli Discord admin CLI wrapper and skill

### DIFF
--- a/.claude/skills/discli/SKILL.md
+++ b/.claude/skills/discli/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: discli
+description: Work with our servers' Discord from the command line using the `discli` CLI — inspect and adjust the server itself (channels, FAQ/onboarding content, webhooks, and other settings). Use when the user wants to review or edit Discord content or configuration, e.g. reading FAQ/onboarding pages to improve them, or checking/tweaking webhooks and channel settings. discli is wrapped in a Docker container under `tools/discli-docker/`; invoke it only through `docker compose exec`.
+argument-hint: [what to review or adjust on Discord]
+tools: Bash, WebFetch
+---
+
+# Using discli
+
+`discli` ([DevRohit06/discli](https://github.com/DevRohit06/discli)) is a Discord CLI we run wrapped in a Docker container, driving our servers' Discord via a bot token.
+
+Primary use is **managing the server itself** — not user interaction or moderation chatter. Typical work:
+
+- Read the **FAQ and onboarding pages** so we can review and improve them together, then apply edits.
+- Inspect and make small adjustments to **server settings** — webhooks, channels, and similar.
+
+Other command families (members, roles, threads, reactions, events, polls) exist and are available when needed, but aren't the focus.
+
+## Command reference
+
+Read the command model before running anything non-trivial — how identifiers resolve (`#channel`, `@user`, raw IDs), the global flags, and each command family:
+
+- https://github.com/DevRohit06/discli/blob/main/docs/guides/cli-usage.mdx
+
+Fetch it with WebFetch (raw form: `https://raw.githubusercontent.com/DevRohit06/discli/main/docs/guides/cli-usage.mdx`) when you need an exact command shape.
+
+## How to invoke — always via Docker
+
+The tool lives in `tools/discli-docker/` (`Dockerfile`, `docker-compose.yml`, `.env.example`). It runs as a long-lived idle container; never start a one-off container or install discli locally.
+
+1. First-time setup: copy `.env.example` to `.env` and fill in the token.
+
+2. Ensure the container is up (start once, it stays running):
+
+   ```bash
+   cd tools/discli-docker && docker compose up -d
+   ```
+
+3. Run every command by exec'ing into the running container:
+
+   ```bash
+   docker compose exec discli discli <command...>
+   ```
+
+   Examples (from `tools/discli-docker/`):
+
+   ```bash
+   docker compose exec discli discli --json message list "#faq" --limit 100
+   docker compose exec discli discli message edit "#faq" <message-id> "updated text"
+   docker compose exec discli discli --json webhook list "#faq"
+   ```
+
+   Confirm exact subcommands and flags against the reference above.
+
+## Conventions
+
+- Pass **`--json`** for anything you need to parse — it emits machine-readable output and meaningful exit codes.
+- discli has its own dedicated bot token, separate from the per-server bots. It comes from `tools/discli-docker/.env` (`DISCORD_BOT_TOKEN`) and is already in the container's env, so exec'd commands inherit it. Never pass a token on the command line.
+- A bot can only edit its **own** messages — not ones another user or bot authored. To "edit" a human-posted page, repost it through the bot.

--- a/tools/discli-docker/.env.example
+++ b/tools/discli-docker/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in the token.
+
+# Dedicated discli bot token (separate from the per-server bots)
+DISCORD_BOT_TOKEN=
+
+# Optional: permission profile (overridden by a --profile flag)
+DISCLI_PROFILE=

--- a/tools/discli-docker/Dockerfile
+++ b/tools/discli-docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir discord-cli-agent

--- a/tools/discli-docker/docker-compose.yml
+++ b/tools/discli-docker/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  discli:
+    build: .
+    container_name: discli
+    env_file: .env
+    volumes:
+      # Persists config.json, permissions.json, audit.log across restarts.
+      - discli-config:/root/.discli
+    # Keep the container idle so we exec commands into it instead of
+    # starting a fresh container per command.
+    command: sleep infinity
+    restart: unless-stopped
+
+volumes:
+  discli-config:


### PR DESCRIPTION
Adds an admin tool for operating our servers' Discord from the command line via the [discli](https://github.com/DevRohit06/discli) CLI, wrapped in Docker, plus a Claude skill documenting its use.

## Changes

- **`tools/discli-docker/`** — Docker wrapper (`Dockerfile` + `docker-compose.yml`) that runs discli as a long-lived idle container; commands run via `docker compose exec`, avoiding a local Python/pip install.
- **`tools/discli-docker/.env.example`** — template for the dedicated discli bot token (`DISCORD_BOT_TOKEN`); real `.env` stays gitignored.
- **`.claude/skills/discli/`** — skill for using discli to inspect and adjust the server's Discord (FAQ/onboarding content, webhooks, channels), with the command-model reference and Docker-only invocation conventions.

## Notes

- discli uses its own dedicated bot application/token, separate from the per-server status bots.
- First-time use: copy `.env.example` to `.env`, add the token, then `docker compose up -d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a containerized command-line tool for inspecting and adjusting Discord server content and configuration.
  * Supports interactive command execution, persistent configuration, structured JSON output, and configurable permission profiles.
  * Added environment configuration for securely supplying the dedicated bot token.

* **Documentation**
  * Added usage guidance, command references, Docker invocation instructions, and operational limitations for Discord content management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->