### PR TITLE
feat(server): auto-provision fresh volumes and report startup phases to the Discord bot

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -243,10 +243,7 @@ jobs:
             docker compose down --timeout 30 || true
             echo "::endgroup::"
 
-            echo "::group::Setup steam-auth and download game"
-            docker compose run --rm steam-auth setup
-            echo "::endgroup::"
-
+            # No steam-auth setup step: serve downloads the game itself on a fresh volume.
             echo "::group::Start containers"
             docker compose up -d
             echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ JunimoServer gives you everything you need to host Stardew Valley:
 
 2. **First-Time Setup**:
 
-    Run the interactive setup to authenticate with Steam and download the game files:
+    Run the interactive setup to authenticate with Steam:
 
     ```sh
     docker compose run --rm -it steam-auth setup
     ```
 
-    This will prompt you for Steam Guard authentication if enabled on your account.
+    This will prompt you for Steam Guard authentication if enabled on your account, and downloads the game files. Once Steam can log in without prompts, a fresh server downloads the game files itself on first start.
 
 3. **Start the Server**:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -160,7 +160,9 @@ ENV APP_NAME="Stardew Dedicated Server" \
     # SMAPI
     SMAPI_USE_CURRENT_SHELL=true \
     SMAPI_VERSION=${SMAPI_VERSION} \
-    SMAPI_MODS_PATH=/data/Mods
+    SMAPI_MODS_PATH=/data/Mods \
+    # Pid file of startapp.sh's phase responder; read by the mod (ApiPortHandoff) and the HEALTHCHECK
+    API_HANDOFF_PID_FILE=/tmp/phase-responder.pid
 
 # add-pkg (base image helper), not raw apt-get: it pre-creates /var/log's symlink target
 # (/config — a runtime volume, absent at build time, so tcpdump's postinst fails without it)
@@ -286,8 +288,10 @@ VOLUME [ "/data/game", "/config/xdg/config/StardewValley" ]
 # Expose HTTP API port for external tools and automated testing
 EXPOSE 8080
 
+# Unhealthy without connecting while the phase responder owns the port: it serves one connection at
+# a time, and a 2s probe would keep stealing it from real status clients.
 HEALTHCHECK --interval=2s --timeout=2s --start-period=120s --retries=15 \
-    CMD curl -fsS --max-time 2 "http://127.0.0.1:${API_PORT:-8080}/health" > /dev/null \
+    CMD { [ ! -e "${API_HANDOFF_PID_FILE}" ] && curl -fsS --max-time 2 "http://127.0.0.1:${API_PORT:-8080}/health" > /dev/null; } \
         || [ "${API_ENABLED:-true}" = "false" ] || exit 1
 
 WORKDIR /data

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -111,20 +111,36 @@ init_display_settings() {
     xset s noblank 2>/dev/null || true
 }
 
-# 503 for everything but /status, so /health keeps meaning "the mod's API is up".
+# Mirrors the mod's API on the two points a client can observe: /status needs the API key when
+# one is set, and everything else gets 503 so /health keeps meaning "the mod's API is up".
 phase_response() {
-    local request_line line path body status
+    local request_line line path name value scheme token="" header_count=0 body status
     IFS= read -r request_line || return 0
     path="${request_line#* }"
     path="${path%% *}"
     path="${path%%\?*}"
-    while IFS= read -r line; do
+    # The client is connected from here on and holds the only listener, so a slow or endless
+    # header stream is cut off instead of waited for.
+    while [ "${header_count}" -lt 64 ] && IFS= read -r -t 5 line; do
+        header_count=$((header_count + 1))
         line="${line%$'\r'}"
         [ -n "${line}" ] || break
+        name="${line%%:*}"
+        if [ "${name,,}" = "authorization" ]; then
+            value="${line#*:}"
+            value="${value#"${value%%[! ]*}"}"
+            scheme="${value:0:7}"
+            if [ "${scheme,,}" = "bearer " ]; then
+                token="${value:7}"
+            fi
+        fi
     done
 
     body="{\"isOnline\":false,\"phase\":\"$(cat "${PHASE_FILE}" 2>/dev/null || echo starting)\"}"
-    if [ "${path}" = "/status" ]; then
+    if [ -n "${API_KEY:-}" ] && [ "${token}" != "${API_KEY}" ]; then
+        status="401 Unauthorized"
+        body='{"error":"Unauthorized. Provide a valid Authorization header: Bearer <api-key>"}'
+    elif [ "${path}" = "/status" ]; then
         status="200 OK"
     else
         status="503 Service Unavailable"

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -10,6 +10,14 @@ GAME_DEST_DIR="/data/game"
 GAME_EXECUTABLE="${GAME_DEST_DIR}/StardewValley"
 SMAPI_EXECUTABLE="${GAME_DEST_DIR}/StardewModdingAPI"
 STEAM_SDK_DIR="/root/.steam/sdk64"
+# Completion marker written by steam-auth only after the full depot download succeeds. Gate on it
+# rather than the StardewValley executable: the downloader pre-allocates every file at full size
+# up front, so the executable exists (zero-filled) mid-download — launching on it would run a
+# half-downloaded game. StardewValleyAppId is 413150 (see tools/steam-service/Program.cs).
+GAME_DOWNLOAD_MARKER="${GAME_DEST_DIR}/.download-manifest-413150"
+API_PORT="${API_PORT:-8080}"
+# Lifecycle phase served on the API port until the mod takes over: "downloading" | "starting".
+PHASE_FILE="/tmp/startup-phase"
 
 # Validate required environment variables
 validate_environment() {
@@ -103,13 +111,66 @@ init_display_settings() {
     xset s noblank 2>/dev/null || true
 }
 
+# 503 for everything but /status, so /health keeps meaning "the mod's API is up".
+phase_response() {
+    local request_line line path body status
+    IFS= read -r request_line || return 0
+    path="${request_line#* }"
+    path="${path%% *}"
+    path="${path%%\?*}"
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        [ -n "${line}" ] || break
+    done
+
+    body="{\"isOnline\":false,\"phase\":\"$(cat "${PHASE_FILE}" 2>/dev/null || echo starting)\"}"
+    if [ "${path}" = "/status" ]; then
+        status="200 OK"
+    else
+        status="503 Service Unavailable"
+    fi
+    printf 'HTTP/1.1 %s\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s' \
+        "${status}" "${#body}" "${body}"
+}
+
+# Keeps /status answering while the game downloads and boots. bash + nc because the image has
+# nothing else. The mod stops it the moment it binds the port itself (ApiPortHandoff).
+start_phase_responder() {
+    if [ "${API_ENABLED:-true}" != "true" ]; then
+        return
+    fi
+
+    if [ -e "${GAME_DOWNLOAD_MARKER}" ]; then
+        echo "starting" > "${PHASE_FILE}"
+    else
+        echo "downloading" > "${PHASE_FILE}"
+    fi
+
+    local in_fifo="/tmp/phase-responder.in" out_fifo="/tmp/phase-responder.out"
+    rm -f "${in_fifo}" "${out_fifo}"
+    mkfifo "${in_fifo}" "${out_fifo}"
+
+    (
+        # The mod TERMs this loop and then asserts the port is free, so the trap has to take nc
+        # down too. Both ends run in the background: bash defers traps during a foreground
+        # command, but not during wait.
+        trap 'pkill -TERM -P $BASHPID || true; exit 0' TERM
+        while true; do
+            # -N makes nc exit when the client closes (Connection: close); -w 5 covers a client that
+            # never does. Each FIFO open blocks until the other end opens, so the two commands open
+            # them in opposite order to avoid a deadlock.
+            nc -l -N -w 5 "${API_PORT}" > "${in_fifo}" < "${out_fifo}" &
+            phase_response < "${in_fifo}" > "${out_fifo}" &
+            wait
+        done
+    ) &
+    # The mod kills this pid before binding; the healthcheck waits for the file to go.
+    echo "$!" > "${API_HANDOFF_PID_FILE}"
+    echo "Phase responder serving /status on port ${API_PORT} ($(cat "${PHASE_FILE}"))"
+}
+
 init_stardew() {
     local STEAM_AUTH_GAME_DIR="/data/game"
-    # Completion marker written by steam-auth only after the full depot download succeeds. Gate on it
-    # rather than the StardewValley executable: the downloader pre-allocates every file at full size
-    # up front, so the executable exists (zero-filled) mid-download — launching on it would run a
-    # half-downloaded game. StardewValleyAppId is 413150 (see tools/steam-service/Program.cs).
-    local GAME_DOWNLOAD_MARKER="${STEAM_AUTH_GAME_DIR}/.download-manifest-413150"
 
     # Installation check
     if [ -e "${GAME_DOWNLOAD_MARKER}" ]; then
@@ -126,25 +187,15 @@ init_stardew() {
         echo "Waiting for steam-auth to re-verify them (it only writes the marker once the depot is complete)."
     fi
 
-    # The early return above already handled the marker-present case, so the download is still in
-    # flight here. Warn, then poll until it completes (the loop's own check skips safely if the
-    # marker races in before the first iteration).
-    echo ""
-    echo -e "\e[33m╔═══════════════════════════════════════════════════════════════════════╗\e[0m"
-    echo -e "\e[33m║  Game files not found! Please run setup first:                        ║\e[0m"
-    echo -e "\e[33m║                                                                       ║\e[0m"
-    echo -e "\e[33m║  make setup                                                           ║\e[0m"
-    echo -e "\e[33m╚═══════════════════════════════════════════════════════════════════════╝\e[0m"
-    echo ""
-    echo "Waiting for game files to appear..."
+    echo "Waiting for steam-auth to finish downloading the game files (see: docker compose logs -f steam-auth)..."
 
-    # Poll until the download completes (marker appears)
     while [ ! -e "${GAME_DOWNLOAD_MARKER}" ]; do
         sleep 5
         echo "Still waiting for game files at ${STEAM_AUTH_GAME_DIR}..."
     done
 
     echo "Game files detected!"
+    echo "starting" > "${PHASE_FILE}"
 
     # Symlink the game directory to expected location
     if [ ! -e "${GAME_DEST_DIR}" ]; then
@@ -251,6 +302,7 @@ init_steam_sdk() {
 echo "Initializing SMAPI..."
 
 # Prepare
+start_phase_responder
 init_time_sync
 init_xauthority
 init_display_settings

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -115,14 +115,17 @@ init_display_settings() {
 # one is set, and everything else gets 503 so /health keeps meaning "the mod's API is up".
 phase_response() {
     local request_line line path name value scheme token="" deadline body status
-    IFS= read -r -n 8192 request_line || return 0
+    # Lines over 8 KiB are dropped (connection closed), not parsed as several records.
+    IFS= read -r -n 8193 request_line || return 0
+    [ "${#request_line}" -le 8192 ] || return 0
     path="${request_line#* }"
     path="${path%% *}"
     path="${path%%\?*}"
     # The client is connected from here on and holds the only listener, so the rest of the
-    # request gets a 5s deadline and 8 KiB lines instead of patience.
+    # request gets a 5s deadline instead of patience.
     deadline=$((SECONDS + 5))
-    while [ $((deadline - SECONDS)) -gt 0 ] && IFS= read -r -t $((deadline - SECONDS)) -n 8192 line; do
+    while [ $((deadline - SECONDS)) -gt 0 ] && IFS= read -r -t $((deadline - SECONDS)) -n 8193 line; do
+        [ "${#line}" -le 8192 ] || return 0
         line="${line%$'\r'}"
         [ -n "${line}" ] || break
         name="${line%%:*}"

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -114,15 +114,15 @@ init_display_settings() {
 # Mirrors the mod's API on the two points a client can observe: /status needs the API key when
 # one is set, and everything else gets 503 so /health keeps meaning "the mod's API is up".
 phase_response() {
-    local request_line line path name value scheme token="" header_count=0 body status
-    IFS= read -r request_line || return 0
+    local request_line line path name value scheme token="" deadline body status
+    IFS= read -r -n 8192 request_line || return 0
     path="${request_line#* }"
     path="${path%% *}"
     path="${path%%\?*}"
-    # The client is connected from here on and holds the only listener, so a slow or endless
-    # header stream is cut off instead of waited for.
-    while [ "${header_count}" -lt 64 ] && IFS= read -r -t 5 line; do
-        header_count=$((header_count + 1))
+    # The client is connected from here on and holds the only listener, so the rest of the
+    # request gets a 5s deadline and 8 KiB lines instead of patience.
+    deadline=$((SECONDS + 5))
+    while [ $((deadline - SECONDS)) -gt 0 ] && IFS= read -r -t $((deadline - SECONDS)) -n 8192 line; do
         line="${line%$'\r'}"
         [ -n "${line}" ] || break
         name="${line%%:*}"

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -110,10 +110,11 @@ The ownership id protects only the dashboard message. Presence is global to the 
 2. Check `DISCORD_CHAT_CHANNEL_ID` is correct
 3. Ensure the bot can read and send in that channel
 
-### Bot Shows "Server Offline" But Server Is Running
+### Bot Shows "Offline" But Server Is Running
 
 1. If `API_KEY` is set on the server, the bot needs the same key
 2. Check for authentication errors: `docker compose logs discord-bot`
+3. A server that is still downloading or booting shows as "Starting", not "Offline" — "Offline" means the bot cannot reach the server's API port at all
 
 ### Wrong Bot Nickname
 

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -114,7 +114,7 @@ The ownership id protects only the dashboard message. Presence is global to the 
 
 1. If `API_KEY` is set on the server, the bot needs the same key
 2. Check for authentication errors: `docker compose logs discord-bot`
-3. A server that is still downloading or booting shows as "Starting", not "Offline" — "Offline" means the bot cannot reach the server's API port at all
+3. A server that is still downloading or booting shows as "Starting", not "Offline" — "Offline" means the bot got no valid `/status` response, either because the port is unreachable or because the request was rejected
 
 ### Wrong Bot Nickname
 

--- a/docs/admins/quick-start/installation.md
+++ b/docs/admins/quick-start/installation.md
@@ -41,7 +41,7 @@ Authenticate with Steam:
 docker compose run --rm -it steam-auth setup
 ```
 
-Follow the prompts for Steam Guard (email code, mobile app, or QR code). Setup also downloads the game files right away. If you skip it and Steam can log in without prompts (a saved session or `STEAM_REFRESH_TOKEN`), the server downloads them itself on first start and reports "starting" until they are in place.
+Follow the prompts for Steam Guard (email code, mobile app, or QR code). Setup also downloads the game files right away. If you skip it and Steam can log in without prompts (a saved session or `STEAM_REFRESH_TOKEN`), the server downloads them itself on first start and reports a startup phase (downloading, then starting) until the game is up.
 
 ## 5. Start the Server
 

--- a/docs/admins/quick-start/installation.md
+++ b/docs/admins/quick-start/installation.md
@@ -35,13 +35,13 @@ docker compose pull
 
 ## 4. First-Time Setup
 
-Authenticate with Steam and download game files:
+Authenticate with Steam:
 
 ```sh
 docker compose run --rm -it steam-auth setup
 ```
 
-Follow the prompts for Steam Guard (email code, mobile app, or QR code).
+Follow the prompts for Steam Guard (email code, mobile app, or QR code). Setup also downloads the game files right away. If you skip it and Steam can log in without prompts (a saved session or `STEAM_REFRESH_TOKEN`), the server downloads them itself on first start and reports "starting" until they are in place.
 
 ## 5. Start the Server
 

--- a/docs/features/discord.md
+++ b/docs/features/discord.md
@@ -11,9 +11,13 @@ The bot's Discord presence shows real-time server information:
 | Server State | Bot Status | Status Text |
 |--------------|------------|-------------|
 | Online | 🟢 Online | `2/8 players \| S-ABC123` |
-| Offline | 🟡 Idle | `Server Offline` |
+| Busy (saving, day change, festival, wedding) | 🟢 Online | `🟡 Busy — Saving, changing day, or running an event.` |
+| Starting: downloading game files (first run) | 🟡 Idle | `🟠 Starting — Downloading game files.` |
+| Starting: launching the game | 🟡 Idle | `🟠 Starting — Launching the game.` |
+| Starting: loading the save | 🟡 Idle | `🟡 Starting — Loading the save.` |
+| Offline (container down or API unreachable) | 🔴 Do Not Disturb | `🔴 Offline — The server is offline.` |
 
-The status displays current player count, max players, and the invite code. You can copy the invite code directly from the bot's status.
+While online, the status displays current player count, max players, and the invite code. You can copy the invite code directly from the bot's status. The startup states come from the game container itself: it answers `/status` with a startup phase until the mod's API takes over, so a first-run download is never mistaken for an outage.
 
 ### Status Dashboard
 

--- a/mod/JunimoServer/Env.cs
+++ b/mod/JunimoServer/Env.cs
@@ -71,6 +71,14 @@ internal class Env
     public static readonly int ApiPort = ParseInt("API_PORT", 8080);
 
     /// <summary>
+    /// Pid file of the startup script's phase responder (see ApiPortHandoff). Set by the server
+    /// image, unset elsewhere.
+    /// </summary>
+    public static readonly string? ApiHandoffPidFile = Environment.GetEnvironmentVariable(
+        "API_HANDOFF_PID_FILE"
+    );
+
+    /// <summary>
     /// Override verbose logging setting from environment.
     /// Returns null if not set (uses config file value).
     /// Set to "true" or "false" to override.

--- a/mod/JunimoServer/Services/Api/ApiPortHandoff.cs
+++ b/mod/JunimoServer/Services/Api/ApiPortHandoff.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using StardewModdingAPI;
+
+namespace JunimoServer.Services.Api;
+
+/// <summary>
+/// Takes the API port over from the startup script's phase responder (docker/rootfs/startapp.sh),
+/// which answers /status until the mod binds. Stopping it right before the bind keeps the port
+/// answered at every moment. Only a live LISTEN socket can block the bind (HttpListener sets
+/// SO_REUSEADDR, so the responder's TIME_WAIT entries never do), so that is what is asserted after
+/// the stop, once, with no bind retry.
+/// </summary>
+internal static class ApiPortHandoff
+{
+    private const int Sigterm = 15;
+    private const int Esrch = 3;
+    private const string ProcNetListenState = "0A";
+    private const int ProcNetLocalAddressColumn = 1;
+    private const int ProcNetStateColumn = 3;
+    private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(5);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int kill(int pid, int sig);
+
+    /// <summary>
+    /// A null or missing <paramref name="pidFile"/> means no responder is running (API disabled,
+    /// or the mod runs outside the container).
+    /// </summary>
+    public static void TakeOver(string? pidFile, int port, IMonitor monitor)
+    {
+        if (string.IsNullOrEmpty(pidFile) || !File.Exists(pidFile))
+        {
+            return;
+        }
+
+        if (!int.TryParse(File.ReadAllText(pidFile).Trim(), out var pid))
+        {
+            throw new InvalidOperationException(
+                $"Phase responder pid file {pidFile} does not contain a pid; refusing to bind port {port}"
+            );
+        }
+
+        // Never SIGKILL: the loop's TERM trap is what stops its nc child; KILL would orphan it
+        // with the port still bound.
+        if (kill(pid, Sigterm) != 0)
+        {
+            var errno = Marshal.GetLastWin32Error();
+            if (errno != Esrch)
+            {
+                throw new InvalidOperationException(
+                    $"Could not signal the phase responder (pid {pid}, errno {errno}); refusing to bind port {port}"
+                );
+            }
+        }
+
+        var sw = Stopwatch.StartNew();
+        WaitUntil(() => !IsProcessAlive(pid), sw);
+        WaitUntil(() => !IsPortListening(port), sw);
+
+        if (IsPortListening(port))
+        {
+            throw new InvalidOperationException(
+                $"Port {port} still has a LISTEN socket {sw.ElapsedMilliseconds}ms after stopping the phase responder (pid {pid}); refusing to bind"
+            );
+        }
+
+        // The container healthcheck starts probing /health once this file is gone.
+        File.Delete(pidFile);
+        monitor.Log(
+            $"Took over API port {port} from the phase responder in {sw.ElapsedMilliseconds}ms",
+            LogLevel.Info
+        );
+    }
+
+    private static void WaitUntil(Func<bool> condition, Stopwatch sw)
+    {
+        while (!condition() && sw.Elapsed < TeardownTimeout)
+        {
+            Thread.Sleep(20);
+        }
+    }
+
+    private static bool IsProcessAlive(int pid)
+    {
+        string stat;
+        try
+        {
+            stat = File.ReadAllText($"/proc/{pid}/stat");
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        // The command name before the state may contain spaces, hence the scan from its ')'.
+        var stateIndex = stat.LastIndexOf(')') + 2;
+        var isZombie = stateIndex < stat.Length && stat[stateIndex] == 'Z';
+        return !isZombie;
+    }
+
+    private static bool IsPortListening(int port)
+    {
+        var portSuffix = ":" + port.ToString("X4");
+        foreach (var table in new[] { "/proc/net/tcp", "/proc/net/tcp6" })
+        {
+            if (!File.Exists(table))
+            {
+                continue;
+            }
+
+            foreach (var line in File.ReadLines(table))
+            {
+                var fields = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (
+                    fields.Length > ProcNetStateColumn
+                    && fields[ProcNetStateColumn] == ProcNetListenState
+                    && fields[ProcNetLocalAddressColumn]
+                        .EndsWith(portSuffix, StringComparison.Ordinal)
+                )
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -1996,7 +1996,9 @@ public partial class ApiService : ModService
             );
             _openApiSpec = document.ToJson();
 
-            // Create and configure listener
+            // Take the port from the startup script's phase responder right before binding, so
+            // it is never unanswered in between.
+            ApiPortHandoff.TakeOver(Env.ApiHandoffPidFile, Env.ApiPort, Monitor);
             _listener = new HttpListener();
             _listener.Prefixes.Add($"http://+:{Env.ApiPort}/");
             _listener.Start();

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -3,7 +3,6 @@ import { dirname } from "node:path";
 import {
     ActivityType,
     Client,
-    Colors,
     DiscordAPIError,
     EmbedBuilder,
     Events,
@@ -20,6 +19,7 @@ import {
     formatFooter,
     parseOwnerId,
 } from "./dashboard";
+import { resolveServerState, type StatusSignals } from "./serverState";
 
 // Configuration from environment
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -62,14 +62,12 @@ function getApiHeaders(): HeadersInit {
     return headers;
 }
 
-interface ServerStatus {
+interface ServerStatus extends StatusSignals {
     playerCount: number;
     maxPlayers: number;
     steamInviteCode: string | null;
     gogInviteCode: string | null;
     serverVersion: string;
-    isOnline: boolean;
-    isReady: boolean;
     lastUpdated: string;
     farmName: string;
     day: number;
@@ -188,15 +186,16 @@ async function fetchServerStatus(): Promise<ServerStatus | null> {
  */
 async function updatePresence(): Promise<void> {
     const status = await fetchServerStatus();
+    const state = resolveServerState(status);
 
     let activityName: string;
 
-    if (!status?.isOnline) {
-        activityName = "Server Offline";
-    } else {
+    if (state.kind === "online" && status) {
         const playerInfo = `${status.playerCount}/${status.maxPlayers} players`;
         const inviteCode = status.steamInviteCode || status.gogInviteCode || "No code";
         activityName = `${playerInfo} | ${inviteCode}`;
+    } else {
+        activityName = `${state.label} — ${state.detail}`;
     }
 
     client.user?.setPresence({
@@ -207,7 +206,7 @@ async function updatePresence(): Promise<void> {
                 state: activityName,
             },
         ],
-        status: status?.isOnline ? "online" : "idle",
+        status: state.presence,
     });
 
     console.log(`[Discord Bot] Status updated: ${activityName}`);
@@ -501,6 +500,7 @@ function clearTrackedMessage(): void {
 /** Builds the dashboard embed from the current server status. */
 async function buildDashboardEmbed(): Promise<EmbedBuilder> {
     const status: ServerStatus | null = await fetchServerStatus();
+    const state = resolveServerState(status);
 
     const embed = new EmbedBuilder()
         .setTitle(DASHBOARD_TITLE)
@@ -508,11 +508,11 @@ async function buildDashboardEmbed(): Promise<EmbedBuilder> {
         .setFooter({ text: formatFooter(STATUS_DASHBOARD_REFRESH_RATE_FORMATTED, dashboardState.ownerId) });
 
     if (!status?.isOnline) {
-        embed
-            .setColor(Colors.Red)
-            .setDescription(
-                "🔴 **The server is currently offline.**\n\n_No game data can be pulled right now. Check back later!_",
-            );
+        const hint =
+            state.kind === "offline"
+                ? "No game data can be pulled right now. Check back later!"
+                : "Game data appears once the save is loaded.";
+        embed.setColor(state.color).setDescription(`${state.label} — **${state.detail}**\n\n_${hint}_`);
     } else {
         const seasonEmojis: Record<string, string> = {
             spring: "🌸 Spring",
@@ -522,12 +522,12 @@ async function buildDashboardEmbed(): Promise<EmbedBuilder> {
         };
         const formattedSeason = seasonEmojis[status.season?.toLowerCase()] || status.season;
 
-        embed.setColor(Colors.Blue).addFields(
+        embed.setColor(state.color).addFields(
             { name: "🏡 Farm Name", value: status.farmName || "Our Farm", inline: true },
             { name: "🗺️ Farm Layout", value: getFarmTypeName(status.farmTypeKey), inline: true },
             {
                 name: "📶 Server Status",
-                value: status.isReady ? "✅ Ready & Running" : "⏳ Saving / Loading",
+                value: status.isReady ? "✅ Ready & Running" : `⏳ ${state.detail}`,
                 inline: true,
             },
             {
@@ -742,9 +742,10 @@ client.on(Events.MessageCreate, async (message: Message) => {
         if (input === "!status") {
             try {
                 const status: ServerStatus | null = await fetchServerStatus();
+                const state = resolveServerState(status);
 
                 if (!status?.isOnline) {
-                    await message.reply("❌ **Server Status:** The server is currently offline.");
+                    await message.reply(`**Server Status:** ${state.label} — ${state.detail}`);
                     return;
                 }
 
@@ -762,7 +763,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
                     `👥 **Players:** ${status.playerCount}/${status.maxPlayers} ${status.isPaused ? "(⏸️ Paused)" : "(▶️ Live)"}`,
                     `📅 **Date:** Day ${status.day} of ${formattedSeason}, Year ${status.year}`,
                     `⏰ **Time:** ${formatStardewTime(status.timeOfDay)}`,
-                    `📡 **Server State:** ${status.isReady ? "Ready ✓" : "Busy (Saving/Transitioning) ⏳"}`,
+                    `📡 **Server State:** ${status.isReady ? "Ready ✓" : `Busy (${state.detail}) ⏳`}`,
                     `🔑 **Invite Code:** \`${status.steamInviteCode || status.gogInviteCode || "None"}\``,
                 ];
 
@@ -951,7 +952,7 @@ async function performStartupChecks(): Promise<void> {
     try {
         const status = await fetchServerStatus();
         if (status) {
-            console.log(`[Discord Bot] API connectivity: OK (server ${status.isOnline ? "online" : "offline"})`);
+            console.log(`[Discord Bot] API connectivity: OK (server ${resolveServerState(status).kind})`);
         } else {
             warnings.push("Could not fetch server status - API may be unavailable");
         }

--- a/tools/discord-bot/src/serverState.test.ts
+++ b/tools/discord-bot/src/serverState.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { resolveServerState } from "./serverState";
+
+describe("resolveServerState", () => {
+    test("unreachable API is offline", () => {
+        const state = resolveServerState(null);
+        expect(state.kind).toBe("offline");
+        expect(state.presence).toBe("dnd");
+    });
+
+    test("online and ready", () => {
+        const state = resolveServerState({ isOnline: true, isReady: true });
+        expect(state.kind).toBe("online");
+        expect(state.presence).toBe("online");
+    });
+
+    test("online but not ready is busy, still online", () => {
+        const state = resolveServerState({ isOnline: true, isReady: false });
+        expect(state.kind).toBe("busy");
+        expect(state.presence).toBe("online");
+    });
+
+    test("mod API up without a loaded save is loading", () => {
+        const state = resolveServerState({ isOnline: false, isReady: false });
+        expect(state.kind).toBe("loading");
+        expect(state.presence).toBe("idle");
+    });
+
+    test("startup phases from the container are provisioning", () => {
+        const downloading = resolveServerState({ isOnline: false, isReady: false, phase: "downloading" });
+        const starting = resolveServerState({ isOnline: false, isReady: false, phase: "starting" });
+        expect(downloading.kind).toBe("provisioning");
+        expect(starting.kind).toBe("provisioning");
+        expect(downloading.detail).not.toBe(starting.detail);
+    });
+
+    test("an unknown phase falls back to loading", () => {
+        expect(resolveServerState({ isOnline: false, isReady: false, phase: "???" }).kind).toBe("loading");
+    });
+
+    test("phase never overrides an online server", () => {
+        expect(resolveServerState({ isOnline: true, isReady: true, phase: "starting" }).kind).toBe("online");
+    });
+});

--- a/tools/discord-bot/src/serverState.ts
+++ b/tools/discord-bot/src/serverState.ts
@@ -1,0 +1,87 @@
+/**
+ * Maps the game server's /status response to the state the bot displays. Before the mod's API
+ * is up, the game container itself answers /status with `isOnline: false` plus a `phase`, which
+ * is what separates a provisioning server from a dead one.
+ */
+
+import { Colors, type PresenceStatusData } from "discord.js";
+
+export interface StatusSignals {
+    isOnline: boolean;
+    isReady: boolean;
+    /** "downloading" or "starting" while the container's startup script answers; absent once the mod does. */
+    phase?: string;
+}
+
+export type ServerStateKind =
+    | "online" // game loaded and accepting players
+    | "busy" // game loaded, mid save / day transition / festival / wedding
+    | "loading" // mod API up, save not loaded yet
+    | "provisioning" // container up, game files downloading or the game process booting
+    | "offline"; // /status unreachable
+
+export interface ServerState {
+    kind: ServerStateKind;
+    label: string;
+    detail: string;
+    presence: PresenceStatusData;
+    color: number;
+}
+
+/** `null` is an unreachable /status: the port is closed, so the server is offline. */
+export function resolveServerState(status: StatusSignals | null): ServerState {
+    if (status === null) {
+        return {
+            kind: "offline",
+            label: "🔴 Offline",
+            detail: "The server is offline.",
+            presence: "dnd",
+            color: Colors.Red,
+        };
+    }
+
+    if (status.isOnline) {
+        return status.isReady
+            ? {
+                  kind: "online",
+                  label: "🟢 Online",
+                  detail: "Ready & running.",
+                  presence: "online",
+                  color: Colors.Blue,
+              }
+            : {
+                  kind: "busy",
+                  label: "🟡 Busy",
+                  detail: "Saving, changing day, or running an event.",
+                  presence: "online",
+                  color: Colors.Yellow,
+              };
+    }
+
+    switch (status.phase) {
+        case "downloading":
+            return {
+                kind: "provisioning",
+                label: "🟠 Starting",
+                detail: "Downloading game files.",
+                presence: "idle",
+                color: Colors.Orange,
+            };
+        case "starting":
+            return {
+                kind: "provisioning",
+                label: "🟠 Starting",
+                detail: "Launching the game.",
+                presence: "idle",
+                color: Colors.Orange,
+            };
+        default:
+            return {
+                kind: "loading",
+                label: "🟡 Starting",
+                detail: "Loading the save.",
+                presence: "idle",
+                color: Colors.Yellow,
+            };
+    }
+}

--- a/tools/steam-service/Program.cs
+++ b/tools/steam-service/Program.cs
@@ -381,18 +381,24 @@ return;
 // Helper functions
 // ============================================================================
 
+/// <summary>
+/// SDK first: the game container launches as soon as the game's completion marker appears and
+/// only links an SDK that is already on the volume.
+/// </summary>
+async Task DownloadGameAndSdkAsync(SteamAuthService svc)
+{
+    if (!args.Contains("--skip-sdk"))
+    {
+        await svc.DownloadGameAsync(SteamworksSdkAppId, Path.Combine(gameDir, ".steam-sdk"));
+    }
+    await svc.DownloadGameAsync(StardewValleyAppId);
+}
+
 async Task DownloadAllAsync(SteamAuthService svc)
 {
     try
     {
-        await svc.DownloadGameAsync(StardewValleyAppId);
-
-        // Also download Steamworks SDK for GameServer mode (unless --skip-sdk)
-        if (!args.Contains("--skip-sdk"))
-        {
-            var steamSdkDir = Path.Combine(gameDir, ".steam-sdk");
-            await svc.DownloadGameAsync(SteamworksSdkAppId, steamSdkDir);
-        }
+        await DownloadGameAndSdkAsync(svc);
     }
     catch (Exception ex)
     {
@@ -755,48 +761,68 @@ async Task RunHttpServerAsync(
 
     await Task.WhenAll(loginTasks);
 
-    // First-run bootstrap: if the game depot isn't present yet, download it in the background so a
-    // fresh `docker compose up` self-provisions instead of waiting for a manual `setup`. Keyed on the
-    // download-complete marker (same signal startapp.sh gates on), so a half-finished prior download
-    // resumes rather than being mistaken for done. Runs off the request path (HTTP server + /health
-    // come up first). On shutdown the task isn't cancelled — Disconnect() aborts the in-flight
-    // download, which is resumable on the next boot; a failed download is likewise retried next boot.
+    // First-run bootstrap, so a fresh `docker compose up` self-provisions without a manual `setup`.
+    // Keyed on the completion marker startapp.sh gates on, so a half-finished download resumes
+    // instead of passing for done. Off the request path so /health comes up first; shutdown just
+    // aborts the in-flight download, which resumes next boot.
     if (!File.Exists(gameDownloadMarker))
     {
-        var bootstrapAccount = accts.Values.FirstOrDefault(s => s.IsLoggedIn);
-        if (bootstrapAccount == null)
+        if (accts.Count == 0)
         {
             Logger.Log(
-                "[SteamService] Game files missing and no account is logged in — cannot auto-download. "
-                    + "Check credentials, or run `setup` manually."
+                "[SteamService] Game files missing and no Steam account is configured — cannot "
+                    + "auto-download. Set STEAM_USERNAME/STEAM_PASSWORD (or STEAM_ACCOUNTS), or run `setup`."
             );
         }
         else
         {
-            _ = Task.Run(async () =>
-            {
-                try
-                {
-                    Logger.Log("[SteamService] Game files not found, downloading on first run...");
-                    await bootstrapAccount.DownloadGameAsync(StardewValleyAppId);
-                    if (!args.Contains("--skip-sdk"))
-                    {
-                        await bootstrapAccount.DownloadGameAsync(
-                            SteamworksSdkAppId,
-                            Path.Combine(gameDir, ".steam-sdk")
-                        );
-                    }
-                    Logger.Log("[SteamService] First-run game download complete.");
-                }
-                catch (Exception ex)
-                {
-                    Logger.Log($"[SteamService] First-run game download failed: {ex.Message}");
-                }
-            });
+            _ = Task.Run(() => BootstrapGameFilesAsync(accts, configs));
         }
     }
 
     await app.RunAsync();
+}
+
+/// <summary>
+/// Retries with back-off instead of failing serve: the game container waits on the marker
+/// indefinitely, so a CDN or login flake must heal without an operator restart. Uses account 0's
+/// one Steam session (login is serialized per account), so no second login can overlap the
+/// ticket endpoints. Each app's own marker skips it once complete, so a retry after a partial
+/// success fetches only what is missing.
+/// </summary>
+async Task BootstrapGameFilesAsync(
+    Dictionary<int, SteamAuthService> accts,
+    Dictionary<int, (string user, string? pass, string? token)> configs
+)
+{
+    var (accountIndex, svc) = accts.OrderBy(kv => kv.Key).First();
+    var cfg = configs[accountIndex];
+    var loginConfig = new SteamAuthService.LoginConfig(cfg.user, cfg.pass, cfg.token);
+    var delay = TimeSpan.FromSeconds(30);
+    var maxDelay = TimeSpan.FromMinutes(5);
+
+    for (var attempt = 1; ; attempt++)
+    {
+        try
+        {
+            Logger.Log(
+                $"[SteamService] Game files not found, downloading on first run (attempt {attempt})..."
+            );
+            await svc.EnsureLoggedInAsync(loginConfig);
+            await DownloadGameAndSdkAsync(svc);
+            Logger.Log("[SteamService] First-run game download complete.");
+            return;
+        }
+        catch (Exception ex)
+        {
+            Logger.Log(
+                $"[SteamService] First-run game download failed (attempt {attempt}): {ex.Message}. "
+                    + $"Retrying in {delay.TotalSeconds:0}s."
+            );
+            await Task.Delay(delay);
+            delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, maxDelay.Ticks));
+        }
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
A fresh deployment comes up with `docker compose up -d` alone, and the Discord bot reflects the server's real lifecycle (offline, provisioning, loading, busy, online) instead of online-or-dead. The bot still talks to `server:8080` only.

- **steam-service:** `serve`'s first-run bootstrap retries with back-off (30s doubling to 5min) instead of giving up until the next restart, and downloads the SDK before the game so the server never boots without it. `setup`/`download` share the same helper.
- **startapp.sh:** a bash+nc responder answers `/status` on the API port with `{"isOnline":false,"phase":"downloading"|"starting"}` while the game is not running; everything else gets 503 so `/health` keeps meaning "the mod's API is up". The "run make setup" banner is gone.
- **Mod (`ApiPortHandoff`):** right before binding, the mod SIGTERMs the responder loop (its trap takes `nc` down), waits for teardown, and asserts via `/proc/net/tcp` and `tcp6` that no LISTEN socket remains. No bind retry; a surviving listener fails loudly. TIME_WAIT is ignored (HttpListener sets SO_REUSEADDR).
- **Image:** `API_HANDOFF_PID_FILE` ENV is the one pid-file contract for script, mod, and healthcheck. The healthcheck reports unhealthy without connecting while the responder owns the port, so 2s probes cannot steal the single-connection listener from status clients.
- **Discord bot:** new `serverState.ts` maps `/status` to online / busy / loading / provisioning / offline and drives presence, the dashboard embed, and `!status`. Unit tests cover every row.
- **Deploy:** the explicit `steam-auth setup` step is removed; docs updated (installation, README, Discord feature table and troubleshooting).

## Verification

Run live against a fresh game-data volume with the worktree's script, mod build, and steam-service image layered on the local server image:

- Cold boot: SDK then game downloaded, marker written, no `LogonSessionReplaced`; `/status` served `downloading` and `/health` 503 during the download; healthcheck stayed "starting"; mod logged `Took over API port 8080 from the phase responder in 28ms`; no `nc` process and no pid file afterwards; container went healthy.
- Warm restart with a 0.3s `/status` poll: unreachable only while the container itself restarted (first 4s), then `phase: starting`, then the mod's own offline shape, then `isOnline: true`. No unreachable poll after the responder came up.
- `dotnet build` for mod and steam-service, `bun test` (21 pass), biome, tsc, `bash -n` all green.

Known and accepted: the responder serves one connection per `nc` spawn, so two clients hitting `/status` within the few milliseconds between connections can see one refused connection. Only the bot's 30s poll and manual requests reach it now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Game files now download automatically on the server’s first start when Steam authentication is available, with startup progress reported.
  - Discord status displays distinguish downloading, starting, loading, busy, online, and offline states with clearer details and presence indicators.

- **Bug Fixes**
  - Improved health reporting prevents startup checks from interfering with status connections.
  - Discord now distinguishes unreachable servers from servers that are still starting.

- **Documentation**
  - Updated setup and troubleshooting guidance for Steam authentication, automatic downloads, and Discord status meanings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->