### PR TITLE
fix(server): skip audio cue modification on headless server

### DIFF
--- a/mod/JunimoServer/Services/ServerOptim/ServerOptimizer.cs
+++ b/mod/JunimoServer/Services/ServerOptim/ServerOptimizer.cs
@@ -73,6 +73,17 @@ public class ServerOptimizer : ModService
             )
         );
 
+        // Skip content-pack audio (Data/AudioChanges): SoundEffect loads fail headless, spamming Error logs.
+        harmony.Patch(
+            original: AccessTools.Method(
+                "StardewValley.Audio.AudioCueModificationManager:ApplyCueModification"
+            ),
+            prefix: new HarmonyMethod(
+                typeof(ServerOptimizerOverrides),
+                nameof(ServerOptimizerOverrides.Disable_Prefix)
+            )
+        );
+
         // harmony.Patch(
         //     original: AccessTools.Method("StardewValley.Game1:CheckGamepadMode"),
         //     prefix: new HarmonyMethod(typeof(ServerOptimizerOverrides), nameof(ServerOptimizerOverrides.Disable_Prefix))


### PR DESCRIPTION
- Add a Harmony prefix skipping `AudioCueModificationManager.ApplyCueModification` on the server.
- This is the only vanilla path that builds a raw `SoundEffect`, which needs an audio output device the headless server doesn't have. It throws `NoAudioHardwareException`, logged at `Error` ("Error loading sound: ...") — test poison and log spam.
- Custom audio from content packs (`Data/AudioChanges`, e.g. Stardew Valley Expanded) all funnels through this method, so one patch covers every such mod.
- Reuses the existing `Disable_Prefix`; no new method added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom audio cue modifications by preventing unnecessary vanilla sound-effect construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->