### PR TITLE
feat(proxy): optional HTTPS proxy with Let's Encrypt IP certificates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ indent_size = 2
 [Makefile]
 indent_style = tab
 
+[{Caddyfile*,*.caddy}]
+indent_style = tab
+
 [*.cs]
 # CSharpier only rewrites whitespace and never inserts braces; IDE0011 closes that
 # gap (build-time via EnforceCodeStyleInBuild in Directory.Build.props).

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,18 @@ VNC_PASSWORD=""
 # STEAM_AUTH_PORT=3001   # internal only (steam-auth sidecar, no host mapping)
 
 ########################################
+#         HTTPS proxy (optional)       #
+########################################
+# Serves the API and VNC web UI over HTTPS with a Let's Encrypt certificate (a bare public
+# IP works). Needs ports 80 and 443 free. See docs/admins/operations/reverse-proxy.md.
+
+# PUBLIC_HOST=""           # a proxy sits in front: certificate subject, HTTP ports move to loopback
+# COMPOSE_PROFILES=proxy   # ...and it is the bundled one; omit this line to bring your own
+# SERVER_URL_NAME=server   # this server's name in its URL
+# PROXY_ROUTING=path       # path: https://PUBLIC_HOST/SERVER_URL_NAME/...
+#                          # subdomain: https://SERVER_URL_NAME.PUBLIC_HOST/... (domain only)
+
+########################################
 #           Performance                #
 ########################################
 

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -50,15 +50,15 @@ jobs:
         run: |
           # Define deployment targets as JSON
           TARGETS='[
-            {"environment": "public-test-preview", "image_tag": "preview", "on_preview": true, "on_release": false}
+            {"environment": "public-test-preview", "image_tag": "preview", "url_name": "preview", "on_preview": true, "on_release": false}
           ]'
-          # {"environment": "public-test-latest", "image_tag": "latest", "on_preview": false, "on_release": true}
+          # {"environment": "public-test-latest", "image_tag": "latest", "url_name": "latest", "on_preview": false, "on_release": true}
 
           MATRIX=$(echo "$TARGETS" | jq -c '[.[] | select(
             (env.TRIGGER == "workflow_dispatch" and env.SELECTED == .environment) or
             (env.TRIGGER == "workflow_run" and env.WORKFLOW_SUCCESS == "success" and .on_preview) or
             (env.TRIGGER == "release" and .on_release)
-          ) | {environment, image_tag}]')
+          ) | {environment, image_tag, url_name}]')
 
           echo "matrix={\"include\":$MATRIX}" >> $GITHUB_OUTPUT
           echo "has_targets=$([ "$MATRIX" != "[]" ] && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -106,6 +106,10 @@ jobs:
           DEPLOY_DISCORD_BOT_TOKEN: ${{ secrets.DEPLOY_DISCORD_BOT_TOKEN }}
           DEPLOY_DISCORD_CHAT_CHANNEL_ID: ${{ secrets.DEPLOY_DISCORD_CHAT_CHANNEL_ID }}
           DEPLOY_DISCORD_BOT_NICKNAME: ${{ vars.DEPLOY_DISCORD_BOT_NICKNAME }}
+          # Optional: enables the HTTPS proxy (docs: operations/reverse-proxy.md).
+          DEPLOY_PUBLIC_HOST: ${{ vars.DEPLOY_PUBLIC_HOST }}
+          DEPLOY_PROXY_ROUTING: ${{ vars.DEPLOY_PROXY_ROUTING }}
+          DEPLOY_SERVER_URL_NAME: ${{ matrix.url_name }}
         run: |
           echo "::group::Generate .env file for ${{ matrix.environment }}"
 
@@ -145,6 +149,13 @@ jobs:
           echo "DISCORD_BOT_TOKEN=$DEPLOY_DISCORD_BOT_TOKEN" >> .env
           echo "DISCORD_CHAT_CHANNEL_ID=$DEPLOY_DISCORD_CHAT_CHANNEL_ID" >> .env
           echo "DISCORD_BOT_NICKNAME=$DEPLOY_DISCORD_BOT_NICKNAME" >> .env
+          if [[ -n "$DEPLOY_PUBLIC_HOST" ]]; then
+            echo "# HTTPS proxy" >> .env
+            echo "COMPOSE_PROFILES=proxy" >> .env
+            echo "PUBLIC_HOST=$DEPLOY_PUBLIC_HOST" >> .env
+            echo "SERVER_URL_NAME=$DEPLOY_SERVER_URL_NAME" >> .env
+            echo "PROXY_ROUTING=${DEPLOY_PROXY_ROUTING:-path}" >> .env
+          fi
           echo "::endgroup::"
 
       - name: Create deploy directory
@@ -163,7 +174,7 @@ jobs:
           username: ${{ secrets.DEPLOY_SSH_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
-          source: "docker-compose.yml,.env"
+          source: "docker-compose.yml,.env,docker/proxy"
           target: ~/srv/${{ matrix.environment }}
 
       # Resolves what the alias (matrix.image_tag) actually points at, for the internal-ci
@@ -242,7 +253,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Stop containers"
-            docker compose down --timeout 30 || true
+            docker compose down --timeout 30 --remove-orphans || true
             echo "::endgroup::"
 
             # No steam-auth setup step: serve downloads the game itself on a fresh volume.
@@ -277,6 +288,27 @@ jobs:
             fi
             docker compose ps
             echo "::endgroup::"
+
+            # The proxy keeps retrying a failed certificate order instead of exiting, so
+            # `compose ps` stays green; only a request through the proxy proves it works.
+            envval() { grep -m1 "^$1=" .env | cut -d= -f2-; }
+            PUBLIC_HOST=$(envval PUBLIC_HOST)
+            if [[ -n "$PUBLIC_HOST" ]]; then
+              echo "::group::Proxy check"
+              SERVER_URL_NAME=$(envval SERVER_URL_NAME)
+              case "$(envval PROXY_ROUTING)" in
+                subdomain) url="https://$SERVER_URL_NAME.$PUBLIC_HOST/health" ;;
+                *) url="https://$PUBLIC_HOST/$SERVER_URL_NAME/health" ;;
+              esac
+              # Retries cover the certificate order, which can take a minute on first start.
+              if ! curl -fsS --retry 12 --retry-delay 10 --retry-all-errors "$url" > /dev/null; then
+                echo "::error::Proxy check failed: $url"
+                docker compose logs --tail=50 proxy
+                exit 1
+              fi
+              echo "$url OK"
+              echo "::endgroup::"
+            fi
 
       - name: Build summary
         run: |

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -85,6 +85,7 @@ jobs:
           # discord-notify must exist in the tree for the `uses: ./…` steps below.
           sparse-checkout: |
             docker-compose.yml
+            docker/proxy
             .github/actions/discord-notify
           sparse-checkout-cone-mode: false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
     stdin_open: true
     tty: true
     ports:
-      - "${VNC_PORT:-5800}:5800"
-      - "${API_PORT:-8080}:${API_PORT:-8080}"
+      # HTTP surfaces. With PUBLIC_HOST set the server sits behind a reverse proxy, so plain
+      # HTTP binds to loopback only (docs: operations/reverse-proxy.md).
+      - "${PUBLIC_HOST:+127.0.0.1:}${VNC_PORT:-5800}:5800"
+      - "${PUBLIC_HOST:+127.0.0.1:}${API_PORT:-8080}:${API_PORT:-8080}"
       # Steam relay ports (used by GameServer.Init for relay network)
       - "${GAME_PORT:-24642}:24642/udp"
       - "${QUERY_PORT:-27015}:27015/udp"
@@ -106,9 +108,32 @@ services:
     # on-failure: won't restart when the bot stops on purpose (exit 0: token unset, bad token, missing intent), will restart on crashes
     restart: on-failure
 
+  # Optional HTTPS proxy for the API and VNC web UI (docs: operations/reverse-proxy.md).
+  proxy:
+    image: caddy:2.11
+    container_name: sdvd-proxy
+    profiles: ["proxy"]
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile.${PROXY_ROUTING:-path}", "--adapter", "caddyfile"]
+    ports:
+      - "80:80"   # Let's Encrypt validation
+      - "443:443"
+    volumes:
+      - ./docker/proxy:/etc/caddy:ro
+      - proxy-data:/data
+    environment:
+      # Interpolation runs before profile filtering, so no `:?` guard here; Caddy refuses
+      # to start on an empty site address instead.
+      PUBLIC_HOST: "${PUBLIC_HOST:-}"
+      SERVER_URL_NAME: "${SERVER_URL_NAME:-server}"
+      API_PORT: "${API_PORT:-8080}"
+    depends_on:
+      - server
+    restart: unless-stopped
+
 volumes:
   steam-session:
   game-data:
   saves:
   settings:
   discord-bot-data:
+  proxy-data:

--- a/docker/proxy/Caddyfile.path
+++ b/docker/proxy/Caddyfile.path
@@ -1,0 +1,12 @@
+# PROXY_ROUTING=path: https://PUBLIC_HOST/SERVER_URL_NAME/...
+{
+	# Browsers send no SNI for bare-IP URLs; serve the host's certificate then.
+	default_sni {$PUBLIC_HOST}
+}
+
+import common.caddy
+
+{$PUBLIC_HOST} {
+	redir /{$SERVER_URL_NAME} /{$SERVER_URL_NAME}/ 301
+	import server /{$SERVER_URL_NAME}
+}

--- a/docker/proxy/Caddyfile.subdomain
+++ b/docker/proxy/Caddyfile.subdomain
@@ -1,0 +1,6 @@
+# PROXY_ROUTING=subdomain: https://SERVER_URL_NAME.PUBLIC_HOST/... (PUBLIC_HOST must be a domain)
+import common.caddy
+
+{$SERVER_URL_NAME}.{$PUBLIC_HOST} {
+	import server ""
+}

--- a/docker/proxy/common.caddy
+++ b/docker/proxy/common.caddy
@@ -1,0 +1,19 @@
+# Routing for one server behind the HTTPS proxy; `args[0]` is the URL prefix ("" for
+# subdomain routing). The site address lives in Caddyfile.path / Caddyfile.subdomain.
+
+(server) {
+	tls {
+		issuer acme {
+			profile shortlived
+		}
+	}
+
+	redir {args[0]}/vnc {args[0]}/vnc/ 301
+	handle_path {args[0]}/vnc/* {
+		reverse_proxy server:5800
+	}
+
+	handle_path {args[0]}/* {
+		reverse_proxy server:{$API_PORT}
+	}
+}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -204,6 +204,7 @@ export default withMermaid(
                             { text: "Upgrading", link: "/admins/operations/upgrading" },
                             { text: "VNC (Advanced)", link: "/admins/operations/vnc" },
                             { text: "Modern Docker Image", link: "/admins/operations/modern-docker" },
+                            { text: "HTTPS & Reverse Proxy", link: "/admins/operations/reverse-proxy" },
                         ],
                     },
                     {

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -21,6 +21,10 @@ These must be set for the server to function:
 | `VNC_PORT` | TCP port for VNC web interface | `5800` |
 | `API_PORT` | Port for the HTTP REST API | `8080` |
 | `API_ENABLED` | Enable HTTP API for external tools | `true` |
+| `PUBLIC_HOST` | Public IP or domain of the [HTTPS proxy](/admins/operations/reverse-proxy); when set, `VNC_PORT` and `API_PORT` bind to loopback | - |
+| `SERVER_URL_NAME` | This server's name in its URL behind the proxy | `server` |
+| `PROXY_ROUTING` | `path` (`https://HOST/NAME/`) or `subdomain` (`https://NAME.HOST/`) | `path` |
+| `COMPOSE_PROFILES` | `proxy` starts the bundled HTTPS proxy; leave unset to use your own | - |
 | `SERVER_FPS` | Render rate: `0` = rendering disabled, `N > 0` = render at N fps | `0` |
 | `VERBOSE_LOGGING` | Override verbose logging setting | - |
 
@@ -186,6 +190,7 @@ The server refuses to start without `VNC_PASSWORD`, or without `API_KEY` while `
 | 27015 | UDP | Steam query | No (relay handles NAT) |
 | 5800 | TCP | VNC web interface | Only for remote access |
 | 8080 | TCP | REST API | Only for external tools |
+| 80, 443 | TCP | HTTPS proxy (optional) | Only with the `proxy` profile |
 | 3001 | TCP | Steam auth (internal) | No |
 
 ## Changing Ports

--- a/docs/admins/operations/index.md
+++ b/docs/admins/operations/index.md
@@ -55,5 +55,6 @@ Save files are stored in the `saves` Docker volume.
 - [Console & Chat Commands](/admins/operations/commands)
 - [Importing Saves](/admins/operations/importing-saves)
 - [Networking](/admins/operations/networking)
+- [HTTPS & Reverse Proxy](/admins/operations/reverse-proxy)
 - [Upgrading](/admins/operations/upgrading)
 - [Web Interface (VNC)](/admins/operations/vnc) (advanced debugging only)

--- a/docs/admins/operations/networking.md
+++ b/docs/admins/operations/networking.md
@@ -44,8 +44,11 @@ joinable over direct IP — even for the account's own player. See
 | 27015 | UDP | Steam SDR query port | No (relay handles NAT) |
 | 5800 | TCP | VNC web interface | Only for remote access |
 | 8080 | TCP | HTTP API | Only for external tools |
+| 80, 443 | TCP | HTTPS proxy (optional) | Only with the `proxy` profile |
 
 Steam SDR uses these ports internally but traffic goes through Valve's relay. No port forwarding required for most setups.
+
+With the [HTTPS proxy](/admins/operations/reverse-proxy), the API and VNC web UI are served on 443 and their plain-HTTP ports stay on loopback.
 
 ### Changing Ports
 
@@ -169,4 +172,8 @@ If you need to configure firewalls, allow:
 **For external API access:**
 
 - Inbound TCP 8080, REST API
+
+**With the HTTPS proxy (replaces the two above):**
+
+- Inbound TCP 80 and 443
 

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -1,0 +1,88 @@
+---
+description: Serve the API and VNC web UI over HTTPS with a Let's Encrypt certificate — for a bare IP or a domain, with path or subdomain routing — using the bundled proxy or your own.
+---
+
+# HTTPS & Reverse Proxy
+
+By default the REST API (`API_PORT`) and the VNC web UI (`VNC_PORT`) are plain HTTP, which is fine for a home or LAN server. HTTPS is needed to show a live status widget on a web page, since browsers block plain-HTTP requests from HTTPS sites, and to keep your VNC and API credentials off the wire. This page sets it up with or without a domain: Let's Encrypt also issues certificates for a bare public IP.
+
+## The three setups
+
+| Setup | For | You set | Reachable from outside |
+|-------|-----|---------|------------------------|
+| No proxy (default) | Home and LAN servers | nothing | plain HTTP on `API_PORT` and `VNC_PORT` |
+| Bundled proxy | One server on a VPS | `COMPOSE_PROFILES=proxy`, `PUBLIC_HOST`, `SERVER_URL_NAME`, `PROXY_ROUTING` | HTTPS on 443 only |
+| Your own proxy | Hosts that already run a proxy | `PUBLIC_HOST`, `SERVER_URL_NAME`, your proxy's routing | whatever your proxy exposes |
+
+Setting `PUBLIC_HOST` declares that a proxy sits in front of the server: the plain-HTTP ports then bind to loopback and are unreachable from outside. Set it only with a proxy in place.
+
+## Variables and URLs
+
+| Variable | Meaning | Example |
+|----------|---------|---------|
+| `PUBLIC_HOST` | Public IP or domain the certificate is issued for | `203.0.113.10`, `example.com` |
+| `SERVER_URL_NAME` | This server's name in its URL: lowercase letters, digits, hyphens | `farm`, `preview` |
+| `PROXY_ROUTING` | `path` (default) or `subdomain` | `subdomain` |
+
+`SERVER_URL_NAME` is not the farm name.
+
+| Routing | API | VNC web UI |
+|---------|-----|------------|
+| `path` | `https://PUBLIC_HOST/SERVER_URL_NAME/status`, `/players`, `/docs`, … | `https://PUBLIC_HOST/SERVER_URL_NAME/vnc/` |
+| `subdomain` | `https://SERVER_URL_NAME.PUBLIC_HOST/status`, … | `https://SERVER_URL_NAME.PUBLIC_HOST/vnc/` |
+
+`path` works for an IP and for a domain. `subdomain` needs a domain, with a DNS record (or wildcard) for that name pointing at the host; with an IP host the certificate request fails, visible in `docker compose logs proxy`.
+
+## How the certificate works
+
+The proxy requests short-lived Let's Encrypt certificates (six days, renewed automatically), the type Let's Encrypt issues for IP addresses; they work for domains too. Validation runs over port 80, so you need:
+
+- a public IP or a domain resolving to this host,
+- ports 80 and 443 free and reachable from the internet.
+
+A server behind a home router without port forwarding cannot get one, which is why the default setup stays plain HTTP.
+
+## Bundled proxy
+
+Add to `.env`:
+
+```sh
+PUBLIC_HOST=203.0.113.10   # a proxy sits in front (or example.com)
+COMPOSE_PROFILES=proxy     # ...and it is the bundled one
+SERVER_URL_NAME=farm
+```
+
+Then `docker compose up -d`. The `proxy` service (Caddy) starts alongside the server, obtains the certificate, and serves `https://203.0.113.10/farm/`. For `https://farm.example.com/` instead, set `PUBLIC_HOST=example.com` and `PROXY_ROUTING=subdomain`.
+
+The proxy configuration lives in [`docker/proxy/`](https://github.com/stardew-valley-dedicated-server/server/tree/master/docker/proxy): `common.caddy` holds the routing for one server, and `Caddyfile.path` / `Caddyfile.subdomain` supply the site address. It reads the variables above from the environment and needs no editing.
+
+Check it worked:
+
+```sh
+docker compose logs proxy        # "certificate obtained successfully"
+curl https://203.0.113.10/farm/health
+```
+
+## Your own proxy
+
+Skip the `proxy` profile, keep `PUBLIC_HOST` and `SERVER_URL_NAME` in `.env`, attach your proxy to the stack's compose network, and route the server's URL to the container. The proxy must strip the path prefix, and the VNC route needs WebSocket pass-through. With Caddy, reuse the same snippet:
+
+```text
+import common.caddy
+
+# path routing
+203.0.113.10 {
+    import server /farm
+}
+
+# or subdomain routing
+farm.example.com {
+    import server ""
+}
+```
+
+Other proxies work the same way as long as their ACME client supports the `shortlived` profile.
+
+## Firewall
+
+With a proxy, open only TCP 80 and 443 for HTTP traffic; `API_PORT` and `VNC_PORT` stay closed. The game ports are unchanged, see [Networking](/admins/operations/networking#ports).

--- a/docs/admins/operations/vnc.md
+++ b/docs/admins/operations/vnc.md
@@ -28,6 +28,8 @@ Replace:
 
 Example: `http://localhost:5800`
 
+Behind the [HTTPS proxy](/admins/operations/reverse-proxy) the web UI is at the server's proxy URL plus `/vnc/`, and the plain-HTTP port is not reachable from outside.
+
 You'll be prompted to enter the VNC password configured in your `.env` file.
 
 ## VNC Settings Panel

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -1,6 +1,6 @@
 # REST API
 
-The dedicated server exposes an HTTP REST API (port 8080 by default, see `API_PORT`) for monitoring and controlling your server programmatically.
+The dedicated server exposes an HTTP REST API (port 8080 by default, see `API_PORT`) for monitoring and controlling your server programmatically. Behind the optional [HTTPS proxy](/admins/operations/reverse-proxy) the same API is served under the server's proxy URL.
 
 Use the sidebar to browse available endpoints.
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -345,8 +345,8 @@ The deploy server pipeline deploys server instances to a VPS. It supports multip
 Example `TARGETS` entries:
 
 ```json
-{"environment": "public-test-preview", "image_tag": "preview", "on_preview": true, "on_release": false}
-{"environment": "public-test-latest", "image_tag": "latest", "on_preview": false, "on_release": true}
+{"environment": "public-test-preview", "image_tag": "preview", "url_name": "preview", "on_preview": true, "on_release": false}
+{"environment": "public-test-latest", "image_tag": "latest", "url_name": "latest", "on_preview": false, "on_release": true}
 ```
 
 ### Setup Requirements
@@ -398,6 +398,8 @@ Add these under **Settings → Environments → Variables**, not as secrets.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DEPLOY_DISCORD_BOT_NICKNAME` | No | Discord bot nickname (defaults to the farm name) |
+| `DEPLOY_PUBLIC_HOST` | No | Public IP or domain of the [HTTPS proxy](/admins/operations/reverse-proxy); setting it enables the proxy. `SERVER_URL_NAME` comes from the matrix entry's `url_name` |
+| `DEPLOY_PROXY_ROUTING` | No | `path` (default) or `subdomain`, see the proxy docs |
 
 ### VPS Preparation
 

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -5260,7 +5260,7 @@ public partial class ApiService : ModService
     <meta name=""viewport"" content=""width=device-width, initial-scale=1"" />
 </head>
 <body>
-    <script id=""api-reference"" data-url=""/swagger/v1/swagger.json""></script>
+    <script id=""api-reference"" data-url=""swagger/v1/swagger.json""></script>
     <script src=""https://cdn.jsdelivr.net/npm/@scalar/api-reference""></script>
 </body>
 </html>";


### PR DESCRIPTION
- Bundled Caddy proxy behind the `proxy` compose profile with path or subdomain routing and short-lived Let's Encrypt certificates for a bare IP or a domain
- `PUBLIC_HOST` declares a proxy in front and moves the API and VNC ports to loopback
- Deploy workflow: per-server URL name, proxy enabled by `DEPLOY_PUBLIC_HOST`, HTTPS health check through the proxy, `docker/proxy` included in the sparse checkout so the SCP step can ship it
- `/docs` loads its OpenAPI spec by relative URL so it works under a path prefix
- Docs: new reverse-proxy guide plus proxy notes on the environment, networking, VNC, and API pages


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTPS reverse-proxy support for the REST API and VNC web UI.
  * Supports path-based and subdomain-based routing, automatic TLS certificates, and WebSocket connections.
  * Added deployment support for enabling and validating proxy configurations.

* **Documentation**
  * Added administrator guidance for HTTPS proxy setup, networking, firewall rules, and configuration variables.
  * Updated API and VNC documentation with proxy access URLs.

* **Bug Fixes**
  * Corrected the API documentation page so its schema reference works from nested URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->