### PR TITLE
refactor(api): extract game-thread action queue into GameThreadDispatcher

### DIFF
--- a/.claude/rules/asynclocal-pitfalls.md
+++ b/.claude/rules/asynclocal-pitfalls.md
@@ -21,7 +21,7 @@ _pendingActions.Enqueue(() =>
 ```
 
 **Boundaries that break flow in this codebase:**
-- `ApiService.RunOnGameThreadAsync` / `TestApiServer.ExecuteOnGameThread` → game-loop queue.
+- `GameThreadDispatcher.RunAsync` (behind `ApiService.RunOnGameThreadAsync`) / `TestApiServer.ExecuteOnGameThread` → game-loop queue.
 - SteamKit `CallbackManager.RunCallbacks()` → library-owned thread.
 - HttpListener handlers without `ConfigureAwait(false)` (continuation may resume on a different thread-pool thread; `ThreadLocal<T>` silently loses the value).
 - xUnit v3 `IAsyncLifetime`: captures the EC *before* `InitializeAsync` runs and re-uses it for the test method body. A custom AsyncLocal mutated inside `InitializeAsync` doesn't reach the body. Use `Xunit.TestContext.Current` (xUnit's own ambient) for test-time identity instead of rolling your own.

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -14,6 +14,7 @@ using JunimoServer.Services.CabinManager;
 using JunimoServer.Services.Commands;
 using JunimoServer.Services.GameCreator;
 using JunimoServer.Services.GameManager;
+using JunimoServer.Services.GameThread;
 using JunimoServer.Services.PasswordProtection;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Roles;
@@ -878,41 +879,10 @@ public partial class ApiService : ModService
     private Timer? _wsCleanupTimer;
 
     /// <summary>
-    /// A queued game-thread action whose execution and timeout compete for an atomic claim: the game
-    /// thread claims pending→executing before running, the timeout callback claims pending→timed-out
-    /// before cancelling. Exactly one side wins, so a timed-out request can never mutate the world
-    /// after its caller was told nothing changed, and an in-flight action is never reported as timed
-    /// out (the caller awaits its real result instead). Must be a reference type — the claim state
-    /// has to be shared between the queue and the timeout callback, not copied per dequeue. Same
-    /// claim pattern as the test client's <c>ExecuteOnGameThread</c> (tests/test-client/ModEntry.cs);
-    /// keep the two in sync.
+    /// Game-thread marshaling for mutating handlers (see <see cref="RunOnGameThreadAsync"/>);
+    /// the game-state snapshot is refreshed after every drain that ran an action.
     /// </summary>
-    private sealed class PendingGameAction
-    {
-        // 0 = pending, 1 = timed out (execution must skip), 2 = executing (timeout must not cancel).
-        private int _state;
-
-        public PendingGameAction(Action action, TaskCompletionSource<bool> completion)
-        {
-            Action = action;
-            Completion = completion;
-        }
-
-        public Action Action { get; }
-        public TaskCompletionSource<bool> Completion { get; }
-
-        public bool TryClaimExecution() => Interlocked.CompareExchange(ref _state, 2, 0) == 0;
-
-        public bool TryClaimTimeout() => Interlocked.CompareExchange(ref _state, 1, 0) == 0;
-    }
-
-    /// <summary>
-    /// Queue of actions to execute on the main game thread.
-    /// Used for game state modifications that would cause collection modification errors
-    /// if executed from the async HTTP thread (e.g., removing buildings during draw).
-    /// Each action includes a TaskCompletionSource to signal completion back to the caller.
-    /// </summary>
-    private readonly ConcurrentQueue<PendingGameAction> _pendingGameActions = new();
+    private readonly GameThreadDispatcher _dispatcher;
 
     /// <summary>
     /// Ticks timestamp of the last OnUpdateTicked call, used by /health to detect game thread stalls.
@@ -1169,10 +1139,12 @@ public partial class ApiService : ModService
         SaveImport.SaveImportService saveImportService,
         NpcIntegrity.NpcSpriteIntegrityService npcSpriteIntegrity,
         Auth.FarmhandOwnershipService farmhandOwnership,
+        GameThreadDispatcher dispatcher,
         PasswordProtectionService? passwordProtectionService = null
     )
         : base(helper, monitor)
     {
+        _dispatcher = dispatcher;
         _settings = settings;
         _persistentOptions = persistentOptions;
         _cabinManager = cabinManager;
@@ -1194,6 +1166,10 @@ public partial class ApiService : ModService
 
         Helper.Events.GameLoop.GameLaunched += OnGameLaunched;
         Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
+        // Mutations (DELETE /farmhands, POST /time, etc.) change game state that read-only
+        // endpoints serve from the snapshot. Refresh immediately after a drain so subsequent
+        // reads see the updated state without waiting up to 1 second.
+        _dispatcher.Drained += TakeGameStateSnapshot;
         Helper.Events.Specialized.UnvalidatedUpdateTicking += OnUnvalidatedUpdateTicking;
         Helper.Events.Specialized.UnvalidatedUpdateTicked += OnUnvalidatedUpdateTicked;
         Helper.Events.Display.Rendered += OnRendered;
@@ -1277,41 +1253,6 @@ public partial class ApiService : ModService
 
     private void OnUpdateTicked(object? sender, UpdateTickedEventArgs e)
     {
-        // Process pending game actions on the main thread.
-        // Intentionally in UpdateTicked (not UnvalidatedUpdateTicked). SMAPI
-        // suppresses this during saving, which prevents mutating API callbacks
-        // (POST /time, /newgame, DELETE /farmhands) from corrupting save data.
-        // Read-only endpoints use the periodic snapshot instead (see TakeGameStateSnapshot).
-        var actionsProcessed = false;
-        while (_pendingGameActions.TryDequeue(out var item))
-        {
-            if (!item.TryClaimExecution())
-            {
-                // The caller's RunOnGameThreadAsync timed out and returned an error; the atomic claim
-                // guarantees the timeout can no longer land once execution starts (and vice versa).
-                continue;
-            }
-            actionsProcessed = true;
-            try
-            {
-                item.Action();
-                item.Completion.TrySetResult(true);
-            }
-            catch (Exception ex)
-            {
-                Monitor.Log($"Error executing pending game action: {ex}", LogLevel.Error);
-                item.Completion.TrySetException(ex);
-            }
-        }
-
-        // Mutations (DELETE /farmhands, POST /time, etc.) change game state that
-        // read-only endpoints serve from the snapshot. Refresh immediately so
-        // subsequent reads see the updated state without waiting up to 1 second.
-        if (actionsProcessed)
-        {
-            TakeGameStateSnapshot();
-        }
-
         // Drain completed wait times and update rolling average (zero-allocation ring buffer)
         while (_completedWaitTimes.TryDequeue(out var waitMs))
         {
@@ -1435,7 +1376,7 @@ public partial class ApiService : ModService
     /// <item><see cref="OnUnvalidatedUpdateTicked"/> (periodic, 1/sec) -- fires even during
     /// game thread stalls but skipped during day transitions to avoid concurrent access
     /// with the save task's farmhand/cabin mutations.</item>
-    /// <item><see cref="OnUpdateTicked"/> (after mutations) -- ensures changes from
+    /// <item><see cref="GameThreadDispatcher.Drained"/> (after mutations) -- ensures changes from
     /// mutating endpoints are immediately visible to subsequent reads.</item>
     /// </list>
     /// HTTP threads read the published snapshot without blocking.
@@ -1956,50 +1897,19 @@ public partial class ApiService : ModService
 
     /// <summary>
     /// Queues an action to run on the main game thread and waits for it to complete.
-    /// Use this for game state modifications from async HTTP handlers.
-    /// Captures the ambient ModRequestContext.RequestId at queue time and
-    /// re-binds it on the game-thread side so structured events emitted
-    /// inside <paramref name="action"/> carry the triggering request id.
-    /// AsyncLocal does not flow across the external pump boundary.
+    /// Use this for game state modifications from async HTTP handlers. Throws
+    /// <see cref="TaskCanceledException"/> if the action is still queued after
+    /// <paramref name="timeoutMs"/>. The measured wait feeds the /stats rolling average;
+    /// a timed-out or faulted call is not recorded (not representative of normal wait times).
     /// </summary>
     private async Task RunOnGameThreadAsync(Action action, int timeoutMs = 5000)
     {
         var sw = Stopwatch.StartNew();
-        var tcs = new TaskCompletionSource<bool>(
-            TaskCreationOptions.RunContinuationsAsynchronously
-        );
-        var capturedRequestId = Diagnostics.ModRequestContext.RequestId;
-        Action wrapped = () =>
-        {
-            using var _correlationScope = Diagnostics.ModRequestContext.Bind(capturedRequestId);
-            action();
-        };
-        var item = new PendingGameAction(wrapped, tcs);
-        _pendingGameActions.Enqueue(item);
-
-        using var cts = new CancellationTokenSource(timeoutMs);
-        using var registration = cts.Token.Register(() =>
-        {
-            // Claim pending→timed-out before cancelling. If the game thread already claimed
-            // execution, don't cancel — the caller awaits the action's real result instead of
-            // being told a mutation that is running right now didn't apply.
-            if (item.TryClaimTimeout())
-            {
-                tcs.TrySetCanceled();
-            }
-        });
-
-        try
-        {
-            await tcs.Task.ConfigureAwait(false);
-            sw.Stop();
-            _completedWaitTimes.Enqueue(sw.Elapsed.TotalMilliseconds);
-        }
-        catch (TaskCanceledException)
-        {
-            // Timeout: don't record (not representative of normal wait times)
-            throw;
-        }
+        await _dispatcher
+            .RunAsync(action, TimeSpan.FromMilliseconds(timeoutMs))
+            .ConfigureAwait(false);
+        sw.Stop();
+        _completedWaitTimes.Enqueue(sw.Elapsed.TotalMilliseconds);
     }
 
     private void OnGameLaunched(object? sender, GameLaunchedEventArgs e)
@@ -3572,7 +3482,7 @@ public partial class ApiService : ModService
                     (DateTime.UtcNow - new DateTime(tickTicks, DateTimeKind.Utc)).TotalMilliseconds
                 : null;
 
-        var pendingActions = _pendingGameActions.Count;
+        var pendingActions = _dispatcher.PendingCount;
 
         bool? gameAvailable = null;
         try
@@ -4235,7 +4145,7 @@ public partial class ApiService : ModService
             GcGen0 = GC.CollectionCount(0),
             GcGen1 = GC.CollectionCount(1),
             GcGen2 = GC.CollectionCount(2),
-            PendingActions = _pendingGameActions.Count,
+            PendingActions = _dispatcher.PendingCount,
             GameThreadWaitMs = Math.Round(Volatile.Read(ref _avgGameThreadWaitMs), 2),
             StartedAtUtc = startedAt?.ToString("o"),
             UptimeSeconds = startedAt is { } t ? (long)(DateTime.UtcNow - t).TotalSeconds : null,

--- a/mod/JunimoServer/Services/GameThread/GameThreadDispatcher.cs
+++ b/mod/JunimoServer/Services/GameThread/GameThreadDispatcher.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using JunimoServer.Services.Diagnostics;
+using StardewModdingAPI;
+using StardewModdingAPI.Events;
+
+namespace JunimoServer.Services.GameThread;
+
+/// <summary>
+/// Marshals discrete actions from background threads (HTTP handlers, scheduled jobs) onto the
+/// game thread and completes a <see cref="Task"/> with the action's outcome. Owns its own
+/// <c>UpdateTicked</c> pump so it drains regardless of which consumers are enabled
+/// (<c>ApiService.Entry</c> returns before subscribing anything when <c>API_ENABLED=false</c>).
+/// Draining happens in <c>UpdateTicked</c>, not <c>UnvalidatedUpdateTicked</c>: SMAPI suppresses
+/// it while a save is in progress, which keeps mutations out of save data. Read-only API
+/// endpoints serve from a periodic snapshot instead of queuing here.
+/// </summary>
+public class GameThreadDispatcher : ModService
+{
+    /// <summary>
+    /// A queued game-thread action whose execution and cancellation compete for an atomic claim:
+    /// the game thread claims pending→executing before running, the cancellation callback claims
+    /// pending→canceled before faulting. Exactly one side wins, so a timed-out or canceled
+    /// request can never mutate the world after its caller was told nothing changed, and an
+    /// in-flight action is never reported as canceled (the caller awaits its real result
+    /// instead). Must be a reference type — the claim state has to be shared between the queue
+    /// and the cancellation callback, not copied per dequeue. Same claim pattern as the test
+    /// client's <c>ExecuteOnGameThread</c> (tests/test-client/ModEntry.cs); keep the two in sync.
+    /// </summary>
+    private sealed class PendingGameAction
+    {
+        // 0 = pending, 1 = canceled (execution must skip), 2 = executing (cancel must not land).
+        private int _state;
+
+        public PendingGameAction(Action action, TaskCompletionSource<bool> completion)
+        {
+            Action = action;
+            Completion = completion;
+        }
+
+        public Action Action { get; }
+        public TaskCompletionSource<bool> Completion { get; }
+
+        public bool TryClaimExecution() => Interlocked.CompareExchange(ref _state, 2, 0) == 0;
+
+        public bool TryClaimCancel() => Interlocked.CompareExchange(ref _state, 1, 0) == 0;
+    }
+
+    private readonly ConcurrentQueue<PendingGameAction> _pending = new();
+
+    /// <summary>Number of actions queued and not yet drained. Read from any thread.</summary>
+    public int PendingCount => _pending.Count;
+
+    /// <summary>
+    /// Raised on the game thread after a drain pass that executed at least one action, so
+    /// consumers can refresh state derived from the mutated world without waiting a tick.
+    /// </summary>
+    public event Action? Drained;
+
+    public GameThreadDispatcher(IModHelper helper, IMonitor monitor)
+        : base(helper, monitor) { }
+
+    public override void Entry()
+    {
+        Helper.Events.GameLoop.UpdateTicked += OnUpdateTicked;
+    }
+
+    /// <summary>
+    /// Queues <paramref name="action"/> for the game thread and waits for it to complete. Throws
+    /// <see cref="TaskCanceledException"/> if the action is still queued when
+    /// <paramref name="timeout"/> elapses; an action the game thread has already started runs to
+    /// completion and reports its real result. Request-style calls use this overload.
+    /// </summary>
+    public async Task RunAsync(Action action, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        await RunAsync(action, cts.Token).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Queues <paramref name="action"/> for the game thread and waits, with no timeout, for it to
+    /// complete. Cancelling <paramref name="ct"/> while the action is still queued skips it and
+    /// throws <see cref="TaskCanceledException"/> carrying that token; an action the game thread
+    /// has already started runs to completion and reports its real result. Background work that
+    /// must wait out a multi-second save uses this overload.
+    /// Captures the ambient <see cref="ModRequestContext.RequestId"/> at queue time and re-binds
+    /// it on the game-thread side so structured events emitted inside the action carry the
+    /// triggering request id — <c>AsyncLocal</c> does not flow across the external pump boundary.
+    /// </summary>
+    public async Task RunAsync(Action action, CancellationToken ct)
+    {
+        var tcs = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        var capturedRequestId = ModRequestContext.RequestId;
+        Action wrapped = () =>
+        {
+            using var _correlationScope = ModRequestContext.Bind(capturedRequestId);
+            action();
+        };
+        var item = new PendingGameAction(wrapped, tcs);
+        _pending.Enqueue(item);
+
+        using var registration = ct.Register(() =>
+        {
+            // Claim pending→canceled before faulting. If the game thread already claimed
+            // execution, don't cancel — the caller awaits the action's real result instead of
+            // being told a mutation that is running right now didn't apply.
+            if (item.TryClaimCancel())
+            {
+                tcs.TrySetCanceled(ct);
+            }
+        });
+
+        await tcs.Task.ConfigureAwait(false);
+    }
+
+    private void OnUpdateTicked(object? sender, UpdateTickedEventArgs e)
+    {
+        var actionsProcessed = false;
+        while (_pending.TryDequeue(out var item))
+        {
+            if (!item.TryClaimExecution())
+            {
+                // The caller's wait timed out or was canceled and it already observed that; the
+                // atomic claim guarantees the cancel can no longer land once execution starts
+                // (and vice versa).
+                continue;
+            }
+            actionsProcessed = true;
+            try
+            {
+                item.Action();
+                item.Completion.TrySetResult(true);
+            }
+            catch (Exception ex)
+            {
+                // Warn, not Error: the exception is faulted to the caller, which decides how to
+                // report it, and Error lines cancel E2E runs (debugging.md).
+                Monitor.Log($"Error executing pending game action: {ex}", LogLevel.Warn);
+                item.Completion.TrySetException(ex);
+            }
+        }
+
+        if (actionsProcessed)
+        {
+            Drained?.Invoke();
+        }
+    }
+}

--- a/mod/JunimoServer/Services/GameThread/GameThreadDispatcher.cs
+++ b/mod/JunimoServer/Services/GameThread/GameThreadDispatcher.cs
@@ -101,8 +101,9 @@ public class GameThreadDispatcher : ModService
             action();
         };
         var item = new PendingGameAction(wrapped, tcs);
-        _pending.Enqueue(item);
 
+        // Register before enqueueing so an already-canceled token claims the item before the
+        // drain can see it; the action then never runs.
         using var registration = ct.Register(() =>
         {
             // Claim pending→canceled before faulting. If the game thread already claimed
@@ -113,6 +114,7 @@ public class GameThreadDispatcher : ModService
                 tcs.TrySetCanceled(ct);
             }
         });
+        _pending.Enqueue(item);
 
         await tcs.Task.ConfigureAwait(false);
     }


### PR DESCRIPTION
### 🔗 Linked issue

Step 1 of the scheduler/world-reset work in `.claude/plans/features/server-cron-scheduler.md` (Decision 6, implementation order step 1). No scheduler code in this PR.

### 📚 Description

- Extract `ApiService`'s game-thread action queue into `Services/GameThread/GameThreadDispatcher : ModService`: the `ConcurrentQueue`, the tri-state atomic claim (`PendingGameAction`), the `TaskCompletionSource` with `RunContinuationsAsynchronously`, the request-id capture + rebind, and the `UpdateTicked` drain.
- The dispatcher owns its own `UpdateTicked` subscription, so it pumps even when `API_ENABLED=false` (`apiservice-entry-is-conditional.md`).
- Two overloads: `RunAsync(Action, TimeSpan)` for request-style calls and `RunAsync(Action, CancellationToken)` with no timeout for background work. Both resolve through the same claim; a cancelled or timed-out item still queued is skipped, an item already claimed runs to completion and reports its real result.
- `ApiService.RunOnGameThreadAsync` stays as a thin private wrapper (time the call, await the dispatcher's timeout overload, record the wait), so zero call sites change and the `/stats` wait-time ring keeps its measuring point.
- The post-drain `TakeGameStateSnapshot()` refresh moves to a subscription on the dispatcher's `Drained` event. `/health` and `/stats` read `PendingCount` from the dispatcher.
- One deliberate delta: a throwing action is logged at `Warn`, not `Error` (`Error` is E2E poison, `debugging.md`); it is still faulted to the caller.
- `asynclocal-pitfalls.md` now names the dispatcher as the game-loop boundary.

Decision 6 checklist walked statically against the new code: timeout while queued (cancelled, skipped by drain); timeout after execution started (real result); token cancel while queued; token cancel after execution started; exception from the action (faulted, `Warn`); request-id rebinding inside the action; continuations off the game thread (`RunContinuationsAsynchronously` + `ConfigureAwait(false)`); no drain during a save (`UpdateTicked`); `API_ENABLED=false` (own subscription in `Entry`); service start ordering (`ApiService` receives the constructed dispatcher by DI and subscribes to `Drained` in `Entry`).

E2E gate: run via the `E2E Tests` workflow dispatched against this PR (local build was blocked on missing Steam credentials).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when server operations must run on the game thread.
  - Added safer handling for canceled or timed-out operations, reducing the chance of stalled requests.
  - Preserved request context while queued operations are processed.
  - Improved status and statistics reporting for pending game-thread work.

- **Documentation**
  - Clarified which game-loop entry points can affect asynchronous execution context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->