### PR TITLE
feat(docs): built-in test server status stub for the docs dev server

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 .vitepress/dist
 .vitepress/cache
 
+# Local overrides (DOCS_TEST_SERVER_API_URL for the status widget)
+.env.local
+
 # Generated at build time from Docker image (see scripts/fetch-openapi.sh)
 assets/openapi.json
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,15 +1,24 @@
 import { fileURLToPath, URL } from "node:url";
-import { defineConfig } from "vitepress";
+import { defineConfig, loadEnv } from "vitepress";
 import { useSidebar } from "vitepress-openapi";
 import { groupIconVitePlugin } from "vitepress-plugin-group-icons";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import spec from "../assets/openapi.json" with { type: "json" };
+import { STUB_BASE, statusStubPlugin } from "./statusStub";
 import { DEFAULT_THEME_ID, themes } from "./theme/themes";
 
 // Docs version: "latest" or "preview" (set via DOCS_VERSION env var during build)
 const docsVersion = process.env.DOCS_VERSION || "latest";
 const isPreview = docsVersion === "preview";
 const base = isPreview ? "/server/preview/" : "/server/";
+
+// API base URL of the public test server, shown on community/test-server.md. CI sets the
+// env var; locally a docs/.env.local file works too. Unset: the dev server stubs it
+// (statusStub.ts), a build ships the page without the card.
+const isBuild = process.argv.includes("build");
+const dotenv = loadEnv("", process.cwd(), "DOCS_");
+const testServerApiUrl =
+    process.env.DOCS_TEST_SERVER_API_URL || dotenv.DOCS_TEST_SERVER_API_URL || (isBuild ? "" : STUB_BASE);
 
 const origin = "https://stardew-valley-dedicated-server.github.io";
 const ogImage = `${origin}${base}og-image.png`;
@@ -26,8 +35,7 @@ export default withMermaid(
             // Bake the build time into the bundle so the sidebar can show "Last built: …"
             define: {
                 __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
-                // API base URL of the public test server, shown on community/test-server.md.
-                __DOCS_TEST_SERVER_API_URL__: JSON.stringify(process.env.DOCS_TEST_SERVER_API_URL ?? ""),
+                __DOCS_TEST_SERVER_API_URL__: JSON.stringify(testServerApiUrl),
             },
             resolve: {
                 alias: [
@@ -39,6 +47,7 @@ export default withMermaid(
                 ],
             },
             plugins: [
+                statusStubPlugin(),
                 groupIconVitePlugin({
                     // Add custom icons which are not available otherwise
                     customIcon: {

--- a/docs/.vitepress/statusStub.ts
+++ b/docs/.vitepress/statusStub.ts
@@ -1,0 +1,59 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { Plugin } from "vite";
+import type { ServerStatus } from "../../tools/discord-bot/src/serverState";
+
+/** Base URL the page fetches `/status` under when no real API URL is configured. */
+export const STUB_BASE = "/__status-stub";
+
+/**
+ * Fake `/status` for `vitepress dev`, so the Public Test Server card works offline. Typed as the
+ * shared contract: a field added to `ServerStatus` without a value here fails the type-check.
+ * Never part of a build (`apply: "serve"`). `vitepress preview` serves the built site through its
+ * own static server, which runs no Vite plugins, so the stub does not exist there.
+ */
+export function statusStubPlugin(): Plugin {
+    const startedAtUtc = new Date(Date.now() - 3 * 86_400_000 - 5 * 3_600_000).toISOString();
+    let version = 0;
+
+    const fakeStatus = (): ServerStatus => ({
+        isOnline: true,
+        isReady: true,
+        dayTransitionComplete: true,
+        isPaused: false,
+        playerCount: 31,
+        maxPlayers: 37,
+        steamInviteCode: "S123456789",
+        gogInviteCode: "G1234567890ABCDEF",
+        serverName: "Preview",
+        farmName: "Junimo",
+        serverVersion: "1.5.0-preview.133",
+        gameVersion: "1.6.15",
+        season: "summer",
+        day: 12,
+        year: 2,
+        timeOfDay: 1330,
+        farmTypeKey: "Standard",
+        tps: 59.6,
+        startedAtUtc,
+        lastUpdated: new Date().toISOString(),
+        version: ++version,
+    });
+
+    const handle = (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+        if (req.url !== `${STUB_BASE}/status`) {
+            next();
+            return;
+        }
+        res.setHeader("Content-Type", "application/json");
+        res.setHeader("Cache-Control", "no-store");
+        res.end(JSON.stringify(fakeStatus()));
+    };
+
+    return {
+        name: "status-stub",
+        apply: "serve",
+        configureServer(server) {
+            server.middlewares.use(handle);
+        },
+    };
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,18 @@ npm run build
 npm run preview
 ```
 
+## Server Status Widget
+
+`npm run dev` serves a built-in fake `/status`, so the card on the Public Test Server page works
+offline. To point dev or a local build at a real server instead, create `docs/.env.local`:
+
+```sh
+DOCS_TEST_SERVER_API_URL=https://203.0.113.10/preview
+```
+
+CI sets the same variable from the `DOCS_TEST_SERVER_API_URL` repository variable. A build
+without it ships the page with no card.
+
 ## Quality Checks
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ npm run preview
 
 ## Server Status Widget
 
-`npm run dev` serves a built-in fake `/status`, so the card on the Public Test Server page works
+`npm run dev` serves a built-in fake `/__status-stub/status`, so the card on the Public Test Server page works
 offline. To point dev or a local build at a real server instead, create `docs/.env.local`:
 
 ```sh


### PR DESCRIPTION
- The docs dev server (`npm run dev`) now serves a fake `/__status-stub/status`, so the status card on the Public Test Server page renders offline without a real server.
- The stub is typed against the shared `ServerStatus` contract, so a new field added to the contract without a stub value fails the type-check.
- The stub is serve-only; production builds never include it. With no `DOCS_TEST_SERVER_API_URL` set, a build ships the page without the card as before.
- `DOCS_TEST_SERVER_API_URL` can now also come from a gitignored `docs/.env.local` for pointing dev or a local build at a real server.
- README documents the stub and the local override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for configuring the Server Status Widget during local development and CI builds.
  - Documented how to connect the widget to a real test server or run it offline with simulated status data.
  - Clarified behavior when no test-server URL is configured.

- **Developer Experience**
  - Added a development-only status service so the Public Test Server page can display status information without requiring a live server.
  - Added support for local environment overrides when configuring the test-server connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->