### PR TITLE
feat(docs): embeddable live server status widget for web pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -51,6 +51,8 @@ jobs:
         working-directory: docs
         env:
           DOCS_VERSION: ${{ inputs.version }}
+          # Baked into the Public Test Server page; unset hides its status widget.
+          DOCS_TEST_SERVER_API_URL: ${{ vars.DOCS_TEST_SERVER_API_URL }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -26,6 +26,8 @@ export default withMermaid(
             // Bake the build time into the bundle so the sidebar can show "Last built: …"
             define: {
                 __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
+                // API base URL of the public test server, shown on community/test-server.md.
+                __DOCS_TEST_SERVER_API_URL__: JSON.stringify(process.env.DOCS_TEST_SERVER_API_URL ?? ""),
             },
             resolve: {
                 alias: [
@@ -205,6 +207,7 @@ export default withMermaid(
                             { text: "VNC (Advanced)", link: "/admins/operations/vnc" },
                             { text: "Modern Docker Image", link: "/admins/operations/modern-docker" },
                             { text: "HTTPS & Reverse Proxy", link: "/admins/operations/reverse-proxy" },
+                            { text: "Public Server Status", link: "/admins/operations/public-status" },
                         ],
                     },
                     {
@@ -320,6 +323,7 @@ export default withMermaid(
                         text: "Community",
                         items: [
                             { text: "Overview", link: "/community/" },
+                            { text: "Public Test Server", link: "/community/test-server" },
                             { text: "FAQ", link: "/community/faq" },
                             { text: "Getting Help", link: "/community/getting-help" },
                             { text: "Reporting Bugs", link: "/community/reporting-bugs" },

--- a/docs/.vitepress/theme/ServerStatusWidget.vue
+++ b/docs/.vitepress/theme/ServerStatusWidget.vue
@@ -1,90 +1,100 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
+import {
+    resolveServerState,
+    type ServerState,
+    type ServerStateKind,
+    type ServerStatus,
+} from "../../../tools/discord-bot/src/serverState";
 
-interface ServerStatus {
-    serverName: string;
-    currentPlayers: number;
-    maxPlayers: number;
-    inviteCode: string;
-    isOnline: boolean;
-}
+type CodeKey = "steamInviteCode" | "gogInviteCode";
 
 const props = defineProps<{
+    /** HTTPS base URL of the API; `/status` is fetched under it. */
     apiUrl: string;
+    /** Header text; the farm name is not a display name. */
+    title?: string;
+    /** Poll interval in ms; 0 disables polling. */
     refreshInterval?: number;
 }>();
 
 const status = ref<ServerStatus | null>(null);
-const isLoading = ref(true);
-const error = ref<string | null>(null);
-const copied = ref(false);
+/** `null` until the first fetch settles. */
+const state = ref<ServerState | null>(null);
+const copiedKey = ref<CodeKey | null>(null);
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
+const inviteCodes: { key: CodeKey; label: string }[] = [
+    { key: "steamInviteCode", label: "Steam invite code" },
+    { key: "gogInviteCode", label: "GOG invite code" },
+];
+
+const stateColors: Record<ServerStateKind, string> = {
+    online: "var(--vp-c-success-1)",
+    busy: "var(--vp-c-warning-1)",
+    loading: "var(--vp-c-warning-1)",
+    provisioning: "var(--vp-c-warning-1)",
+    offline: "var(--vp-c-danger-1)",
+};
+
 const playerPercentage = computed(() => {
-    if (!status.value) {
+    if (!status.value || status.value.maxPlayers <= 0) {
         return 0;
     }
-    return (status.value.currentPlayers / status.value.maxPlayers) * 100;
+    return Math.min(100, (status.value.playerCount / status.value.maxPlayers) * 100);
 });
 
-const statusColor = computed(() => {
-    if (!status.value?.isOnline) {
-        return "var(--vp-c-danger-1)";
+const farmDate = computed(() => {
+    if (!status.value) {
+        return "";
     }
-    if (status.value.currentPlayers >= status.value.maxPlayers) {
-        return "var(--vp-c-warning-1)";
-    }
-    return "var(--vp-c-success-1)";
+    const season = status.value.season ? status.value.season[0].toUpperCase() + status.value.season.slice(1) : "";
+    return `${status.value.farmName} Farm, ${season} ${status.value.day}, Year ${status.value.year}`;
 });
 
-const statusText = computed(() => {
-    if (!status.value?.isOnline) {
-        return "Offline";
-    }
-    if (status.value.currentPlayers >= status.value.maxPlayers) {
-        return "Full";
-    }
-    return "Online";
-});
+// A hung request must not settle after a newer one and overwrite its result.
+let latestRequest = 0;
 
 async function fetchStatus() {
-    // TODO: Replace mock with real API call
-    // const response = await fetch(props.apiUrl);
-    // const data = await response.json();
-
-    // Mock response for development
-    await new Promise((resolve) => setTimeout(resolve, 500)); // Simulate network delay
-
-    status.value = {
-        serverName: "JunimoServer Public Test",
-        currentPlayers: 3,
-        maxPlayers: 8,
-        inviteCode: "SG8ZJXDNMTK4",
-        isOnline: true,
-    };
-    error.value = null;
-    isLoading.value = false;
+    const request = ++latestRequest;
+    let data: ServerStatus | null = null;
+    try {
+        const response = await fetch(`${props.apiUrl.replace(/\/+$/, "")}/status`, { cache: "no-store" });
+        if (response.ok) {
+            data = (await response.json()) as ServerStatus;
+        }
+    } catch {
+        data = null;
+    }
+    if (request !== latestRequest) {
+        return;
+    }
+    status.value = data;
+    state.value = resolveServerState(data);
 }
 
-async function copyInviteCode() {
-    if (!status.value?.inviteCode) {
+async function copyInviteCode(key: CodeKey) {
+    const code = status.value?.[key];
+    if (!code) {
         return;
     }
     try {
-        await navigator.clipboard.writeText(status.value.inviteCode);
-        copied.value = true;
-        setTimeout(() => (copied.value = false), 2000);
+        await navigator.clipboard.writeText(code);
     } catch {
-        // Fallback for older browsers
+        // Fallback for browsers without the async clipboard API.
         const textarea = document.createElement("textarea");
-        textarea.value = status.value.inviteCode;
+        textarea.value = code;
         document.body.appendChild(textarea);
         textarea.select();
         document.execCommand("copy");
         document.body.removeChild(textarea);
-        copied.value = true;
-        setTimeout(() => (copied.value = false), 2000);
     }
+    copiedKey.value = key;
+    setTimeout(() => {
+        if (copiedKey.value === key) {
+            copiedKey.value = null;
+        }
+    }, 2000);
 }
 
 onMounted(() => {
@@ -104,62 +114,63 @@ onUnmounted(() => {
 
 <template>
     <div class="server-status-widget">
-        <!-- Loading State -->
-        <div v-if="isLoading" class="loading">
+        <div v-if="!state" class="loading">
             <div class="spinner"></div>
             <span>Connecting to server...</span>
         </div>
 
-        <!-- Error State -->
-        <div v-else-if="error" class="error">
-            <span class="error-icon">!</span>
-            <span>{{ error }}</span>
-        </div>
-
-        <!-- Server Info -->
-        <template v-else-if="status">
+        <template v-else>
             <div class="header">
                 <div class="server-info">
-                    <h3 class="server-name">{{ status.serverName }}</h3>
-                    <div class="status-badge" :style="{ '--status-color': statusColor }">
+                    <h3 class="server-name">{{ props.title ?? "Server Status" }}</h3>
+                    <div class="status-badge" :style="{ '--status-color': stateColors[state.kind] }">
                         <span class="status-dot"></span>
-                        <span class="status-text">{{ statusText }}</span>
+                        <span class="status-text">{{ state.label }}</span>
                     </div>
                 </div>
             </div>
 
-            <div class="stats">
-                <div class="stat">
-                    <span class="stat-label">Players</span>
-                    <div class="player-bar-container">
-                        <div class="player-bar">
-                            <div
-                                class="player-bar-fill"
-                                :style="{ width: `${playerPercentage}%` }"
-                            ></div>
+            <p class="note">{{ state.detail }}</p>
+
+            <template v-if="status?.isOnline">
+                <div class="stats">
+                    <div class="stat">
+                        <span class="stat-label">Players</span>
+                        <div class="player-bar-container">
+                            <div class="player-bar">
+                                <div class="player-bar-fill" :style="{ width: `${playerPercentage}%` }"></div>
+                            </div>
+                            <span class="player-count">{{ status.playerCount }}/{{ status.maxPlayers }}</span>
                         </div>
-                        <span class="player-count">{{ status.currentPlayers }}/{{ status.maxPlayers }}</span>
+                    </div>
+
+                    <div class="stat">
+                        <span class="stat-label">In-game date</span>
+                        <span class="farm-date">{{ farmDate }}</span>
                     </div>
                 </div>
 
-                <div class="stat">
-                    <span class="stat-label">Invite Code</span>
-                    <div class="invite-code-row">
-                        <code class="invite-code">{{ status.inviteCode || "N/A" }}</code>
-                        <button
-                            v-if="status.inviteCode"
-                            class="copy-btn"
-                            :class="{ copied }"
-                            @click="copyInviteCode"
-                            :title="copied ? 'Copied!' : 'Copy invite code'"
-                        >
-                            <span v-if="copied">&#10003;</span>
-                            <span v-else>&#128203;</span>
-                        </button>
+                <div class="stats">
+                    <div v-for="code in inviteCodes" :key="code.key" class="stat">
+                        <span class="stat-label">{{ code.label }}</span>
+                        <div class="invite-code-row">
+                            <code v-if="status[code.key]" class="invite-code">{{ status[code.key] }}</code>
+                            <span v-else class="invite-code pending">not yet available</span>
+                            <button
+                                v-if="status[code.key]"
+                                class="copy-btn"
+                                :class="{ copied: copiedKey === code.key }"
+                                :title="copiedKey === code.key ? 'Copied!' : `Copy ${code.label}`"
+                                @click="copyInviteCode(code.key)"
+                            >
+                                <span v-if="copiedKey === code.key">&#10003;</span>
+                                <span v-else>&#128203;</span>
+                            </button>
+                        </div>
                     </div>
                 </div>
-            </div>
-
+            </template>
+            <p v-else class="hint">{{ state.hint }}</p>
         </template>
     </div>
 </template>
@@ -212,27 +223,6 @@ onUnmounted(() => {
     to { transform: rotate(360deg); }
 }
 
-.error {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 10px;
-    padding: 32px;
-    color: var(--vp-c-danger-1);
-}
-
-.error-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    background: var(--vp-c-danger-soft);
-    border-radius: 50%;
-    font-weight: bold;
-    font-size: 14px;
-}
-
 .header {
     margin-bottom: 20px;
 }
@@ -280,11 +270,27 @@ onUnmounted(() => {
     50% { opacity: 0.6; transform: scale(0.9); }
 }
 
+.note,
+.hint {
+    margin: 0 0 16px;
+    font-size: 14px;
+    color: var(--vp-c-text-2);
+}
+
+.hint {
+    margin-bottom: 0;
+    font-style: italic;
+}
+
 .stats {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 16px;
-    margin-bottom: 20px;
+    margin-bottom: 16px;
+}
+
+.stats:last-child {
+    margin-bottom: 0;
 }
 
 @media (max-width: 480px) {
@@ -339,6 +345,12 @@ onUnmounted(() => {
     font-variant-numeric: tabular-nums;
 }
 
+.farm-date {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--vp-c-text-1);
+}
+
 .invite-code-row {
     display: flex;
     align-items: center;
@@ -359,6 +371,13 @@ onUnmounted(() => {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.invite-code.pending {
+    color: var(--vp-c-text-3);
+    font-family: inherit;
+    font-style: italic;
+    letter-spacing: normal;
 }
 
 .copy-btn {
@@ -388,5 +407,4 @@ onUnmounted(() => {
     border-color: var(--vp-c-success-1);
     color: var(--vp-c-success-1);
 }
-
 </style>

--- a/docs/admins/operations/index.md
+++ b/docs/admins/operations/index.md
@@ -56,5 +56,6 @@ Save files are stored in the `saves` Docker volume.
 - [Importing Saves](/admins/operations/importing-saves)
 - [Networking](/admins/operations/networking)
 - [HTTPS & Reverse Proxy](/admins/operations/reverse-proxy)
+- [Public Server Status](/admins/operations/public-status)
 - [Upgrading](/admins/operations/upgrading)
 - [Web Interface (VNC)](/admins/operations/vnc) (advanced debugging only)

--- a/docs/admins/operations/public-status.md
+++ b/docs/admins/operations/public-status.md
@@ -1,0 +1,49 @@
+---
+description: Show your server's live status on a website — what /status exposes, the HTTPS requirement, and how to embed the status widget.
+---
+
+# Public Server Status
+
+The API's `/status` endpoint reports whether the server is online, how many players are connected, the current invite codes, and the in-game date. It needs no API key, so a web page can read it directly and show your players a live status card.
+
+## What `/status` exposes
+
+The endpoint returns the fields documented in the [API reference](/developers/api/introduction). The invite codes look sensitive but are public information: JunimoServer forces the lobby public, so the code alone never gates entry. Turn on [password protection](/features/password-protection/) before publishing the status anywhere. Every other endpoint stays behind `API_KEY`.
+
+## The HTTPS requirement
+
+A browser on an HTTPS page refuses to fetch plain `http://<ip>:8080/status`, so the API needs an HTTPS URL. [HTTPS & Reverse Proxy](/admins/operations/reverse-proxy) sets that up, with or without a domain; the status URL is then the server's proxy URL plus `/status`. Cross-origin reads are already allowed, so nothing else is needed.
+
+## Embedding the widget
+
+### VitePress sites
+
+Copy [`ServerStatusWidget.vue`](https://github.com/stardew-valley-dedicated-server/server/blob/master/docs/.vitepress/theme/ServerStatusWidget.vue) and the state mapping it imports, [`serverState.ts`](https://github.com/stardew-valley-dedicated-server/server/blob/master/tools/discord-bot/src/serverState.ts), into your theme and point the widget's import at the copied file. Register the component in `enhanceApp` and place it on a page:
+
+```md
+<ServerStatusWidget api-url="https://203.0.113.10/farm" title="My Farm" />
+```
+
+Props:
+
+| Prop | Description | Default |
+|------|-------------|---------|
+| `api-url` | HTTPS base URL of the API; the widget fetches `/status` under it | required |
+| `title` | Header text | `Server Status` |
+| `refresh-interval` | Poll interval in milliseconds; `0` disables polling | `30000` |
+
+The widget reports the same states as the Discord bot: **Online** (`isOnline` and `isReady`), **Busy** (`isOnline` but saving, changing day, or running an event), **Starting** (`isOnline` false: the container is downloading game files, launching the game, or loading the save), and **Offline** (the request failed).
+
+### Anywhere else
+
+The whole contract is one `fetch`:
+
+```js
+const res = await fetch("https://203.0.113.10/farm/status", { cache: "no-store" });
+if (!res.ok) throw new Error("unreachable");
+const status = await res.json();
+// status.isOnline, status.isReady, status.phase ("downloading" or "starting" before the game runs),
+// status.playerCount, status.maxPlayers,
+// status.steamInviteCode (null until the Steam lobby is published), status.gogInviteCode,
+// status.farmName, status.season, status.day, status.year
+```

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -4,7 +4,7 @@ description: Serve the API and VNC web UI over HTTPS with a Let's Encrypt certif
 
 # HTTPS & Reverse Proxy
 
-By default the REST API (`API_PORT`) and the VNC web UI (`VNC_PORT`) are plain HTTP, which is fine for a home or LAN server. HTTPS keeps your API and VNC credentials off the wire, and it is required to show a live status widget on a web page, since browsers block plain-HTTP requests from HTTPS sites. This page sets it up with or without a domain: Let's Encrypt also issues certificates for a bare public IP.
+By default the REST API (`API_PORT`) and the VNC web UI (`VNC_PORT`) are plain HTTP, which is fine for a home or LAN server. HTTPS keeps your API and VNC credentials off the wire, and it is required to show the [live status widget](/admins/operations/public-status) on a web page, since browsers block plain-HTTP requests from HTTPS sites. This page sets it up with or without a domain: Let's Encrypt also issues certificates for a bare public IP.
 
 ## Setups
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -6,6 +6,10 @@ description: The JunimoServer community — FAQ, where to get help, how to repor
 
 JunimoServer is a community project. Glad to have you here!
 
+## Play
+
+- [Public Test Server](/community/test-server): Try JunimoServer without hosting anything
+
 ## Get Help
 
 - [FAQ](/community/faq): Common questions

--- a/docs/community/test-server.md
+++ b/docs/community/test-server.md
@@ -1,0 +1,20 @@
+---
+description: Join the public JunimoServer test server — live status, player count, and invite codes for Steam and GOG.
+---
+
+<script setup>
+const apiUrl = __DOCS_TEST_SERVER_API_URL__;
+</script>
+
+# Public Test Server
+
+The project runs a public test server so you can try JunimoServer before hosting your own. It runs the latest preview build, so expect occasional restarts and the odd rough edge. Anything that looks broken is worth a [bug report](/community/reporting-bugs).
+
+<ServerStatusWidget v-if="apiUrl" :api-url="apiUrl" title="Public Test Server" />
+
+## How to join
+
+1. Copy the invite code for your platform above. Steam codes start with `S`, GOG codes with `G`.
+2. In Stardew Valley, open **Co-op → Join → Enter Invite Code** and paste it.
+
+The status refreshes every 30 seconds. **Starting** means the server is booting or loading the save, **Busy** means it is saving or changing the day, and **Offline** means it is down. All three usually clear within a few minutes.

--- a/docs/developers/api/introduction.md
+++ b/docs/developers/api/introduction.md
@@ -33,7 +33,7 @@ If `API_KEY` is set, send it with every request:
 Authorization: Bearer <your-api-key>
 ```
 
-Each endpoint page in this reference says whether it needs the key. Health, status and the docs pages work without one.
+Each endpoint page in this reference says whether it needs the key. Health, status and the docs pages work without one. To show `/status` on a website, see [Public Server Status](/admins/operations/public-status).
 
 ### Example
 

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -324,6 +324,8 @@ Add to the **`github-pages`** GitHub Environment (Settings → Environments):
 
 The R2 token must have **Object Read & Write** on this bucket (both restore and persist run), and `R2_ACCOUNT_ID` must be the account that owns it. The deploy mirrors with `aws s3 sync … --delete`, so this bucket must be dedicated to the docs snapshot — pointing it at a shared bucket (e.g. the E2E report bucket) would delete everything else in it, and a shared retention rule could sweep the snapshot. Leave all four settings empty to disable R2 (full-rebuild deploys still work; single-half deploys refuse); set some but not all and the deploy fails, so it's all-or-nothing.
 
+The **repository variable** `DOCS_TEST_SERVER_API_URL` holds the public test server's API base URL (for example `https://203.0.113.10/preview`). The docs build bakes it into the [Public Test Server](/community/test-server) page; when it is unset, the page shows no status widget.
+
 ## Deploy Server Pipeline
 
 [Open in Github](https://github.com/stardew-valley-dedicated-server/server/tree/master/.github/workflows/deploy-server.yml)

--- a/tools/discord-bot/src/discordState.test.ts
+++ b/tools/discord-bot/src/discordState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveServerState } from "./serverState";
+import { resolveServerState } from "./discordState";
 
 describe("resolveServerState", () => {
     test("unreachable API is offline", () => {

--- a/tools/discord-bot/src/discordState.ts
+++ b/tools/discord-bot/src/discordState.ts
@@ -1,0 +1,30 @@
+/** Discord presentation of a server state: emoji label, presence, and embed color. */
+
+import { Colors, type PresenceStatusData } from "discord.js";
+import {
+    resolveServerState as resolveSharedState,
+    type ServerState,
+    type ServerStateKind,
+    type StatusSignals,
+} from "./serverState";
+
+export type { ServerStateKind, ServerStatus, StatusSignals } from "./serverState";
+
+export interface DiscordServerState extends ServerState {
+    presence: PresenceStatusData;
+    color: number;
+}
+
+const presentation: Record<ServerStateKind, { emoji: string; presence: PresenceStatusData; color: number }> = {
+    online: { emoji: "🟢", presence: "online", color: Colors.Blue },
+    busy: { emoji: "🟡", presence: "online", color: Colors.Yellow },
+    loading: { emoji: "🟡", presence: "idle", color: Colors.Yellow },
+    provisioning: { emoji: "🟠", presence: "idle", color: Colors.Orange },
+    offline: { emoji: "🔴", presence: "dnd", color: Colors.Red },
+};
+
+export function resolveServerState(status: StatusSignals | null): DiscordServerState {
+    const state = resolveSharedState(status);
+    const { emoji, presence, color } = presentation[state.kind];
+    return { ...state, label: `${emoji} ${state.label}`, presence, color };
+}

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -22,8 +22,8 @@ import {
     formatFooter,
     parseOwnerId,
 } from "./dashboard";
+import { resolveServerState, type ServerStatus } from "./discordState";
 import { createLogger, log } from "./log";
-import { resolveServerState, type StatusSignals } from "./serverState";
 
 // Configuration from environment
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -64,22 +64,6 @@ function getApiHeaders(): HeadersInit {
         headers.Authorization = `Bearer ${API_KEY}`;
     }
     return headers;
-}
-
-interface ServerStatus extends StatusSignals {
-    playerCount: number;
-    maxPlayers: number;
-    steamInviteCode: string | null;
-    gogInviteCode: string | null;
-    serverVersion: string;
-    lastUpdated: string;
-    farmName: string;
-    day: number;
-    season: string;
-    year: number;
-    timeOfDay: number;
-    farmTypeKey: string;
-    isPaused: boolean;
 }
 
 interface PlayerInfo {
@@ -558,11 +542,7 @@ async function buildDashboardEmbed(): Promise<EmbedBuilder> {
         .setFooter({ text: formatFooter(STATUS_DASHBOARD_REFRESH_RATE_FORMATTED, dashboardState.ownerId) });
 
     if (!status?.isOnline) {
-        const hint =
-            state.kind === "offline"
-                ? "No game data can be pulled right now. Check back later!"
-                : "Game data appears once the save is loaded.";
-        embed.setColor(state.color).setDescription(`${state.label} — **${state.detail}**\n\n_${hint}_`);
+        embed.setColor(state.color).setDescription(`${state.label} — **${state.detail}**\n\n_${state.hint}_`);
     } else {
         const seasonEmojis: Record<string, string> = {
             spring: "🌸 Spring",

--- a/tools/discord-bot/src/serverState.ts
+++ b/tools/discord-bot/src/serverState.ts
@@ -1,16 +1,38 @@
 /**
- * Maps the game server's /status response to the state the bot displays. Before the mod's API
- * is up, the game container itself answers /status with `isOnline: false` plus a `phase`, which
- * is what separates a provisioning server from a dead one.
+ * Maps the game server's /status response to a displayed state. Shared by the Discord bot
+ * (see discordState.ts) and the docs site's status widget, so both report the same state
+ * for the same response. Before the mod's API is up, the game container itself answers
+ * /status with `isOnline: false` plus a `phase`, which is what separates a provisioning
+ * server from a dead one.
  */
-
-import { Colors, type PresenceStatusData } from "discord.js";
 
 export interface StatusSignals {
     isOnline: boolean;
     isReady: boolean;
     /** "downloading" or "starting" while the container's startup script answers; absent once the mod does. */
     phase?: string;
+}
+
+/**
+ * The mod's /status response. Owner: `ServerStatus` in mod/JunimoServer/Services/Api/ApiService.cs
+ * (camelCased by the JSON serializer); keep the two in sync.
+ */
+export interface ServerStatus extends StatusSignals {
+    playerCount: number;
+    maxPlayers: number;
+    steamInviteCode: string | null;
+    gogInviteCode: string | null;
+    serverVersion: string;
+    gameVersion: string;
+    dayTransitionComplete: boolean;
+    lastUpdated: string;
+    farmName: string;
+    day: number;
+    season: string;
+    year: number;
+    timeOfDay: number;
+    farmTypeKey: string;
+    isPaused: boolean;
 }
 
 export type ServerStateKind =
@@ -24,64 +46,40 @@ export interface ServerState {
     kind: ServerStateKind;
     label: string;
     detail: string;
-    presence: PresenceStatusData;
-    color: number;
+    /** Shown in place of game data while there is none; absent once the game is loaded. */
+    hint?: string;
 }
+
+const NO_GAME_DATA_HINT = "Game data appears once the save is loaded.";
 
 /** `null` is an unreachable /status: the port is closed, so the server is offline. */
 export function resolveServerState(status: StatusSignals | null): ServerState {
     if (status === null) {
         return {
             kind: "offline",
-            label: "🔴 Offline",
+            label: "Offline",
             detail: "The server is offline.",
-            presence: "dnd",
-            color: Colors.Red,
+            hint: "No game data can be pulled right now. Check back later!",
         };
     }
 
     if (status.isOnline) {
         return status.isReady
-            ? {
-                  kind: "online",
-                  label: "🟢 Online",
-                  detail: "Ready & running.",
-                  presence: "online",
-                  color: Colors.Blue,
-              }
-            : {
-                  kind: "busy",
-                  label: "🟡 Busy",
-                  detail: "Saving, changing day, or running an event.",
-                  presence: "online",
-                  color: Colors.Yellow,
-              };
+            ? { kind: "online", label: "Online", detail: "Ready & running." }
+            : { kind: "busy", label: "Busy", detail: "Saving, changing day, or running an event." };
     }
 
     switch (status.phase) {
         case "downloading":
             return {
                 kind: "provisioning",
-                label: "🟠 Starting",
+                label: "Starting",
                 detail: "Downloading game files.",
-                presence: "idle",
-                color: Colors.Orange,
+                hint: NO_GAME_DATA_HINT,
             };
         case "starting":
-            return {
-                kind: "provisioning",
-                label: "🟠 Starting",
-                detail: "Launching the game.",
-                presence: "idle",
-                color: Colors.Orange,
-            };
+            return { kind: "provisioning", label: "Starting", detail: "Launching the game.", hint: NO_GAME_DATA_HINT };
         default:
-            return {
-                kind: "loading",
-                label: "🟡 Starting",
-                detail: "Loading the save.",
-                presence: "idle",
-                color: Colors.Yellow,
-            };
+            return { kind: "loading", label: "Starting", detail: "Loading the save.", hint: NO_GAME_DATA_HINT };
     }
 }


### PR DESCRIPTION
- `ServerStatusWidget` fetches `/status` from the API base URL and shows Online, Busy, Starting, and Offline with the same state mapping as the Discord bot
- discord-bot: state mapping split into a shared, Discord-free module used by the widget
- Public Test Server community page; its API URL is baked in at build time from the `DOCS_TEST_SERVER_API_URL` repository variable, unset hides the widget
- docs: public-status guide, cross-links from the proxy, API, and operations pages