### PR TITLE
chore(deploy): wire bot nickname var, clarify docs, default FarmName to "Server"

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -232,7 +232,7 @@ jobs:
           if [ "$LATEST_SRC" = none ]; then
             case "${RESTORE_STATUS:-}" in
               failed)  echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable." ;;
-              skipped) echo "::error::Latest not built this run and R2 is not configured (no snapshot to restore) — configure R2, or re-run with rebuild_latest=true." ;;
+              skipped) echo "::error::Latest not built this run and the R2 restore was skipped (R2 not configured, or aws CLI unavailable — see the restore step's warning) — fix that, or re-run with rebuild_latest=true." ;;
               *)       echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true." ;;
             esac
             exit 1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -226,14 +226,14 @@ jobs:
 
           # Failed restore can leave partial content, so a `live` half may be truncated.
           if [ "${RESTORE_STATUS:-}" = failed ] && { [ "$LATEST_SRC" = live ] || [ "$PREVIEW_SRC" = live ]; }; then
-            echo "::error::R2 restore was incomplete — a restored half may be truncated. Retry once R2 is reachable."
+            echo "::error::Refusing deploy: the R2 snapshot restore was incomplete, so a preserved half may be truncated and would publish partial docs. Retry once R2 is reachable."
             exit 1
           fi
           if [ "$LATEST_SRC" = none ]; then
             case "${RESTORE_STATUS:-}" in
-              failed)  echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable." ;;
-              skipped) echo "::error::Latest not built this run and the R2 restore was skipped (see the restore step's warning for why) — fix that, or re-run with rebuild_latest=true." ;;
-              *)       echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true." ;;
+              failed)  echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and the R2 snapshot read failed, so the live copy can't be preserved. Retry once R2 is reachable." ;;
+              skipped) echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and the R2 snapshot restore was skipped, so the live copy can't be preserved — see the \"Restore live snapshot from R2\" step's warning for why. Fix that, or re-run with rebuild_latest=true." ;;
+              *)       echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and no R2 snapshot exists to preserve the live copy — publishing now would wipe live 'latest'. Re-run with rebuild_latest=true (or configure R2)." ;;
             esac
             exit 1
           fi
@@ -241,10 +241,10 @@ jobs:
             # LATEST-ONLY wipes any live preview, so ship it only when a successful read (ok)
             # confirmed the snapshot — hence live — has no preview.
             if [ "${RESTORE_STATUS:-}" != ok ]; then
-              echo "::error::Preview absence unconfirmed (restore: ${RESTORE_STATUS:-unknown}) — refusing LATEST-ONLY. Retry, or re-run with rebuild_preview=true."
+              echo "::error::Refusing latest-only deploy: couldn't confirm whether live 'preview' exists (snapshot restore: ${RESTORE_STATUS:-unknown}), so publishing might silently wipe it. Retry, or re-run with rebuild_preview=true."
               exit 1
             fi
-            echo "::warning::Deploying LATEST-ONLY — preview confirmed absent from R2."
+            echo "::warning::Deploying latest-only — live 'preview' confirmed absent from the R2 snapshot, so nothing is wiped."
           fi
 
       - name: Setup Pages

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -230,11 +230,11 @@ jobs:
             exit 1
           fi
           if [ "$LATEST_SRC" = none ]; then
-            if [ "${RESTORE_STATUS:-}" = failed ]; then
-              echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable."
-            else
-              echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true."
-            fi
+            case "${RESTORE_STATUS:-}" in
+              failed)  echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable." ;;
+              skipped) echo "::error::Latest not built this run and R2 is not configured (no snapshot to restore) — configure R2, or re-run with rebuild_latest=true." ;;
+              *)       echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true." ;;
+            esac
             exit 1
           fi
           if [ "$PREVIEW_SRC" = none ]; then

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -232,7 +232,7 @@ jobs:
           if [ "$LATEST_SRC" = none ]; then
             case "${RESTORE_STATUS:-}" in
               failed)  echo "::error::Latest not built this run and the R2 read failed — refusing. Retry once R2 is reachable." ;;
-              skipped) echo "::error::Latest not built this run and the R2 restore was skipped (R2 not configured, or aws CLI unavailable — see the restore step's warning) — fix that, or re-run with rebuild_latest=true." ;;
+              skipped) echo "::error::Latest not built this run and the R2 restore was skipped (see the restore step's warning for why) — fix that, or re-run with rebuild_latest=true." ;;
               *)       echo "::error::Latest missing and absent from R2 — refusing. Re-run with rebuild_latest=true." ;;
             esac
             exit 1

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -146,8 +146,10 @@ jobs:
           allow_forks: false
 
       # A half not rebuilt this run is restored from the currently-live site, snapshotted in R2
-      # (durable, no lifecycle rule) by "Persist live snapshot to R2". Unconfigured R2 is
-      # tolerated: live/site stays empty, so only a single-half deploy refuses (in the decide step).
+      # (durable, no lifecycle rule) by "Persist live snapshot to R2". R2 deliberately off (all
+      # four vars empty) is tolerated — live/site stays empty, so only a single-half deploy refuses
+      # (in the decide step). A configured-but-broken R2 (partial config, unreachable, AccessDenied,
+      # or an uncertified snapshot) fails the job here rather than deploy against a bad snapshot.
       - name: Restore live snapshot from R2
         id: restore
         env:
@@ -159,25 +161,45 @@ jobs:
           # masker would turn every `-` in the whole log into *** (see e2e-tests.yml).
           R2_BUCKET: ${{ vars.R2_BUCKET_DOCS }}
         run: |
-          # restore_status, read by the decide step: skipped (R2 off) | ok (snapshot reflects
-          # live, empty bucket included) | failed (read error, or a partial snapshot missing its
-          # .snapshot-complete marker). A single-half deploy ships only a confirmed (ok) half.
+          # restore_status, read by the decide step: skipped (R2 deliberately off — all four vars
+          # empty) | ok (snapshot reflects live; an empty but readable bucket counts). Any
+          # configured-but-broken state (partial config, aws missing, read error, or a snapshot
+          # missing its .snapshot-complete marker) fails the job here — a silently stale snapshot
+          # is worse than a red deploy.
           set -uo pipefail
           mkdir -p live/site
           endpoint="https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com"
-          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
-            echo "::warning::R2 not configured — skipping snapshot restore."; status=skipped
-          elif ! command -v aws >/dev/null 2>&1; then
-            echo "::warning::aws CLI not found — skipping snapshot restore."; status=skipped
-          elif ! aws s3 sync "s3://${R2_BUCKET}/" live/site/ --endpoint-url "$endpoint" --no-progress; then
-            echo "::warning::R2 snapshot read failed — a single-half deploy will refuse."; status=failed
-          elif [ -n "$(ls -A live/site 2>/dev/null)" ] && [ ! -f live/site/.snapshot-complete ]; then
-            echo "::warning::R2 snapshot has no completion marker (persist was interrupted) — a single-half deploy will refuse."; status=failed
-          else
-            status=ok
+
+          # Count the four R2 settings (names are the github-pages env keys, for error messages).
+          n=0; missing=""
+          for pair in "R2_BUCKET_DOCS:${R2_BUCKET:-}" "R2_ACCESS_KEY_ID:${AWS_ACCESS_KEY_ID:-}" "R2_SECRET_ACCESS_KEY:${AWS_SECRET_ACCESS_KEY:-}" "R2_ACCOUNT_ID:${R2_ACCOUNT_ID:-}"; do
+            if [ -n "${pair#*:}" ]; then n=$((n+1)); else missing="$missing ${pair%%:*}"; fi
+          done
+
+          if [ "$n" -eq 0 ]; then
+            echo "::warning::R2 not configured — skipping snapshot restore. Single-half deploys will refuse until R2 is set up in the github-pages environment."
+            echo "restore_status=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$n" -lt 4 ]; then
+            echo "::error::R2 is partially configured — missing:${missing}. Set all four (R2_BUCKET_DOCS variable + R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_ACCOUNT_ID secrets) in the github-pages environment, or unset all four to disable R2."
+            exit 1
+          fi
+          if ! command -v aws >/dev/null 2>&1; then
+            echo "::error::aws CLI not found on the runner — cannot restore the R2 snapshot."
+            exit 1
+          fi
+          if ! err=$(aws s3 sync "s3://${R2_BUCKET}/" live/site/ --endpoint-url "$endpoint" --no-progress 2>&1); then
+            echo "$err"
+            echo "::error::R2 snapshot read failed for bucket '${R2_BUCKET}'. Verify the R2 token has Object Read & Write on this bucket and that R2_ACCOUNT_ID matches the bucket's account (see the aws error logged above)."
+            exit 1
+          fi
+          if [ -n "$(ls -A live/site 2>/dev/null)" ] && [ ! -f live/site/.snapshot-complete ]; then
+            echo "::error::R2 snapshot for '${R2_BUCKET}' has no .snapshot-complete marker — a prior persist was interrupted, so the snapshot may be truncated. Re-run with rebuild_latest=true and rebuild_preview=true to rebuild both halves and re-seed R2."
+            exit 1
           fi
           rm -f live/site/.snapshot-complete   # never let the marker leak into the deployed site
-          echo "restore_status=$status" >> "$GITHUB_OUTPUT"
+          echo "restore_status=ok" >> "$GITHUB_OUTPUT"
 
       - name: Restore missing halves and decide deploy
         id: check
@@ -221,27 +243,22 @@ jobs:
           echo "preview_src=$PREVIEW_SRC" >> "$GITHUB_OUTPUT"
 
           # deploy-pages replaces the whole site, so never publish a half we can't fully obtain —
-          # that wipes it live. Ship a half only if built this run, restored intact, or confirmed
-          # absent (ok). Full rebuilds never reach these guards, so an R2 outage can't block them.
-
-          # Failed restore can leave partial content, so a `live` half may be truncated.
-          if [ "${RESTORE_STATUS:-}" = failed ] && { [ "$LATEST_SRC" = live ] || [ "$PREVIEW_SRC" = live ]; }; then
-            echo "::error::Refusing deploy: the R2 snapshot restore was incomplete, so a preserved half may be truncated and would publish partial docs. Retry once R2 is reachable."
-            exit 1
-          fi
+          # that wipes it live. Ship a half only if built this run or restored from a readable
+          # snapshot. A broken R2 already failed the restore step, so RESTORE_STATUS here is only
+          # 'ok' (snapshot readable) or 'skipped' (R2 deliberately off).
           if [ "$LATEST_SRC" = none ]; then
-            case "${RESTORE_STATUS:-}" in
-              failed)  echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and the R2 snapshot read failed, so the live copy can't be preserved. Retry once R2 is reachable." ;;
-              skipped) echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and the R2 snapshot restore was skipped, so the live copy can't be preserved — see the \"Restore live snapshot from R2\" step's warning for why. Fix that, or re-run with rebuild_latest=true." ;;
-              *)       echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and no R2 snapshot exists to preserve the live copy — publishing now would wipe live 'latest'. Re-run with rebuild_latest=true (or configure R2)." ;;
-            esac
+            if [ "${RESTORE_STATUS:-}" = skipped ]; then
+              echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and R2 is off, so the live copy can't be preserved — publishing now would wipe live 'latest'. Configure R2, or re-run with rebuild_latest=true."
+            else
+              echo "::error::Refusing deploy: 'latest' wasn't rebuilt this run and the R2 snapshot holds no 'latest' to preserve — publishing now would wipe live 'latest'. Re-run with rebuild_latest=true to seed it."
+            fi
             exit 1
           fi
           if [ "$PREVIEW_SRC" = none ]; then
-            # LATEST-ONLY wipes any live preview, so ship it only when a successful read (ok)
-            # confirmed the snapshot — hence live — has no preview.
+            # LATEST-ONLY wipes any live preview, so ship it only when a readable snapshot (ok)
+            # confirmed the live site has no preview.
             if [ "${RESTORE_STATUS:-}" != ok ]; then
-              echo "::error::Refusing latest-only deploy: couldn't confirm whether live 'preview' exists (snapshot restore: ${RESTORE_STATUS:-unknown}), so publishing might silently wipe it. Retry, or re-run with rebuild_preview=true."
+              echo "::error::Refusing latest-only deploy: R2 is off, so we can't confirm whether live 'preview' exists and publishing might silently wipe it. Configure R2, or re-run with rebuild_preview=true."
               exit 1
             fi
             echo "::warning::Deploying latest-only — live 'preview' confirmed absent from the R2 snapshot, so nothing is wiped."
@@ -266,8 +283,6 @@ jobs:
       # so the snapshot always equals live — for both default-branch and release-tag deploys.
       - name: Persist live snapshot to R2
         if: success()
-        # Best-effort: a snapshot-write failure must not red the deploy that already published.
-        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -275,25 +290,45 @@ jobs:
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET: ${{ vars.R2_BUCKET_DOCS }}
         run: |
+          # Mirror the just-published site to R2 so a later single-half deploy can restore the half
+          # it doesn't rebuild. R2 deliberately off (all four vars empty) is tolerated; any
+          # configured-but-broken state fails the job — the site already published, but a silently
+          # stale snapshot would break the next single-half deploy with no warning.
           set -uo pipefail
           endpoint="https://${R2_ACCOUNT_ID:-}.r2.cloudflarestorage.com"
-          if [ -z "${R2_BUCKET:-}" ] || [ -z "${AWS_ACCESS_KEY_ID:-}" ] || [ -z "${AWS_SECRET_ACCESS_KEY:-}" ] || [ -z "${R2_ACCOUNT_ID:-}" ]; then
-            echo "::warning::R2 not configured — snapshot not persisted; single-half deploys will refuse until it is."; exit 0
+
+          n=0; missing=""
+          for pair in "R2_BUCKET_DOCS:${R2_BUCKET:-}" "R2_ACCESS_KEY_ID:${AWS_ACCESS_KEY_ID:-}" "R2_SECRET_ACCESS_KEY:${AWS_SECRET_ACCESS_KEY:-}" "R2_ACCOUNT_ID:${R2_ACCOUNT_ID:-}"; do
+            if [ -n "${pair#*:}" ]; then n=$((n+1)); else missing="$missing ${pair%%:*}"; fi
+          done
+          if [ "$n" -eq 0 ]; then
+            echo "::warning::R2 not configured — snapshot not persisted; single-half deploys will refuse until it is."
+            exit 0
           fi
-          command -v aws >/dev/null 2>&1 || { echo "::warning::aws CLI not found — snapshot not persisted."; exit 0; }
+          if [ "$n" -lt 4 ]; then
+            echo "::error::R2 is partially configured — missing:${missing}. Set all four in the github-pages environment, or unset all four to disable R2."
+            exit 1
+          fi
+          command -v aws >/dev/null 2>&1 || { echo "::error::aws CLI not found on the runner — cannot persist the R2 snapshot."; exit 1; }
 
           # The .snapshot-complete marker certifies a full mirror. Clear it first so an interrupted
-          # sync leaves the snapshot uncertified; mirror; write it last. Bail if it can't be cleared
-          # — a surviving marker would certify a partial sync. (rm of a missing key exits 0: first seed.)
+          # sync leaves the snapshot uncertified; mirror; write it last. (rm of a missing key exits 0.)
           marker="s3://${R2_BUCKET}/.snapshot-complete"
-          if ! aws s3 rm "$marker" --endpoint-url "$endpoint" >/dev/null 2>&1; then
-            echo "::warning::Could not clear the R2 completion marker — keeping the last certified snapshot."; exit 0
+          if ! err=$(aws s3 rm "$marker" --endpoint-url "$endpoint" 2>&1); then
+            echo "$err"
+            echo "::error::Could not clear the R2 completion marker in '${R2_BUCKET}'. Verify the R2 token has Object Read & Write on this bucket and that R2_ACCOUNT_ID matches its account (see the aws error above)."
+            exit 1
           fi
-          if ! aws s3 sync dist/ "s3://${R2_BUCKET}/" --endpoint-url "$endpoint" --no-progress --delete; then
-            echo "::warning::R2 mirror failed — next single-half deploy will refuse until the next persist."; exit 0
+          if ! err=$(aws s3 sync dist/ "s3://${R2_BUCKET}/" --endpoint-url "$endpoint" --no-progress --delete 2>&1); then
+            echo "$err"
+            echo "::error::R2 mirror (sync) to '${R2_BUCKET}' failed (see the aws error above)."
+            exit 1
           fi
-          printf 'ok' | aws s3 cp - "$marker" --endpoint-url "$endpoint" >/dev/null 2>&1 \
-            || echo "::warning::Mirror done but marker write failed — next single-half deploy will refuse until the next persist."
+          if ! err=$(printf 'ok' | aws s3 cp - "$marker" --endpoint-url "$endpoint" 2>&1); then
+            echo "$err"
+            echo "::error::R2 mirror completed but writing the .snapshot-complete marker failed, so the snapshot is uncertified and the next single-half deploy would refuse (see the aws error above)."
+            exit 1
+          fi
           echo "Live snapshot updated in R2."
 
       - name: Build summary and notification fields

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -105,6 +105,7 @@ jobs:
           DEPLOY_API_KEY: ${{ secrets.DEPLOY_API_KEY }}
           DEPLOY_DISCORD_BOT_TOKEN: ${{ secrets.DEPLOY_DISCORD_BOT_TOKEN }}
           DEPLOY_DISCORD_CHAT_CHANNEL_ID: ${{ secrets.DEPLOY_DISCORD_CHAT_CHANNEL_ID }}
+          DEPLOY_DISCORD_BOT_NICKNAME: ${{ vars.DEPLOY_DISCORD_BOT_NICKNAME }}
         run: |
           echo "::group::Generate .env file for ${{ matrix.environment }}"
 
@@ -143,6 +144,7 @@ jobs:
           echo "# Discord bot (optional)" >> .env
           echo "DISCORD_BOT_TOKEN=$DEPLOY_DISCORD_BOT_TOKEN" >> .env
           echo "DISCORD_CHAT_CHANNEL_ID=$DEPLOY_DISCORD_CHAT_CHANNEL_ID" >> .env
+          echo "DISCORD_BOT_NICKNAME=$DEPLOY_DISCORD_BOT_NICKNAME" >> .env
           echo "::endgroup::"
 
       - name: Create deploy directory

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -7,7 +7,7 @@ The bot runs alongside your server, so its identity is your farm's: its nickname
 ## 1. Create the Bot
 
 1. Open the [Discord Developer Portal](https://discord.com/developers/applications) and click **New Application**
-2. On **General Information**, copy the **Application ID** (needed in step 2)
+2. On **General Information**, set the bot's name and icon, then copy the **Application ID** (needed in step 2)
 3. On the **Bot** tab, click **Reset Token** and copy the token (needed in step 3)
 
 ::: warning Keep Token Secret
@@ -90,6 +90,8 @@ The ownership id protects only the dashboard message. Presence is global to the 
 :::
 
 ## Bot Nickname
+
+The nickname is what your Discord server shows in place of the bot's username; the username and profile picture themselves come from the Developer Portal.
 
 | Configuration | Behavior |
 |---------------|----------|

--- a/docs/admins/configuration/server-settings.md
+++ b/docs/admins/configuration/server-settings.md
@@ -27,7 +27,7 @@ This file is auto-created with defaults on first server startup. If the file doe
 ```json
 {
   "Game": {
-    "FarmName": "Junimo",
+    "FarmName": "Server",
     "FarmType": 0,
     "ProfitMargin": 1.0,
     "StartingCabins": 1,
@@ -66,7 +66,7 @@ These settings only take effect when creating a **new** game. They are ignored w
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `FarmName` | Farm name displayed in-game | `"Junimo"` |
+| `FarmName` | Farm name displayed in-game | `"Server"` |
 | `FarmType` | Farm map type: a number `0`-`7` or a name for a built-in farm, or a farm Id string for a mod-added farm (see table below) | `0` |
 | `ProfitMargin` | Sell price multiplier | `1.0` |
 | `StartingCabins` | Number of cabins created with new game. Ignored when `CabinStrategy` is `"None"`, which always places `min(designated map spots, MaxPlayers)` cabins up front | `1` |

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -298,9 +298,16 @@ GitHub forbids approving your own pull request, which with a single maintainer m
 
 Deploys the documentation site to GitHub Pages. Runs automatically after builds or can be triggered manually to rebuild from existing Docker images.
 
-The site has two halves — `latest` (site root) and `preview` (`/preview/`) — and `deploy-pages` replaces the whole site each run. A run that rebuilds only one half restores the other from a durable snapshot of the currently-live site kept in Cloudflare R2, so recovery never depends on an expiring artifact. After every successful deploy the merged site is mirrored back to R2 (`aws s3 sync … --delete`), best-effort — a snapshot-write failure warns but never fails the deploy.
+The site has two halves — `latest` (site root) and `preview` (`/preview/`) — and `deploy-pages` replaces the whole site each run. A run that rebuilds only one half restores the other from a durable snapshot of the currently-live site kept in Cloudflare R2, so recovery never depends on an expiring artifact. After every successful deploy the merged site is mirrored back to R2 (`aws s3 sync … --delete`).
 
-A full rebuild (both halves built that run) never needs the snapshot, so it deploys even if R2 is down. A single-half run only proceeds when the half it doesn't rebuild is *confirmed* — either restored intact from the snapshot, or confirmed genuinely absent by a successful snapshot read. Otherwise it refuses rather than wipe a live half: it refuses when the missing half is `latest` and absent from the snapshot (empty bucket or R2 unconfigured; re-run with `rebuild_latest=true` to seed), when the snapshot read failed or was only partially restored (retry once R2 is reachable), and when `preview` isn't rebuilt this run and its absence can't be confirmed — an unconfigured/skipped or failed restore can't prove the live site has no preview, so LATEST-ONLY is only deployed against a confirmed snapshot (re-run with `rebuild_preview=true` to force a preview, or seed R2 first).
+R2 has exactly two acceptable states, and anything else fails the deploy loudly rather than silently deploying against a bad snapshot:
+
+- **Deliberately off** — all four R2 settings empty. Restore and persist skip; a full rebuild deploys fine, and a single-half run refuses (the half it doesn't rebuild can't be confirmed).
+- **Fully configured and reachable** — the snapshot restores and re-mirrors normally.
+
+A configured-but-broken R2 — partial configuration, an unreachable endpoint, an `AccessDenied` token, or a snapshot missing its `.snapshot-complete` marker — **reds the run** (the restore step fails before publishing, or the persist step fails after). This is deliberate: catching a misconfiguration immediately is worth more than tolerating a rare outage, since a silently stale snapshot would surface only later, as a hard-to-trace refusal. The error messages name the failed operation and the likely fix (token scope, `R2_ACCOUNT_ID`, missing settings).
+
+A single-half run still refuses rather than wipe a live half when the half it doesn't rebuild can't be confirmed present: the missing half is `latest` and absent from the snapshot (re-run with `rebuild_latest=true` to seed), or `preview` isn't rebuilt and R2 is off so its absence can't be confirmed (re-run with `rebuild_preview=true`, or configure R2). LATEST-ONLY deploys only against a readable snapshot that confirms no live preview exists.
 
 The snapshot's integrity is self-certifying: the persist step clears a `.snapshot-complete` marker before mirroring and rewrites it last, so an interrupted persist leaves no marker and the next restore treats that partial snapshot as unusable rather than deploying truncated content.
 
@@ -315,7 +322,7 @@ Add to the **`github-pages`** GitHub Environment (Settings → Environments):
 | `R2_SECRET_ACCESS_KEY` | Secret | R2 token secret |
 | `R2_BUCKET_DOCS` | Variable | Name of a **dedicated** R2 bucket with **no lifecycle rule** (a per-age expiry would sweep the snapshot). Kept as a variable, not a secret — the name's hyphen would trip the secret masker. |
 
-The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. If R2 is left unconfigured, full-rebuild deploys still work; single-half deploys refuse (the half they don't rebuild can't be confirmed), so configure R2 or re-run rebuilding both halves.
+The R2 token must have **Object Read & Write** on this bucket (both restore and persist run), and `R2_ACCOUNT_ID` must be the account that owns it. The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. Leave all four settings empty to disable R2 (full-rebuild deploys still work; single-half deploys refuse); set some but not all and the deploy fails, so it's all-or-nothing.
 
 ## Deploy Server Pipeline
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -335,20 +335,11 @@ The deploy server pipeline deploys server instances to a VPS. It supports multip
 2. **Add the environment to the workflow matrix** in `.github/workflows/deploy-server.yml`
 3. **Update the workflow dispatch options** to include the new environment
 
-Example matrix entry:
+Example `TARGETS` entries:
 
-```yaml
-matrix:
-    include:
-        - environment: public-test
-          image_tag: preview
-          on_preview: true
-          on_release: false
-
-        - environment: production
-          image_tag: latest
-          on_preview: false
-          on_release: true
+```json
+{"environment": "public-test-preview", "image_tag": "preview", "on_preview": true, "on_release": false}
+{"environment": "public-test-latest", "image_tag": "latest", "on_preview": false, "on_release": true}
 ```
 
 ### Setup Requirements
@@ -359,8 +350,8 @@ Each deployment target needs a **GitHub Environment** with its configuration.
 
 1. Go to **Settings** → **Environments** in your repository
 2. Click **New environment**
-3. Name it to match the workflow matrix (e.g., `public-test`, `production`)
-4. Add the secrets listed below
+3. Name it to match the workflow matrix (e.g., `public-test-preview`, `public-test-latest`)
+4. Add the secrets and variables listed below
 
 #### Environment Secrets
 
@@ -390,8 +381,16 @@ Generate a secure API key with: `openssl rand -base64 32`
 :::
 
 ::: tip
-If multiple servers share the same VPS and credentials, **repository-level** secrets can be used as fallbacks. Environment-level secrets override repository-level secrets with the same name.
+If multiple servers share the same VPS and credentials, **repository-level** secrets and variables can be used as fallbacks. Environment-level values override repository-level ones with the same name.
 :::
+
+#### Environment Variables
+
+Add these under **Settings → Environments → Variables**, not as secrets.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `DEPLOY_DISCORD_BOT_NICKNAME` | No | Discord bot nickname (defaults to the farm name) |
 
 ### VPS Preparation
 
@@ -422,7 +421,7 @@ The script outputs the private key to add as `DEPLOY_SSH_KEY` in GitHub.
 **3. Configure Firewall**
 
 ```sh
-# Example for public-test environment
+# Example for the public-test-preview environment
 ufw allow 24642/udp  # Game port
 ufw allow 5800/tcp   # VNC web interface
 ```
@@ -433,7 +432,7 @@ To manually trigger a deployment:
 
 1. Go to **Actions** → **Deploy Server**
 2. Click **Run workflow**
-3. Select which environment to deploy (e.g., `public-test`)
+3. Select which environment to deploy (e.g., `public-test-preview`)
 4. Optionally check "Skip graceful shutdown" for emergency deploys
 5. Click **Run workflow**
 

--- a/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
+++ b/mod/JunimoServer/Services/GameCreator/NewGameConfig.cs
@@ -8,7 +8,7 @@ public class NewGameConfig
     public FarmTypeSetting WhichFarm { get; set; } = FarmTypeSetting.Default;
     public bool UseSeparateWallets { get; set; } = false;
     public int StartingCabins { get; set; } = 1;
-    public string FarmName { get; set; } = "Junimo";
+    public string FarmName { get; set; } = "Server";
     public int MaxPlayers { get; set; } = 10;
     public CabinStrategy CabinStrategy { get; set; } = CabinStrategy.CabinStack;
     public bool AllowCabinRelocation { get; set; } = true;

--- a/mod/JunimoServer/Services/Settings/ServerSettings.cs
+++ b/mod/JunimoServer/Services/Settings/ServerSettings.cs
@@ -25,7 +25,7 @@ public class ServerSettings
 
 public class GameSettings
 {
-    public string FarmName { get; set; } = "Junimo";
+    public string FarmName { get; set; } = "Server";
     public FarmTypeSetting FarmType { get; set; } = FarmTypeSetting.Default;
     public float ProfitMargin { get; set; } = 1.0f;
     public int StartingCabins { get; set; } = 1;

--- a/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainerOptions.cs
@@ -26,9 +26,9 @@ public class ServerContainerOptions
     #region Game Settings (server-settings.json -> game)
 
     /// <summary>
-    /// Farm name. Default is "Junimo".
+    /// Farm name. Default is "Server".
     /// </summary>
-    public string FarmName { get; set; } = "Junimo";
+    public string FarmName { get; set; } = "Server";
 
     /// <summary>Boot farm type written to server-settings.json.</summary>
     public FarmTypeSetting FarmType { get; set; } = FarmTypeSetting.FromIndex(0);

--- a/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ManagedServer.cs
@@ -1519,7 +1519,7 @@ internal sealed class ManagedServer : IAsyncDisposable
     /// </summary>
     public async Task CreateNewGameAsync(
         FarmTypeSetting farmType,
-        string farmName = "Junimo",
+        string farmName = "Server",
         int startingCabins = 1,
         string cabinStrategy = "CabinStack",
         int? maxPlayers = null,

--- a/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/ResourceLease.cs
@@ -121,7 +121,7 @@ public sealed class ResourceLease : IAsyncDisposable
     /// </summary>
     public async Task CreateNewGameAsync(
         FarmTypeSetting farmType,
-        string farmName = "Junimo",
+        string farmName = "Server",
         int startingCabins = 1,
         string cabinStrategy = "CabinStack",
         int? maxPlayers = null,

--- a/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
+++ b/tests/JunimoServer.Tests/Infrastructure/TestBase.cs
@@ -720,7 +720,7 @@ public abstract class TestBase : IAsyncLifetime, IDisposable
     /// </summary>
     protected async Task CreateNewGameOnServerAsync(
         FarmTypeSetting farmType,
-        string farmName = "Junimo",
+        string farmName = "Server",
         int startingCabins = 1,
         string cabinStrategy = "CabinStack",
         int? maxPlayers = null,

--- a/tests/JunimoServer.Tests/ServerSettingsTests.cs
+++ b/tests/JunimoServer.Tests/ServerSettingsTests.cs
@@ -46,7 +46,7 @@ public class ServerSettingsTests : TestBase
         new List<object[]>
         {
             // Game settings
-            new object[] { "Game.FarmName", "Junimo" },
+            new object[] { "Game.FarmName", "Server" },
             new object[] { "Game.FarmType", "0" },
             new object[] { "Game.ProfitMargin", 1.0f },
             new object[]


### PR DESCRIPTION
- **deploy-server.yml:** pass `DEPLOY_DISCORD_BOT_NICKNAME` (GitHub Environment variable) into the generated `.env` as `DISCORD_BOT_NICKNAME`
- **deploy-docs.yml:** the "latest missing" refusal now distinguishes an unconfigured-R2 restore (`skipped`) from a genuinely-empty snapshot, so the error names the real cause instead of always telling operators to re-run with `rebuild_latest=true`
- **ci-cd.md:** document the `TARGETS` JSON entries (replacing the stale matrix example) and add an Environment Variables section for `DEPLOY_DISCORD_BOT_NICKNAME`
- **discord.md:** note that the nickname is distinct from the username/icon set in the Developer Portal
- **Default `FarmName` changed from `"Junimo"` to `"Server"`** across the mod, test infrastructure, and docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * New servers and game configurations now use **“Server”** as the default farm name instead of **“Junimo.”**
  * Discord bot deployments can configure the displayed bot nickname through deployment settings.
  * R2 snapshot restoration and persistence now fail deployments when configuration or snapshot operations are incomplete or unreachable; intentionally disabled R2 storage remains supported.

* **Documentation**
  * Updated Discord setup, deployment, environment, recovery, and server settings guidance to reflect the new defaults, nickname configuration, deployment model, and stricter snapshot requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->