### PR TITLE
fix(cabins): fix shared stack spot handling under CabinStack

### DIFF
--- a/docs/features/cabin-strategies.md
+++ b/docs/features/cabin-strategies.md
@@ -104,6 +104,8 @@ Players can reposition their cabin using the `!cabin` chat command on the farm. 
 
 This works under every strategy. Under `CabinStack` and `FarmhouseStack`, a moved-out cabin becomes a real, visible building that everyone can see and enter through its own door — under `FarmhouseStack` this is the way to let players meet inside each other's homes while non-movers keep the tidy shared farmhouse entrance.
 
+Under `CabinStack` the shared spot itself is off-limits: `!cabin` refuses a target that overlaps it, and a player whose cabin has moved out sees a door-less stand-in cabin there in place of their own.
+
 To forbid cabin moves entirely, set `AllowCabinRelocation` to `false` in `server-settings.json`:
 
 ```json

--- a/docs/players/commands.md
+++ b/docs/players/commands.md
@@ -9,7 +9,7 @@ Chat commands available to all players on a JunimoServer. Type in the chat box (
 | `!help` | Show available commands |
 | `!info` | Server info (farm, version, uptime, players, your ping) |
 | `!invitecode` | Show invite code to share with friends |
-| `!cabin` | Relocate your cabin to your right (must be on farm) |
+| `!cabin` | Relocate your cabin to your right (must be on farm, not onto the shared cabin spot) |
 
 Debris is cleared automatically when relocating.
 

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -683,14 +683,8 @@ public class StackSpotInfo
     /// <summary>True when an admin-set override is active (vs the map default).</summary>
     public bool IsOverride { get; set; }
 
-    /// <summary>True when the spot currently fails placement validation.</summary>
+    /// <summary>True when a cabin footprint at the spot currently fails placement validation.</summary>
     public bool IsObstructed { get; set; }
-
-    /// <summary>
-    /// True when obstruction was actually evaluated (a hidden cabin existed to test against).
-    /// False means the stack is empty, so <see cref="IsObstructed"/> is not meaningful.
-    /// </summary>
-    public bool ObstructionChecked { get; set; }
 }
 
 /// <summary>
@@ -1824,7 +1818,6 @@ public partial class ApiService : ModService
                     TileY = spot.Spot.Y,
                     IsOverride = spot.IsOverride,
                     IsObstructed = spot.IsObstructed,
-                    ObstructionChecked = spot.ObstructionChecked,
                 };
             }
 

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
@@ -502,26 +502,6 @@ public partial class CabinManagerService
                 building.SetWarpsToFarmCabinDoor();
             }
 
-            // Live-heal connected peers who were shown a door-dead dummy under the old CabinStack
-            // strategy (its indoors nulled locally in their intro-message copy). A plain MarkDirty
-            // yields only a child delta a null-target peer ignores; MarkReassigned() forces a full
-            // NetRef resend so the interior reappears without a reconnect (position already
-            // converged via the staging SetPosition deltas). Skip any cabin a farmer is currently
-            // inside — a full-object resend replaces the location root out from under a peer
-            // standing in it (readActiveLocation fixes currentLocation only when it IS the replaced
-            // root). Dummies are never occupied (their door is dead), so they always heal; real
-            // occupied cabins already hold the correct interior and are safely skipped.
-            if (OnlineFarmers.CountOthers() > 0)
-            {
-                foreach (var building in visibleCabins)
-                {
-                    if (building.GetIndoors<Cabin>()?.farmers.Any() == false)
-                    {
-                        building.indoors.MarkReassigned();
-                    }
-                }
-            }
-
             placedCount = migration.PlacedCabinIndoorNames.Count;
             message =
                 $"Migration committed: strategy is now None with {visibleCabins.Count} cabin(s) "
@@ -544,20 +524,17 @@ public partial class CabinManagerService
                 + $"({spot.X},{spot.Y}).";
         }
 
-        // Reconnect note — CabinStack only. The →CabinStack ghost's position is a pure per-peer
-        // intro fiction: the master building stays hidden at (-20,-20) and no net field holds the
-        // stack-spot coordinate, so no field push can heal it — MarkDirty(tileX/tileY) would
-        // replicate (-20,-20), moving the cabin OFF the spot, and re-sending the whole location
-        // introduction (message 3) replaces the root out from under a peer standing inside a
-        // structure interior (readActiveLocation fixes currentLocation only when it IS the replaced
-        // root). The rejoin's fresh intro is the supported convergence point. (The →None commit
-        // heals its interior half live above and its positions converge via the staging deltas, so
-        // it needs no note.)
-        if (migration.ToStrategy == CabinStrategy.CabinStack && OnlineFarmers.CountOthers() > 0)
+        // Connected peers hold intro-only state no delta can fix: the →CabinStack ghost position
+        // (master tile is hidden) and the →None phantom (master never had it). Re-sending the
+        // Farm intro would orphan a peer standing inside a cabin, so they reconnect instead.
+        if (OnlineFarmers.CountOthers() > 0)
         {
             message +=
-                " Connected players keep seeing the pre-migration cabin layout until they "
-                + "reconnect.";
+                migration.ToStrategy == CabinStrategy.CabinStack
+                    ? " Connected players keep seeing the pre-migration cabin layout until they "
+                        + "reconnect."
+                    : " Connected players who had moved their cabin may still see a stale cabin "
+                        + "at the old shared spot until they reconnect.";
         }
 
         ApplyStrategyDurably(migration.ToStrategy);

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
@@ -151,14 +151,7 @@ public partial class CabinManagerService
     private bool IsStackSpotResolved(Farm farm, CabinMigrationState migration)
     {
         var spot = GetEffectiveStackSpot(farm, migration);
-        var probe = farm.buildings.FirstOrDefault(b => b.isCabin && b.IsInHiddenStack());
-        if (probe == null)
-        {
-            // No hidden cabin means no ghost will ever render there — nothing to validate.
-            return true;
-        }
-
-        return CabinPlacementValidator.TryValidate(farm, probe, spot.ToPoint(), out _);
+        return CabinPlacementValidator.TryValidateFootprint(farm, spot.ToPoint(), out _);
     }
 
     /// <summary>
@@ -371,11 +364,7 @@ public partial class CabinManagerService
 
         // FarmhouseStack → CabinStack: no building moves — the placement chooses the spot
         // where the shared stack ghost will appear after commit.
-        var probe = farm.buildings.FirstOrDefault(b => b.isCabin && b.IsInHiddenStack());
-        if (
-            probe != null
-            && !CabinPlacementValidator.TryValidate(farm, probe, topLeft, out var ghostReason)
-        )
+        if (!CabinPlacementValidator.TryValidateFootprint(farm, topLeft, out var ghostReason))
         {
             message = $"Can't use ({topLeft.X},{topLeft.Y}) as the stack position: {ghostReason}.";
             return false;

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -1056,7 +1056,7 @@ public partial class CabinManagerService : ModService
                 // real cabin's interior makes its owner's home unresolvable there (festival
                 // loadActors throws). No hidden cabin means nobody sees one at the spot.
                 var skinSource = farm.buildings.FirstOrDefault(b =>
-                    b.isCabin && b != cabin && b.IsInHiddenStack()
+                    b.isCabin && b.IsInHiddenStack()
                 );
                 if (skinSource != null)
                 {

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -640,40 +640,24 @@ public partial class CabinManagerService : ModService
             // developed tile, silently weakening the "ghost lands on the just-vacated spot"
             // guarantee of this switch. Validate it now that the sweep has vacated the
             // designated spots; on failure fall back to the map default.
-            if (to == CabinStrategy.CabinStack && Data.DefaultCabinLocation.HasValue)
-            {
-                var probe = farm.buildings.FirstOrDefault(b => b.isCabin && b.IsInHiddenStack());
-                if (
-                    probe != null
-                    && !CabinPlacementValidator.TryValidate(
-                        farm,
-                        probe,
-                        Data.DefaultCabinLocation.Value.ToPoint(),
-                        out var overrideReason
-                    )
+            if (
+                to == CabinStrategy.CabinStack
+                && Data.DefaultCabinLocation.HasValue
+                && !CabinPlacementValidator.TryValidateFootprint(
+                    farm,
+                    Data.DefaultCabinLocation.Value.ToPoint(),
+                    out var overrideReason
                 )
-                {
-                    Monitor.Log(
-                        $"Stack-position override {Data.DefaultCabinLocation.Value} is no longer "
-                            + $"valid ({overrideReason}); falling back to the map's default stack "
-                            + "position.",
-                        LogLevel.Warn
-                    );
-                    Data.DefaultCabinLocation = null;
-                    Data.Write();
-                }
-                else if (probe == null)
-                {
-                    // Empty hidden stack: no footprint to test against, so the override is kept
-                    // unvalidated rather than silently trusted. GetStackSpotStatus reports it
-                    // unchecked and it is verified once the stack holds a cabin.
-                    Monitor.Log(
-                        $"Stack-position override {Data.DefaultCabinLocation.Value} kept but not "
-                            + "validated: the hidden stack is empty, so there is no cabin footprint "
-                            + "to test against yet.",
-                        LogLevel.Debug
-                    );
-                }
+            )
+            {
+                Monitor.Log(
+                    $"Stack-position override {Data.DefaultCabinLocation.Value} is no longer "
+                        + $"valid ({overrideReason}); falling back to the map's default stack "
+                        + "position.",
+                    LogLevel.Warn
+                );
+                Data.DefaultCabinLocation = null;
+                Data.Write();
             }
         }
         // Remaining directions (CabinStack → FarmhouseStack, or a materializing direction
@@ -762,15 +746,12 @@ public partial class CabinManagerService : ModService
 
     /// <summary>
     /// Read model for the CabinStack shared stack spot: the tile each player's ghost cabin
-    /// renders at, whether it comes from the persisted override or the map default, whether
-    /// obstruction could be evaluated at all (<see cref="ObstructionChecked"/> — false when the
-    /// hidden stack is empty, so there is no cabin footprint to test against), and whether the
-    /// spot currently fails placement validation (obstructed; meaningful only when checked).
+    /// renders at, whether it comes from the persisted override or the map default, and
+    /// whether a cabin footprint there currently fails placement validation.
     /// </summary>
     public readonly record struct StackSpotStatus(
         Point Spot,
         bool IsOverride,
-        bool ObstructionChecked,
         bool IsObstructed,
         string ObstructionReason
     );
@@ -794,31 +775,16 @@ public partial class CabinManagerService : ModService
         }
 
         var spot = StackLocation.Create(Data).ToPoint();
-        // Obstruction is only testable against a real cabin footprint; with an empty hidden
-        // stack (no probe) it is unknowable, so report it unchecked rather than implying a clear
-        // spot. The check runs for real once the stack holds a cabin.
-        var probe = farm.buildings.FirstOrDefault(b => b.isCabin && b.IsInHiddenStack());
-        var obstructionChecked = probe != null;
-        string reason = null;
-        var obstructed =
-            obstructionChecked
-            && !CabinPlacementValidator.TryValidate(farm, probe, spot, out reason);
-        return new StackSpotStatus(
-            spot,
-            Data.DefaultCabinLocation.HasValue,
-            obstructionChecked,
-            obstructed,
-            reason ?? ""
-        );
+        var obstructed = !CabinPlacementValidator.TryValidateFootprint(farm, spot, out var reason);
+        return new StackSpotStatus(spot, Data.DefaultCabinLocation.HasValue, obstructed, reason);
     }
 
     /// <summary>
     /// Sets the CabinStack shared stack spot (writes the persisted DefaultCabinLocation).
     /// CabinStack-only; refused during a staged migration (the migration owns the spot
-    /// choice via 'cabins migrate place'); validator-gated against a hidden probe cabin.
-    /// Connected players keep seeing the old spot until they reconnect — the ghost position
-    /// is written into each peer's location-introduction message, and deltas rewrite warps,
-    /// not positions.
+    /// choice via 'cabins migrate place'); footprint-validated. Connected players keep
+    /// seeing the old spot until they reconnect — the ghost position is written into each
+    /// peer's location-introduction message, and deltas rewrite warps, not positions.
     /// </summary>
     public bool TrySetStackSpot(Point topLeft, out string message)
     {
@@ -845,12 +811,7 @@ public partial class CabinManagerService : ModService
             return false;
         }
 
-        var farm = Game1.getFarm();
-        var probe = farm.buildings.FirstOrDefault(b => b.isCabin && b.IsInHiddenStack());
-        if (
-            probe != null
-            && !CabinPlacementValidator.TryValidate(farm, probe, topLeft, out var reason)
-        )
+        if (!CabinPlacementValidator.TryValidateFootprint(Game1.getFarm(), topLeft, out var reason))
         {
             message = $"Can't use ({topLeft.X},{topLeft.Y}) as the stack spot: {reason}.";
             return false;
@@ -858,16 +819,9 @@ public partial class CabinManagerService : ModService
 
         Data.DefaultCabinLocation = topLeft.ToVector2();
         Data.Write();
-        // A null probe (empty hidden stack) means the spot couldn't be validated against a real
-        // footprint — accept it (nothing to obstruct yet) but say so, matching the unchecked
-        // status GetStackSpotStatus reports until the stack is populated.
-        const string reconnectNote = "Connected players see it after they reconnect.";
         message =
-            probe != null
-                ? $"Stack spot set to ({topLeft.X},{topLeft.Y}). {reconnectNote}"
-                : $"Stack spot set to ({topLeft.X},{topLeft.Y}), but not yet validated — no cabin "
-                    + $"in the stack to check against; it is verified once the stack is populated. "
-                    + reconnectNote;
+            $"Stack spot set to ({topLeft.X},{topLeft.Y}). "
+            + "Connected players see it after they reconnect.";
         Monitor.Log(message, LogLevel.Info);
         return true;
     }

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -1050,30 +1050,23 @@ public partial class CabinManagerService : ModService
             }
             else if (cabin != null && !cabin.IsInHiddenStack())
             {
-                // This peer's own cabin is NOT in the hidden stack (they moved it via
-                // /cabin, or it imported visible under KeepExisting), so they'd otherwise
-                // see an empty spot at the shared StackLocation where everyone else sees a
-                // cabin. Render one hidden-stack cabin there as a *door-dead* dummy so the
-                // empty spot is filled without exposing another player's home.
-                //
-                // Both routes (!cabin-moved and KeepExisting-imported-visible) reach this
-                // branch through the identical `!IsInHiddenStack()` precondition, which is all
-                // this branch reads — the saved-position intent map is not consulted here. So
-                // the !cabin-moved E2E test (DummyCabin_AfterMoveAndReconnect...) covers the
-                // KeepExisting route by equivalence; a separate KeepExisting test would
-                // exercise the same dummy code with heavier strategy-setup, not new coverage.
-                //
-                // FirstOrDefault + null-guard are load-bearing defense: a First/. would turn
-                // the (effectively unreachable on a real join — EnsureAtLeastXCabins replenishes
-                // the hidden pool before locationIntroduction) zero-candidate case into a broken
-                // join handshake. IsInHiddenStack() checks (-20,-20) only, so lobby cabins at
-                // (-21,-21) are excluded automatically.
-                var dummy = farm.buildings.FirstOrDefault(b =>
+                // Own cabin is visible, so fill the stack spot with a door-less phantom in this
+                // peer's copy. Must be a fresh Building: clients resolve every farmer's home by
+                // interior name across Farm.buildings and never rebuild interiors, so nulling a
+                // real cabin's interior makes its owner's home unresolvable there (festival
+                // loadActors throws). No hidden cabin means nobody sees one at the spot.
+                var skinSource = farm.buildings.FirstOrDefault(b =>
                     b.isCabin && b != cabin && b.IsInHiddenStack()
                 );
-                if (dummy != null)
+                if (skinSource != null)
                 {
-                    PlaceDoorDeadDummyCabin(dummy);
+                    var phantom = new Building(
+                        "Cabin",
+                        StackLocation.Create(_cabinManagerData).Location
+                    );
+                    phantom.skinId.Value = skinSource.skinId.Value;
+                    phantom.daysOfConstructionLeft.Value = 0;
+                    farm.buildings.Add(phantom);
                 }
             }
         }
@@ -1084,31 +1077,6 @@ public partial class CabinManagerService : ModService
             farm.Root,
             forceCurrentLocation
         );
-    }
-
-    /// <summary>
-    /// Renders a hidden-stack cabin at the shared StackLocation as a door-dead dummy, mutating
-    /// only the per-peer message copy passed in. The cabin fills the empty spot the peer would
-    /// otherwise see, but its door is a no-op — stepping on it does nothing, so it never exposes
-    /// the real owner's home.
-    ///
-    /// How the door is killed sure-fire: Building.doAction only warps the player inside when
-    /// GetIndoors() != null (decompiled Building.cs:950). GetIndoors() reads indoors.Value then
-    /// nonInstancedIndoorsName; null both → no interior → no entry. The client never re-creates
-    /// the interior: LoadFromBuildingData's createIndoors is gated on `hasLoaded || forConstruction`
-    /// (Building.cs:523), and hasLoaded is only ever set on the master (Building.load() early-returns
-    /// `if (!Game1.IsMasterGame)`), so on a farmhand client hasLoaded stays false and the nulled
-    /// interior survives deserialization. humanDoor IS reset from data on the client, but that's
-    /// irrelevant once GetIndoors() is null. This mutates the deserialized copy only (NetRoot.Connect
-    /// builds a fresh graph), so master state and other peers are untouched.
-    /// </summary>
-    private void PlaceDoorDeadDummyCabin(Building dummy)
-    {
-        dummy.SetPosition(StackLocation.Create(_cabinManagerData).ToPoint());
-        // Kill the door: null both interior references so GetIndoors() returns null on the client.
-        // No need to set interior warps — there is no interior to warp into anymore.
-        dummy.indoors.Value = null;
-        dummy.nonInstancedIndoorsName.Value = null;
     }
 
     /// <summary>

--- a/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinPlacementValidator.cs
@@ -19,6 +19,18 @@ namespace JunimoServer.Services.CabinManager;
 /// </summary>
 public static class CabinPlacementValidator
 {
+    /// <summary>
+    /// Validates a cabin-sized footprint at <paramref name="topLeft"/> without a cabin to
+    /// move: the probe is a detached Building, so no footprint is exempted as "its own tiles"
+    /// and the check is the same whether or not any cabin currently exists. Used for the
+    /// CabinStack shared stack spot, which is empty on the master.
+    /// </summary>
+    public static bool TryValidateFootprint(Farm farm, Point topLeft, out string failureReason)
+    {
+        var probe = new Building("Cabin", topLeft.ToVector2());
+        return TryValidate(farm, probe, topLeft, out failureReason);
+    }
+
     public static bool TryValidate(
         Farm farm,
         Building cabin,

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -74,6 +74,33 @@ public static class CabinCommand
                 // Place cabin on the right-hand side of the farmer
                 var topLeft = new Point((int)farmer.Tile.X + 1, (int)farmer.Tile.Y);
 
+                // Under CabinStack the stack spot is empty on the master but every client
+                // renders a cabin there. Player moves only: migration may still use the spot.
+                if (cabinService.options.IsCabinStack)
+                {
+                    var stack = StackLocation.Create(cabinService.Data).ToPoint();
+                    var stackRect = new Rectangle(
+                        stack.X,
+                        stack.Y,
+                        cabin.tilesWide.Value,
+                        cabin.tilesHigh.Value
+                    );
+                    var targetRect = new Rectangle(
+                        topLeft.X,
+                        topLeft.Y,
+                        cabin.tilesWide.Value,
+                        cabin.tilesHigh.Value
+                    );
+                    if (stackRect.Intersects(targetRect))
+                    {
+                        helper.SendPrivateMessage(
+                            msg.SourceFarmer,
+                            "Can't move cabin: that spot is reserved for the shared cabin location."
+                        );
+                        return;
+                    }
+                }
+
                 if (
                     !CabinPlacementValidator.TryValidate(
                         Game1.getFarm(),

--- a/mod/JunimoServer/Services/Commands/CabinsConsoleCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinsConsoleCommand.cs
@@ -107,12 +107,7 @@ internal static class CabinsConsoleCommand
                     _monitor.Log(
                         $"Stack spot: ({s.Spot.X},{s.Spot.Y}) "
                             + (s.IsOverride ? "(override)" : "(map default)")
-                            + (
-                                !s.ObstructionChecked
-                                    ? " — obstruction not checked (stack is empty)"
-                                : s.IsObstructed ? $" — OBSTRUCTED: {s.ObstructionReason}"
-                                : ""
-                            ),
+                            + (s.IsObstructed ? $" — OBSTRUCTED: {s.ObstructionReason}" : ""),
                         LogLevel.Info
                     );
                 }

--- a/mod/JunimoServer/Services/Commands/StackSpotCommand.cs
+++ b/mod/JunimoServer/Services/Commands/StackSpotCommand.cs
@@ -58,12 +58,7 @@ public static class StackSpotCommand
                         msg.SourceFarmer,
                         $"Stack spot: ({s.Spot.X},{s.Spot.Y}) "
                             + (s.IsOverride ? "(override)" : "(map default)")
-                            + (
-                                !s.ObstructionChecked
-                                    ? " — obstruction not checked (stack is empty)"
-                                : s.IsObstructed ? $" — obstructed: {s.ObstructionReason}"
-                                : ""
-                            )
+                            + (s.IsObstructed ? $" — obstructed: {s.ObstructionReason}" : "")
                     );
                     return;
                 }

--- a/tests/JunimoServer.Tests/CabinMigrationTests.cs
+++ b/tests/JunimoServer.Tests/CabinMigrationTests.cs
@@ -22,13 +22,12 @@ namespace JunimoServer.Tests;
 public class CabinMigrationTests : TestBase
 {
     /// <summary>
-    /// Designated cabin spot on the Standard farm used as the deliberately-obstructed
-    /// position (observed in prior None-strategy run logs; see cabin-system invariant 9).
-    /// The primary player's !cabin-placed cabin occupies it, so auto-place must skip it
-    /// and every later pass must leave it untouched.
+    /// Second designated cabin spot on the Standard farm (order: (23,31), (66,37), (17,10),
+    /// (17,48)). The first is the shared stack spot, which !cabin refuses. The primary's
+    /// !cabin-placed cabin obstructs it; auto-place must skip it and never move it.
     /// </summary>
-    private const int ObstructedSpotX = 23;
-    private const int ObstructedSpotY = 31;
+    private const int ObstructedSpotX = 66;
+    private const int ObstructedSpotY = 37;
 
     private bool _needsServerReset;
 

--- a/tests/JunimoServer.Tests/CabinMigrationTests.cs
+++ b/tests/JunimoServer.Tests/CabinMigrationTests.cs
@@ -22,9 +22,11 @@ namespace JunimoServer.Tests;
 public class CabinMigrationTests : TestBase
 {
     /// <summary>
-    /// Second designated cabin spot on the Standard farm (order: (23,31), (66,37), (17,10),
-    /// (17,48)). The first is the shared stack spot, which !cabin refuses. The primary's
-    /// !cabin-placed cabin obstructs it; auto-place must skip it and never move it.
+    /// Second designated cabin spot on the Standard farm's separate layout (Paths tile 30,
+    /// selected by the default CabinLayoutNearby=false; order: (23,31), (66,37), (17,10),
+    /// (17,48), (44,12), (39,32), (7,24)). The first is the shared stack spot, which !cabin
+    /// refuses. The primary's !cabin-placed cabin obstructs it; auto-place must skip it and
+    /// never move it.
     /// </summary>
     private const int ObstructedSpotX = 66;
     private const int ObstructedSpotY = 37;

--- a/tests/JunimoServer.Tests/CabinMigrationTests.cs
+++ b/tests/JunimoServer.Tests/CabinMigrationTests.cs
@@ -286,18 +286,14 @@ public class CabinMigrationTests : TestBase
     }
 
     /// <summary>
-    /// Item-6 live convergence: a CabinStack → None commit heals a CONNECTED peer's door-dead dummy
-    /// interior in place (via NetRef MarkReassigned), so the peer sees the migrated world without a
-    /// reconnect. The primary moves its cabin out and reconnects so its client renders a door-dead
-    /// dummy at the shared stack (HasInterior == false); after the → None commit — while it stays
-    /// connected — every cabin in its own farm view becomes enterable (HasInterior == true).
+    /// A connected peer sees every master cabin at its placed tile, enterable, after a
+    /// CabinStack → None commit without reconnecting. The peer's intro-only phantom at the
+    /// stack spot stays until reconnect and is excluded.
     /// </summary>
     [Fact]
-    public async Task StagedMigration_StackedToNone_HealsConnectedPeerDummyInteriorLive()
+    public async Task StagedMigration_StackedToNone_ConnectedPeerSeesPlacedCabinsLive()
     {
-        LogSection(
-            "Staged CabinStack → None migration: connected peer's dummy interior heals live"
-        );
+        LogSection("Staged CabinStack → None migration: connected peer sees placed cabins live");
 
         var ct = TestCt;
         _needsServerReset = true;
@@ -403,7 +399,6 @@ public class CabinMigrationTests : TestBase
         );
         Assert.True(allPlaced, "all staged placements should complete (RemainingCount == 0)");
 
-        // Commit WITH the peer connected — the heal fires (OnlineFarmers.CountOthers() > 0).
         var commit = await ServerApi.RunConsoleCommand("cabins", new[] { "migrate", "commit" }, ct);
         Assert.True(commit?.Success == true, $"cabins migrate commit failed: {commit?.Error}");
         var committed = await PollingHelper.WaitUntilAsync(
@@ -418,33 +413,54 @@ public class CabinMigrationTests : TestBase
         );
         Assert.True(committed, "commit should flip the strategy to None and clear Migration");
 
-        // The live heal: without any reconnect, every cabin in the peer's own farm view is now
-        // enterable — the door-dead dummy's interior was resent via indoors.MarkReassigned().
-        var healed = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinDummyInterior_HealedLive,
+        // Every master cabin must be enterable at its placed tile in the peer's view.
+        var master = await ServerApi.GetCabins(ct);
+        Assert.NotNull(master);
+        Assert.True(
+            master.Cabins.Count > 1 && master.Cabins.All(c => !c.IsHidden),
+            $"expected >1 visible master cabins under None; got {master.Cabins.Count} "
+                + $"({master.Cabins.Count(c => c.IsHidden)} hidden)"
+        );
+        FarmBuildingsResult? lastView = null;
+        var converged = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinMigration_PlacedCabinsVisibleOnPeer,
             async () =>
             {
-                var view = await GameClient.Actions.GetFarmBuildings(ct);
-                if (view?.Success != true)
+                lastView = await GameClient.Actions.GetFarmBuildings(ct);
+                if (lastView?.Success != true)
                 {
                     return false;
                 }
-                var visible = view.Cabins.Where(c => c.TileX >= 0).ToList();
-                return visible.Count > 1 && visible.All(c => c.HasInterior);
+                return master.Cabins.All(m =>
+                    lastView.Cabins.Any(c =>
+                        c.TileX == m.TileX && c.TileY == m.TileY && c.HasInterior
+                    )
+                );
             },
             TestTimings.NetworkSyncTimeout,
             cancellationToken: ct
         );
         Assert.True(
-            healed,
-            "after the → None commit the connected peer's door-dead dummy interior should heal live "
-                + "(all cabins in its farm view enterable) without a reconnect"
+            converged,
+            "after the → None commit every master cabin should be enterable at its placed tile in "
+                + "the connected peer's farm view without a reconnect (saw: "
+                + (
+                    lastView == null
+                        ? "null"
+                        : string.Join(
+                            ", ",
+                            lastView.Cabins.Select(c =>
+                                $"({c.TileX},{c.TileY},interior={c.HasInterior})"
+                            )
+                        )
+                )
+                + ")"
         );
 
         await DisconnectAsync();
         var removed = await ServerApi.WaitForPlayerRemovedByIdAsync(ownerId, ct: ct);
         Assert.True(removed, "the player should be removed server-side before the class reset");
-        await Exceptions.AssertNoExceptionsAsync("after CabinStack → None live interior heal");
+        await Exceptions.AssertNoExceptionsAsync("after CabinStack → None live convergence");
     }
 
     /// <summary>

--- a/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
+++ b/tests/JunimoServer.Tests/CabinPlacementValidationTests.cs
@@ -260,6 +260,107 @@ public class CabinPlacementValidationTests : TestBase
         await Exceptions.AssertNoExceptionsAsync("after farmer-collision !cabin");
     }
 
+    /// <summary>
+    /// !cabin onto the shared stack spot is rejected as "reserved" before validation; the cabin
+    /// stays hidden and no intent is recorded.
+    /// </summary>
+    [Fact]
+    public async Task StackSpotTarget_RejectsAsReservedAndDoesNotMove()
+    {
+        var ct = TestCt;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+        await SettleJoinAsync(client, ct);
+        var baseline = await GetOurCabinAsync(ownerId, ct);
+
+        var cabinsBefore = await ServerApi.GetCabins(ct);
+        Assert.True(
+            cabinsBefore?.StackSpot != null,
+            "/cabins reports no StackSpot under CabinStack"
+        );
+        var stack = cabinsBefore!.StackSpot!;
+
+        // !cabin places at farmer.Tile + (1,0).
+        var farmerTileX = stack.TileX - 1;
+        var farmerTileY = stack.TileY;
+        var warp = await GameClient.Actions.Warp("Farm", farmerTileX, farmerTileY);
+        Assert.True(warp?.Success == true, $"Warp to Farm failed: {warp?.Error}");
+        var arrived = await GameClient.WaitForLocationAsync("^Farm$", ct: ct);
+        Assert.True(arrived is not null, "Client did not sync to Farm before the reserved check");
+
+        // The handler reads the server's farmer tile, which lags the client warp.
+        var farmerSettled = await ServerApi.WaitForFarmerServerTileAsync(
+            ownerId,
+            farmerTileX,
+            farmerTileY,
+            ct: ct
+        );
+        Assert.True(
+            farmerSettled,
+            "Our farmer did not replicate next to the stack spot before the reserved check"
+        );
+
+        // Resend is safe: a static check, nothing an early accept could mask.
+        var rejection = await Chat.ResendUntilResponseAsync(
+            "!cabin",
+            "reserved",
+            replyFamilyPrefix: "Can't move cabin",
+            timeout: TestTimings.CabinAssignmentTimeout
+        );
+        Assert.True(
+            rejection.Matched,
+            $"Expected a 'reserved' rejection reply; {rejection.Describe()}"
+        );
+
+        var after = await GetOurCabinAsync(ownerId, ct);
+        Assert.True(after.IsHidden, "Cabin should still be hidden after a reserved-spot reject");
+        Assert.Equal((baseline.TileX, baseline.TileY), (after.TileX, after.TileY));
+
+        var cabinsAfter = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabinsAfter);
+        Assert.DoesNotContain(ownerId, cabinsAfter.SavedPositionPlayerIds);
+
+        await Exceptions.AssertNoExceptionsAsync("after reserved-spot !cabin");
+    }
+
+    /// <summary>
+    /// The reservation is CabinStack-only: under FarmhouseStack nothing renders at the stack
+    /// spot, so !cabin onto it is an ordinary accepted move.
+    /// </summary>
+    [Fact]
+    public async Task StackSpotTarget_FarmhouseStack_AcceptsMove()
+    {
+        var ct = TestCt;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "FarmhouseStack");
+
+        var client = await Farmers.ConnectNewAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+        await SettleJoinAsync(client, ct);
+
+        var spot = CabinPlacementHelper.StandardFarmStackSpot;
+        await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, spot.X - 1, spot.Y, ct);
+
+        CabinInfoResponse? moved = null;
+        var ok = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinPlacement_Moved,
+            async () =>
+            {
+                await GameClient.SendChat("!cabin");
+                moved = await GetOurCabinAsync(ownerId, ct);
+                return !moved.IsHidden;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        Assert.True(ok, "Cabin did not move onto the stack spot under FarmhouseStack");
+        Assert.Equal(spot, (moved!.TileX, moved.TileY));
+
+        await Exceptions.AssertNoExceptionsAsync("after FarmhouseStack stack-spot !cabin");
+    }
+
     #region Helpers
 
     /// <summary>

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -459,7 +459,7 @@ public class CabinPositionPersistenceTests : TestBase
     /// triggers the new dummy-found branch in OnLocationIntroductionMessage on reconnect. The
     /// mutation lives only in the per-peer message copy, so /cabins (master) can't see it —
     /// this asserts the join completes, master's tile for the moved cabin is unchanged (the
-    /// dummy relocate must not touch master state), and no errors fired.
+    /// dummy must not touch master state), and no errors fired.
     /// </summary>
     [Fact]
     public async Task DummyCabin_ReconnectAfterMove_JoinSucceedsAndMasterUnchanged()
@@ -477,7 +477,7 @@ public class CabinPositionPersistenceTests : TestBase
         await Farmers.DisconnectAndWaitForSlotAsync(ownerId, client.FarmerName, ct);
         await Farmers.ReconnectAsync(client.FarmerName, ct: ct);
 
-        // Master cabin tile is unchanged — the dummy relocate mutated only the message copy.
+        // Master cabin tile is unchanged — the dummy lives only in the message copy.
         var afterReconnect = await GetOurCabinAsync(ownerId, ct);
         Assert.False(afterReconnect.IsHidden, "A's moved cabin should still be visible in master");
         Assert.Equal(movedTile, (afterReconnect.TileX, afterReconnect.TileY));
@@ -555,6 +555,91 @@ public class CabinPositionPersistenceTests : TestBase
         Log("Client rendered a door-dead dummy cabin at the shared stack after moving its own");
 
         await Exceptions.AssertNoExceptionsAsync("after dummy positive-observation");
+    }
+
+    /// <summary>
+    /// The stack dummy must not touch a real cabin: clients resolve homes by interior name and
+    /// never rebuild interiors. A moves and reconnects; on A's client B's home and every hidden
+    /// cabin keep their interior.
+    /// </summary>
+    [Fact]
+    public async Task DummyCabin_AfterMoveAndReconnect_OtherPlayersHomeStaysResolvable()
+    {
+        var ct = TestCt;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var clientA = await Farmers.ConnectFastAsync(ct: ct);
+        var ownerIdA = clientA.JoinResult.UniqueMultiplayerId;
+
+        await using var farmerB = await Farmers.ConnectSecondFarmerAsync(ct: ct);
+
+        var diagnostics = await ServerApi.GetDiagnosticsState(ct);
+        var bCabin = diagnostics?.Cabins.FirstOrDefault(c => c.OwnerId == farmerB.Uid);
+        Assert.True(
+            !string.IsNullOrEmpty(bCabin?.IndoorsName),
+            $"B's cabin has no interior name in master state (cabin found: {bCabin != null})"
+        );
+        var bHome = bCabin!.IndoorsName;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerIdA, ct);
+
+        // Reconnect: the fresh Farm intro carries the dummy.
+        await Farmers.DisconnectAndWaitForSlotAsync(ownerIdA, clientA.FarmerName, ct);
+        await Farmers.ReconnectAsync(clientA.FarmerName, ct: ct);
+
+        FarmBuildingsResult? view = null;
+        FarmBuildingInfo? bHomeOnA = null;
+        FarmBuildingInfo? dummy = null;
+        var resolved = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_DummyCabin_OtherHomeResolvableOnClient,
+            async () =>
+            {
+                view = await GameClient.Actions.GetFarmBuildings(ct);
+                if (view?.Success != true)
+                {
+                    return false;
+                }
+
+                bHomeOnA = view.Cabins.FirstOrDefault(c => c.Name == bHome);
+                dummy = view.Cabins.FirstOrDefault(c =>
+                    c.TileX >= 0 && !(c.TileX == movedTile.X && c.TileY == movedTile.Y)
+                );
+                return bHomeOnA != null && dummy != null;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+
+        var seen =
+            view == null
+                ? "null"
+                : string.Join(
+                    ", ",
+                    view.Cabins.Select(c =>
+                        $"({c.TileX},{c.TileY},name={c.Name},interior={c.HasInterior})"
+                    )
+                );
+        Assert.True(
+            resolved,
+            $"A's client did not see both the stack dummy and B's home '{bHome}' (saw: {seen})"
+        );
+        Assert.True(
+            bHomeOnA!.HasInterior,
+            $"B's home '{bHome}' lost its interior on A's client — B's home is unresolvable there (saw: {seen})"
+        );
+        Assert.False(dummy!.HasInterior, "Dummy cabin door is live — it must be door-dead");
+
+        // No hidden cabin was borrowed as the dummy.
+        var hiddenWithoutInterior = view!.Cabins.Where(c => c.TileX < 0 && !c.HasInterior).ToList();
+        Assert.True(
+            hiddenWithoutInterior.Count == 0,
+            $"A hidden-stack cabin lost its interior on A's client (saw: {seen})"
+        );
+        Log($"A's client resolves B's home '{bHome}' with the stack dummy present");
+
+        // Disconnect B before this class's DisposeAsync runs /newgame (409s while connected).
+        await farmerB.DisconnectAsync();
+        await Exceptions.AssertNoExceptionsAsync("after other-home resolvability check");
     }
 
     #region Helpers

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -1422,16 +1422,9 @@ public class StackSpotInfoResponse
     [JsonPropertyName("isOverride")]
     public bool IsOverride { get; set; }
 
-    /// <summary>True when the spot currently fails placement validation.</summary>
+    /// <summary>True when a cabin footprint at the spot currently fails placement validation.</summary>
     [JsonPropertyName("isObstructed")]
     public bool IsObstructed { get; set; }
-
-    /// <summary>
-    /// True when obstruction was actually evaluated (a hidden cabin existed to test against);
-    /// false means the stack is empty and <see cref="IsObstructed"/> is not meaningful.
-    /// </summary>
-    [JsonPropertyName("obstructionChecked")]
-    public bool ObstructionChecked { get; set; }
 }
 
 /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
+++ b/tests/JunimoServer.Tests/Helpers/CabinPlacementHelper.cs
@@ -24,6 +24,13 @@ public static class CabinPlacementHelper
     /// <summary>Where !cabin places the cabin's top-left when the farmer stands at the tile above.</summary>
     public static readonly (int X, int Y) ExpectedCabinTile = (FarmerTileX + 1, FarmerTileY);
 
+    /// <summary>
+    /// The standard farm's default CabinStack stack spot: the first designated cabin position
+    /// of the separate layout (Maps/Farm Paths layer, tile index 30, Order 1), which the
+    /// default CabinLayoutNearby=false selects.
+    /// </summary>
+    public static readonly (int X, int Y) StandardFarmStackSpot = (23, 31);
+
     /// <summary>Expected cabin top-left for a farmer warped to (<paramref name="tileX"/>,<paramref name="tileY"/>).</summary>
     public static (int X, int Y) ExpectedCabinTileFor(int tileX, int tileY) => (tileX + 1, tileY);
 

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -105,8 +105,9 @@ public enum WaitName
     // CabinPositionPersistenceTests.cs — !cabin reset (1)
     Polling_CabinReset_CabinHidden,
 
-    // CabinPositionPersistenceTests.cs — dummy cabin at shared stack (1)
+    // CabinPositionPersistenceTests.cs — dummy cabin at shared stack (2)
     Polling_DummyCabin_VisibleInClientFarm,
+    Polling_DummyCabin_OtherHomeResolvableOnClient,
 
     // CabinPositionPersistenceTests.cs — same-pass sweep reflected in snapshot (1)
     Polling_CabinSweep_PostReloadSettled,
@@ -246,9 +247,9 @@ public enum WaitName
     /// <summary>'cabins stackspot x y' landed: /cabins StackSpot shows the override.</summary>
     Polling_CabinStackSpot_Set,
 
-    /// <summary>A connected peer's door-dead dummy interior became enterable after a →None commit
-    /// healed it live (no reconnect).</summary>
-    Polling_CabinDummyInterior_HealedLive,
+    /// <summary>Every master cabin is enterable at its placed tile on a connected peer after a
+    /// →None commit.</summary>
+    Polling_CabinMigration_PlacedCabinsVisibleOnPeer,
 
     // CabinStrategyFarmhouseStackTests.cs + CabinStrategyTests.cs — cabin-link repair (2)
     /// <summary>Cabin gone from /cabins after /test/break_cabin_link nulled its back-link.</summary>

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -428,7 +428,7 @@ public class ActionsController
     /// <summary>
     /// Lists this client's view of the farm's cabin buildings (name + tile). The server
     /// rewrites each peer's locationIntroduction copy (CabinManagerService), so the client's
-    /// farm can differ from master state — e.g. a dummy cabin relocated to the shared stack
+    /// farm can differ from master state — e.g. a door-less dummy cabin at the shared stack
     /// for a player whose own cabin was moved. /cabins (master state) cannot observe that, so
     /// this is the positive-observation gate for the per-peer cabin mutations.
     /// </summary>


### PR DESCRIPTION
Three fixes around the shared cabin spot under `CabinStack`, one commit each. Intended to be merged with **Rebase and merge** so each commit lands as its own changelog entry.

- Festivals no longer kick players who moved their cabin out of the shared spot. Their client was shown another player's cabin there with no interior, so the game could not find that player's home and crashed at festival start. The spot now shows an empty stand-in cabin that belongs to nobody. Adds a two-farmhand E2E test and reworks the migration convergence test around placed cabins.
- `!cabin` refuses to move a cabin onto the shared spot under `CabinStack`, since every player sees a cabin there and a move onto it put two buildings on the same tiles. Other strategies are unaffected. Adds E2E tests for the refused `CabinStack` move and the accepted `FarmhouseStack` move; docs mention the reserved spot.
- Checks on the shared spot always run now, against a cabin-sized probe, instead of borrowing a hidden cabin and skipping when none exists. A visible cabin on the spot always counts as blocking it. The "was this checked" tri-state is removed from the status record, the API response, both stack-spot commands, and the test client.

The `!cabin reset` reply intentionally does not mention reconnecting: the follow-up branch `feat/cabin-live-farm-reintroduction` re-sends the farm live and makes that hint unnecessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CabinStack now prevents cabins from being moved onto the shared cabin spot.
  - Cabin placement checks consistently validate the full cabin footprint.
  - Players whose cabins move away can see a doorless stand-in at the shared spot.

- **Bug Fixes**
  - Cabin migrations and reconnects now preserve access to placed cabins and other players’ homes.
  - Stack spot status messages no longer show an “obstruction not checked” state.

- **Documentation**
  - Updated cabin movement and command guidance to explain shared-spot restrictions and stand-in cabins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->