### PR TITLE
feat(cabins): connected players see cabin moves, resets and migrations without reconnecting

### DIFF
--- a/docs/features/cabin-strategies.md
+++ b/docs/features/cabin-strategies.md
@@ -19,7 +19,7 @@ Benefits:
 - No cabin placement conflicts
 - Each player still has their own private space
 
-Admins can move the shared spot every player sees their cabin at: `cabins stackspot` (server console) shows the current spot, `cabins stackspot <x> <y>` sets it, and the in-game `!stackspot` / `!stackspot place` admin chat command does the same visually. Connected players see the new spot after they reconnect.
+Admins can move the shared spot every player sees their cabin at: `cabins stackspot` (server console) shows the current spot, `cabins stackspot <x> <y>` sets it, and the in-game `!stackspot` / `!stackspot place` admin chat command does the same visually. Connected players see the new spot right away, except players inside a building, who see it after next leaving the farm (or a reconnect). A player changing areas at that exact moment may need to reconnect.
 
 ## FarmhouseStack
 
@@ -56,7 +56,7 @@ A rejected settings-file switch reverts only the server's active strategy — th
 
 Directions that materialize a cabin on a developed farm go through a staged, admin-driven migration. Nothing is ever destroyed: every placement is validated against the live farm (occupied or blocked spots are skipped, never cleared), the current strategy stays fully active while you stage, and the switch happens only at an explicit commit — so aborting is always safe.
 
-Prefer committing while the server is empty: players connected during the migration keep seeing the pre-migration cabin layout until they reconnect.
+Players connected during the commit get the new layout right away, except players inside a building, who get it after next leaving the farm (or a reconnect); the commit output names them. Commit at a calm moment: a player changing areas at that exact instant may need to reconnect.
 
 1. `cabins migrate start <strategy>` (server console) — validates the direction, auto-places what fits on the map's designated spots, and reports how many placements remain.
 2. Place the remainder anywhere valid: stand in-game where a cabin should go and run `!migrate place` (admin chat command, places to your right like `!cabin`), or use `cabins migrate place <x> <y>` from the console. `cabins migrate status` shows progress.

--- a/mod/JunimoServer/Services/Api/ApiService.cs
+++ b/mod/JunimoServer/Services/Api/ApiService.cs
@@ -120,6 +120,12 @@ public class PlayerInfo
 
     /// <summary>Whether the player is currently online.</summary>
     public bool IsOnline { get; set; }
+
+    /// <summary>
+    /// Unique name of the location the player is in, or is arriving in (the replicated
+    /// destination, ahead of the netcode interpolation window). Empty when unresolved.
+    /// </summary>
+    public string Location { get; set; } = "";
 }
 
 /// <summary>
@@ -1503,6 +1509,7 @@ public partial class ApiService : ModService
                         Id = farmer.UniqueMultiplayerID,
                         Name = farmer.Name ?? farmer.displayName ?? "Unknown",
                         IsOnline = true,
+                        Location = farmer.GetTargetLocation()?.NameOrUniqueName ?? "",
                     }
                 );
             }

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.FarmReintroduction.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.FarmReintroduction.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using JunimoServer.Util;
+using StardewModdingAPI;
+using StardewValley;
+using StardewValley.Network;
+
+namespace JunimoServer.Services.CabinManager;
+
+// Live Farm re-introduction for connected peers. The per-peer CabinStack fiction (the own
+// hidden cabin relocated to the shared stack spot, or a phantom filling it) exists only in the
+// copy OnLocationIntroductionMessage serializes; no net field carries it, so after '!cabin
+// reset', a migration commit or a stack-spot change the only repair is a fresh location
+// introduction (message 3). Vanilla sends one at join and in answer to a warp request, and the
+// client (Multiplayer.readActiveLocation) has two behaviours an unsolicited one must respect:
+//   - While Game1.locationRequest is open (from fade start until the answer arrives) it takes
+//     the message as that warp's answer whatever the force flag: the player lands in the Farm
+//     at the foreign warp's coordinates and the fade-complete block, guarded on the request,
+//     never runs. The server learns of a warp only at completion, so no server-side location
+//     check can exclude this.
+//   - It repoints Game1.currentLocation only when that IS the Farm. A peer inside a Farm
+//     building keeps the old interior and, since getLocationFromName("Farm") answers from the
+//     current location's root, walks back into the orphaned old Farm on exit.
+// Hence two deliveries. Immediately: for the chat-command sender, who cannot be mid-warp while
+// typing, and for every peer of an admin action (migration commit, stack spot), where the
+// admin picks the moment and the docs name the mid-warp case as a reconnect. Deferred, for a
+// peer inside a Farm building: piggybacked behind the answer to their own next warp request
+// off the farm, where the request is provably closed and the peer stands off the Farm.
+public partial class CabinManagerService
+{
+    private readonly HashSet<long> _pendingFarmReintroductions = new();
+
+    /// <summary>
+    /// Re-sends the Farm to <paramref name="peerId"/> right now. Only for the peer who just
+    /// sent a chat command (see the file comment). Returns false, sending nothing, when the
+    /// peer is offline or stands inside a Farm building; callers then fall back to
+    /// <see cref="QueueFarmReintroduction"/>.
+    /// </summary>
+    public bool TryReintroduceFarmNow(long peerId)
+    {
+        if (!Game1.hasLoadedGame || Game1.server is not GameServer server)
+        {
+            return false;
+        }
+
+        var farmer = Game1.GetPlayer(peerId);
+        if (farmer == null || farmer == Game1.player || Game1.Multiplayer.isDisconnecting(farmer))
+        {
+            return false;
+        }
+
+        // Target, not the interpolated value: a peer who just entered their cabin still reads
+        // as "on the Farm" for 15 server ticks otherwise, and a forced re-send in that window
+        // would pull them out onto the Farm at the interior's coordinates.
+        var farm = Game1.getFarm();
+        var location = farmer.GetTargetLocation();
+        if (location != null && location != farm && location.Root?.Value == farm)
+        {
+            return false;
+        }
+
+        // On the Farm itself the force flag makes the client re-enter it (map modifications,
+        // lights, seasonal tilesheets); elsewhere the plain swap suffices and the next warp
+        // onto the Farm is a normal entry.
+        SendFarmIntroduction(server, peerId, forceCurrent: location == farm, trigger: "now");
+        return true;
+    }
+
+    /// <summary>
+    /// Re-sends the Farm to <paramref name="peerId"/> behind the answer to their next warp
+    /// request off the farm. A join or disconnect drops the entry.
+    /// </summary>
+    public void QueueFarmReintroduction(long peerId)
+    {
+        _pendingFarmReintroductions.Add(peerId);
+    }
+
+    /// <summary>
+    /// Admin-triggered variant for every connected player: re-sends now to those the gate
+    /// admits and queues the rest. Returns the names of the queued players, or null when
+    /// nobody is online. An admin picks the moment, so a player mid-warp at that instant is
+    /// documented as a reconnect case rather than deferring everyone.
+    /// </summary>
+    public List<string> ReintroduceFarmToOnlinePeers()
+    {
+        var peers = OnlineFarmers.Others();
+        if (peers.Count == 0)
+        {
+            return null;
+        }
+
+        var deferred = new List<string>();
+        foreach (var peer in peers)
+        {
+            if (!TryReintroduceFarmNow(peer.UniqueMultiplayerID))
+            {
+                QueueFarmReintroduction(peer.UniqueMultiplayerID);
+                deferred.Add(peer.Name);
+            }
+        }
+        return deferred;
+    }
+
+    /// <summary>
+    /// Message suffix for <see cref="ReintroduceFarmToOnlinePeers"/>: empty when nobody was
+    /// queued.
+    /// </summary>
+    public static string DescribeDeferredReintroductions(List<string> deferred)
+    {
+        if (deferred == null || deferred.Count == 0)
+        {
+            return "";
+        }
+
+        return $" {string.Join(", ", deferred)} "
+            + (deferred.Count == 1 ? "is" : "are")
+            + " inside a building and will see it after next leaving the farm (or a reconnect).";
+    }
+
+    private void SendFarmIntroduction(
+        GameServer server,
+        long peerId,
+        bool forceCurrent,
+        string trigger
+    )
+    {
+        var farm = Game1.getFarm();
+
+        // A pending Farm delta is broadcast after updateRoots ticks the clock, so it would
+        // outrank the full's fields on the client and rewrite the fiction (a just-reset cabin
+        // back off-map). Flushed here it precedes the full on the wire at the same version.
+        Game1.Multiplayer.broadcastLocationDelta(farm);
+
+        NetworkHelper.SendLocation(server, peerId, farm, forceCurrent);
+
+        // readActiveLocation evicts only the Farm itself from the client's name lookup; the
+        // interior names keep resolving to the orphaned old objects, and doors warp by name.
+        foreach (var building in farm.buildings)
+        {
+            var indoors = building.indoors.Value;
+            if (indoors != null)
+            {
+                server.sendMessage(
+                    peerId,
+                    Multiplayer.removeLocationFromLookup,
+                    Game1.serverHost.Value,
+                    indoors.NameOrUniqueName
+                );
+            }
+        }
+
+        Monitor.Log(
+            $"Re-introduced the Farm to peer {peerId} ({trigger}, forceCurrent={forceCurrent})",
+            LogLevel.Debug
+        );
+        Diagnostics.ModEventLog.Emit(
+            "cabin_farm_reintroduced",
+            new
+            {
+                playerId = peerId,
+                forceCurrent,
+                trigger,
+            }
+        );
+    }
+
+    // Postfix on GameServer.warpFarmer: runs after vanilla (or NetworkTweaker's WarpFix prefix)
+    // answered the peer's warp request with a location introduction, so a Farm introduction
+    // queued behind it cannot be mistaken for that answer.
+    private static void WarpFarmer_Postfix(Farmer farmer)
+    {
+        _instance?.DeliverPendingFarmReintroduction(farmer);
+    }
+
+    private void DeliverPendingFarmReintroduction(Farmer farmer)
+    {
+        if (
+            farmer == null
+            || !_pendingFarmReintroductions.Contains(farmer.UniqueMultiplayerID)
+            || Game1.server is not GameServer server
+        )
+        {
+            return;
+        }
+
+        // warpFarmer set currentLocation to the answered destination. A Farm-rooted answer
+        // (WarpFix resending the Farm for a mis-flagged structure) leaves the peer inside a
+        // Farm building, so the entry stays queued for a later warp.
+        var destination = farmer.currentLocation;
+        if (destination == null || destination.Root?.Value == Game1.getFarm())
+        {
+            return;
+        }
+
+        _pendingFarmReintroductions.Remove(farmer.UniqueMultiplayerID);
+        SendFarmIntroduction(server, farmer.UniqueMultiplayerID, forceCurrent: false, "warp");
+    }
+}

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.Migration.cs
@@ -513,20 +513,12 @@ public partial class CabinManagerService
                 + $"({spot.X},{spot.Y}).";
         }
 
-        // Connected peers hold intro-only state no delta can fix: the →CabinStack ghost position
-        // (master tile is hidden) and the →None phantom (master never had it). Re-sending the
-        // Farm intro would orphan a peer standing inside a cabin, so they reconnect instead.
-        if (OnlineFarmers.CountOthers() > 0)
-        {
-            message +=
-                migration.ToStrategy == CabinStrategy.CabinStack
-                    ? " Connected players keep seeing the pre-migration cabin layout until they "
-                        + "reconnect."
-                    : " Connected players who had moved their cabin may still see a stale cabin "
-                        + "at the old shared spot until they reconnect.";
-        }
-
         ApplyStrategyDurably(migration.ToStrategy);
+
+        // Connected peers hold intro-only state no delta can fix: the →CabinStack ghost position
+        // (master tile is hidden) and the →None phantom (master never had it). Re-send the Farm
+        // now that the strategy is flipped, so the interceptor emits the new fiction.
+        message += DescribeDeferredReintroductions(ReintroduceFarmToOnlinePeers());
 
         Data.ActiveMigration = null;
         Data.Write();

--- a/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
+++ b/mod/JunimoServer/Services/CabinManager/CabinManagerService.cs
@@ -187,6 +187,17 @@ public partial class CabinManagerService : ModService
             )
         );
 
+        // Deferred Farm re-introduction rides behind the answer to a peer's own warp request
+        // (see CabinManagerService.FarmReintroduction).
+        harmony.Patch(
+            original: AccessTools.Method(
+                typeof(GameServer),
+                "warpFarmer",
+                new[] { typeof(Farmer), typeof(short), typeof(short), typeof(string), typeof(bool) }
+            ),
+            postfix: new HarmonyMethod(typeof(CabinManagerService), nameof(WarpFarmer_Postfix))
+        );
+
         // Defensive: make Utility.getHomeOfFarmer null-safe.
         // The vanilla implementation calls RequireLocation which throws KeyNotFoundException
         // if the cabin interior isn't findable yet (e.g. during new game setup, day transitions,
@@ -462,10 +473,13 @@ public partial class CabinManagerService : ModService
     private static void OnPlayerDisconnected_Postfix(long disconnectee)
     {
         CleanupAbandonedCabinClaim(disconnectee);
+        _instance?._pendingFarmReintroductions.Remove(disconnectee);
     }
 
     private void OnServerJoined(long peer)
     {
+        // The join introduction carries the current fiction; a queued re-send is moot.
+        _pendingFarmReintroductions.Remove(peer);
         AddPeer(peer);
         EnsureAtLeastXCabins(excludePeer: peer);
     }
@@ -782,9 +796,9 @@ public partial class CabinManagerService : ModService
     /// <summary>
     /// Sets the CabinStack shared stack spot (writes the persisted DefaultCabinLocation).
     /// CabinStack-only; refused during a staged migration (the migration owns the spot
-    /// choice via 'cabins migrate place'); footprint-validated. Connected players keep
-    /// seeing the old spot until they reconnect — the ghost position is written into each
-    /// peer's location-introduction message, and deltas rewrite warps, not positions.
+    /// choice via 'cabins migrate place'); footprint-validated. Connected players get a Farm
+    /// re-introduction — the ghost position lives only in each peer's location-introduction
+    /// copy, and deltas rewrite warps, not positions.
     /// </summary>
     public bool TrySetStackSpot(Point topLeft, out string message)
     {
@@ -820,8 +834,8 @@ public partial class CabinManagerService : ModService
         Data.DefaultCabinLocation = topLeft.ToVector2();
         Data.Write();
         message =
-            $"Stack spot set to ({topLeft.X},{topLeft.Y}). "
-            + "Connected players see it after they reconnect.";
+            $"Stack spot set to ({topLeft.X},{topLeft.Y})."
+            + DescribeDeferredReintroductions(ReintroduceFarmToOnlinePeers());
         Monitor.Log(message, LogLevel.Info);
         return true;
     }

--- a/mod/JunimoServer/Services/Commands/CabinCommand.cs
+++ b/mod/JunimoServer/Services/Commands/CabinCommand.cs
@@ -124,6 +124,18 @@ public static class CabinCommand
                 cabinService.Data.Write();
 
                 cabin.Relocate(topLeft);
+
+                // The move itself replicates as deltas; the re-send fills the now-empty stack
+                // spot in the sender's copy with the phantom (CabinStack only, see the
+                // interceptor). The gate can still refuse a sender who stepped into a building
+                // between the on-Farm check above and here.
+                if (
+                    cabinService.options.IsCabinStack
+                    && !cabinService.TryReintroduceFarmNow(msg.SourceFarmer)
+                )
+                {
+                    cabinService.QueueFarmReintroduction(msg.SourceFarmer);
+                }
             }
         );
     }
@@ -205,11 +217,26 @@ public static class CabinCommand
                 )
             );
         }
-        helper.SendPrivateMessage(
-            msg.SourceFarmer,
-            cabinService.options.IsFarmHouseStack
-                ? "Cabin reset — you'll exit at the farmhouse again."
-                : "Cabin reset — it's back in the shared stack."
-        );
+        string reply;
+        if (cabinService.options.IsFarmHouseStack)
+        {
+            // No fiction to repair: the peer's copy shows every cabin hidden, and the position
+            // delta hides this one too.
+            reply = "Cabin reset — you'll exit at the farmhouse again.";
+        }
+        else if (cabinService.TryReintroduceFarmNow(msg.SourceFarmer))
+        {
+            reply = "Cabin reset — it's back in the shared stack.";
+        }
+        else
+        {
+            // Sender is inside a Farm building (their cabin, usually): the re-send waits for
+            // their next warp off the farm.
+            cabinService.QueueFarmReintroduction(msg.SourceFarmer);
+            reply =
+                "Cabin reset — it's back in the shared stack. You'll see it there after you "
+                + "next leave the farm (or reconnect).";
+        }
+        helper.SendPrivateMessage(msg.SourceFarmer, reply);
     }
 }

--- a/mod/JunimoServer/Services/NetworkTweaks/NetworkTweaker.cs
+++ b/mod/JunimoServer/Services/NetworkTweaks/NetworkTweaker.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using HarmonyLib;
 using JunimoServer.Services.PersistentOption;
 using JunimoServer.Services.Settings;
+using JunimoServer.Util;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
@@ -228,15 +229,11 @@ public class NetworkTweaker : ModService
             y * 64 - (farmer.Sprite.getHeight() - 32) + 16
         );
 
-        // Call private sendLocation via reflection
-        var sendLocationMethod = AccessTools.Method(
-            typeof(GameServer),
-            "sendLocation",
-            new[] { typeof(long), typeof(GameLocation), typeof(bool) }
-        );
-        sendLocationMethod.Invoke(
+        NetworkHelper.SendLocation(
             __instance,
-            new object[] { farmer.UniqueMultiplayerID, location, false }
+            farmer.UniqueMultiplayerID,
+            location,
+            forceCurrent: false
         );
 
         return false; // Skip original

--- a/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
+++ b/mod/JunimoServer/Services/PasswordProtection/PasswordProtectionService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using HarmonyLib;
@@ -25,7 +24,6 @@ public class PasswordProtectionService : ModService
     private readonly IMonitor _monitor;
     private readonly LobbyService _lobbyService;
     private readonly CabinManagerService _cabinManager;
-    private static MethodInfo _sendLocationMethod;
 
     /// <summary>
     /// Thread-safe dictionary tracking authentication state per player.
@@ -114,12 +112,6 @@ public class PasswordProtectionService : ModService
         // Vanilla checkFarmhandRequest skips sendLocation for the lobby cabin because
         // isAlwaysActiveLocation() returns true for building interiors nested in the
         // always-active Farm. Without this, ApplyWakeUpPosition crashes on the client.
-        _sendLocationMethod = AccessTools.Method(
-            typeof(GameServer),
-            "sendLocation",
-            new[] { typeof(long), typeof(GameLocation), typeof(bool) }
-        );
-
         harmony.Patch(
             original: AccessTools.Method(
                 typeof(GameServer),
@@ -237,7 +229,7 @@ public class PasswordProtectionService : ModService
         long peer
     )
     {
-        if (_instance == null || !_instance.IsEnabled || _sendLocationMethod == null)
+        if (_instance == null || !_instance.IsEnabled)
         {
             return true;
         }
@@ -274,7 +266,7 @@ public class PasswordProtectionService : ModService
             LogLevel.Debug
         );
 
-        _sendLocationMethod.Invoke(__instance, new object[] { peer, lobbyGameLocation, true });
+        NetworkHelper.SendLocation(__instance, peer, lobbyGameLocation, forceCurrent: true);
         return true;
     }
 

--- a/mod/JunimoServer/Util/FarmerExtensions.cs
+++ b/mod/JunimoServer/Util/FarmerExtensions.cs
@@ -1,12 +1,35 @@
+using HarmonyLib;
 using Microsoft.Xna.Framework;
 using StardewValley;
 using StardewValley.Locations;
+using StardewValley.Network;
 
 #nullable enable
 namespace JunimoServer.Util;
 
 public static class FarmerExtensions
 {
+    // Character.currentLocationRef is protected; the public currentLocation getter only
+    // exposes the interpolated value.
+    private static readonly AccessTools.FieldRef<Character, NetLocationRef> _currentLocationRef =
+        AccessTools.FieldRefAccess<Character, NetLocationRef>("currentLocationRef");
+
+    /// <summary>
+    /// The location a remote farmer is in or about to be in. A farmhand's replicated
+    /// <c>currentLocationRef</c> fields are interpolation-wait netfields, so <c>currentLocation</c>
+    /// keeps answering the OLD location for <c>InterpolationTicks</c> (15 server ticks) after
+    /// the client's warp delta arrived; the target value is the destination the delta carried.
+    /// Null when the name does not resolve on the server.
+    /// </summary>
+    public static GameLocation? GetTargetLocation(this Farmer farmer)
+    {
+        var target = _currentLocationRef(farmer);
+        var name = target.locationName.TargetValue ?? target.locationName.Value;
+        return string.IsNullOrEmpty(name)
+            ? null
+            : Game1.getLocationFromName(name, target.isStructure.TargetValue);
+    }
+
     public static void WarpHome(this Farmer farmer)
     {
         var cabin = Game1.getFarm().GetCabin(farmer.UniqueMultiplayerID);

--- a/mod/JunimoServer/Util/NetworkHelper.cs
+++ b/mod/JunimoServer/Util/NetworkHelper.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.NetworkInformation;
+using System.Reflection;
 using System.Threading.Tasks;
+using HarmonyLib;
 using JunimoServer.Services.MessageInterceptors;
 using Netcode;
 using StardewValley;
@@ -56,6 +58,29 @@ public class NetworkHelper
     {
         Timeout = TimeSpan.FromSeconds(5),
     };
+
+    private static readonly MethodInfo _sendLocationMethod = AccessTools.Method(
+        typeof(GameServer),
+        "sendLocation",
+        new[] { typeof(long), typeof(GameLocation), typeof(bool) }
+    );
+
+    /// <summary>
+    /// Sends a full location introduction (message 3) to one peer through the private
+    /// GameServer.sendLocation. Outgoing interceptors (CabinManagerService's farm rewrite) see
+    /// it like any join-time introduction. <paramref name="forceCurrent"/> makes the client
+    /// switch to the location and run its entry reset; without it the client only swaps an
+    /// always-active location in place, or answers an open warp request with it.
+    /// </summary>
+    public static void SendLocation(
+        GameServer server,
+        long peerId,
+        GameLocation location,
+        bool forceCurrent
+    )
+    {
+        _sendLocationMethod.Invoke(server, new object[] { peerId, location, forceCurrent });
+    }
 
     public static IPAddress GetIpAddressLocal()
     {

--- a/tests/JunimoServer.Tests/CabinMigrationTests.cs
+++ b/tests/JunimoServer.Tests/CabinMigrationTests.cs
@@ -289,7 +289,8 @@ public class CabinMigrationTests : TestBase
     /// <summary>
     /// A connected peer sees every master cabin at its placed tile, enterable, after a
     /// CabinStack → None commit without reconnecting. The peer's intro-only phantom at the
-    /// stack spot stays until reconnect and is excluded.
+    /// stack spot (placed live by the !cabin move's re-introduction) is removed by the
+    /// commit's re-introduction, both without a reconnect.
     /// </summary>
     [Fact]
     public async Task StagedMigration_StackedToNone_ConnectedPeerSeesPlacedCabinsLive()
@@ -308,8 +309,8 @@ public class CabinMigrationTests : TestBase
         await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, 40, 18, ct);
         await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, 40, 30, ct);
 
-        // Move the cabin out of the stack at the standard footprint, then reconnect so the client
-        // receives a fresh Farm introduction carrying the door-dead dummy at the shared stack.
+        // Move the cabin out of the stack at the standard footprint; the move re-sends the Farm
+        // introduction, which carries the door-dead dummy at the shared stack.
         await CabinPlacementHelper.WarpAndClearFootprintAsync(GameClient, ct);
         CabinInfoResponse? movedCabin = null;
         var moved = await PollingHelper.WaitUntilAsync(
@@ -326,11 +327,9 @@ public class CabinMigrationTests : TestBase
         Assert.True(moved, "the primary's cabin should move out of the stack via !cabin");
         var movedTile = (movedCabin!.TileX, movedCabin.TileY);
 
-        await Farmers.DisconnectAndWaitForSlotAsync(ownerId, primary.FarmerName, ct);
-        await Farmers.ReconnectAsync(primary.FarmerName, ct: ct);
-
-        // Pre-condition: the client renders a door-dead dummy (HasInterior == false) alongside its
-        // own enterable moved cabin — the nulled interior the commit must heal.
+        // Pre-condition: without a reconnect, the client renders a door-dead dummy
+        // (HasInterior == false) alongside its own enterable moved cabin — the phantom the
+        // commit must remove.
         var sawDummy = await PollingHelper.WaitUntilAsync(
             WaitName.Polling_DummyCabin_VisibleInClientFarm,
             async () =>
@@ -445,6 +444,40 @@ public class CabinMigrationTests : TestBase
             converged,
             "after the → None commit every master cabin should be enterable at its placed tile in "
                 + "the connected peer's farm view without a reconnect (saw: "
+                + (
+                    lastView == null
+                        ? "null"
+                        : string.Join(
+                            ", ",
+                            lastView.Cabins.Select(c =>
+                                $"({c.TileX},{c.TileY},interior={c.HasInterior})"
+                            )
+                        )
+                )
+                + ")"
+        );
+
+        // The door-less phantom is intro-only state the commit cannot delta away; the commit
+        // re-sends the Farm introduction to the peer standing on the Farm, and under None the
+        // interceptor leaves the master Farm untouched.
+        var phantomGone = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinMigration_PhantomGoneLive,
+            async () =>
+            {
+                lastView = await GameClient.Actions.GetFarmBuildings(ct);
+                return lastView?.Success == true
+                    && lastView.IsLiveFarm
+                    && lastView.Cabins.All(c => c.HasInterior)
+                    && master.Cabins.All(m =>
+                        lastView.Cabins.Any(c => c.TileX == m.TileX && c.TileY == m.TileY)
+                    );
+            },
+            TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            phantomGone,
+            "after the commit no door-less cabin should remain in the peer's view without a reconnect (saw: "
                 + (
                     lastView == null
                         ? "null"

--- a/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
+++ b/tests/JunimoServer.Tests/CabinPositionPersistenceTests.cs
@@ -268,26 +268,7 @@ public class CabinPositionPersistenceTests : TestBase
         Assert.NotNull(withIntent);
         Assert.Contains(ownerId, withIntent.SavedPositionPlayerIds);
 
-        // Resend each poll: /cabins is snapshot-backed, so the hide can lag the reset by a
-        // tick. Resending !cabin reset is idempotent — once hidden it just replies
-        // "nothing to reset".
-        CabinInfoResponse? afterReset = null;
-        CabinsResponse? snapshot = null;
-        var reset = await PollingHelper.WaitUntilAsync(
-            WaitName.Polling_CabinReset_CabinHidden,
-            async () =>
-            {
-                await GameClient.SendChat("!cabin reset");
-                snapshot = await ServerApi.GetCabins(ct);
-                afterReset = snapshot?.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
-                return afterReset?.IsHidden == true
-                    && snapshot?.SavedPositionPlayerIds.Contains(ownerId) == false;
-            },
-            TestTimings.CabinAssignmentTimeout,
-            cancellationToken: ct
-        );
-
-        Assert.True(reset, "Cabin did not return to the hidden stack after !cabin reset");
+        await ResetCabinViaCommandAsync(ownerId, ct);
         Log($"Cabin reset to hidden stack; intent cleared for owner {ownerId}");
 
         await SleepToSaveAsync(ct);
@@ -642,6 +623,141 @@ public class CabinPositionPersistenceTests : TestBase
         await Exceptions.AssertNoExceptionsAsync("after other-home resolvability check");
     }
 
+    /// <summary>
+    /// !cabin reset without a reconnect: the owner stands on the Farm, so the server re-sends
+    /// the Farm introduction right away. The owner's client shows its cabin at the shared stack
+    /// spot again (nothing left at the moved tile), the door is live, and the interior entered
+    /// is the live one — IsLiveFarm proves the client did not walk into an orphaned pre-swap
+    /// copy, which a name-only location check could not tell apart.
+    /// </summary>
+    [Fact]
+    public async Task ResetCabin_LiveFarmReintroduction_OwnerEntersCabinAtStackSpot()
+    {
+        var ct = TestCt;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectFastAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        var stackSpot = await GetStackSpotAsync(ct);
+
+        await ResetCabinViaCommandAsync(ownerId, ct);
+
+        var view = await WaitForOwnCabinAtStackSpotAsync(
+            WaitName.Polling_CabinReset_OwnCabinAtStackSpotOnClient,
+            stackSpot,
+            movedTile,
+            ct
+        );
+        Log($"Client renders the reset cabin at the stack spot ({stackSpot.X},{stackSpot.Y})");
+
+        await EnterOwnCabinAsync(view, stackSpot, ct);
+
+        var stepOut = await GameClient.Actions.WalkOntoTile();
+        Assert.True(stepOut?.Success == true, $"step-out failed: {stepOut?.Error}");
+        Assert.NotNull(await GameClient.WaitForLocationAsync("^Farm$", ct: ct));
+
+        await Exceptions.AssertNoExceptionsAsync("after live Farm re-introduction");
+    }
+
+    /// <summary>
+    /// !cabin reset from inside the cabin: an immediate re-send would orphan the interior the
+    /// owner stands in, so the server defers it and says so. The client stays inside, keeps its
+    /// live copy, exits onto the (still stale) Farm, and the re-send rides behind the answer to
+    /// the owner's next warp off the farm — after which the cabin renders at the stack spot and
+    /// is enterable.
+    /// </summary>
+    [Fact]
+    public async Task ResetCabin_FromInsideCabin_ReintroducedOnNextTripOffFarm()
+    {
+        var ct = TestCt;
+        await CreateNewGameOnServerAsync(farmType: 0, cabinStrategy: "CabinStack");
+
+        var client = await Farmers.ConnectFastAsync(ct: ct);
+        var ownerId = client.JoinResult.UniqueMultiplayerId;
+
+        var movedTile = await MoveCabinViaCommandAsync(ownerId, ct);
+        var stackSpot = await GetStackSpotAsync(ct);
+
+        // The move reaches the client as a position delta; poll the client's view for it.
+        FarmBuildingsResult? beforeReset = null;
+        var movedOnClient = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinReset_MovedCabinOnClient,
+            async () =>
+            {
+                beforeReset = await GameClient.Actions.GetFarmBuildings(ct);
+                return beforeReset?.Success == true
+                    && beforeReset.Cabins.Any(c =>
+                        (c.TileX, c.TileY) == movedTile && c.HasInterior
+                    );
+            },
+            TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            movedOnClient,
+            $"the moved cabin never showed at {movedTile} on the client (saw: {DescribeView(beforeReset)})"
+        );
+        await EnterOwnCabinAsync(beforeReset!, movedTile, ct);
+
+        // The gate reads the server's replicated view of the player's location, which trails
+        // the client's warp by a farmer-delta period; wait until /players shows the cabin.
+        var serverSeesInside = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinReset_ServerSeesPlayerInsideCabin,
+            async () =>
+            {
+                var players = await ServerApi.GetPlayers(ct);
+                var me = players?.Players.FirstOrDefault(p => p.Id == ownerId);
+                return me?.Location.StartsWith("FarmHouse", StringComparison.Ordinal) == true;
+            },
+            TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(serverSeesInside, "the server never saw the player inside the cabin");
+
+        await ResetCabinViaCommandAsync(ownerId, ct);
+        var reply = await GameClient.Chat.WaitForMessageContainingAsync(
+            new[] { "next leave the farm" }
+        );
+        Assert.NotNull(reply);
+
+        var state = await GameClient.GetState();
+        Assert.Matches("^FarmHouse.+", state?.Location ?? "");
+        var insideView = await GameClient.Actions.GetFarmBuildings(ct);
+        Assert.True(
+            insideView?.IsLiveFarm == true,
+            "the deferred reset must not replace the Farm under a player inside a cabin"
+        );
+
+        // Exit: the server re-pointed the interior warps at the stack spot's door (a delta), so
+        // the owner lands on the Farm even though their copy shows no cabin there yet.
+        var stepOut = await GameClient.Actions.WalkOntoTile();
+        Assert.True(stepOut?.Success == true, $"step-out failed: {stepOut?.Error}");
+        Assert.NotNull(await GameClient.WaitForLocationAsync("^Farm$", ct: ct));
+
+        // Leaving the farm makes the client request the bus stop from the server; the queued
+        // Farm re-introduction follows that answer.
+        var offFarm = await GameClient.Actions.Warp("BusStop", 12, 24);
+        Assert.True(offFarm?.Success == true, $"warp to BusStop failed: {offFarm?.Error}");
+        Assert.NotNull(await GameClient.WaitForLocationAsync("^BusStop$", ct: ct));
+
+        var view = await WaitForOwnCabinAtStackSpotAsync(
+            WaitName.Polling_CabinReset_ReintroducedAfterWarpOffFarm,
+            stackSpot,
+            movedTile,
+            ct
+        );
+        Log("Deferred Farm re-introduction landed after the warp off the farm");
+
+        var back = await GameClient.Actions.Warp("Farm", stackSpot.X, stackSpot.Y + 4);
+        Assert.True(back?.Success == true, $"warp to Farm failed: {back?.Error}");
+        Assert.NotNull(await GameClient.WaitForLocationAsync("^Farm$", ct: ct));
+        await EnterOwnCabinAsync(view, stackSpot, ct);
+
+        await Exceptions.AssertNoExceptionsAsync("after deferred Farm re-introduction");
+    }
+
     #region Helpers
 
     /// <summary>
@@ -678,6 +794,110 @@ public class CabinPositionPersistenceTests : TestBase
         Assert.True(ok, "Cabin did not move out of the hidden stack after !cabin");
         return (moved!.TileX, moved.TileY);
     }
+
+    /// <summary>
+    /// Sends !cabin reset until /cabins shows the owner's cabin hidden with the intent cleared.
+    /// Resend each poll: /cabins is snapshot-backed, so the hide can lag the reset by a tick,
+    /// and the command is idempotent — once hidden it just replies "nothing to reset".
+    /// </summary>
+    private async Task ResetCabinViaCommandAsync(long ownerId, CancellationToken ct)
+    {
+        var reset = await PollingHelper.WaitUntilAsync(
+            WaitName.Polling_CabinReset_CabinHidden,
+            async () =>
+            {
+                await GameClient.SendChat("!cabin reset");
+                var snapshot = await ServerApi.GetCabins(ct);
+                var afterReset = snapshot?.Cabins.FirstOrDefault(c => c.OwnerId == ownerId);
+                return afterReset?.IsHidden == true
+                    && snapshot?.SavedPositionPlayerIds.Contains(ownerId) == false;
+            },
+            TestTimings.CabinAssignmentTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(reset, "Cabin did not return to the hidden stack after !cabin reset");
+    }
+
+    private async Task<(int X, int Y)> GetStackSpotAsync(CancellationToken ct)
+    {
+        var cabins = await ServerApi.GetCabins(ct);
+        Assert.NotNull(cabins?.StackSpot);
+        return (cabins!.StackSpot!.TileX, cabins.StackSpot.TileY);
+    }
+
+    /// <summary>
+    /// Polls the client's farm view until the owner's cabin renders at the stack spot with a
+    /// live door and nothing remains at <paramref name="movedTile"/>, i.e. the re-sent Farm
+    /// introduction (with its relocation fiction) replaced the client's copy.
+    /// </summary>
+    private async Task<FarmBuildingsResult> WaitForOwnCabinAtStackSpotAsync(
+        WaitName waitName,
+        (int X, int Y) stackSpot,
+        (int X, int Y) movedTile,
+        CancellationToken ct
+    )
+    {
+        FarmBuildingsResult? view = null;
+        var reintroduced = await PollingHelper.WaitUntilAsync(
+            waitName,
+            async () =>
+            {
+                view = await GameClient.Actions.GetFarmBuildings(ct);
+                if (view?.Success != true)
+                {
+                    return false;
+                }
+                return view.Cabins.Any(c => (c.TileX, c.TileY) == stackSpot && c.HasInterior)
+                    && view.Cabins.All(c => (c.TileX, c.TileY) != movedTile);
+            },
+            TestTimings.NetworkSyncTimeout,
+            cancellationToken: ct
+        );
+        Assert.True(
+            reintroduced,
+            "the client should render its reset cabin at the stack spot with nothing left at "
+                + $"the moved tile (saw: {DescribeView(view)})"
+        );
+        Assert.True(view!.IsLiveFarm, "the client's farm view is not the one in Game1.locations");
+        return view;
+    }
+
+    /// <summary>
+    /// Walks onto the door of the cabin at <paramref name="cabinTile"/> in the client's view
+    /// and asserts the client entered that cabin's live interior.
+    /// </summary>
+    private async Task EnterOwnCabinAsync(
+        FarmBuildingsResult view,
+        (int X, int Y) cabinTile,
+        CancellationToken ct
+    )
+    {
+        var cabin = view.Cabins.FirstOrDefault(c => (c.TileX, c.TileY) == cabinTile);
+        Assert.True(
+            cabin != null,
+            $"no cabin at {cabinTile} in the client's view: {DescribeView(view)}"
+        );
+
+        var enter = await GameClient.Actions.WalkOntoTile(cabin!.DoorX, cabin.DoorY, direction: 0);
+        Assert.True(enter?.Success == true, $"door entry failed: {enter?.Error}");
+        var inside = await GameClient.WaitForLocationAsync("^FarmHouse.+", ct: ct);
+        Assert.True(inside != null, "the client did not enter its cabin interior");
+        Assert.Equal(cabin.Name, inside!.Location);
+
+        var insideView = await GameClient.Actions.GetFarmBuildings(ct);
+        Assert.True(
+            insideView?.IsLiveFarm == true,
+            "the client entered an interior of an orphaned (replaced) Farm"
+        );
+    }
+
+    private static string DescribeView(FarmBuildingsResult? view) =>
+        view == null
+            ? "null"
+            : string.Join(
+                ", ",
+                view.Cabins.Select(c => $"({c.TileX},{c.TileY},interior={c.HasInterior})")
+            );
 
     /// <summary>
     /// Rewrites the in-container cabinStrategy via the shared settings-file helper; the

--- a/tests/JunimoServer.Tests/Clients/GameTestClient.cs
+++ b/tests/JunimoServer.Tests/Clients/GameTestClient.cs
@@ -313,6 +313,13 @@ public class FarmBuildingInfo
     [JsonPropertyName("tileY")]
     public int TileY { get; set; }
 
+    /// <summary>Tile of the human door: the walk-onto target.</summary>
+    [JsonPropertyName("doorX")]
+    public int DoorX { get; set; }
+
+    [JsonPropertyName("doorY")]
+    public int DoorY { get; set; }
+
     /// <summary>True if this building has an interior the player can enter (door is live).</summary>
     [JsonPropertyName("hasInterior")]
     public bool HasInterior { get; set; }
@@ -328,6 +335,13 @@ public class FarmBuildingsResult
 
     [JsonPropertyName("cabins")]
     public List<FarmBuildingInfo> Cabins { get; set; } = new();
+
+    /// <summary>
+    /// True when the client's farm view is the Farm in Game1.locations; false when the player
+    /// stands inside an interior of a Farm that a re-sent introduction replaced.
+    /// </summary>
+    [JsonPropertyName("isLiveFarm")]
+    public bool IsLiveFarm { get; set; }
 }
 
 public class LocationWarpInfo

--- a/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
+++ b/tests/JunimoServer.Tests/Clients/ServerApiClient.cs
@@ -91,6 +91,10 @@ public class PlayerInfo
 
     [JsonPropertyName("isOnline")]
     public bool IsOnline { get; set; }
+
+    /// <summary>Unique name of the location the server sees the player in (or arriving in).</summary>
+    [JsonPropertyName("location")]
+    public string Location { get; set; } = string.Empty;
 }
 
 /// <summary>

--- a/tests/JunimoServer.Tests/Helpers/WaitName.cs
+++ b/tests/JunimoServer.Tests/Helpers/WaitName.cs
@@ -102,8 +102,21 @@ public enum WaitName
     Polling_CabinExitWarp_FarmhouseDoorOnClient,
     Polling_CabinExitWarp_OwnDoorOnClient,
 
-    // CabinPositionPersistenceTests.cs — !cabin reset (1)
+    // CabinPositionPersistenceTests.cs — !cabin reset (5)
     Polling_CabinReset_CabinHidden,
+
+    /// <summary>The !cabin move reached the client's farm view as a position delta.</summary>
+    Polling_CabinReset_MovedCabinOnClient,
+
+    /// <summary>/players reports the player inside its cabin (replicated location caught up).</summary>
+    Polling_CabinReset_ServerSeesPlayerInsideCabin,
+
+    /// <summary>The owner's client shows its cabin at the shared stack spot again after a
+    /// live Farm re-introduction (no reconnect).</summary>
+    Polling_CabinReset_OwnCabinAtStackSpotOnClient,
+
+    /// <summary>The queued Farm re-introduction landed after the owner's warp off the farm.</summary>
+    Polling_CabinReset_ReintroducedAfterWarpOffFarm,
 
     // CabinPositionPersistenceTests.cs — dummy cabin at shared stack (2)
     Polling_DummyCabin_VisibleInClientFarm,
@@ -250,6 +263,10 @@ public enum WaitName
     /// <summary>Every master cabin is enterable at its placed tile on a connected peer after a
     /// →None commit.</summary>
     Polling_CabinMigration_PlacedCabinsVisibleOnPeer,
+
+    /// <summary>The peer's door-less phantom is gone after the commit's Farm re-introduction,
+    /// without a reconnect.</summary>
+    Polling_CabinMigration_PhantomGoneLive,
 
     // CabinStrategyFarmhouseStackTests.cs + CabinStrategyTests.cs — cabin-link repair (2)
     /// <summary>Cabin gone from /cabins after /test/break_cabin_link nulled its back-link.</summary>

--- a/tests/test-client/GameControl/ActionsController.cs
+++ b/tests/test-client/GameControl/ActionsController.cs
@@ -453,12 +453,15 @@ public class ActionsController
                 continue;
             }
 
+            var door = building.getPointForHumanDoor();
             cabins.Add(
                 new FarmBuildingInfo
                 {
                     Name = building.GetIndoors()?.NameOrUniqueName ?? "",
                     TileX = building.tileX.Value,
                     TileY = building.tileY.Value,
+                    DoorX = door.X,
+                    DoorY = door.Y,
                     // HasInterior == false means the door is dead: Building.doAction only warps
                     // the player inside when GetIndoors() != null, so a null interior is an
                     // unenterable (door-dead) cabin — what the dummy-cabin prop must be.
@@ -467,7 +470,15 @@ public class ActionsController
             );
         }
 
-        return new FarmBuildingsResult { Success = true, Cabins = cabins };
+        return new FarmBuildingsResult
+        {
+            Success = true,
+            Cabins = cabins,
+            // Game1.getFarm() answers from the current location's root when the player is
+            // inside a building, so a Farm replaced by a re-sent introduction while the player
+            // stood in one of its interiors is reachable here but absent from Game1.locations.
+            IsLiveFarm = Game1.locations.Contains(farm),
+        };
     }
 
     /// <summary>
@@ -630,6 +641,10 @@ public class FarmBuildingInfo
     public int TileX { get; set; }
     public int TileY { get; set; }
 
+    /// <summary>Tile of the human door (Building.getPointForHumanDoor): the walk-onto target.</summary>
+    public int DoorX { get; set; }
+    public int DoorY { get; set; }
+
     /// <summary>True if this building has an interior the player can enter (door is live).</summary>
     public bool HasInterior { get; set; }
 }
@@ -639,6 +654,12 @@ public class FarmBuildingsResult
     public bool Success { get; set; }
     public string? Error { get; set; }
     public List<FarmBuildingInfo> Cabins { get; set; } = new();
+
+    /// <summary>
+    /// True when the farm this view was read from is the one in Game1.locations. False means
+    /// the player stands inside an interior of a Farm that a re-sent introduction replaced.
+    /// </summary>
+    public bool IsLiveFarm { get; set; }
 }
 
 public class LocationWarpInfo


### PR DESCRIPTION
### 🔗 Linked issue

Builds on #614 (`fix/cabinstack-dummy-null`); no separate issue.

### 📚 Description

Under CabinStack the per-peer stack fiction (own hidden cabin relocated to the shared spot, or a phantom filling it) lives only in the join-time Farm introduction, so `!cabin`, `!cabin reset`, a migration commit or a stack-spot change left connected players stale until they reconnected.

- Server re-sends the Farm introduction (message 3) to a peer so the fiction updates live: immediately for the chat-command sender and for every peer of an admin action
- Deferred for a peer inside a Farm building: the re-send rides behind the server's answer to their next warp request off the farm (postfix on `GameServer.warpFarmer`), since replacing the Farm under a player inside one of its interiors orphans that interior
- Every send flushes the Farm's pending delta first, then sends one `removeLocationFromLookup` (message 24) per instanced interior so door warps by name don't hit stale client lookup entries
- The inside-a-building gate reads the replicated location's target value via a Harmony field accessor; the interpolated value trails a client's warp by 15 server ticks
- `sendLocation` reflection lookup moves into `NetworkHelper` as the single site
- `/players` gains the replicated player location; the test client reports building door tiles and whether its farm view is the live one
- Docs: `cabin-strategies.md` notes the accepted risk that a player mid-warp at the instant of an admin commit or stack-spot change may need to reconnect
- Tests: `CabinPositionPersistenceTests` and `CabinMigrationTests` cover the immediate and deferred re-send paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cabin moves, resets, and layout migrations now update connected players’ farm views without requiring a reconnect.
  - Players inside buildings receive updates after leaving the building or reconnecting.
  - Player information now includes the player’s current or upcoming location.

- **Bug Fixes**
  - Prevented outdated cabin layouts and phantom cabin entries from remaining visible after changes.
  - Improved handling of players changing areas during cabin updates; affected players may be prompted to reconnect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->