### PR TITLE
docs: documentation moves to docs.junimoserver.com

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
     label: Final checks
     description: "Before submitting, please make sure you do the following:"
     options:
-      - label: Read the [contribution guide](https://stardew-valley-dedicated-server.github.io/server/community/contributing).
+      - label: Read the [contribution guide](https://docs.junimoserver.com/community/contributing).
         required: true
       - label: Check existing [issues](https://github.com/stardew-valley-dedicated-server/server/issues).
         required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -29,7 +29,7 @@ body:
     label: Final checks
     description: "Before submitting, please make sure you do the following:"
     options:
-      - label: Read the [contribution guide](https://stardew-valley-dedicated-server.github.io/server/community/contributing).
+      - label: Read the [contribution guide](https://docs.junimoserver.com/community/contributing).
         required: true
       - label: Check existing [issues](https://github.com/stardew-valley-dedicated-server/server/issues).
         required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 Before creating the pull request, please make sure you do the following:
 
 - Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
-- Read the contribution docs at https://stardew-valley-dedicated-server.github.io/server/community/contributing
+- Read the contribution docs at https://docs.junimoserver.com/community/contributing
 - Make sure the PR title follows conventional commits (https://www.conventionalcommits.org)
 
 This PR is reviewed automatically by two bots, each with its own lane:

--- a/.github/actions/discord-notify/action.yml
+++ b/.github/actions/discord-notify/action.yml
@@ -80,7 +80,7 @@ runs:
         # This is the one place that URL lives; it's served from the docs site. Callers with no name
         # (internal CI) are left alone and keep the avatar their webhook is configured with.
         if [ -n "$USERNAME" ] && [ -z "$AVATAR_URL" ]; then
-          AVATAR_URL="https://stardew-valley-dedicated-server.github.io/server/logo.png"
+          AVATAR_URL="https://docs.junimoserver.com/logo.png"
         fi
 
         payload=$(jq -cn \

--- a/.github/scripts/stamp-issue-versions.ts
+++ b/.github/scripts/stamp-issue-versions.ts
@@ -11,7 +11,7 @@ interface ChannelConfig {
     commentBody: (value: string, docsUrl: string) => string;
 }
 
-const DOCS_URL = "https://stardew-valley-dedicated-server.github.io/server/admins/operations/upgrading";
+const DOCS_URL = "https://docs.junimoserver.com/admins/operations/upgrading";
 
 const CHANNELS: Record<string, ChannelConfig> = {
     preview: {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ Thank you for your interest in contributing to JunimoServer! ❤️
 3. Make changes using [Conventional Commits](https://www.conventionalcommits.org/)
 4. Open a PR targeting `master`
 
-**For detailed instructions:** See the [Contributing Guide](https://stardew-valley-dedicated-server.github.io/server/community/contributing)
+**For detailed instructions:** See the [Contributing Guide](https://docs.junimoserver.com/community/contributing)
 
 ## Resources
 
-- [Reporting Bugs](https://stardew-valley-dedicated-server.github.io/server/community/reporting-bugs) - How to report issues effectively
-- [CI/CD & Releases](https://stardew-valley-dedicated-server.github.io/server/developers/contributing/ci-cd) - Understanding the development workflow
-- [Getting Help](https://stardew-valley-dedicated-server.github.io/server/community/getting-help) - Where to ask questions
+- [Reporting Bugs](https://docs.junimoserver.com/community/reporting-bugs) - How to report issues effectively
+- [CI/CD & Releases](https://docs.junimoserver.com/developers/contributing/ci-cd) - Understanding the development workflow
+- [Getting Help](https://docs.junimoserver.com/community/getting-help) - Where to ask questions

--- a/README.md
+++ b/README.md
@@ -123,11 +123,11 @@ You can also pin to a specific version (e.g., `IMAGE_VERSION=1.0.0` or `IMAGE_VE
 
 ## Documentation
 
-Explore the [full documentation](https://stardew-valley-dedicated-server.github.io/server/) to get started. Here's what you'll find:
+Explore the [full documentation](https://docs.junimoserver.com/) to get started. Here's what you'll find:
 
-- **[Getting Started](https://stardew-valley-dedicated-server.github.io/server/getting-started/introduction):** Step-by-step instructions on setting up and managing your server.
-- **[Server Guide](https://stardew-valley-dedicated-server.github.io/server/guide/using-the-server):** Learn how to use and manage your server.
-- **[Community](https://stardew-valley-dedicated-server.github.io/server/community/getting-help):** Find out how to get involved and get help.
+- **[Getting Started](https://docs.junimoserver.com/getting-started/introduction):** Step-by-step instructions on setting up and managing your server.
+- **[Server Guide](https://docs.junimoserver.com/guide/using-the-server):** Learn how to use and manage your server.
+- **[Community](https://docs.junimoserver.com/community/getting-help):** Find out how to get involved and get help.
 
 ## Support
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,7 +10,7 @@ import { DEFAULT_THEME_ID, themes } from "./theme/themes";
 // Docs version: "latest" or "preview" (set via DOCS_VERSION env var during build)
 const docsVersion = process.env.DOCS_VERSION || "latest";
 const isPreview = docsVersion === "preview";
-const base = isPreview ? "/server/preview/" : "/server/";
+const base = isPreview ? "/preview/" : "/";
 
 // API base URL of the public test server, shown on community/test-server.md. CI sets the
 // env var; locally a docs/.env.local file works too. Unset: the dev server stubs it
@@ -20,7 +20,7 @@ const dotenv = loadEnv("", process.cwd(), "DOCS_");
 const testServerApiUrl =
     process.env.DOCS_TEST_SERVER_API_URL || dotenv.DOCS_TEST_SERVER_API_URL || (isBuild ? "" : STUB_BASE);
 
-const origin = "https://stardew-valley-dedicated-server.github.io";
+const origin = "https://docs.junimoserver.com";
 const ogImage = `${origin}${base}og-image.png`;
 
 const openApiSidebar = useSidebar({ spec, linkPrefix: "/developers/api/" });
@@ -151,7 +151,7 @@ export default withMermaid(
             // sitemap as `new URL(relativeUrl, hostname)`, so the hostname must carry
             // the deploy subpath (and its trailing slash — without it `new URL` resolves
             // against the parent and drops the base). `base` already differs per deploy
-            // (/server/ vs /server/preview/), keeping sitemap locs aligned with the
+            // (/ vs /preview/), keeping sitemap locs aligned with the
             // og:url/canonical tags, which also use `${origin}${base}`.
             hostname: `${origin}${base}`,
         },

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -16,8 +16,8 @@ defineProps<{
 }>();
 
 const versions: Version[] = [
-    { id: "latest", name: "Latest", path: "/server/", badge: "unstable", badgeType: "warning" },
-    { id: "preview", name: "Preview", path: "/server/preview/", badge: "unstable", badgeType: "warning" },
+    { id: "latest", name: "Latest", path: "/", badge: "unstable", badgeType: "warning" },
+    { id: "preview", name: "Preview", path: "/preview/", badge: "unstable", badgeType: "warning" },
 ];
 
 const { isMediumScreen, extraMenuTarget, isInlineOpen, toggleInline } = useNavBarExtra("__versionSwitcherObserver");
@@ -28,7 +28,7 @@ const currentVersion = computed(() => {
         return versions[0];
     }
     const path = window.location.pathname;
-    if (path.startsWith("/server/preview")) {
+    if (path.startsWith("/preview")) {
         return versions.find((v) => v.id === "preview") || versions[0];
     }
     return versions[0];
@@ -43,10 +43,8 @@ function switchToVersion(version: Version) {
     let relativePath = currentPath;
 
     // Remove current version prefix to get relative path
-    if (currentPath.startsWith("/server/preview/")) {
-        relativePath = currentPath.replace("/server/preview", "");
-    } else if (currentPath.startsWith("/server/")) {
-        relativePath = currentPath.replace("/server", "");
+    if (currentPath.startsWith("/preview/")) {
+        relativePath = currentPath.replace("/preview", "");
     }
 
     if (!relativePath.startsWith("/")) {

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -28,7 +28,7 @@ const currentVersion = computed(() => {
         return versions[0];
     }
     const path = window.location.pathname;
-    if (path.startsWith("/preview")) {
+    if (path.startsWith("/preview/")) {
         return versions.find((v) => v.id === "preview") || versions[0];
     }
     return versions[0];

--- a/docs/.vitepress/theme/VersionSwitcher.vue
+++ b/docs/.vitepress/theme/VersionSwitcher.vue
@@ -44,12 +44,12 @@ function switchToVersion(version: Version) {
 
     // Remove current version prefix to get relative path
     if (currentPath.startsWith("/preview/")) {
-        relativePath = currentPath.replace("/preview", "");
+        relativePath = currentPath.slice("/preview".length);
     }
 
-    if (!relativePath.startsWith("/")) {
-        relativePath = `/${relativePath}`;
-    }
+    // Exactly one leading slash: a path like /preview//host would otherwise become the
+    // protocol-relative //host and navigate off-site.
+    relativePath = `/${relativePath.replace(/^\/+/, "")}`;
 
     const newPath = version.path.replace(/\/$/, "") + relativePath;
     window.location.href = newPath;

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -847,7 +847,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
                     `• Wallet-Type: **${settings.server.separateWallets ? "💰 Separate Wallets" : "🤝 Shared Wallet"}**`,
                     `• Profit Margin Multiplier: **${settings.game.profitMargin}x**`,
                     `• Night Monsters Spawn: **${settings.game.spawnMonstersAtNight}**`,
-                    `• Cabin Strategy: \`${settings.server.cabinStrategy}\` ([Learn More](https://stardew-valley-dedicated-server.github.io/server/features/cabin-strategies.html#cabinstack-default))`,
+                    `• Cabin Strategy: \`${settings.server.cabinStrategy}\` ([Learn More](https://docs.junimoserver.com/features/cabin-strategies.html#cabinstack-default))`,
                 ];
 
                 await message.reply(lines.join("\n"));


### PR DESCRIPTION
- VitePress base becomes `/` (preview at `/preview/`), origin becomes `https://docs.junimoserver.com`; canonical, og:url and sitemap follow
- Version switcher strips the new path prefixes
- Hardcoded github.io docs links updated in README, CONTRIBUTING, issue/PR templates, issue version stamper, Discord notify avatar and Discord bot
- No workflow changes; `deploy-docs.yml` already lays out `dist/` and `dist/preview`

After merge: run `deploy-docs.yml` with `rebuild_latest` and `rebuild_preview` both checked, since the R2 snapshot still holds the `/server/` base path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the README, contribution guides, issue templates, pull request template, and community support resources.
  * Documentation is now hosted at `docs.junimoserver.com`.
  * Updated production, preview, and version-switching paths for the documentation site.
  * Updated the server command’s Cabin Strategy link.

* **Chores**
  * Updated automated issue comments to use the new documentation URLs.
  * Updated the Discord notification fallback avatar link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->