### PR TITLE
fix(api): declare public endpoints on the attribute and emit bearer security in the spec

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ VNC_PASSWORD=""
 # HTTP API for external tools (default: true)
 # API_ENABLED=true
 
-# API key required by authenticated endpoints (recommended in production)
+# API key for the HTTP API (recommended in production)
 # Generate: openssl rand -base64 32
 # API_KEY=""
 

--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ VNC_PASSWORD=""
 # HTTP API for external tools (default: true)
 # API_ENABLED=true
 
-# API key protecting write endpoints (recommended in production)
+# API key required by authenticated endpoints (recommended in production)
 # Generate: openssl rand -base64 32
 # API_KEY=""
 

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -129,7 +129,7 @@ When `true`, the REST API is available for external tools and monitoring. See [R
 
 ### API_KEY
 
-When set, all API endpoints require an `Authorization: Bearer <api-key>` header (except `/health` and `/docs`).
+When set, API endpoints require an `Authorization: Bearer <api-key>` header. The [API reference](/developers/api/introduction) marks which endpoints are public.
 
 Generate a secure key:
 
@@ -138,7 +138,7 @@ openssl rand -base64 32
 ```
 
 ::: tip When do I need this?
-Currently, only the Discord bot uses the API. If you:
+The Discord bot and the in-container `diagnostics` tool send the key on every request. If you:
 - **Use the Discord bot**: Set the same `API_KEY` for both server and bot
 - **Don't use the Discord bot**: You can skip `API_KEY` if the API port (default 8080) is not exposed externally
 - **Build custom integrations** (web dashboard, monitoring, etc.): Set `API_KEY` and include it in your requests

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -138,7 +138,7 @@ openssl rand -base64 32
 ```
 
 ::: tip When do I need this?
-The Discord bot and the in-container `diagnostics` tool send the key on every request. If you:
+The Discord bot and the `diagnostics` command use the API. If you:
 - **Use the Discord bot**: Set the same `API_KEY` for both server and bot
 - **Don't use the Discord bot**: You can skip `API_KEY` if the API port (default 8080) is not exposed externally
 - **Build custom integrations** (web dashboard, monitoring, etc.): Set `API_KEY` and include it in your requests

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -137,20 +137,15 @@ Generate a secure key:
 openssl rand -base64 32
 ```
 
-::: tip When do I need this?
-The Discord bot and the `diagnostics` command use the API. If you:
-- **Use the Discord bot**: Set the same `API_KEY` for both server and bot
-- **Don't use the Discord bot**: You can skip `API_KEY` if the API port (default 8080) is not exposed externally
-- **Build custom integrations** (web dashboard, monitoring, etc.): Set `API_KEY` and include it in your requests
-:::
-
-::: warning
-Without `API_KEY`, anyone with network access to the API port (default 8080) can read server data and control your server. Always set this if the API is accessible from untrusted networks.
+::: tip Who needs the key
+- **Discord bot**: set the same `API_KEY` for the server and the bot.
+- **`diagnostics` command**: reads the key from the container environment.
+- **Your own integrations**: send the `Authorization` header.
 :::
 
 ### ALLOW_INSECURE_SETUP
 
-By default the server aborts startup when `VNC_PASSWORD` is empty or (with `API_ENABLED=true`) `API_KEY` is empty — leaving the VNC interface or HTTP API exposed without authentication. Set `ALLOW_INSECURE_SETUP=true` to override the abort on closed networks where the affected ports are not reachable from untrusted clients.
+The server refuses to start without `VNC_PASSWORD`, or without `API_KEY` while `API_ENABLED=true`. Set `ALLOW_INSECURE_SETUP=true` to start anyway. Only do this on networks where the VNC and API ports are not reachable by untrusted clients.
 
 ## Port Summary
 

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -27,13 +27,13 @@ The API is enabled by default. Configure via environment variables:
 
 ## Authentication
 
-When `API_KEY` is set, every endpoint marked with the bearer lock in the reference requires it via the `Authorization` header:
+If `API_KEY` is set, send it with every request:
 
 ```http
 Authorization: Bearer <your-api-key>
 ```
 
-Endpoints without the lock (health checks, server status, this documentation) answer without a key.
+Endpoints with a lock icon in the reference need the key. The others (health, status, docs) work without it.
 
 ### Example
 

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -23,13 +23,13 @@ The API is enabled by default. Configure via environment variables:
 |----------|-------------|---------|
 | `API_ENABLED` | Enable/disable the API | `true` |
 | `API_PORT` | Port for the API server | `8080` |
-| `API_KEY` | API key required by authenticated endpoints | (empty = no auth) |
+| `API_KEY` | API key required by authenticated endpoints | (empty = no auth; startup then requires `ALLOW_INSECURE_SETUP=true`) |
 
 ## Authentication
 
 When `API_KEY` is set, every endpoint marked with the bearer lock in the reference requires it via the `Authorization` header:
 
-```
+```http
 Authorization: Bearer <your-api-key>
 ```
 

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -23,34 +23,26 @@ The API is enabled by default. Configure via environment variables:
 |----------|-------------|---------|
 | `API_ENABLED` | Enable/disable the API | `true` |
 | `API_PORT` | Port for the API server | `8080` |
-| `API_KEY` | API key for write endpoints | (empty = no auth) |
+| `API_KEY` | API key required by authenticated endpoints | (empty = no auth) |
 
 ## Authentication
 
-When `API_KEY` is set, all endpoints require authentication via the `Authorization` header:
+When `API_KEY` is set, every endpoint marked with the bearer lock in the reference requires it via the `Authorization` header:
 
 ```
 Authorization: Bearer <your-api-key>
 ```
 
-### Public Endpoints
-
-These endpoints remain accessible without authentication:
-
-| Endpoint | Purpose |
-|----------|---------|
-| `/health` | Health checks for monitoring tools |
-| `/docs` | API documentation UI |
-| `/swagger/v1/swagger.json` | OpenAPI specification |
+Endpoints without the lock (health checks, server status, this documentation) answer without a key.
 
 ### Example
 
 ```sh
 # Without auth (will fail if API_KEY is set)
-curl "http://localhost:8080/status"
+curl "http://localhost:8080/players"
 
 # With auth
-curl "http://localhost:8080/status" \
+curl "http://localhost:8080/players" \
   -H "Authorization: Bearer your-api-key"
 ```
 

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -33,7 +33,7 @@ If `API_KEY` is set, send it with every request:
 Authorization: Bearer <your-api-key>
 ```
 
-Endpoints with a lock icon in the reference need the key. The others (health, status, docs) work without it.
+Each endpoint page in this reference says whether it needs the key. Health, status and the docs pages work without one.
 
 ### Example
 

--- a/mod/JunimoServer/Services/Api/ApiAttributes.cs
+++ b/mod/JunimoServer/Services/Api/ApiAttributes.cs
@@ -14,12 +14,6 @@ public class ApiEndpointAttribute : Attribute
     public string? Description { get; set; }
     public string? Tag { get; set; }
 
-    /// <summary>
-    /// Served without the API key even when <c>API_KEY</c> is set. The request router and the
-    /// OpenAPI security model both read this flag, so it is the only place an endpoint's auth
-    /// requirement is declared. Never set on a <c>/test/*</c> route: those must stay
-    /// indistinguishable from unknown routes in production (401 without a key, 404 with one).
-    /// </summary>
     public bool Public { get; set; }
 
     public ApiEndpointAttribute(string method, string path)

--- a/mod/JunimoServer/Services/Api/ApiAttributes.cs
+++ b/mod/JunimoServer/Services/Api/ApiAttributes.cs
@@ -14,6 +14,14 @@ public class ApiEndpointAttribute : Attribute
     public string? Description { get; set; }
     public string? Tag { get; set; }
 
+    /// <summary>
+    /// Served without the API key even when <c>API_KEY</c> is set. The request router and the
+    /// OpenAPI security model both read this flag, so it is the only place an endpoint's auth
+    /// requirement is declared. Never set on a <c>/test/*</c> route: those must stay
+    /// indistinguishable from unknown routes in production (401 without a key, 404 with one).
+    /// </summary>
+    public bool Public { get; set; }
+
     public ApiEndpointAttribute(string method, string path)
     {
         Method = method.ToUpperInvariant();

--- a/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.TestEndpoints.cs
@@ -24,11 +24,6 @@ namespace JunimoServer.Services.Api;
 // Test-only HTTP endpoints (/test/*), split out from ApiService so the production
 // dispatcher never names them. Reachable only under Env.IsTest — see the gate in
 // ApiService.HandleRequest and the OpenAPI filter in ApiService.StartServer.
-//
-// SEAM: to compile these out of production binaries entirely, define
-// INCLUDE_TEST_ENDPOINTS for test builds only and wrap this file's body (and
-// ApiService.TestEndpoints.Models.cs's body) plus the two // SEAM references in
-// ApiService.cs (the dispatcher gate and the OpenAPI predicate).
 public partial class ApiService
 {
     /// <summary>

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -186,7 +186,7 @@ public class DiagnosticsStateResponse
     /// <summary>UMIs in <c>Multiplayer.disconnectingFarmers</c> (mid-disconnect).</summary>
     public long[] DisconnectingFarmers { get; set; } = System.Array.Empty<long>();
 
-    // ── Save-import assertion probes (counts/booleans/small ints only; no identifiers). ──
+    // ── Save-import assertion probes ──
     // The post-swap Server-host FarmHouse must be empty after the contents/NPC move.
     /// <summary>Placed-object count in the host FarmHouse (must be 0 after a swap import).</summary>
     public int FarmHouseObjectCount { get; set; }
@@ -253,13 +253,11 @@ public class DiagnosticsCabinState
     /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, which
     /// yields the live otherFarmers copy while the owner is connected (so the in-flight userID
-    /// stamp is visible here before disconnect persists it to farmhandData). Exposed as a bool,
-    /// not the raw ID, so the snapshot never carries a platform identifier.</summary>
+    /// stamp is visible here before disconnect persists it to farmhandData). Exposed as a bool, not the raw ID.</summary>
     public bool OwnerHasUserId { get; set; }
 
     /// <summary>Whether the cabin owner (its farmhand) has a server-side ownership record
-    /// (recorded at the join gate's approve moment or by a save-import bind). Bool, not the raw
-    /// ID, as with <see cref="OwnerHasUserId"/>.</summary>
+    /// (recorded at the join gate's approve moment or by a save-import bind). Bool, not the raw ID.</summary>
     public bool OwnerHasOwner { get; set; }
 
     /// <summary>Platform tag of the cabin owner's ownership record ("steam"/"galaxy"), or ""
@@ -297,13 +295,11 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID,
-    /// so the snapshot never carries a platform identifier.</summary>
+    /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID.</summary>
     public bool HasUserId { get; set; }
 
     /// <summary>Whether this slot has a server-side ownership record (recorded at the join
-    /// gate's approve moment or by a save-import bind). Bool, not the raw ID — same
-    /// rule as <see cref="HasUserId"/>.</summary>
+    /// gate's approve moment or by a save-import bind). Bool, not the raw ID.</summary>
     public bool HasOwner { get; set; }
 
     /// <summary>Platform tag of the ownership record ("steam"/"galaxy"), or "" when unowned.</summary>
@@ -1129,12 +1125,6 @@ public partial class ApiService : ModService
     /// </summary>
     private static readonly bool _authEnabled = !string.IsNullOrEmpty(Env.ApiKey);
 
-    /// <summary>
-    /// (method, path) pairs whose <see cref="ApiEndpointAttribute.Public"/> flag is set. Any
-    /// request not in this set requires the API key when one is configured; a path with no
-    /// attribute is therefore never public, and a /test/* route is never public regardless of
-    /// its attribute.
-    /// </summary>
     private static readonly HashSet<(string Method, string Path)> _publicEndpoints =
         typeof(ApiService)
             .GetMethods(
@@ -1959,7 +1949,6 @@ public partial class ApiService : ModService
             // Generate OpenAPI spec. Test-only endpoints are spec-visible iff they are
             // runtime-reachable (Env.IsTest) — the same gate the dispatcher uses, so the
             // published contract and the routing cannot drift.
-            // SEAM: if INCLUDE_TEST_ENDPOINTS is introduced, wrap this predicate's IsTestPath/Env.IsTest use.
             var document = OpenApiGenerator.Generate(
                 typeof(ApiService),
                 "Stardew Dedicated Server API",
@@ -2164,7 +2153,6 @@ public partial class ApiService : ModService
                 return;
             }
 
-            // Validate API key unless the endpoint's attribute marks it Public.
             if (!_publicEndpoints.Contains((method, path)) && !ValidateApiKey(request))
             {
                 await WriteUnauthorizedAsync(response);
@@ -2177,7 +2165,6 @@ public partial class ApiService : ModService
             // and an authenticated caller gets the same 404 a missing route gets.
             // Never mark a /test/* route Public — that would both unauthenticate these
             // routes AND leak their existence (404 vs 401) in production.
-            // SEAM: if INCLUDE_TEST_ENDPOINTS is introduced, wrap this block.
             if (IsTestPath(path))
             {
                 if (!Env.IsTest)
@@ -3734,11 +3721,6 @@ public partial class ApiService : ModService
         return report;
     }
 
-    /// <summary>
-    /// Long-poll variant of <c>/players</c>. Query params: <c>since=N</c> (last observed
-    /// snapshot version), <c>playerId=N</c> (wait until that player is present), and
-    /// <c>timeout=ms</c> (bounded by <see cref="WaitMaxTimeout"/>).
-    /// </summary>
     [ApiEndpoint("GET", "/wait/players", Summary = "Long-poll connected players", Tag = "Server")]
     [ApiResponse(typeof(PlayersResponse), 200, Description = "Player list once the filters match")]
     [ApiResponse(typeof(void), 408, Description = "Timeout elapsed with no match")]
@@ -5265,7 +5247,6 @@ public partial class ApiService : ModService
         await response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
     }
 
-    /// <summary>Serialized OpenAPI document, generated once in <see cref="StartServer"/>.</summary>
     [ApiEndpoint(
         "GET",
         "/swagger/v1/swagger.json",
@@ -5275,10 +5256,6 @@ public partial class ApiService : ModService
     )]
     private string HandleGetOpenApiSpec() => _openApiSpec ?? "{}";
 
-    /// <summary>
-    /// Interactive API reference page. Served without the key because a browser navigation
-    /// cannot attach a bearer header, and the spec it renders is public anyway.
-    /// </summary>
     [ApiEndpoint("GET", "/docs", Summary = "API documentation UI", Tag = "Docs", Public = true)]
     private string HandleGetDocs()
     {

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -1132,7 +1132,8 @@ public partial class ApiService : ModService
     /// <summary>
     /// (method, path) pairs whose <see cref="ApiEndpointAttribute.Public"/> flag is set. Any
     /// request not in this set requires the API key when one is configured; a path with no
-    /// attribute is therefore never public.
+    /// attribute is therefore never public, and a /test/* route is never public regardless of
+    /// its attribute.
     /// </summary>
     private static readonly HashSet<(string Method, string Path)> _publicEndpoints =
         typeof(ApiService)
@@ -1143,7 +1144,7 @@ public partial class ApiService : ModService
                     | BindingFlags.Public
             )
             .Select(m => m.GetCustomAttribute<ApiEndpointAttribute>())
-            .Where(ep => ep is { Public: true })
+            .Where(ep => ep is { Public: true } && !IsTestPath(ep.Path))
             .Select(ep => (ep!.Method, ep.Path))
             .ToHashSet();
 
@@ -2227,7 +2228,7 @@ public partial class ApiService : ModService
                         );
                         break;
                     case "/diagnostics/handler-timing":
-                        await WriteJsonAsync(response, BuildHandlerTimingReport());
+                        await WriteJsonAsync(response, HandleGetHandlerTiming());
                         break;
                     case "/stats":
                         await WriteJsonAsync(response, HandleGetStats());
@@ -3706,7 +3707,7 @@ public partial class ApiService : ModService
         Tag = "Diagnostics"
     )]
     [ApiResponse(typeof(HandlerTimingReport), 200)]
-    private HandlerTimingReport BuildHandlerTimingReport()
+    private HandlerTimingReport HandleGetHandlerTiming()
     {
         var report = new HandlerTimingReport();
         foreach (var (name, acc) in _handlerTimings)

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -186,7 +186,7 @@ public class DiagnosticsStateResponse
     /// <summary>UMIs in <c>Multiplayer.disconnectingFarmers</c> (mid-disconnect).</summary>
     public long[] DisconnectingFarmers { get; set; } = System.Array.Empty<long>();
 
-    // ── Save-import assertion probes (counts/booleans/small ints only; unauthenticated-safe). ──
+    // ── Save-import assertion probes (counts/booleans/small ints only; no identifiers). ──
     // The post-swap Server-host FarmHouse must be empty after the contents/NPC move.
     /// <summary>Placed-object count in the host FarmHouse (must be 0 after a swap import).</summary>
     public int FarmHouseObjectCount { get; set; }
@@ -254,12 +254,12 @@ public class DiagnosticsCabinState
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, which
     /// yields the live otherFarmers copy while the owner is connected (so the in-flight userID
     /// stamp is visible here before disconnect persists it to farmhandData). Exposed as a bool,
-    /// not the raw ID: /diagnostics/state is unauthenticated and the ID is a stable identifier.</summary>
+    /// not the raw ID, so the snapshot never carries a platform identifier.</summary>
     public bool OwnerHasUserId { get; set; }
 
     /// <summary>Whether the cabin owner (its farmhand) has a server-side ownership record
     /// (recorded at the join gate's approve moment or by a save-import bind). Bool, not the raw
-    /// ID — same unauthenticated-endpoint rule as <see cref="OwnerHasUserId"/>.</summary>
+    /// ID, as with <see cref="OwnerHasUserId"/>.</summary>
     public bool OwnerHasOwner { get; set; }
 
     /// <summary>Platform tag of the cabin owner's ownership record ("steam"/"galaxy"), or ""
@@ -272,7 +272,7 @@ public class DiagnosticsCabinState
 
     /// <summary>Count of placed objects (chests/machines) in the cabin interior. Used by the
     /// save-import contents-move test to assert the owner's chests moved into the cabin. Count
-    /// only (not contents) — /diagnostics/state is unauthenticated.</summary>
+    /// only, not contents.</summary>
     public int ObjectCount { get; set; }
 
     /// <summary>Count of items in the cabin fridge (save-import contents move).</summary>
@@ -297,13 +297,13 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID:
-    /// /diagnostics/state is unauthenticated and the ID is a stable identifier.</summary>
+    /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID,
+    /// so the snapshot never carries a platform identifier.</summary>
     public bool HasUserId { get; set; }
 
     /// <summary>Whether this slot has a server-side ownership record (recorded at the join
     /// gate's approve moment or by a save-import bind). Bool, not the raw ID — same
-    /// unauthenticated-endpoint rule as <see cref="HasUserId"/>.</summary>
+    /// rule as <see cref="HasUserId"/>.</summary>
     public bool HasOwner { get; set; }
 
     /// <summary>Platform tag of the ownership record ("steam"/"galaxy"), or "" when unowned.</summary>
@@ -1128,6 +1128,24 @@ public partial class ApiService : ModService
     /// Whether API key authentication is enabled.
     /// </summary>
     private static readonly bool _authEnabled = !string.IsNullOrEmpty(Env.ApiKey);
+
+    /// <summary>
+    /// (method, path) pairs whose <see cref="ApiEndpointAttribute.Public"/> flag is set. Any
+    /// request not in this set requires the API key when one is configured; a path with no
+    /// attribute is therefore never public.
+    /// </summary>
+    private static readonly HashSet<(string Method, string Path)> _publicEndpoints =
+        typeof(ApiService)
+            .GetMethods(
+                BindingFlags.Instance
+                    | BindingFlags.Static
+                    | BindingFlags.NonPublic
+                    | BindingFlags.Public
+            )
+            .Select(m => m.GetCustomAttribute<ApiEndpointAttribute>())
+            .Where(ep => ep is { Public: true })
+            .Select(ep => (ep!.Method, ep.Path))
+            .ToHashSet();
 
     public ApiService(
         IModHelper helper,
@@ -1982,7 +2000,7 @@ public partial class ApiService : ModService
             if (_authEnabled)
             {
                 Monitor.Log(
-                    "API authentication enabled - all endpoints require Authorization header",
+                    "API authentication enabled - endpoints not marked public require Authorization header",
                     LogLevel.Info
                 );
             }
@@ -2145,22 +2163,8 @@ public partial class ApiService : ModService
                 return;
             }
 
-            // Public endpoints (no auth required).
-            // /diagnostics/state is public because it is a test-harness
-            // failure-diagnosis endpoint: callers are the test containers
-            // inside the Testcontainers network, not external Internet
-            // clients. Exposing it unauthenticated lets a timed-out poll
-            // grab ground-truth state without having to pass the API key.
-            var isPublicEndpoint =
-                path == "/health"
-                || path == "/wait/health"
-                || path == "/stats"
-                || path == "/docs"
-                || path == "/swagger/v1/swagger.json"
-                || path == "/diagnostics/state";
-
-            // Validate API key for protected endpoints
-            if (!isPublicEndpoint && !ValidateApiKey(request))
+            // Validate API key unless the endpoint's attribute marks it Public.
+            if (!_publicEndpoints.Contains((method, path)) && !ValidateApiKey(request))
             {
                 await WriteUnauthorizedAsync(response);
                 return;
@@ -2170,7 +2174,7 @@ public partial class ApiService : ModService
             // gates above. Placed AFTER auth so production behaves identically to an unknown
             // route: an unauthenticated caller already got 401 (same as any non-public path),
             // and an authenticated caller gets the same 404 a missing route gets.
-            // DO NOT add /test/* to isPublicEndpoint — that would both unauthenticate these
+            // Never mark a /test/* route Public — that would both unauthenticate these
             // routes AND leak their existence (404 vs 401) in production.
             // SEAM: if INCLUDE_TEST_ENDPOINTS is introduced, wrap this block.
             if (IsTestPath(path))
@@ -2244,10 +2248,10 @@ public partial class ApiService : ModService
                         await WriteJsonAsync(response, HandleGetAuthStatus());
                         break;
                     case "/swagger/v1/swagger.json":
-                        await WriteJsonRawAsync(response, _openApiSpec ?? "{}");
+                        await WriteJsonRawAsync(response, HandleGetOpenApiSpec());
                         break;
                     case "/docs":
-                        await WriteHtmlAsync(response, GetScalarHtml());
+                        await WriteHtmlAsync(response, HandleGetDocs());
                         break;
                     default:
                         await WriteNotFoundAsync(response, path);
@@ -2789,7 +2793,7 @@ public partial class ApiService : ModService
     /// Invite code derivation and version are computed per-request (both thread-safe).
     /// Game state fields come from <see cref="TakeGameStateSnapshot"/>.
     /// </summary>
-    [ApiEndpoint("GET", "/status", Summary = "Get server status", Tag = "Server")]
+    [ApiEndpoint("GET", "/status", Summary = "Get server status", Tag = "Server", Public = true)]
     [ApiResponse(typeof(ServerStatus), 200, Description = "Server status and game state")]
     private ServerStatus HandleGetStatus()
     {
@@ -3430,7 +3434,7 @@ public partial class ApiService : ModService
         return s;
     }
 
-    [ApiEndpoint("GET", "/health", Summary = "Health check", Tag = "Health")]
+    [ApiEndpoint("GET", "/health", Summary = "Health check", Tag = "Health", Public = true)]
     [ApiResponse(typeof(HealthResponse), 200, Description = "Health status")]
     private HealthResponse HandleGetHealth()
     {
@@ -3509,6 +3513,9 @@ public partial class ApiService : ModService
     /// Returns 200 + current /status response when filters match a newer
     /// snapshot, or 408 if the timeout elapses with no match.
     /// </summary>
+    [ApiEndpoint("GET", "/wait/status", Summary = "Long-poll server status", Tag = "Server")]
+    [ApiResponse(typeof(ServerStatus), 200, Description = "Server status once the filters match")]
+    [ApiResponse(typeof(void), 408, Description = "Timeout elapsed with no match")]
     private async Task HandleWaitStatusAsync(
         HttpListenerRequest request,
         HttpListenerResponse response,
@@ -3692,6 +3699,13 @@ public partial class ApiService : ModService
 
     private static long ToUs(TimeSpan ts) => (long)(ts.TotalMilliseconds * 1000.0);
 
+    [ApiEndpoint(
+        "GET",
+        "/diagnostics/handler-timing",
+        Summary = "Per-handler request timing averages",
+        Tag = "Diagnostics"
+    )]
+    [ApiResponse(typeof(HandlerTimingReport), 200)]
     private HandlerTimingReport BuildHandlerTimingReport()
     {
         var report = new HandlerTimingReport();
@@ -3719,6 +3733,14 @@ public partial class ApiService : ModService
         return report;
     }
 
+    /// <summary>
+    /// Long-poll variant of <c>/players</c>. Query params: <c>since=N</c> (last observed
+    /// snapshot version), <c>playerId=N</c> (wait until that player is present), and
+    /// <c>timeout=ms</c> (bounded by <see cref="WaitMaxTimeout"/>).
+    /// </summary>
+    [ApiEndpoint("GET", "/wait/players", Summary = "Long-poll connected players", Tag = "Server")]
+    [ApiResponse(typeof(PlayersResponse), 200, Description = "Player list once the filters match")]
+    [ApiResponse(typeof(void), 408, Description = "Timeout elapsed with no match")]
     private async Task HandleWaitPlayersAsync(
         HttpListenerRequest request,
         HttpListenerResponse response,
@@ -3792,6 +3814,13 @@ public partial class ApiService : ModService
     /// <item><c>timeout=ms</c> — bounded by <see cref="WaitMaxTimeout"/>.</item>
     /// </list>
     /// </summary>
+    [ApiEndpoint("GET", "/wait/farmhands", Summary = "Long-poll farmhand slots", Tag = "Farmhands")]
+    [ApiResponse(
+        typeof(FarmhandsResponse),
+        200,
+        Description = "Farmhand list once the filters match"
+    )]
+    [ApiResponse(typeof(void), 408, Description = "Timeout elapsed with no match")]
     private async Task HandleWaitFarmhandsAsync(
         HttpListenerRequest request,
         HttpListenerResponse response,
@@ -3912,6 +3941,15 @@ public partial class ApiService : ModService
     /// <see cref="WaitMaxTimeout"/>; callers must wrap in an outer
     /// re-issue loop.
     /// </summary>
+    [ApiEndpoint(
+        "GET",
+        "/wait/health",
+        Summary = "Long-poll health",
+        Tag = "Health",
+        Public = true
+    )]
+    [ApiResponse(typeof(HealthResponse), 200, Description = "Health status once the filters match")]
+    [ApiResponse(typeof(void), 408, Description = "Timeout elapsed with no match")]
     private async Task HandleWaitHealthAsync(
         HttpListenerRequest request,
         HttpListenerResponse response,
@@ -5226,7 +5264,22 @@ public partial class ApiService : ModService
         await response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
     }
 
-    private string GetScalarHtml()
+    /// <summary>Serialized OpenAPI document, generated once in <see cref="StartServer"/>.</summary>
+    [ApiEndpoint(
+        "GET",
+        "/swagger/v1/swagger.json",
+        Summary = "OpenAPI specification",
+        Tag = "Docs",
+        Public = true
+    )]
+    private string HandleGetOpenApiSpec() => _openApiSpec ?? "{}";
+
+    /// <summary>
+    /// Interactive API reference page. Served without the key because a browser navigation
+    /// cannot attach a bearer header, and the spec it renders is public anyway.
+    /// </summary>
+    [ApiEndpoint("GET", "/docs", Summary = "API documentation UI", Tag = "Docs", Public = true)]
+    private string HandleGetDocs()
     {
         return @"<!DOCTYPE html>
 <html>

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -1989,10 +1989,7 @@ public partial class ApiService : ModService
             );
             if (_authEnabled)
             {
-                Monitor.Log(
-                    "API authentication enabled - endpoints not marked public require Authorization header",
-                    LogLevel.Info
-                );
+                Monitor.Log("API authentication enabled", LogLevel.Info);
             }
             else
             {
@@ -2159,12 +2156,8 @@ public partial class ApiService : ModService
                 return;
             }
 
-            // Test-only routes — a third early-return gate, mirroring the WebSocket and auth
-            // gates above. Placed AFTER auth so production behaves identically to an unknown
-            // route: an unauthenticated caller already got 401 (same as any non-public path),
-            // and an authenticated caller gets the same 404 a missing route gets.
-            // Never mark a /test/* route Public — that would both unauthenticate these
-            // routes AND leak their existence (404 vs 401) in production.
+            // After auth on purpose: in production a /test/* path must look like any other
+            // unknown route (401 without a key, 404 with one).
             if (IsTestPath(path))
             {
                 if (!Env.IsTest)

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -253,11 +253,11 @@ public class DiagnosticsCabinState
     /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, which
     /// yields the live otherFarmers copy while the owner is connected (so the in-flight userID
-    /// stamp is visible here before disconnect persists it to farmhandData). Exposed as a bool, not the raw ID.</summary>
+    /// stamp is visible here before disconnect persists it to farmhandData).</summary>
     public bool OwnerHasUserId { get; set; }
 
     /// <summary>Whether the cabin owner (its farmhand) has a server-side ownership record
-    /// (recorded at the join gate's approve moment or by a save-import bind). Bool, not the raw ID.</summary>
+    /// (recorded at the join gate's approve moment or by a save-import bind).</summary>
     public bool OwnerHasOwner { get; set; }
 
     /// <summary>Platform tag of the cabin owner's ownership record ("steam"/"galaxy"), or ""
@@ -295,11 +295,11 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. Exposed as a bool, not the raw ID.</summary>
+    /// IsCustomized=false is the abandoned-claim state.</summary>
     public bool HasUserId { get; set; }
 
     /// <summary>Whether this slot has a server-side ownership record (recorded at the join
-    /// gate's approve moment or by a save-import bind). Bool, not the raw ID.</summary>
+    /// gate's approve moment or by a save-import bind).</summary>
     public bool HasOwner { get; set; }
 
     /// <summary>Platform tag of the ownership record ("steam"/"galaxy"), or "" when unowned.</summary>

--- a/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
+++ b/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
@@ -52,7 +52,6 @@ public static class OpenApiGenerator
             },
         };
 
-        // Bearer scheme for the API key; every operation not marked Public requires it.
         document.Components.SecuritySchemes[BearerSchemeName] = new OpenApiSecurityScheme
         {
             Type = OpenApiSecuritySchemeType.Http,

--- a/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
+++ b/mod/JunimoServer/Services/Api/OpenApiGenerator.cs
@@ -13,6 +13,8 @@ namespace JunimoServer.Services.Api;
 /// </summary>
 public static class OpenApiGenerator
 {
+    private const string BearerSchemeName = "bearerAuth";
+
     /// <summary>
     /// Generates an OpenAPI document from a type's methods decorated with ApiEndpoint attributes.
     /// </summary>
@@ -50,6 +52,14 @@ public static class OpenApiGenerator
             },
         };
 
+        // Bearer scheme for the API key; every operation not marked Public requires it.
+        document.Components.SecuritySchemes[BearerSchemeName] = new OpenApiSecurityScheme
+        {
+            Type = OpenApiSecuritySchemeType.Http,
+            Scheme = "bearer",
+            Description = "The server's API_KEY. Only enforced when API_KEY is set.",
+        };
+
         var methods = serviceType
             .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
             .Where(m =>
@@ -72,6 +82,14 @@ public static class OpenApiGenerator
             if (!string.IsNullOrEmpty(endpoint.Tag))
             {
                 operation.Tags.Add(endpoint.Tag);
+            }
+
+            if (!endpoint.Public)
+            {
+                operation.Security = new List<OpenApiSecurityRequirement>
+                {
+                    new OpenApiSecurityRequirement { [BearerSchemeName] = Array.Empty<string>() },
+                };
             }
 
             // Add responses

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -243,12 +243,12 @@ public class DiagnosticsCabinState
 
     /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, so it
-    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID.</summary>
+    /// reflects the live otherFarmers copy while the owner is connected.</summary>
     [JsonPropertyName("ownerHasUserId")]
     public bool OwnerHasUserId { get; set; }
 
     /// <summary>Whether the cabin owner has a server-side ownership record (join-gate recorder
-    /// or save-import bind). Bool, not the raw ID.</summary>
+    /// or save-import bind).</summary>
     [JsonPropertyName("ownerHasOwner")]
     public bool OwnerHasOwner { get; set; }
 
@@ -296,12 +296,12 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID.</summary>
+    /// IsCustomized=false is the abandoned-claim state.</summary>
     [JsonPropertyName("hasUserId")]
     public bool HasUserId { get; set; }
 
     /// <summary>Whether this slot has a server-side ownership record (join-gate recorder or
-    /// save-import bind). Bool, not the raw ID.</summary>
+    /// save-import bind).</summary>
     [JsonPropertyName("hasOwner")]
     public bool HasOwner { get; set; }
 

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -243,8 +243,7 @@ public class DiagnosticsCabinState
 
     /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, so it
-    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID,
-    /// so the snapshot never carries a platform identifier.</summary>
+    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID.</summary>
     [JsonPropertyName("ownerHasUserId")]
     public bool OwnerHasUserId { get; set; }
 
@@ -297,8 +296,7 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID,
-    /// so the snapshot never carries a platform identifier.</summary>
+    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID.</summary>
     [JsonPropertyName("hasUserId")]
     public bool HasUserId { get; set; }
 

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -243,8 +243,8 @@ public class DiagnosticsCabinState
 
     /// <summary>Whether the owner has a platform ID (Steam/GOG) stamped; true with
     /// OwnerIsCustomized=false is the abandoned-claim state. Resolved via cabin.owner, so it
-    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID
-    /// (/diagnostics/state is unauthenticated).</summary>
+    /// reflects the live otherFarmers copy while the owner is connected. A bool, not the raw ID,
+    /// so the snapshot never carries a platform identifier.</summary>
     [JsonPropertyName("ownerHasUserId")]
     public bool OwnerHasUserId { get; set; }
 
@@ -297,8 +297,8 @@ public class DiagnosticsFarmhandState
     public string LastSleepLocation { get; set; } = "";
 
     /// <summary>Whether a platform ID (Steam/GOG) is stamped on this slot; true with
-    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID
-    /// (/diagnostics/state is unauthenticated).</summary>
+    /// IsCustomized=false is the abandoned-claim state. A bool, not the raw ID,
+    /// so the snapshot never carries a platform identifier.</summary>
     [JsonPropertyName("hasUserId")]
     public bool HasUserId { get; set; }
 

--- a/tools/diagnostics/ServerClient.cs
+++ b/tools/diagnostics/ServerClient.cs
@@ -21,7 +21,7 @@ internal sealed class ServerClient
     private const string CabinsPath = "/cabins";
 
     /// <summary>
-    /// Collection order. /health, /stats and /diagnostics/state are public; the rest need the key
+    /// Collection order. /health is public; the rest need the key
     /// (sending Bearer on all is harmless). /health goes first — it answers without the game thread,
     /// so it's the one read that survives a frozen server.
     /// </summary>

--- a/tools/diagnostics/ServerClient.cs
+++ b/tools/diagnostics/ServerClient.cs
@@ -21,7 +21,7 @@ internal sealed class ServerClient
     private const string CabinsPath = "/cabins";
 
     /// <summary>
-    /// Collection order. /health is public; the rest need the key
+    /// Collection order. /health and /status are public; the rest need the key
     /// (sending Bearer on all is harmless). /health goes first — it answers without the game thread,
     /// so it's the one read that survives a frozen server.
     /// </summary>

--- a/tools/diagnostics/ServerClient.cs
+++ b/tools/diagnostics/ServerClient.cs
@@ -21,9 +21,8 @@ internal sealed class ServerClient
     private const string CabinsPath = "/cabins";
 
     /// <summary>
-    /// Collection order. /health and /status are public; the rest need the key
-    /// (sending Bearer on all is harmless). /health goes first — it answers without the game thread,
-    /// so it's the one read that survives a frozen server.
+    /// Collection order. /health goes first: it answers without the game thread, so it is the
+    /// one read that survives a frozen server.
     /// </summary>
     private static readonly string[] Paths =
     {


### PR DESCRIPTION
`HandleRequestAsync` decided auth from a hand-written path list that exempted `/stats` and `/diagnostics/state`, so a keyed server still served process stats and internal game state (farmhand slots, cabin ownership, master-player mail/event flags) to anyone who could reach the published API port.

- Add `Public` to `ApiEndpointAttribute`. The router builds its exemption set from the attribute by reflection; a path without an attribute is never public, and `/test/*` is never public regardless of the attribute.
- Public set: `/health`, `/wait/health`, `/status`, `/docs`, `/swagger/v1/swagger.json`. Everything else needs the bearer key when `API_KEY` is set. `/status` is public on purpose: the lobby is public by design and the password is the access gate.
- Attribute the routed paths that had none (`/wait/*`, `/diagnostics/handler-timing`, `/docs`, the swagger JSON) so the attribute table equals the route table; they now appear in the generated reference.
- `OpenApiGenerator.Generate` emits a `bearerAuth` HTTP bearer scheme and a per-operation `security` requirement on every non-public operation. The method signature is unchanged for the reflection-invoked `tools/openapi-generator`.
- Docs drop the hand-maintained "Public Endpoints" table and the `(except /health and /docs)` parenthetical; the reference carries the lock per endpoint. Stale "unauthenticated" comments on the diagnostics DTOs are rewritten.
- The `/test/*` gate and the `/ws` auth handshake are unchanged. E2E tests run keyless with `ALLOW_INSECURE_SETUP=true` and are unaffected.

Verification:
- Keyed local container (`API_KEY` set, no `ALLOW_INSECURE_SETUP`): `/diagnostics/state`, `/stats`, `/players`, `/wait/status`, `/diagnostics/handler-timing`, `/test/anything` return 401 with `WWW-Authenticate: Bearer` without a key; `/status`, `/health`, `/wait/health`, `/docs`, `/swagger/v1/swagger.json` return 200 without a key; with the key the protected ones return 200 and `/test/anything` returns 404. `POST /status` without a key is 401 (the public set is method-aware).
- `/data/openapi.json` from the built image: `components.securitySchemes.bearerAuth` present; 22 operations carry `security`, the 5 public ones do not; no `/test/*` paths.
- Docs site builds against that spec; 22 reference pages render the lock.
- `make test FILTER="SaveImportTests|LobbyHomedSpouseTests"`: 12 passed keyless, with 41 keyless `/diagnostics/state` requests served 200 in the server log. `AbandonedClaimTests` needs `WithSteam=true` and could not run on this machine (no `STEAM_ACCOUNTS` configured).

Closes the `api-public-endpoint-list-leaks-internal-state` plan; the plan file was untracked and is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - API authentication now uses explicit endpoint visibility rules.
  - Health, status, and API documentation endpoints remain publicly accessible.
  - Other endpoints, including diagnostics state, require the configured API key.
  - OpenAPI documentation now identifies protected endpoints and documents bearer authentication.

- **Documentation**
  - Updated configuration, API, client, and diagnostics guidance to reflect current authentication requirements.
  - Clarified which tools and integrations require authenticated API requests.
  - Documented startup requirements for API keys and insecure setup configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->