### PR TITLE
ci: deployed servers can post the Discord status dashboard

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -106,6 +106,7 @@ jobs:
           DEPLOY_API_KEY: ${{ secrets.DEPLOY_API_KEY }}
           DEPLOY_DISCORD_BOT_TOKEN: ${{ secrets.DEPLOY_DISCORD_BOT_TOKEN }}
           DEPLOY_DISCORD_CHAT_CHANNEL_ID: ${{ secrets.DEPLOY_DISCORD_CHAT_CHANNEL_ID }}
+          DEPLOY_STATUS_DASHBOARD_CHANNEL_ID: ${{ vars.DEPLOY_STATUS_DASHBOARD_CHANNEL_ID }}
           DEPLOY_SERVER_NAME: ${{ vars.DEPLOY_SERVER_NAME }}
           # Optional: enables the HTTPS proxy (docs: operations/reverse-proxy.md).
           DEPLOY_PUBLIC_HOST: ${{ vars.DEPLOY_PUBLIC_HOST }}
@@ -149,6 +150,7 @@ jobs:
           echo "# Discord bot (optional)" >> .env
           echo "DISCORD_BOT_TOKEN=$DEPLOY_DISCORD_BOT_TOKEN" >> .env
           echo "DISCORD_CHAT_CHANNEL_ID=$DEPLOY_DISCORD_CHAT_CHANNEL_ID" >> .env
+          echo "STATUS_DASHBOARD_CHANNEL_ID=$DEPLOY_STATUS_DASHBOARD_CHANNEL_ID" >> .env
           echo "SERVER_NAME=$DEPLOY_SERVER_NAME" >> .env
           if [[ -n "$DEPLOY_PUBLIC_HOST" ]]; then
             echo "# HTTPS proxy" >> .env

--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -105,7 +105,7 @@ jobs:
           DEPLOY_VNC_PASSWORD: ${{ secrets.DEPLOY_VNC_PASSWORD }}
           DEPLOY_API_KEY: ${{ secrets.DEPLOY_API_KEY }}
           DEPLOY_DISCORD_BOT_TOKEN: ${{ secrets.DEPLOY_DISCORD_BOT_TOKEN }}
-          DEPLOY_DISCORD_CHAT_CHANNEL_ID: ${{ secrets.DEPLOY_DISCORD_CHAT_CHANNEL_ID }}
+          DEPLOY_DISCORD_CHAT_CHANNEL_ID: ${{ vars.DEPLOY_DISCORD_CHAT_CHANNEL_ID }}
           DEPLOY_STATUS_DASHBOARD_CHANNEL_ID: ${{ vars.DEPLOY_STATUS_DASHBOARD_CHANNEL_ID }}
           DEPLOY_SERVER_NAME: ${{ vars.DEPLOY_SERVER_NAME }}
           # Optional: enables the HTTPS proxy (docs: operations/reverse-proxy.md).

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -370,7 +370,6 @@ All secrets use the `DEPLOY_` prefix.
 |--------|----------|-------------|
 | `DEPLOY_API_KEY` | No | API key for authenticating API/WebSocket requests |
 | `DEPLOY_DISCORD_BOT_TOKEN` | No | Discord bot token for status display |
-| `DEPLOY_DISCORD_CHAT_CHANNEL_ID` | No | Discord channel ID for chat relay |
 | `DEPLOY_GAME_PORT` | Yes | UDP port for game connections |
 | `DEPLOY_SSH_HOST` | Yes | Server IP address or hostname |
 | `DEPLOY_SSH_KEY` | Yes | SSH private key (Ed25519 recommended) |
@@ -400,6 +399,7 @@ Add these under **Settings → Environments → Variables**, not as secrets.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DEPLOY_SERVER_NAME` | No | Display name shown as the Discord bot nickname and on status widgets (defaults to the farm name) |
+| `DEPLOY_DISCORD_CHAT_CHANNEL_ID` | No | Discord channel ID for the two-way [chat relay](/admins/configuration/discord#chat-relay) |
 | `DEPLOY_STATUS_DASHBOARD_CHANNEL_ID` | No | Discord channel ID for the [status dashboard](/admins/configuration/discord#status-dashboard) embed; may be the chat relay channel |
 | `DEPLOY_PUBLIC_HOST` | No | Public IP or domain of the [HTTPS proxy](/admins/operations/reverse-proxy); setting it enables the proxy. `SERVER_URL_NAME` comes from the matrix entry's `url_name` |
 | `DEPLOY_PROXY_ROUTING` | No | `path` (default) or `subdomain`, see the proxy docs |

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -400,6 +400,7 @@ Add these under **Settings → Environments → Variables**, not as secrets.
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `DEPLOY_SERVER_NAME` | No | Display name shown as the Discord bot nickname and on status widgets (defaults to the farm name) |
+| `DEPLOY_STATUS_DASHBOARD_CHANNEL_ID` | No | Discord channel ID for the [status dashboard](/admins/configuration/discord#status-dashboard) embed; may be the chat relay channel |
 | `DEPLOY_PUBLIC_HOST` | No | Public IP or domain of the [HTTPS proxy](/admins/operations/reverse-proxy); setting it enables the proxy. `SERVER_URL_NAME` comes from the matrix entry's `url_name` |
 | `DEPLOY_PROXY_ROUTING` | No | `path` (default) or `subdomain`, see the proxy docs |
 


### PR DESCRIPTION
- `deploy-server.yml` forwards the `DEPLOY_STATUS_DASHBOARD_CHANNEL_ID` environment variable into the generated `.env` as `STATUS_DASHBOARD_CHANNEL_ID`, so deployed bots post the status dashboard embed
- `DEPLOY_DISCORD_CHAT_CHANNEL_ID` is read from environment variables instead of secrets; channel ids are not sensitive. The `public-test-preview` environment already has it as a variable and the secret is deleted
- CI docs list both channel ids in the environment variables table