### PR TITLE
chore(ci): rename deploy target to public-test-preview

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -17,8 +17,8 @@ on:
         required: true
         type: choice
         options:
-          - public-test
-          # - production
+          - public-test-preview
+          # - public-test-latest
       skip_graceful_shutdown:
         description: 'Skip graceful shutdown (emergency deploy)'
         required: false
@@ -50,9 +50,9 @@ jobs:
         run: |
           # Define deployment targets as JSON
           TARGETS='[
-            {"environment": "public-test", "image_tag": "preview", "on_preview": true, "on_release": false}
+            {"environment": "public-test-preview", "image_tag": "preview", "on_preview": true, "on_release": false}
           ]'
-          # {"environment": "production", "image_tag": "latest", "on_preview": false, "on_release": true}
+          # {"environment": "public-test-latest", "image_tag": "latest", "on_preview": false, "on_release": true}
 
           MATRIX=$(echo "$TARGETS" | jq -c '[.[] | select(
             (env.TRIGGER == "workflow_dispatch" and env.SELECTED == .environment) or


### PR DESCRIPTION
Renames the single `public-test` deploy target to `public-test-preview`.

- Matrix target and `workflow_dispatch` environment choice renamed `public-test` → `public-test-preview`.
- Commented-out second target renamed `production`/`latest` → `public-test-latest` to reserve the naming for the latest-image bot later.

**Why:** each game-server environment runs its own Discord bot, and the bot token is an environment-scoped secret (`DEPLOY_DISCORD_BOT_TOKEN`). Naming the environment per image variant lets a future `public-test-latest` deploy resolve its own bot token without colliding on one shared gateway session.

**Already provisioned (no code needed):** the GitHub Environment `public-test-preview` exists with all 11 scoped secrets. The `deploy` job already sets `environment: ${{ matrix.environment }}`, so the scoped token resolves per target.

**Operator note:** deploys now land in `~/srv/public-test-preview` (fresh stack, full Steam setup on first run) and reuse the same Steam account as the old `~/srv/public-test` stack — bring that one down around cutover to avoid a single-login session kick. The old `public-test` GitHub Environment can be deleted once a preview deploy is verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the preview deployment environment naming for improved clarity.
  * Preview deployments continue using the existing preview image and trigger behavior.
  * Adjusted release targeting configuration to better distinguish preview and production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->