### PR TITLE
chore: clarify block-master pre-push message

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -47,6 +47,7 @@ pre-push:
       # Single-quoted echoes: lefthook wraps the script in sh -c "...", so embedded
       # double-quotes would break that outer quoting and swallow the exit code.
       run: |
-        echo '✋ Direct push to master is blocked — open a PR instead.'
-        echo '   (Deliberate push? Temporarily remove the block-master hook in lefthook.yml.)'
+        echo '✋ Push blocked: master is checked out, so this hook blocks every push from it.'
+        echo '   Pushing/deleting another branch? Switch off master first (git switch <branch>).'
+        echo '   Really pushing to master? Temporarily remove the block-master hook in lefthook.yml.'
         exit 1


### PR DESCRIPTION
## What

Reword the `block-master` pre-push hook's message.

## Why

`block-master` uses `only: ref: master`, so it fires on **any** push while master is checked out — not just pushes that target master. Deleting or pushing an unrelated branch from master was blocked with a message that implied a direct push to master, which is confusing.

## Changes

- Message now states the real trigger (master is checked out → every push from it is blocked).
- Points to the quick fix: switch off master first (`git switch <branch>`).
- Keeps the deliberate-push escape hatch (temporarily remove the hook).

No behavior change — still the blunt, fail-loud guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the pre-push hook’s messages to clearly explain that pushes are blocked while the master branch is checked out.
  - Added guidance to switch to another branch before pushing, or remove the hook temporarily when a direct push to master is intentional.

- **Bug Fixes**
  - No changes were made to the existing push-blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->