### PR TITLE
docs(reverse-proxy): add Traefik as the recommended external-proxy setup

### DIFF
--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -65,7 +65,7 @@ curl https://203.0.113.10/farm/health
 
 ## Your own proxy
 
-When the host already runs a reverse proxy — or runs other services that should share one — skip the bundled `proxy` profile and route to the server from your proxy. Keep `PUBLIC_HOST` and `SERVER_URL_NAME` in `.env`: `PUBLIC_HOST` keeps the plain API and VNC ports on loopback, and routing then lives in your proxy rather than these variables.
+When the host already runs a reverse proxy — or runs other services that should share one — skip the bundled `proxy` profile and route to the server from your proxy. Keep `PUBLIC_HOST` in `.env` — it binds the plain API and VNC ports to loopback. Routing now lives in your proxy, not in these variables; `SERVER_URL_NAME` just names the path prefix the examples below route to.
 
 Connect the two through a dedicated external Docker network that both the proxy and the server join, rather than attaching the proxy to this stack's network — one shared network scales to every service on the host. Create it once:
 
@@ -134,7 +134,7 @@ services:
     environment:
       CONTAINERS: 1   # discover containers and their labels
       NETWORKS: 1     # resolve traefik.docker.network
-      # everything else stays denied: read-only, no POST/EXEC/write access
+      # Traefik also reads the events stream, on by default; POST and all write access stay denied
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks: [socket]

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -12,7 +12,7 @@ By default the REST API (`API_PORT`) and the VNC web UI (`VNC_PORT`) are plain H
 |-------|-----|---------|------------------------|
 | No proxy (default) | Home and LAN servers | nothing | plain HTTP on `API_PORT` and `VNC_PORT` |
 | Bundled proxy | One server on a VPS | `COMPOSE_PROFILES=proxy`, `PUBLIC_HOST`, `SERVER_URL_NAME`, `PROXY_ROUTING` | HTTPS on 443 only |
-| Your own proxy | A host with an existing or shared proxy | `PUBLIC_HOST`, `SERVER_URL_NAME`, a shared `proxy` network + your proxy's routing | whatever your proxy exposes |
+| Your own proxy | A host with an existing or shared proxy | `PUBLIC_HOST`, a shared `proxy` network + your proxy's routing | whatever your proxy exposes |
 
 Setting `PUBLIC_HOST` declares that a proxy sits in front of the server: the plain-HTTP ports then bind to loopback and are unreachable from outside. Set it only with a proxy in place.
 

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -31,7 +31,7 @@ Setting `PUBLIC_HOST` declares that a proxy sits in front of the server: the pla
 | `path` | `https://PUBLIC_HOST/SERVER_URL_NAME/status`, `/players`, `/docs`, … | `https://PUBLIC_HOST/SERVER_URL_NAME/vnc/` |
 | `subdomain` | `https://SERVER_URL_NAME.PUBLIC_HOST/status`, … | `https://SERVER_URL_NAME.PUBLIC_HOST/vnc/` |
 
-`path` works for an IP and for a domain. `subdomain` needs a domain, with a DNS record (or wildcard) for that name pointing at the host; with an IP host the certificate request fails, visible in `docker compose logs proxy`.
+`path` works for an IP and for a domain. `subdomain` needs a domain, with a DNS record (or wildcard) for that name pointing at the host; with an IP host the certificate request fails, visible in the proxy's logs.
 
 ## Certificate
 
@@ -65,7 +65,7 @@ curl https://203.0.113.10/farm/health
 
 ## Your own proxy
 
-When the host already runs a reverse proxy — or runs other services that should share one — skip the bundled `proxy` profile and route to the server from your proxy. Keep `PUBLIC_HOST` in `.env` — it binds the plain API and VNC ports to loopback. Routing now lives in your proxy, not in these variables; `SERVER_URL_NAME` just names the path prefix the examples below route to.
+When the host already runs a reverse proxy — or runs other services that should share one — skip the bundled `proxy` profile and route to the server from your proxy. Keep `PUBLIC_HOST` in `.env` — it binds the plain API and VNC ports to loopback. Routing now lives in your proxy, not in these variables; `SERVER_URL_NAME` just names the path prefix the examples below route to. The examples assume a domain; for a bare IP, use the bundled proxy (or a proxy whose ACME client can request Let's Encrypt's short-lived profile, the type it issues for IP addresses).
 
 Connect the two through a dedicated external Docker network that both the proxy and the server join, rather than attaching the proxy to this stack's network — one shared network scales to every service on the host. Create it once:
 

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -88,7 +88,7 @@ services:
       - traefik.http.routers.api.entrypoints=websecure
       - traefik.http.routers.api.tls.certresolver=le
       - traefik.http.routers.api.service=api
-      - traefik.http.services.api.loadbalancer.server.port=8080   # = API_PORT
+      - traefik.http.services.api.loadbalancer.server.port=${API_PORT:-8080}
       # VNC web UI at /vnc/ — prefix stripped, WebSocket passes through natively
       - traefik.http.routers.vnc.rule=Host(`farm.example.com`) && PathPrefix(`/vnc`)
       - traefik.http.routers.vnc.entrypoints=websecure
@@ -103,7 +103,7 @@ networks:
     external: true
 ```
 
-The `/vnc` router is more specific than the root API router, so Traefik's default rule-length priority sends `/vnc/*` to the VNC UI and everything else to the API. Reach VNC at `https://farm.example.com/vnc/` (trailing slash), the same URL the bundled proxy uses. This is subdomain routing; for path routing add a `stripprefix` for `/SERVER_URL_NAME` to the API router too.
+The `/vnc` router is more specific than the root API router, so Traefik's default rule-length priority sends `/vnc/*` to the VNC UI and everything else to the API. Reach VNC at `https://farm.example.com/vnc/` (trailing slash), the same URL the bundled proxy uses. This is subdomain routing; for path routing, prefix both routers with `/SERVER_URL_NAME`: give the API router a `PathPrefix` rule for `/SERVER_URL_NAME` and a matching `stripprefix`, and change the VNC rule to match `/SERVER_URL_NAME/vnc` and strip that same prefix.
 
 ### Recommended: Traefik with a socket proxy
 

--- a/docs/admins/operations/reverse-proxy.md
+++ b/docs/admins/operations/reverse-proxy.md
@@ -12,7 +12,7 @@ By default the REST API (`API_PORT`) and the VNC web UI (`VNC_PORT`) are plain H
 |-------|-----|---------|------------------------|
 | No proxy (default) | Home and LAN servers | nothing | plain HTTP on `API_PORT` and `VNC_PORT` |
 | Bundled proxy | One server on a VPS | `COMPOSE_PROFILES=proxy`, `PUBLIC_HOST`, `SERVER_URL_NAME`, `PROXY_ROUTING` | HTTPS on 443 only |
-| Your own proxy | Hosts that already run a proxy | `PUBLIC_HOST`, `SERVER_URL_NAME`, your proxy's routing | whatever your proxy exposes |
+| Your own proxy | A host with an existing or shared proxy | `PUBLIC_HOST`, `SERVER_URL_NAME`, a shared `proxy` network + your proxy's routing | whatever your proxy exposes |
 
 Setting `PUBLIC_HOST` declares that a proxy sits in front of the server: the plain-HTTP ports then bind to loopback and are unreachable from outside. Set it only with a proxy in place.
 
@@ -65,23 +65,91 @@ curl https://203.0.113.10/farm/health
 
 ## Your own proxy
 
-Skip the `proxy` profile, keep `PUBLIC_HOST` and `SERVER_URL_NAME` in `.env`, attach your proxy to the stack's compose network, and route the server's URL to the container. The proxy must strip the path prefix, and the VNC route needs WebSocket pass-through. With Caddy, reuse the same snippet:
+When the host already runs a reverse proxy — or runs other services that should share one — skip the bundled `proxy` profile and route to the server from your proxy. Keep `PUBLIC_HOST` and `SERVER_URL_NAME` in `.env`: `PUBLIC_HOST` keeps the plain API and VNC ports on loopback, and routing then lives in your proxy rather than these variables.
 
-```text
-import common.caddy
+Connect the two through a dedicated external Docker network that both the proxy and the server join, rather than attaching the proxy to this stack's network — one shared network scales to every service on the host. Create it once:
 
-# path routing
-203.0.113.10 {
-    import server /farm
-}
-
-# or subdomain routing
-farm.example.com {
-    import server ""
-}
+```sh
+docker network create proxy
 ```
 
-Other proxies work the same way as long as their ACME client supports the `shortlived` profile.
+Attach the server to it with a compose override, `docker-compose.proxy.yml` beside your `.env`:
+
+```yaml
+# docker compose -f docker-compose.yml -f docker-compose.proxy.yml up -d
+services:
+  server:
+    networks: [default, proxy]   # default keeps server↔steam-auth; proxy reaches the proxy
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=proxy
+      # API at the domain root
+      - traefik.http.routers.api.rule=Host(`farm.example.com`)
+      - traefik.http.routers.api.entrypoints=websecure
+      - traefik.http.routers.api.tls.certresolver=le
+      - traefik.http.routers.api.service=api
+      - traefik.http.services.api.loadbalancer.server.port=8080   # = API_PORT
+      # VNC web UI at /vnc/ — prefix stripped, WebSocket passes through natively
+      - traefik.http.routers.vnc.rule=Host(`farm.example.com`) && PathPrefix(`/vnc`)
+      - traefik.http.routers.vnc.entrypoints=websecure
+      - traefik.http.routers.vnc.tls.certresolver=le
+      - traefik.http.routers.vnc.service=vnc
+      - traefik.http.routers.vnc.middlewares=vnc-strip
+      - traefik.http.middlewares.vnc-strip.stripprefix.prefixes=/vnc
+      - traefik.http.services.vnc.loadbalancer.server.port=5800
+
+networks:
+  proxy:
+    external: true
+```
+
+The `/vnc` router is more specific than the root API router, so Traefik's default rule-length priority sends `/vnc/*` to the VNC UI and everything else to the API. Reach VNC at `https://farm.example.com/vnc/` (trailing slash), the same URL the bundled proxy uses. This is subdomain routing; for path routing add a `stripprefix` for `/SERVER_URL_NAME` to the API router too.
+
+### Recommended: Traefik with a socket proxy
+
+Run Traefik as its own stack so every service on the host shares it, and give it the Docker API through a read-only socket proxy rather than the raw socket — Traefik never needs write access, and mounting the bare socket is root-equivalent on the host. `docker-compose.traefik.yml` in its own directory:
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3
+    command:
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --providers.docker.endpoint=tcp://dockerproxy:2375   # not the socket
+      - --providers.docker.network=proxy
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.email=you@example.com
+      - --certificatesresolvers.le.acme.storage=/letsencrypt/acme.json
+      - --certificatesresolvers.le.acme.httpchallenge.entrypoint=web
+    ports: ["80:80", "443:443"]
+    volumes:
+      - ./letsencrypt:/letsencrypt   # persist certs across restarts
+    networks: [proxy, socket]
+    restart: unless-stopped
+
+  dockerproxy:
+    image: tecnativa/docker-socket-proxy
+    environment:
+      CONTAINERS: 1   # discover containers and their labels
+      NETWORKS: 1     # resolve traefik.docker.network
+      # everything else stays denied: read-only, no POST/EXEC/write access
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks: [socket]
+    restart: unless-stopped
+
+networks:
+  proxy:
+    external: true
+  socket:
+    internal: true   # traefik ↔ socket proxy only, off the shared network
+```
+
+Only `dockerproxy` touches the socket, read-only and limited to container and network listing; Traefik reads it over an internal network and owns ports 80 and 443. Adapt from here for your own needs — pin image tags, add access logs or a dashboard, or swap the ACME challenge.
+
+Already running Caddy or another proxy? Route to `server:$API_PORT` and `server:5800` on the shared network the same way; the VNC route needs WebSocket pass-through, and reusing the bundled [`docker/proxy/`](https://github.com/stardew-valley-dedicated-server/server/tree/master/docker/proxy) config additionally requires an ACME client that supports the `shortlived` profile.
 
 ## Firewall
 


### PR DESCRIPTION
@
Reworks the "Your own proxy" section of the reverse-proxy admin guide around a shared external Docker network and a Traefik example.

## Changes

- Document a shared external `proxy` Docker network that both the proxy and the server join, replacing the "attach your proxy to the stack's network" direction — one shared network scales to every service on the host.
- Add a Traefik + `tecnativa/docker-socket-proxy` example (subdomain routing by default), with a `docker-compose.proxy.yml` server override carrying the routing labels.
- Route the API at the domain root and the VNC UI at `/vnc/` (stripprefix, native WebSocket pass-through), matching the URLs the bundled proxy already serves.
- Give Traefik read-only Docker access via the socket proxy (CONTAINERS + NETWORKS only) so the raw socket is never mounted into Traefik.
- Update the Setups table row for the shared-proxy case.

Docs-only change; no code paths touched.
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated reverse-proxy setup guidance to recommend a dedicated external Docker network.
  - Added a complete Traefik v3 configuration using a read-only Docker socket proxy.
  - Clarified routing for server and proxy endpoints, including path-prefix and subpath configurations.
  - Updated the Traefik API example to support configurable API ports.
  - Added guidance for bare-IP deployments using Let’s Encrypt’s short-lived certificate profile.
  - Clarified proxy-log troubleshooting and Docker socket access restrictions.
  - Replaced Caddy-specific routing guidance with shared-network routing for API and VNC ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->