### PR TITLE
docs(mods): add mod compatibility guidance and diagnostics reporting

### DIFF
--- a/docs/community/reporting-bugs.md
+++ b/docs/community/reporting-bugs.md
@@ -35,9 +35,10 @@ The zip is saved in a `diagnostics` folder next to your `docker-compose.yml` fil
 your issue — it covers the environment and logs the template asks for. See the [diagnostics
 command](/admins/operations/commands) for what's included.
 
-Passwords and API keys are masked in the bundle, but the logs are included as-is and can contain
-details like player names, platform IDs, or file paths. GitHub issues are public, so skim the zip
-and remove anything you'd rather not share.
+::: warning
+Passwords and API keys are masked, but logs are attached as-is and may include player names,
+platform IDs, or file paths. Issues are public — skim the zip before attaching.
+:::
 
 ::: tip
 This command is part of the standard server image. The [modern (Alpine)

--- a/docs/community/reporting-bugs.md
+++ b/docs/community/reporting-bugs.md
@@ -20,8 +20,25 @@ Check [open issues](https://github.com/stardew-valley-dedicated-server/server/is
    - Clear title
    - Steps to reproduce
    - Expected vs actual behavior
-   - Environment (OS, Docker version, JunimoServer version)
-   - Logs and error messages
+   - Environment and logs — the diagnostics bundle below gathers these for you
+
+## Collect Diagnostics
+
+Rather than copying logs by hand, run the diagnostics bundle. It gathers the server logs,
+version, and setup into a single zip:
+
+```sh
+docker compose exec -it server diagnostics
+```
+
+The zip is saved in a `diagnostics` folder next to your `docker-compose.yml` file. Attach it to
+your issue — it covers the environment and logs the template asks for. See the [diagnostics
+command](/admins/operations/commands) for what's included.
+
+::: tip
+This command is part of the standard server image. The [modern (Alpine)
+image](/admins/operations/modern-docker) doesn't include it, so attach your logs manually there.
+:::
 
 ## Found a Fix?
 
@@ -55,7 +72,7 @@ Server crashes with NullReferenceException
 - Mods: Expanded Cabins v2.1.0
 
 **Logs:**
-[Attach relevant log output here]
+[Attach the diagnostics zip, or paste relevant log output]
 
 **Additional Context:**
 Works fine with 10 or fewer cabins. Issue only occurs with 11+.

--- a/docs/community/reporting-bugs.md
+++ b/docs/community/reporting-bugs.md
@@ -35,6 +35,10 @@ The zip is saved in a `diagnostics` folder next to your `docker-compose.yml` fil
 your issue — it covers the environment and logs the template asks for. See the [diagnostics
 command](/admins/operations/commands) for what's included.
 
+Passwords and API keys are masked in the bundle, but the logs are included as-is and can contain
+details like player names, platform IDs, or file paths. GitHub issues are public, so skim the zip
+and remove anything you'd rather not share.
+
 ::: tip
 This command is part of the standard server image. The [modern (Alpine)
 image](/admins/operations/modern-docker) doesn't include it, so attach your logs manually there.

--- a/docs/features/mods.md
+++ b/docs/features/mods.md
@@ -23,6 +23,7 @@ Download SMAPI mods from sources like:
 - [Nexus Mods](https://www.nexusmods.com/stardewvalley)
 - [ModDrop](https://www.moddrop.com/stardew-valley)
 - [CurseForge](https://www.curseforge.com/stardewvalley)
+- [Stardew Valley Official Forum](https://forums.stardewvalley.net/forums/mods.25/)
 
 Extract mod folders into your `mods` directory.
 

--- a/docs/features/mods.md
+++ b/docs/features/mods.md
@@ -22,7 +22,7 @@ Download SMAPI mods from sources like:
 
 - [Nexus Mods](https://www.nexusmods.com/stardewvalley)
 - [ModDrop](https://www.moddrop.com/stardew-valley)
-- [Stardew Valley Official Forum](https://forums.stardewvalley.net/index.php?forums/mods.10/)
+- [CurseForge](https://www.curseforge.com/stardewvalley)
 
 Extract mod folders into your `mods` directory.
 

--- a/docs/features/mods.md
+++ b/docs/features/mods.md
@@ -4,6 +4,10 @@ JunimoServer supports SMAPI mods.
 
 ## Installing Mods
 
+::: tip
+[Back up your saves](/features/backup) before adding or changing mods.
+:::
+
 ### 1. Create a Mods Directory
 
 Create a directory on your host machine to store mods:
@@ -41,7 +45,8 @@ docker compose up -d
 ```
 
 ::: tip Verify Mods Loaded
-Connect to VNC and check the SMAPI console. SMAPI lists all loaded mods at startup.
+Attach to the [server console](/admins/operations/commands) with `docker compose exec server
+attach-cli` — its top pane shows the server logs, where SMAPI lists all loaded mods at startup.
 :::
 
 ## Mod Types
@@ -53,23 +58,72 @@ Connect to VNC and check the SMAPI console. SMAPI lists all loaded mods at start
 | **Client-only** | Client only | UI improvements, client utilities |
 
 ::: warning Content Mods
-Content mods that add items, NPCs, or maps must be installed on both the server and all connecting clients. Mismatched mods cause sync issues. Share your mod list with players.
+Content mods that add items, NPCs, or maps must be installed on **both the server and every
+client**, with matching versions and configuration. A mismatch causes sync issues such as missing
+items or NPCs, so share your mod list and versions with players.
 :::
 
-## Finding Compatible Mods
+## Mod Compatibility
 
-When choosing mods for your server:
+Most mods work on JunimoServer without any changes. Assume a mod is fine unless it's listed
+below or you run into problems with it.
 
-- Look for "multiplayer compatible" in mod descriptions
-- Check mod comments/forums for multiplayer feedback
-- Test with a small group before adding to production
-- Prefer actively maintained mods
+We don't keep a list of mods that are known to work. Such a list would suggest that anything
+missing from it is unsupported, which isn't true, and it would be impossible to keep up to date
+across thousands of mods and every game update. This page lists only the mods and types of mods
+that are known to cause problems.
+
+When picking mods, prefer ones that are actively maintained and check the comments for
+multiplayer feedback.
+
+### Mod types that usually don't work
+
+These are broad types rather than specific mods. A headless server can't support them:
+
+- **Client and UI mods on the server** — the server doesn't render graphics or take input, so
+  UI, HUD, and interface mods do nothing there. Install them on each player's client instead.
+- **Mods that need keyboard, mouse, or the game window** — the server runs headless with input
+  and rendering turned off, so anything driven by keybinds or per-frame drawing won't work.
+- **Mods that assume single-player** — the server always runs in multiplayer mode, so a mod that
+  expects one local player can behave unexpectedly.
+- **Mods that change the save-folder layout** — the server manages its own save folders and
+  Docker volumes, so a mod that restructures how saves are stored can conflict with that.
+- **Mods that add their own always-on or no-pause behavior** — the server already runs
+  always-on and handles day transitions itself, so a mod doing the same can fight it.
+
+::: warning Mods that add host-side events
+The server plays the host automatically, with no one at the keyboard to click through prompts.
+Mods that add new host-side events, festivals, or cutscenes can stall it if the automation
+doesn't know how to advance them — most often as a hang during a day transition. This doesn't
+mean they're incompatible, but test them before running them on a live server.
+:::
+
+### Known incompatible mods
+
+| Mod | Problem | Status | Last checked |
+|-----|---------|--------|--------------|
+| _None so far_ | — | — | — |
+
+**Status** is either **Incompatible** (no known workaround) or **Workaround** (works with the
+setup noted in the row). **Last checked** is the date we last confirmed the entry — if it's old,
+the mod may have changed since, so it's worth re-testing and opening a PR if it works now.
+
+### Reporting a problem
+
+If a mod misbehaves, please [report it](/community/reporting-bugs) so we can fix it or add it
+here. Attaching a [diagnostics bundle](/community/reporting-bugs#collect-diagnostics) gives us the
+logs and setup automatically — no copy-pasting. In your own words, also tell us:
+
+- **The mod's name and version**
+- **Where it goes wrong** — on the server, on a client, or when connecting
+
+Each report becomes a fix or a new entry, which keeps this list short and accurate.
 
 ## Troubleshooting
 
 ### Mod Not Loading
 
-1. **Check SMAPI console**: Look for error messages in VNC
+1. **Check the server console**: Look for error messages in `docker compose exec server attach-cli`
 2. **Verify mod location**: Ensure correct directory structure
 3. **Check dependencies**: Some mods require other mods
 4. **Update mods**: Ensure compatibility with your game version
@@ -77,14 +131,6 @@ When choosing mods for your server:
 ### "Missing assembly" Errors
 
 The mod is missing a dependency. Check the mod's page for required mods.
-
-### Players Missing Items/NPCs
-
-Content mod mismatch. Ensure all players have:
-
-- Same mods installed
-- Same mod versions
-- Same configuration (if applicable)
 
 ### Performance Issues
 
@@ -94,29 +140,3 @@ If performance degrades after adding mods:
 - Check mod resource usage requirements
 - Consider increasing server resources
 - Remove unused mods
-
-## Best Practices
-
-- Keep mods updated
-- Read mod descriptions for requirements and compatibility
-- Backup saves before adding mods
-- Test new mods before rolling out to all players
-- Keep a list of installed mods and versions
-
-## Directory Structure
-
-After setup, your mod structure should look like:
-
-```
-your-server/
-├── docker-compose.yml
-├── .env
-└── mods/
-    ├── SomeContentMod/
-    │   └── manifest.json
-    └── AnotherMod/
-        └── manifest.json
-```
-
-The server mounts these at `/data/Mods/extra` and SMAPI loads them automatically.
-


### PR DESCRIPTION
- Rework the mod support page around a maintainable denylist model: most mods work; list the mod *types* a headless server can't support; keep a known-incompatible table for verified cases.
- Add a warning for mods that add host-side events/festivals/cutscenes, which can stall the automated host at a day transition.
- Explain why there is intentionally no known-good/allowlist.
- Route log/console guidance to the attach-cli console instead of VNC (which needs rendering enabled first).
- Add a "Collect Diagnostics" section to the bug-reporting page so people attach a diagnostics zip instead of copy-pasting console output; link it from the mod page.
- Fold duplicated troubleshooting, best-practices, and directory sections into single homes; cross-link save backup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bug-reporting guidance to use a diagnostics archive containing server information and logs.
  * Added instructions for attaching diagnostics to issues, including manual log attachment for Alpine images.
  * Expanded mod compatibility guidance with troubleshooting, known incompatibilities, reporting steps, and save-backup advice.
  * Updated mod-loading verification instructions to use the server console instead of VNC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->