### PR TITLE
feat(discord): cleaner server status dashboard with uptime and a last-known fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,7 +93,7 @@ VNC_PASSWORD=""
 
 # Channel for the live status dashboard, by name or ID
 # STATUS_DASHBOARD_CHANNEL=""
-# Embed update frequency in seconds (low frequency can cause rate limits)
+# Embed update frequency in seconds (minimum 20)
 # STATUS_DASHBOARD_REFRESH_RATE=30
 
 ########################################

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -2,7 +2,9 @@
 # Plain repo-relative paths to single files, one per line — not full .gitignore
 # syntax, and not directories (the hook copies with copyFileSync).
 # .env: build reads GAME_PATH via Directory.Build.props. .env.test: E2E tests.
+# tools/discli-docker/.env: discli bot token, so `docker compose exec` works in worktrees.
 # node_modules is NOT copied — the hook runs `npm ci` in the worktree instead.
 .env
 .env.test
 .sdvd_runner_key
+tools/discli-docker/.env

--- a/docs/.vitepress/theme/ServerStatusWidget.vue
+++ b/docs/.vitepress/theme/ServerStatusWidget.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, onUnmounted, ref } from "vue";
 import {
     formatStardewDate,
     formatStardewTime,
+    formatUptime,
     joinableInviteCode,
     resolveServerState,
     type ServerState,
@@ -84,21 +85,6 @@ const farmDate = computed(() => (status.value ? formatStardewDate(status.value) 
 
 const clock = computed(() => (status.value ? formatStardewTime(status.value.timeOfDay) : ""));
 
-/** Coarse uptime ("3d 4h", "4h 12m", "12m"); precise seconds would only churn between polls. */
-function formatUptime(startedAtUtc: string, now: number): string {
-    const totalMinutes = Math.max(0, Math.floor((now - Date.parse(startedAtUtc)) / 60000));
-    const days = Math.floor(totalMinutes / 1440);
-    const hours = Math.floor((totalMinutes % 1440) / 60);
-    const minutes = totalMinutes % 60;
-    if (days > 0) {
-        return `${days}d ${hours}h`;
-    }
-    if (hours > 0) {
-        return `${hours}h ${minutes}m`;
-    }
-    return `${minutes}m`;
-}
-
 /** Uptime shown inside the status badge while online; "" otherwise. */
 const uptime = computed(() =>
     status.value?.isOnline && status.value.startedAtUtc
@@ -113,7 +99,7 @@ const vitals = computed(() => {
     const items = [
         {
             key: "tps",
-            iconPath: "M12 20V10M18 20V4M6 20v-4",
+            iconPath: "M3 12h4l3-8 4 16 3-8h4",
             value: status.value.tps.toFixed(1),
             unit: "TPS",
             info: "Game ticks per second the server actually runs, averaged over the last 30 seconds.",
@@ -122,7 +108,7 @@ const vitals = computed(() => {
     if (roundTripMs.value !== null) {
         items.push({
             key: "rtt",
-            iconPath: "M3 12h4l3-8 4 16 3-8h4",
+            iconPath: "M12 20V10M18 20V4M6 20v-4",
             value: String(roundTripMs.value),
             unit: "ms",
             info: "Round-trip from your browser to the server's API. A rough distance hint, not your in-game ping.",
@@ -230,18 +216,14 @@ onUnmounted(() => {
                     <div class="status-badge" :style="{ '--status-color': stateColors[state.kind] }">
                         <span class="status-dot"></span>
                         <span class="status-text">{{ state.label }}</span>
-                        <span v-if="uptime" class="status-uptime" title="Time since the server process last started">· {{ uptime }}</span>
+                        <span v-if="uptime" class="status-uptime" title="Time since the server process last started">· up {{ uptime }}</span>
                     </div>
                 </div>
                 <div class="meta-row">
                     <p v-if="status?.serverVersion" class="version">
                         <span class="version-chip">
-                            <span class="stat-label">Image</span>
+                            <span class="stat-label">Build Version</span>
                             <code>{{ status.serverVersion }}</code>
-                        </span>
-                        <span v-if="status.gameVersion" class="version-chip">
-                            <span class="stat-label">Stardew</span>
-                            <code>{{ status.gameVersion }}</code>
                         </span>
                     </p>
                     <p v-if="status?.isOnline" class="vitals">

--- a/docs/.vitepress/theme/ServerStatusWidget.vue
+++ b/docs/.vitepress/theme/ServerStatusWidget.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import {
+    formatStardewDate,
     formatStardewTime,
     joinableInviteCode,
     resolveServerState,
@@ -79,13 +80,7 @@ const playerSlotColumns = computed(() => {
     return rows > 0 ? Math.ceil(playerSlots.value / rows) : 0;
 });
 
-const farmDate = computed(() => {
-    if (!status.value) {
-        return "";
-    }
-    const season = status.value.season ? status.value.season[0].toUpperCase() + status.value.season.slice(1) : "";
-    return `${season} ${status.value.day}, Year ${status.value.year}`;
-});
+const farmDate = computed(() => (status.value ? formatStardewDate(status.value) : ""));
 
 const clock = computed(() => (status.value ? formatStardewTime(status.value.timeOfDay) : ""));
 

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -2,7 +2,7 @@
 
 Setup instructions for the Discord bot. See [Discord Integration](/features/discord) for the feature overview.
 
-The bot runs alongside your server, so its identity is your farm's: its nickname shows your farm name, and its presence shows your player count and invite code. That requires a Discord app of your own — free, one-time, about 5 minutes.
+The bot runs alongside your server, so its identity is your farm's: its nickname shows your farm name, and its presence shows your player count, version, and invite code. That requires a Discord app of your own — free, one-time, about 5 minutes.
 
 ## 1. Create the Bot
 
@@ -42,7 +42,7 @@ DISCORD_BOT_TOKEN=your_bot_token_here
 API_KEY=your_api_key_here
 ```
 
-Restart with `docker compose up -d`. The bot comes online and its presence shows the player count and invite code — no further setup needed. The features below are optional.
+Restart with `docker compose up -d`. The bot comes online and its presence shows the player count, version, and invite code — no further setup needed. The features below are optional.
 
 ## Chat Relay
 
@@ -71,11 +71,11 @@ The relay has no rate limit of its own. If spam is a concern, set Discord's slow
 
 ## Status Dashboard
 
-A status embed (farm name, date, players, invite code) posted to a channel and kept up to date by editing the same message in place.
+A status embed (state, players, in-game date, image and game version, tick rate, invite code) posted to a channel and kept up to date by editing the same message in place.
 
 ```sh
 STATUS_DASHBOARD_CHANNEL=farm-status
-# Seconds between updates (default 30)
+# Seconds between updates (default 30, minimum 20)
 STATUS_DASHBOARD_REFRESH_RATE=60
 ```
 
@@ -98,7 +98,7 @@ Mention the bot with a command to ask it directly, for example `@Preview !status
 
 | Command | Reply |
 |---------|-------|
-| `!status` | Farm name, date and time, players, and the invite code |
+| `!status` | Server state, players, in-game date, versions, tick rate, and the invite code |
 | `!players` | Who is online and cabin availability |
 | `!server` | Tick rate, memory, and gameplay settings |
 | `!help` | This list |

--- a/docs/admins/configuration/discord.md
+++ b/docs/admins/configuration/discord.md
@@ -71,7 +71,7 @@ The relay has no rate limit of its own. If spam is a concern, set Discord's slow
 
 ## Status Dashboard
 
-A status embed (state, players, in-game date, image and game version, tick rate, invite code) posted to a channel and kept up to date by editing the same message in place.
+A status embed (state, players, in-game date, image version, uptime, invite code) posted to a channel and kept up to date by editing the same message in place.
 
 ```sh
 STATUS_DASHBOARD_CHANNEL=farm-status

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -78,7 +78,7 @@ server's files to match.
 | `DISCORD_BOT_TOKEN` | Discord bot token | - |
 | `DISCORD_CHAT_CHANNEL` | Chat relay channel, by name or ID | - |
 | `STATUS_DASHBOARD_CHANNEL` | Status dashboard channel, by name or ID | - |
-| `STATUS_DASHBOARD_REFRESH_RATE` | Dashboard update interval in seconds | `30` |
+| `STATUS_DASHBOARD_REFRESH_RATE` | Dashboard update interval in seconds, minimum 20 | `30` |
 
 See [Discord Integration](/admins/configuration/discord) for setup instructions.
 

--- a/docs/admins/operations/public-status.md
+++ b/docs/admins/operations/public-status.md
@@ -8,7 +8,7 @@ The API's `/status` endpoint reports whether the server is online, how many play
 
 ## What `/status` exposes
 
-The endpoint returns the fields documented in the [API reference](/developers/api/introduction). The invite code looks sensitive but is public information: JunimoServer forces the lobby public, so the code alone never gates entry. Turn on [password protection](/features/password-protection/) before publishing the status anywhere. Every other endpoint stays behind `API_KEY`.
+The endpoint returns the fields documented in the [API reference](/developers/api/introduction). The invite code looks sensitive but is public information: JunimoServer forces the lobby public, so the code alone never gates entry. Turn on [password protection](/features/password-protection/) before publishing the status anywhere. The rest of the API needs `API_KEY`, so set one before exposing anything beyond `/status`.
 
 ## The HTTPS requirement
 
@@ -31,7 +31,7 @@ Props:
 | `api-url` | HTTPS base URL of the API; the widget fetches `/status` under it | required |
 | `refresh-interval` | Poll interval in milliseconds; `0` disables polling | `30000` |
 
-The header shows the server's `SERVER_NAME`, else the farm name, the same rule the Discord bot uses for its nickname. The widget reports the same states as the bot: **Online** (`isOnline` and `isReady`), **Busy** (`isOnline` but saving, changing day, or running an event), **Starting** (`isOnline` false: the container is downloading game files, launching the game, or loading the save), and **Offline** (the request failed). It also shows the image and Stardew versions, the in-game clock, the measured tick rate, the browser's round-trip to the API, and the uptime beside the Online badge. The top accent line fills over one refresh interval, and a reload resumes the cycle from the last poll.
+The header shows the server's `SERVER_NAME`, else the farm name, the same rule the Discord bot uses for its nickname. The widget reports the same states as the bot: **Online** (`isOnline` and `isReady`), **Busy** (`isOnline` but saving, changing day, or running an event), **Starting** (`isOnline` false: the container is downloading game files, launching the game, or loading the save), and **Offline** (the request failed). It also shows the image version, the in-game clock, the measured tick rate, the browser's round-trip to the API, and the uptime beside the Online badge. The top accent line fills over one refresh interval, and a reload resumes the cycle from the last poll.
 
 ### Anywhere else
 

--- a/docs/admins/operations/public-status.md
+++ b/docs/admins/operations/public-status.md
@@ -4,11 +4,11 @@ description: Show your server's live status on a website — what /status expose
 
 # Public Server Status
 
-The API's `/status` endpoint reports whether the server is online, how many players are connected, the current invite codes, and the in-game date. It needs no API key, so a web page can read it directly and show your players a live status card.
+The API's `/status` endpoint reports whether the server is online, how many players are connected, the invite code, and the in-game date. It needs no API key, so a web page can read it directly and show your players a live status card.
 
 ## What `/status` exposes
 
-The endpoint returns the fields documented in the [API reference](/developers/api/introduction). The invite codes look sensitive but are public information: JunimoServer forces the lobby public, so the code alone never gates entry. Turn on [password protection](/features/password-protection/) before publishing the status anywhere. Every other endpoint stays behind `API_KEY`.
+The endpoint returns the fields documented in the [API reference](/developers/api/introduction). The invite code looks sensitive but is public information: JunimoServer forces the lobby public, so the code alone never gates entry. Turn on [password protection](/features/password-protection/) before publishing the status anywhere. Every other endpoint stays behind `API_KEY`.
 
 ## The HTTPS requirement
 

--- a/docs/community/test-server.md
+++ b/docs/community/test-server.md
@@ -45,7 +45,7 @@ Join if you're happy testing the rough edges: you want to help test preview buil
 |--------|---------|
 | **Online** | Ready to join |
 | **Starting** | Booting or loading the save |
-| **Busy** | Saving or changing the day |
+| **Busy** | Saving, changing the day, or running an event |
 | **Offline** | Not reachable |
 
 Starting, Busy, and Offline usually clear within a few minutes.

--- a/docs/features/discord.md
+++ b/docs/features/discord.md
@@ -10,18 +10,18 @@ The bot's Discord presence shows real-time server information:
 
 | Server State | Bot Status | Status Text |
 |--------------|------------|-------------|
-| Online | 🟢 Online | `2/8 players \| S-ABC123` |
+| Online | 🟢 Online | `2/8 players \| SGF0LUHHTYF5`, alternating with `v1.5.0 \| SGF0LUHHTYF5` |
 | Busy (saving, day change, festival, wedding) | 🟢 Online | `🟡 Busy — Saving, changing day, or running an event.` |
 | Starting: downloading game files (first run) | 🟡 Idle | `🟠 Starting — Downloading game files.` |
 | Starting: launching the game | 🟡 Idle | `🟠 Starting — Launching the game.` |
 | Starting: loading the save | 🟡 Idle | `🟡 Starting — Loading the save.` |
 | Offline (container down or API unreachable) | 🔴 Do Not Disturb | `🔴 Offline — The server is offline.` |
 
-While online, the status displays current player count, max players, and the invite code. You can copy the invite code directly from the bot's status. The startup states come from the game container itself: it answers `/status` with a startup phase until the mod's API takes over, so a first-run download is never mistaken for an outage.
+While online, the status line has room for the invite code plus one more item, so it alternates between the player count and the image version on each refresh. You can copy the invite code directly from the bot's status. The startup states come from the game container itself: it answers `/status` with a startup phase until the mod's API takes over, so a first-run download is never mistaken for an outage.
 
 ### Status Dashboard
 
-An auto-updating embed posted to a channel of your choice (`STATUS_DASHBOARD_CHANNEL`), showing farm name and layout, in-game date and time, player count, and the invite code. The bot edits the same message in place on a configurable interval (`STATUS_DASHBOARD_REFRESH_RATE`).
+An auto-updating embed posted to a channel of your choice (`STATUS_DASHBOARD_CHANNEL`), showing the server state, player count, in-game date and time, image and game version, tick rate, and the invite code. The bot edits the same message in place on a configurable interval (`STATUS_DASHBOARD_REFRESH_RATE`).
 
 ### Chat Relay
 

--- a/docs/features/discord.md
+++ b/docs/features/discord.md
@@ -10,18 +10,18 @@ The bot's Discord presence shows real-time server information:
 
 | Server State | Bot Status | Status Text |
 |--------------|------------|-------------|
-| Online | 🟢 Online | `2/8 players \| SGF0LUHHTYF5`, alternating with `v1.5.0 \| SGF0LUHHTYF5` |
-| Busy (saving, day change, festival, wedding) | 🟢 Online | `🟡 Busy — Saving, changing day, or running an event.` |
-| Starting: downloading game files (first run) | 🟡 Idle | `🟠 Starting — Downloading game files.` |
-| Starting: launching the game | 🟡 Idle | `🟠 Starting — Launching the game.` |
-| Starting: loading the save | 🟡 Idle | `🟡 Starting — Loading the save.` |
-| Offline (container down or API unreachable) | 🔴 Do Not Disturb | `🔴 Offline — The server is offline.` |
+| Online | 🟢 Online | `2/8 players, code SGF0LUHHTYF5`, alternating with `v1.5.0, code SGF0LUHHTYF5` |
+| Busy (saving, festival, wedding) | 🟢 Online | `Saving or running an event.` |
+| Starting: downloading game files (first run) | 🟡 Idle | `Downloading game files.` |
+| Starting: launching the game | 🟡 Idle | `Launching the game.` |
+| Starting: loading the save | 🟡 Idle | `Loading the save.` |
+| Offline (container down or API unreachable) | 🔴 Do Not Disturb | `Currently unreachable.` |
 
 While online, the status line has room for the invite code plus one more item, so it alternates between the player count and the image version on each refresh. You can copy the invite code directly from the bot's status. The startup states come from the game container itself: it answers `/status` with a startup phase until the mod's API takes over, so a first-run download is never mistaken for an outage.
 
 ### Status Dashboard
 
-An auto-updating embed posted to a channel of your choice (`STATUS_DASHBOARD_CHANNEL`), showing the server state, player count, in-game date and time, image and game version, tick rate, and the invite code. The bot edits the same message in place on a configurable interval (`STATUS_DASHBOARD_REFRESH_RATE`).
+An auto-updating embed posted to a channel of your choice (`STATUS_DASHBOARD_CHANNEL`), showing the server state, player count, in-game date and time, image version, uptime, and the invite code — falling back to the last-known snapshot while the server is unreachable. The bot edits the same message in place on a configurable interval (`STATUS_DASHBOARD_REFRESH_RATE`).
 
 ### Chat Relay
 

--- a/tools/discord-bot/src/dashboard.test.ts
+++ b/tools/discord-bot/src/dashboard.test.ts
@@ -110,6 +110,13 @@ describe("buildDashboardEmbed", () => {
         expect(embed.fields).toBeUndefined();
     });
 
+    test("a starting server with a last-known snapshot still shows its hint, not stale fields", () => {
+        const starting = { ...ONLINE_STATUS, isOnline: false, isReady: false, phase: "starting" };
+        const embed = buildDashboardEmbed(starting, resolveServerState(starting), FOOTER, ONLINE_STATUS, NOW).toJSON();
+        expect(embed.description).toBe("**🟠 Starting**\n\nGame data appears once the save is loaded.");
+        expect(embed.fields).toBeUndefined();
+    });
+
     test("offline without a last-known snapshot: headline + hint only, no fields", () => {
         const embed = buildDashboardEmbed(null, resolveServerState(null), FOOTER).toJSON();
         expect(embed.description).toBe("**🔴 Offline**\n\nNo game data can be pulled right now. Check back later!");

--- a/tools/discord-bot/src/dashboard.test.ts
+++ b/tools/discord-bot/src/dashboard.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import {
+    buildDashboardEmbed,
     classifyDashboardEmbed,
     DASHBOARD_TITLE,
     type EmbedLike,
     formatFooter,
+    formatRefreshRate,
     isDashboardEmbed,
     parseDashboardState,
     parseOwnerId,
 } from "./dashboard";
+import { resolveServerState, type ServerStatus } from "./discordState";
 
 const OWNER_ID = "3f2c8a1e-9b4d-4c6f-8a2e-1d5b7c9e0f3a";
 const OTHER_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
@@ -19,23 +22,119 @@ function dashboardEmbed(footerText: string | null): EmbedLike {
     };
 }
 
+const ONLINE_STATUS: ServerStatus = {
+    isOnline: true,
+    isReady: true,
+    playerCount: 1,
+    maxPlayers: 10,
+    steamInviteCode: "SGF0LUHHTYF5",
+    gogInviteCode: "GGF0LUHHTYF5",
+    serverVersion: "1.5.0-preview.134",
+    gameVersion: "1.6.15",
+    dayTransitionComplete: true,
+    lastUpdated: "2026-01-01T00:00:00Z",
+    farmName: "Junimo",
+    serverName: "",
+    startedAtUtc: "2026-01-01T00:00:00Z",
+    day: 14,
+    season: "spring",
+    year: 1,
+    timeOfDay: 650,
+    farmTypeKey: "Standard",
+    isPaused: false,
+    tps: 5.04,
+    version: 1,
+};
+
+describe("buildDashboardEmbed", () => {
+    const FOOTER = "footer";
+
+    function fields(status: ServerStatus): Record<string, string> {
+        const embed = buildDashboardEmbed(status, resolveServerState(status), FOOTER).toJSON();
+        return Object.fromEntries((embed.fields ?? []).map((f) => [f.name, f.value]));
+    }
+
+    test("online: one row of state, players, and date; one row of versions and tick rate; the invite code", () => {
+        const embed = buildDashboardEmbed(ONLINE_STATUS, resolveServerState(ONLINE_STATUS), FOOTER).toJSON();
+        expect(embed.title).toBe(DASHBOARD_TITLE);
+        expect(embed.footer?.text).toBe(FOOTER);
+        expect(embed.description).toBeUndefined();
+        expect(embed.fields?.map((f) => [f.name, f.inline])).toEqual([
+            ["Status", true],
+            ["Players", true],
+            ["In-game date", true],
+            ["Image", true],
+            ["Stardew", true],
+            ["Average TPS", true],
+            ["Invite code", false],
+        ]);
+        expect(fields(ONLINE_STATUS)).toMatchObject({
+            Status: "Online",
+            Players: "**1** / 10",
+            "In-game date": "Spring 14, Year 1 · 6:50 AM",
+            Image: "`1.5.0-preview.134`",
+            Stardew: "`1.6.15`",
+            "Average TPS": "5.0",
+            "Invite code": "`SGF0LUHHTYF5`",
+        });
+    });
+
+    test("busy shows the reason after the state, paused is marked on the players", () => {
+        const status = { ...ONLINE_STATUS, isReady: false, isPaused: true };
+        expect(fields(status).Status).toBe("Busy — Saving, changing day, or running an event.");
+        expect(fields(status).Players).toBe("**1** / 10 _(paused)_");
+    });
+
+    test("the invite code is pending until the Steam lobby is published", () => {
+        expect(fields({ ...ONLINE_STATUS, steamInviteCode: null })["Invite code"]).toBe("_not yet available_");
+    });
+
+    test("a version the mod has not reported yet shows a dash", () => {
+        expect(fields({ ...ONLINE_STATUS, gameVersion: "" }).Stardew).toBe("—");
+    });
+
+    test("not online: state and hint only, no fields", () => {
+        const embed = buildDashboardEmbed(null, resolveServerState(null), FOOTER).toJSON();
+        expect(embed.fields).toBeUndefined();
+        expect(embed.description).toBe(
+            "**Offline** — The server is offline.\n_No game data can be pulled right now. Check back later!_",
+        );
+    });
+
+    test("no emoji anywhere in the embed", () => {
+        for (const status of [ONLINE_STATUS, null]) {
+            const json = JSON.stringify(buildDashboardEmbed(status, resolveServerState(status), FOOTER).toJSON());
+            expect(json).not.toMatch(/\p{Extended_Pictographic}/u);
+        }
+    });
+});
+
+describe("formatRefreshRate", () => {
+    test("seconds unless the rate is a whole number of minutes", () => {
+        expect(formatRefreshRate(30)).toBe("30 seconds");
+        expect(formatRefreshRate(90)).toBe("90 seconds");
+        expect(formatRefreshRate(60)).toBe("1 minute");
+        expect(formatRefreshRate(120)).toBe("2 minutes");
+    });
+});
+
 describe("formatFooter", () => {
-    test("stamps the owner id when present", () => {
-        expect(formatFooter("30 seconds", OWNER_ID)).toBe(`Automatically updates every 30 seconds • id:${OWNER_ID}`);
+    test("stamps the owner id's prefix when present", () => {
+        expect(formatFooter(30, OWNER_ID)).toBe("Automatically updates every 30 seconds • id:3f2c8a1e");
     });
 
     test("omits the stamp in degraded mode", () => {
-        expect(formatFooter("2 minutes", null)).toBe("Automatically updates every 2 minutes");
+        expect(formatFooter(120, null)).toBe("Automatically updates every 2 minutes");
     });
 });
 
 describe("parseOwnerId", () => {
-    test("round-trips the id written by formatFooter", () => {
-        expect(parseOwnerId(formatFooter("30 seconds", OWNER_ID))).toBe(OWNER_ID);
+    test("round-trips the stamp written by formatFooter", () => {
+        expect(parseOwnerId(formatFooter(30, OWNER_ID))).toBe(OWNER_ID.slice(0, 8));
     });
 
     test("returns null for an unstamped footer", () => {
-        expect(parseOwnerId(formatFooter("30 seconds", null))).toBeNull();
+        expect(parseOwnerId(formatFooter(30, null))).toBeNull();
     });
 
     test("returns null for empty, null, and undefined input", () => {
@@ -55,6 +154,10 @@ describe("isDashboardEmbed", () => {
         expect(isDashboardEmbed(dashboardEmbed(null))).toBeTrue();
     });
 
+    test("still adopts a dashboard posted under the earlier title", () => {
+        expect(isDashboardEmbed({ title: "🧑‍🌾 Stardew Valley Server Status Dashboard" })).toBeTrue();
+    });
+
     test("rejects other embeds and missing embeds", () => {
         expect(isDashboardEmbed({ title: "Some other embed" })).toBeFalse();
         expect(isDashboardEmbed({ title: null })).toBeFalse();
@@ -70,22 +173,27 @@ describe("classifyDashboardEmbed", () => {
     });
 
     test("our stamp is mine", () => {
-        const embed = dashboardEmbed(formatFooter("30 seconds", OWNER_ID));
+        const embed = dashboardEmbed(formatFooter(30, OWNER_ID));
+        expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("mine");
+    });
+
+    test("a footer stamped with our full id is still mine", () => {
+        const embed = dashboardEmbed(`Automatically updates every 30 seconds • id:${OWNER_ID}`);
         expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("mine");
     });
 
     test("an unstamped dashboard is legacy", () => {
-        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter("30 seconds", null)), OWNER_ID)).toBe("legacy");
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, null)), OWNER_ID)).toBe("legacy");
         expect(classifyDashboardEmbed(dashboardEmbed(null), OWNER_ID)).toBe("legacy");
     });
 
     test("another deployment's stamp is foreign", () => {
-        const embed = dashboardEmbed(formatFooter("30 seconds", OTHER_ID));
+        const embed = dashboardEmbed(formatFooter(30, OTHER_ID));
         expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("foreign");
     });
 
     test("degraded mode adopts every dashboard by title, regardless of stamp", () => {
-        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter("30 seconds", OTHER_ID)), null)).toBe("mine");
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, OTHER_ID)), null)).toBe("mine");
         expect(classifyDashboardEmbed(dashboardEmbed(null), null)).toBe("mine");
     });
 

--- a/tools/discord-bot/src/dashboard.test.ts
+++ b/tools/discord-bot/src/dashboard.test.ts
@@ -14,6 +14,9 @@ import { resolveServerState, type ServerStatus } from "./discordState";
 
 const OWNER_ID = "3f2c8a1e-9b4d-4c6f-8a2e-1d5b7c9e0f3a";
 const OTHER_ID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d";
+const LAST_CHECKED = "1:30 PM";
+// A fixed "now" 3d 4h after ONLINE_STATUS.startedAtUtc, so uptime renders deterministically.
+const NOW = Date.parse("2026-01-01T00:00:00Z") + (3 * 1440 + 4 * 60) * 60000;
 
 function dashboardEmbed(footerText: string | null): EmbedLike {
     return {
@@ -49,40 +52,41 @@ const ONLINE_STATUS: ServerStatus = {
 describe("buildDashboardEmbed", () => {
     const FOOTER = "footer";
 
-    function fields(status: ServerStatus): Record<string, string> {
-        const embed = buildDashboardEmbed(status, resolveServerState(status), FOOTER).toJSON();
+    function fields(status: ServerStatus | null, lastKnown: ServerStatus | null = null): Record<string, string> {
+        const embed = buildDashboardEmbed(status, resolveServerState(status), FOOTER, lastKnown, NOW).toJSON();
         return Object.fromEntries((embed.fields ?? []).map((f) => [f.name, f.value]));
     }
 
-    test("online: one row of state, players, and date; one row of versions and tick rate; the invite code", () => {
-        const embed = buildDashboardEmbed(ONLINE_STATUS, resolveServerState(ONLINE_STATUS), FOOTER).toJSON();
+    test("online: headline with uptime, players/date inline, build version and invite full-width", () => {
+        const embed = buildDashboardEmbed(ONLINE_STATUS, resolveServerState(ONLINE_STATUS), FOOTER, null, NOW).toJSON();
         expect(embed.title).toBe(DASHBOARD_TITLE);
         expect(embed.footer?.text).toBe(FOOTER);
-        expect(embed.description).toBeUndefined();
+        expect(embed.description).toBe("**🟢 Online** · up 3d 4h");
+        expect(embed.color).toBe(resolveServerState(ONLINE_STATUS).color);
         expect(embed.fields?.map((f) => [f.name, f.inline])).toEqual([
-            ["Status", true],
             ["Players", true],
             ["In-game date", true],
-            ["Image", true],
-            ["Stardew", true],
-            ["Average TPS", true],
+            ["Build Version", false],
             ["Invite code", false],
         ]);
         expect(fields(ONLINE_STATUS)).toMatchObject({
-            Status: "Online",
-            Players: "**1** / 10",
-            "In-game date": "Spring 14, Year 1 · 6:50 AM",
-            Image: "`1.5.0-preview.134`",
-            Stardew: "`1.6.15`",
-            "Average TPS": "5.0",
+            Players: "`1 / 10`",
+            "In-game date": "`Spring 14, Year 1 · 6:50 AM`",
+            "Build Version": "`1.5.0-preview.134`",
             "Invite code": "`SGF0LUHHTYF5`",
         });
     });
 
-    test("busy shows the reason after the state, paused is marked on the players", () => {
-        const status = { ...ONLINE_STATUS, isReady: false, isPaused: true };
-        expect(fields(status).Status).toBe("Busy — Saving, changing day, or running an event.");
-        expect(fields(status).Players).toBe("**1** / 10 _(paused)_");
+    test("busy keeps the fields but leads with the busy headline and color", () => {
+        const status = { ...ONLINE_STATUS, isReady: false };
+        const embed = buildDashboardEmbed(status, resolveServerState(status), FOOTER, null, NOW).toJSON();
+        expect(embed.description).toBe("**🟠 Busy** · up 3d 4h");
+        expect(embed.color).toBe(resolveServerState(status).color);
+        expect(fields(status).Players).toBe("`1 / 10`");
+    });
+
+    test("a paused server is marked on the players value", () => {
+        expect(fields({ ...ONLINE_STATUS, isPaused: true }).Players).toBe("`1 / 10` _(paused)_");
     });
 
     test("the invite code is pending until the Steam lobby is published", () => {
@@ -90,51 +94,73 @@ describe("buildDashboardEmbed", () => {
     });
 
     test("a version the mod has not reported yet shows a dash", () => {
-        expect(fields({ ...ONLINE_STATUS, gameVersion: "" }).Stardew).toBe("—");
+        expect(fields({ ...ONLINE_STATUS, serverVersion: "" })["Build Version"]).toBe("—");
     });
 
-    test("not online: state and hint only, no fields", () => {
-        const embed = buildDashboardEmbed(null, resolveServerState(null), FOOTER).toJSON();
+    test("uptime is left off the headline when the server's start time is unknown", () => {
+        const status = { ...ONLINE_STATUS, startedAtUtc: null };
+        const embed = buildDashboardEmbed(status, resolveServerState(status), FOOTER, null, NOW).toJSON();
+        expect(embed.description).toBe("**🟢 Online**");
+    });
+
+    test("a state with no game data shows its hint in place of fields", () => {
+        const starting = { ...ONLINE_STATUS, isOnline: false, isReady: false, phase: "starting" };
+        const embed = buildDashboardEmbed(starting, resolveServerState(starting), FOOTER, null, NOW).toJSON();
+        expect(embed.description).toBe("**🟠 Starting**\n\nGame data appears once the save is loaded.");
         expect(embed.fields).toBeUndefined();
-        expect(embed.description).toBe(
-            "**Offline** — The server is offline.\n_No game data can be pulled right now. Check back later!_",
-        );
     });
 
-    test("no emoji anywhere in the embed", () => {
-        for (const status of [ONLINE_STATUS, null]) {
-            const json = JSON.stringify(buildDashboardEmbed(status, resolveServerState(status), FOOTER).toJSON());
-            expect(json).not.toMatch(/\p{Extended_Pictographic}/u);
-        }
+    test("offline without a last-known snapshot: headline + hint only, no fields", () => {
+        const embed = buildDashboardEmbed(null, resolveServerState(null), FOOTER).toJSON();
+        expect(embed.description).toBe("**🔴 Offline**\n\nNo game data can be pulled right now. Check back later!");
+        expect(embed.color).toBe(resolveServerState(null).color);
+        expect(embed.fields).toBeUndefined();
+    });
+
+    test("offline with a last-known snapshot shows its fields, without the invite", () => {
+        const embed = buildDashboardEmbed(null, resolveServerState(null), FOOTER, ONLINE_STATUS).toJSON();
+        expect(embed.description).toBe("**🔴 Offline**");
+        expect(embed.fields?.map((f) => f.name)).toEqual(["Players", "In-game date", "Build Version"]);
+        expect(fields(null, ONLINE_STATUS)).toMatchObject({
+            Players: "`1 / 10`",
+            "In-game date": "`Spring 14, Year 1 · 6:50 AM`",
+            "Build Version": "`1.5.0-preview.134`",
+        });
     });
 });
 
 describe("formatRefreshRate", () => {
     test("seconds unless the rate is a whole number of minutes", () => {
-        expect(formatRefreshRate(30)).toBe("30 seconds");
-        expect(formatRefreshRate(90)).toBe("90 seconds");
-        expect(formatRefreshRate(60)).toBe("1 minute");
-        expect(formatRefreshRate(120)).toBe("2 minutes");
+        expect(formatRefreshRate(30)).toBe("30s");
+        expect(formatRefreshRate(90)).toBe("90s");
+        expect(formatRefreshRate(60)).toBe("1m");
+        expect(formatRefreshRate(120)).toBe("2m");
     });
 });
 
 describe("formatFooter", () => {
-    test("stamps the owner id's prefix when present", () => {
-        expect(formatFooter(30, OWNER_ID)).toBe("Automatically updates every 30 seconds • id:3f2c8a1e");
+    test("cadence, last-checked time, and the owner id's prefix", () => {
+        expect(formatFooter(30, OWNER_ID, LAST_CHECKED)).toBe(
+            "↻ Updates every 30s · Last checked 1:30 PM · Server ID: 3f2c8a1e",
+        );
     });
 
-    test("omits the stamp in degraded mode", () => {
-        expect(formatFooter(120, null)).toBe("Automatically updates every 2 minutes");
+    test("omits the stamp when persistence is unavailable", () => {
+        expect(formatFooter(120, null, LAST_CHECKED)).toBe("↻ Updates every 2m · Last checked 1:30 PM");
     });
 });
 
 describe("parseOwnerId", () => {
     test("round-trips the stamp written by formatFooter", () => {
-        expect(parseOwnerId(formatFooter(30, OWNER_ID))).toBe(OWNER_ID.slice(0, 8));
+        expect(parseOwnerId(formatFooter(30, OWNER_ID, LAST_CHECKED))).toBe(OWNER_ID.slice(0, 8));
+    });
+
+    test("still reads the legacy footer format so older dashboards are re-adopted", () => {
+        expect(parseOwnerId("Automatically updates every 30 seconds • id:3f2c8a1e")).toBe("3f2c8a1e");
     });
 
     test("returns null for an unstamped footer", () => {
-        expect(parseOwnerId(formatFooter(30, null))).toBeNull();
+        expect(parseOwnerId(formatFooter(30, null, LAST_CHECKED))).toBeNull();
     });
 
     test("returns null for empty, null, and undefined input", () => {
@@ -144,8 +170,8 @@ describe("parseOwnerId", () => {
     });
 
     test("returns null when the separator is present but the id is empty", () => {
-        expect(parseOwnerId("Automatically updates every 30 seconds • id:")).toBeNull();
-        expect(parseOwnerId("Automatically updates every 30 seconds • id:   ")).toBeNull();
+        expect(parseOwnerId("↻ Updates every 30s · Last checked 1:30 PM · Server ID: ")).toBeNull();
+        expect(parseOwnerId("↻ Updates every 30s · Last checked 1:30 PM · Server ID:   ")).toBeNull();
     });
 });
 
@@ -173,27 +199,34 @@ describe("classifyDashboardEmbed", () => {
     });
 
     test("our stamp is mine", () => {
-        const embed = dashboardEmbed(formatFooter(30, OWNER_ID));
+        const embed = dashboardEmbed(formatFooter(30, OWNER_ID, LAST_CHECKED));
         expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("mine");
     });
 
     test("a footer stamped with our full id is still mine", () => {
-        const embed = dashboardEmbed(`Automatically updates every 30 seconds • id:${OWNER_ID}`);
+        const embed = dashboardEmbed(`↻ Updates every 30s · Last checked 1:30 PM · Server ID: ${OWNER_ID}`);
         expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("mine");
     });
 
     test("an unstamped dashboard is legacy", () => {
-        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, null)), OWNER_ID)).toBe("legacy");
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, null, LAST_CHECKED)), OWNER_ID)).toBe("legacy");
         expect(classifyDashboardEmbed(dashboardEmbed(null), OWNER_ID)).toBe("legacy");
     });
 
-    test("another deployment's stamp is foreign", () => {
-        const embed = dashboardEmbed(formatFooter(30, OTHER_ID));
-        expect(classifyDashboardEmbed(embed, OWNER_ID)).toBe("foreign");
+    test("another deployment's stamp is foreign, in the current and legacy formats", () => {
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, OTHER_ID, LAST_CHECKED)), OWNER_ID)).toBe(
+            "foreign",
+        );
+        expect(
+            classifyDashboardEmbed(
+                dashboardEmbed(`Automatically updates every 30 seconds • id:${OTHER_ID.slice(0, 8)}`),
+                OWNER_ID,
+            ),
+        ).toBe("foreign");
     });
 
     test("degraded mode adopts every dashboard by title, regardless of stamp", () => {
-        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, OTHER_ID)), null)).toBe("mine");
+        expect(classifyDashboardEmbed(dashboardEmbed(formatFooter(30, OTHER_ID, LAST_CHECKED)), null)).toBe("mine");
         expect(classifyDashboardEmbed(dashboardEmbed(null), null)).toBe("mine");
     });
 

--- a/tools/discord-bot/src/dashboard.ts
+++ b/tools/discord-bot/src/dashboard.ts
@@ -73,7 +73,9 @@ export function buildDashboardEmbed(
     lastKnown: ServerStatus | null = null,
     now: number = Date.now(),
 ): EmbedBuilder {
-    const hasLastKnown = !status?.isOnline && lastKnown !== null;
+    // Only an unreachable server (status null) falls back to the snapshot; a `starting`/`loading`
+    // server has its own no-game-data hint, so stale fields never masquerade as its live state.
+    const hasLastKnown = status === null && lastKnown !== null;
     // Uptime rides the headline beside the label (a live server only), like the docs widget's badge.
     const uptime = status?.isOnline && status.startedAtUtc ? ` · up ${formatUptime(status.startedAtUtc, now)}` : "";
     const headline = `**${state.emoji} ${state.label}**${uptime}`;

--- a/tools/discord-bot/src/dashboard.ts
+++ b/tools/discord-bot/src/dashboard.ts
@@ -5,21 +5,30 @@
 
 import { type APIEmbedField, EmbedBuilder } from "discord.js";
 import type { DiscordServerState } from "./discordState";
-import { formatStardewDate, formatStardewTime, joinableInviteCode, type ServerStatus } from "./serverState";
+import {
+    formatStardewDate,
+    formatStardewTime,
+    formatUptime,
+    joinableInviteCode,
+    type ServerStatus,
+} from "./serverState";
 
 export const DASHBOARD_TITLE = "Server Status";
 
 /** Dashboards posted under this title are still adopted; the next edit gives them the current one. */
 const LEGACY_DASHBOARD_TITLE = "🧑‍🌾 Stardew Valley Server Status Dashboard";
 
-const FOOTER_ID_SEPARATOR = " • id:";
+const OWNER_ID_SEPARATOR = " · Server ID: ";
+// Footers written before the redesign used this; still recognized so the bot re-adopts and
+// re-stamps its own older dashboards (and still detects foreign ones) instead of duplicating.
+const LEGACY_OWNER_ID_SEPARATOR = " • id:";
 
 /** Footer stamp length: a UUID prefix keeps the footer short and is unique enough among the handful of deployments sharing a channel. */
 const STAMP_LENGTH = 8;
 
-/** Headline for a state: the label alone while online, otherwise with the reason. */
+/** State line for the text `!status` reply: the label while online, otherwise with the reason. */
 export function formatStateLine(state: DiscordServerState): string {
-    return state.kind === "online" ? state.label : `${state.label} — ${state.detail}`;
+    return state.kind === "online" ? state.label : `${state.label}: ${state.detail}`;
 }
 
 /** Version strings as code chips; a version the mod has not reported yet shows a dash. */
@@ -28,54 +37,68 @@ function versionChip(version: string): string {
 }
 
 /**
- * The status fields of a running server, shared by the dashboard embed and the `!status`
- * reply. Laid out like the docs site's status widget: state, players, and in-game date on
- * one row, versions and tick rate on the next, and the invite code across the full width.
+ * The fields of a running server: Players and in-game date share the top row (inline), while the
+ * build version and the invite code each take a full-width row. A last-known snapshot passes
+ * `includeInvite: false` (the invite only makes sense for a reachable server).
  */
-export function buildStatusFields(status: ServerStatus, state: DiscordServerState): APIEmbedField[] {
-    const players = `**${status.playerCount}** / ${status.maxPlayers}${status.isPaused ? " _(paused)_" : ""}`;
-    const date = `${formatStardewDate(status)} · ${formatStardewTime(status.timeOfDay)}`;
-    const inviteCode = joinableInviteCode(status);
-    return [
-        { name: "Status", value: formatStateLine(state), inline: true },
+export function buildStatusFields(status: ServerStatus, includeInvite = true): APIEmbedField[] {
+    const players = `\`${status.playerCount} / ${status.maxPlayers}\`${status.isPaused ? " _(paused)_" : ""}`;
+    const date = `\`${formatStardewDate(status)} · ${formatStardewTime(status.timeOfDay)}\``;
+    const fields: APIEmbedField[] = [
         { name: "Players", value: players, inline: true },
         { name: "In-game date", value: date, inline: true },
-        { name: "Image", value: versionChip(status.serverVersion), inline: true },
-        { name: "Stardew", value: versionChip(status.gameVersion), inline: true },
-        { name: "Average TPS", value: status.tps.toFixed(1), inline: true },
-        { name: "Invite code", value: inviteCode ? `\`${inviteCode}\`` : "_not yet available_", inline: false },
+        { name: "Build Version", value: versionChip(status.serverVersion), inline: false },
     ];
+    if (includeInvite) {
+        const inviteCode = joinableInviteCode(status);
+        fields.push({
+            name: "Invite code",
+            value: inviteCode ? `\`${inviteCode}\`` : "_not yet available_",
+            inline: false,
+        });
+    }
+    return fields;
 }
 
-/** The dashboard embed for a /status response (null when unreachable). */
+/**
+ * The dashboard embed. Every state leads with a `dot label` headline; a live server appends its
+ * uptime. A running server adds its live fields, an unreachable one falls back to the last-known
+ * snapshot (`lastKnown`) once the bot has seen the server online, and a server with no game data
+ * yet shows the state's hint in place of fields.
+ */
 export function buildDashboardEmbed(
     status: ServerStatus | null,
     state: DiscordServerState,
     footerText: string,
+    lastKnown: ServerStatus | null = null,
+    now: number = Date.now(),
 ): EmbedBuilder {
+    const hasLastKnown = !status?.isOnline && lastKnown !== null;
+    // Uptime rides the headline beside the label (a live server only), like the docs widget's badge.
+    const uptime = status?.isOnline && status.startedAtUtc ? ` · up ${formatUptime(status.startedAtUtc, now)}` : "";
+    const headline = `**${state.emoji} ${state.label}**${uptime}`;
     const embed = new EmbedBuilder()
         .setTitle(DASHBOARD_TITLE)
         .setColor(state.color)
-        .setTimestamp()
-        .setFooter({ text: footerText });
+        .setFooter({ text: footerText })
+        .setDescription(headline);
 
-    if (!status?.isOnline) {
-        const lines = [`**${state.label}** — ${state.detail}`];
-        if (state.hint) {
-            lines.push(`_${state.hint}_`);
-        }
-        return embed.setDescription(lines.join("\n"));
+    if (status?.isOnline) {
+        return embed.addFields(buildStatusFields(status));
     }
-    return embed.addFields(buildStatusFields(status, state));
+    if (hasLastKnown && lastKnown) {
+        return embed.addFields(buildStatusFields(lastKnown, false));
+    }
+    // No game data to show yet: the hint explains what the reader is waiting for.
+    if (state.hint) {
+        embed.setDescription(`${headline}\n\n${state.hint}`);
+    }
+    return embed;
 }
 
-/** "30 seconds", "1 minute", "2 minutes"; a rate that is not a whole number of minutes stays in seconds. */
+/** Compact refresh cadence for the footer: "30s", "1m", "2m". */
 export function formatRefreshRate(seconds: number): string {
-    if (seconds % 60 !== 0) {
-        return `${seconds} seconds`;
-    }
-    const minutes = seconds / 60;
-    return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+    return seconds % 60 === 0 ? `${seconds / 60}m` : `${seconds}s`;
 }
 
 /**
@@ -128,25 +151,32 @@ export interface EmbedLike {
 }
 
 /**
- * Builds the dashboard footer text, stamped with the owner id's prefix. When `ownerId` is
- * null (degraded mode, persistence unavailable) no ownership stamp is included.
+ * The dashboard footer: refresh cadence, when the status was last checked, and the deployment's
+ * ownership stamp. When `ownerId` is null (persistence unavailable) the stamp is omitted.
  */
-export function formatFooter(refreshSeconds: number, ownerId: string | null): string {
-    const base = `Automatically updates every ${formatRefreshRate(refreshSeconds)}`;
-    return ownerId ? `${base}${FOOTER_ID_SEPARATOR}${ownerId.slice(0, STAMP_LENGTH)}` : base;
+export function formatFooter(refreshSeconds: number, ownerId: string | null, lastChecked: string): string {
+    const parts = [`↻ Updates every ${formatRefreshRate(refreshSeconds)}`, `Last checked ${lastChecked}`];
+    if (ownerId) {
+        parts.push(`Server ID: ${ownerId.slice(0, STAMP_LENGTH)}`);
+    }
+    return parts.join(" · ");
 }
 
-/** Extracts the ownership stamp from a footer text, or null if none is present. */
+/** Extracts the ownership stamp from a footer, trying the current format then the legacy one. */
 export function parseOwnerId(footerText: string | null | undefined): string | null {
     if (!footerText) {
         return null;
     }
-    const index = footerText.lastIndexOf(FOOTER_ID_SEPARATOR);
-    if (index === -1) {
-        return null;
+    for (const separator of [OWNER_ID_SEPARATOR, LEGACY_OWNER_ID_SEPARATOR]) {
+        const index = footerText.lastIndexOf(separator);
+        if (index !== -1) {
+            const id = footerText.slice(index + separator.length).trim();
+            if (id.length > 0) {
+                return id;
+            }
+        }
     }
-    const id = footerText.slice(index + FOOTER_ID_SEPARATOR.length).trim();
-    return id.length > 0 ? id : null;
+    return null;
 }
 
 /** A message is a dashboard iff its first embed carries the dashboard title. */

--- a/tools/discord-bot/src/dashboard.ts
+++ b/tools/discord-bot/src/dashboard.ts
@@ -1,11 +1,82 @@
 /**
- * Pure helpers for dashboard message ownership: footer stamping, owner-id parsing,
- * and classifying channel messages during the adoption scan.
+ * Pure helpers for the dashboard message: building the embed, footer stamping, owner-id
+ * parsing, and classifying channel messages during the adoption scan.
  */
 
-export const DASHBOARD_TITLE = "🧑‍🌾 Stardew Valley Server Status Dashboard";
+import { type APIEmbedField, EmbedBuilder } from "discord.js";
+import type { DiscordServerState } from "./discordState";
+import { formatStardewDate, formatStardewTime, joinableInviteCode, type ServerStatus } from "./serverState";
+
+export const DASHBOARD_TITLE = "Server Status";
+
+/** Dashboards posted under this title are still adopted; the next edit gives them the current one. */
+const LEGACY_DASHBOARD_TITLE = "🧑‍🌾 Stardew Valley Server Status Dashboard";
 
 const FOOTER_ID_SEPARATOR = " • id:";
+
+/** Footer stamp length: a UUID prefix keeps the footer short and is unique enough among the handful of deployments sharing a channel. */
+const STAMP_LENGTH = 8;
+
+/** Headline for a state: the label alone while online, otherwise with the reason. */
+export function formatStateLine(state: DiscordServerState): string {
+    return state.kind === "online" ? state.label : `${state.label} — ${state.detail}`;
+}
+
+/** Version strings as code chips; a version the mod has not reported yet shows a dash. */
+function versionChip(version: string): string {
+    return version ? `\`${version}\`` : "—";
+}
+
+/**
+ * The status fields of a running server, shared by the dashboard embed and the `!status`
+ * reply. Laid out like the docs site's status widget: state, players, and in-game date on
+ * one row, versions and tick rate on the next, and the invite code across the full width.
+ */
+export function buildStatusFields(status: ServerStatus, state: DiscordServerState): APIEmbedField[] {
+    const players = `**${status.playerCount}** / ${status.maxPlayers}${status.isPaused ? " _(paused)_" : ""}`;
+    const date = `${formatStardewDate(status)} · ${formatStardewTime(status.timeOfDay)}`;
+    const inviteCode = joinableInviteCode(status);
+    return [
+        { name: "Status", value: formatStateLine(state), inline: true },
+        { name: "Players", value: players, inline: true },
+        { name: "In-game date", value: date, inline: true },
+        { name: "Image", value: versionChip(status.serverVersion), inline: true },
+        { name: "Stardew", value: versionChip(status.gameVersion), inline: true },
+        { name: "Average TPS", value: status.tps.toFixed(1), inline: true },
+        { name: "Invite code", value: inviteCode ? `\`${inviteCode}\`` : "_not yet available_", inline: false },
+    ];
+}
+
+/** The dashboard embed for a /status response (null when unreachable). */
+export function buildDashboardEmbed(
+    status: ServerStatus | null,
+    state: DiscordServerState,
+    footerText: string,
+): EmbedBuilder {
+    const embed = new EmbedBuilder()
+        .setTitle(DASHBOARD_TITLE)
+        .setColor(state.color)
+        .setTimestamp()
+        .setFooter({ text: footerText });
+
+    if (!status?.isOnline) {
+        const lines = [`**${state.label}** — ${state.detail}`];
+        if (state.hint) {
+            lines.push(`_${state.hint}_`);
+        }
+        return embed.setDescription(lines.join("\n"));
+    }
+    return embed.addFields(buildStatusFields(status, state));
+}
+
+/** "30 seconds", "1 minute", "2 minutes"; a rate that is not a whole number of minutes stays in seconds. */
+export function formatRefreshRate(seconds: number): string {
+    if (seconds % 60 !== 0) {
+        return `${seconds} seconds`;
+    }
+    const minutes = seconds / 60;
+    return minutes === 1 ? "1 minute" : `${minutes} minutes`;
+}
 
 /**
  * Persisted dashboard state. `ownerId` is this deployment's identity, stamped into every
@@ -57,12 +128,12 @@ export interface EmbedLike {
 }
 
 /**
- * Builds the dashboard footer text. When `ownerId` is null (degraded mode,
- * persistence unavailable) no ownership stamp is included.
+ * Builds the dashboard footer text, stamped with the owner id's prefix. When `ownerId` is
+ * null (degraded mode, persistence unavailable) no ownership stamp is included.
  */
-export function formatFooter(refreshRateFormatted: string, ownerId: string | null): string {
-    const base = `Automatically updates every ${refreshRateFormatted}`;
-    return ownerId ? `${base}${FOOTER_ID_SEPARATOR}${ownerId}` : base;
+export function formatFooter(refreshSeconds: number, ownerId: string | null): string {
+    const base = `Automatically updates every ${formatRefreshRate(refreshSeconds)}`;
+    return ownerId ? `${base}${FOOTER_ID_SEPARATOR}${ownerId.slice(0, STAMP_LENGTH)}` : base;
 }
 
 /** Extracts the ownership stamp from a footer text, or null if none is present. */
@@ -80,7 +151,7 @@ export function parseOwnerId(footerText: string | null | undefined): string | nu
 
 /** A message is a dashboard iff its first embed carries the dashboard title. */
 export function isDashboardEmbed(embed: EmbedLike | null | undefined): boolean {
-    return embed?.title === DASHBOARD_TITLE;
+    return embed?.title === DASHBOARD_TITLE || embed?.title === LEGACY_DASHBOARD_TITLE;
 }
 
 /**
@@ -111,5 +182,6 @@ export function classifyDashboardEmbed(
     if (stamp === null) {
         return "legacy";
     }
-    return stamp === ownerId ? "mine" : "foreign";
+    // Prefix match: footers written before the stamp was shortened carry the full id.
+    return ownerId.startsWith(stamp) ? "mine" : "foreign";
 }

--- a/tools/discord-bot/src/discordState.ts
+++ b/tools/discord-bot/src/discordState.ts
@@ -1,6 +1,6 @@
 /** Discord presentation of a server state: status emoji, presence, and embed color. */
 
-import { Colors, type PresenceStatusData } from "discord.js";
+import type { PresenceStatusData } from "discord.js";
 import {
     resolveServerState as resolveSharedState,
     type ServerState,
@@ -11,18 +11,20 @@ import {
 export type { ServerStateKind, ServerStatus, StatusSignals } from "./serverState";
 
 export interface DiscordServerState extends ServerState {
-    /** Colored dot for the presence line; the dashboard embed shows `color` instead. */
+    /** Status dot on the embed headline; its color matches `color` so the dot and accent bar read as one. */
     emoji: string;
     presence: PresenceStatusData;
     color: number;
 }
 
+// Each color is the Twemoji hex of that state's headline dot (the emoji Discord renders), so the
+// accent bar matches the dot exactly. Resync if the dot glyphs ever change.
 const presentation: Record<ServerStateKind, Pick<DiscordServerState, "emoji" | "presence" | "color">> = {
-    online: { emoji: "🟢", presence: "online", color: Colors.Blue },
-    busy: { emoji: "🟡", presence: "online", color: Colors.Yellow },
-    loading: { emoji: "🟡", presence: "idle", color: Colors.Yellow },
-    provisioning: { emoji: "🟠", presence: "idle", color: Colors.Orange },
-    offline: { emoji: "🔴", presence: "dnd", color: Colors.Red },
+    online: { emoji: "🟢", presence: "online", color: 0x78b159 },
+    busy: { emoji: "🟠", presence: "online", color: 0xf4900c },
+    loading: { emoji: "🟡", presence: "idle", color: 0xfdcb58 },
+    provisioning: { emoji: "🟠", presence: "idle", color: 0xf4900c },
+    offline: { emoji: "🔴", presence: "dnd", color: 0xdd2e44 },
 };
 
 export function resolveServerState(status: StatusSignals | null): DiscordServerState {

--- a/tools/discord-bot/src/discordState.ts
+++ b/tools/discord-bot/src/discordState.ts
@@ -1,4 +1,4 @@
-/** Discord presentation of a server state: emoji label, presence, and embed color. */
+/** Discord presentation of a server state: status emoji, presence, and embed color. */
 
 import { Colors, type PresenceStatusData } from "discord.js";
 import {
@@ -11,11 +11,13 @@ import {
 export type { ServerStateKind, ServerStatus, StatusSignals } from "./serverState";
 
 export interface DiscordServerState extends ServerState {
+    /** Colored dot for the presence line; the dashboard embed shows `color` instead. */
+    emoji: string;
     presence: PresenceStatusData;
     color: number;
 }
 
-const presentation: Record<ServerStateKind, { emoji: string; presence: PresenceStatusData; color: number }> = {
+const presentation: Record<ServerStateKind, Pick<DiscordServerState, "emoji" | "presence" | "color">> = {
     online: { emoji: "🟢", presence: "online", color: Colors.Blue },
     busy: { emoji: "🟡", presence: "online", color: Colors.Yellow },
     loading: { emoji: "🟡", presence: "idle", color: Colors.Yellow },
@@ -25,6 +27,5 @@ const presentation: Record<ServerStateKind, { emoji: string; presence: PresenceS
 
 export function resolveServerState(status: StatusSignals | null): DiscordServerState {
     const state = resolveSharedState(status);
-    const { emoji, presence, color } = presentation[state.kind];
-    return { ...state, label: `${emoji} ${state.label}`, presence, color };
+    return { ...state, ...presentation[state.kind] };
 }

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -7,7 +7,7 @@ import {
     DiscordAPIError,
     DiscordjsError,
     DiscordjsErrorCodes,
-    EmbedBuilder,
+    type EmbedBuilder,
     Events,
     GatewayCloseCodes,
     GatewayIntentBits,
@@ -21,16 +21,18 @@ import {
 } from "discord.js";
 import { type ChannelRef, describeChannelRef, matchesChannelRef, parseChannelRef } from "./channels";
 import {
+    buildDashboardEmbed,
+    buildStatusFields,
     classifyDashboardEmbed,
-    DASHBOARD_TITLE,
     type DashboardMessageKind,
     formatFooter,
+    formatStateLine,
     parseDashboardState,
     parseOwnerId,
 } from "./dashboard";
 import { resolveServerState, type ServerStatus } from "./discordState";
 import { createLogger, log } from "./log";
-import { formatStardewTime, joinableInviteCode } from "./serverState";
+import { joinableInviteCode } from "./serverState";
 
 // Configuration from environment
 const DISCORD_BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -39,11 +41,12 @@ const API_KEY = process.env.API_KEY || "";
 const WS_URL = process.env.WS_URL || `${API_URL.replace("http://", "ws://").replace("https://", "wss://")}/ws`;
 const CHAT_CHANNEL = parseChannelRef(process.env.DISCORD_CHAT_CHANNEL);
 const DASHBOARD_CHANNEL = parseChannelRef(process.env.STATUS_DASHBOARD_CHANNEL);
-const STATUS_DASHBOARD_REFRESH_RATE = Number(process.env.STATUS_DASHBOARD_REFRESH_RATE) || 30;
-const STATUS_DASHBOARD_REFRESH_RATE_FORMATTED =
-    STATUS_DASHBOARD_REFRESH_RATE < 60
-        ? `${STATUS_DASHBOARD_REFRESH_RATE} seconds`
-        : `${Math.round(STATUS_DASHBOARD_REFRESH_RATE / 60)} minutes`;
+// Every update edits one message per channel; the same floor as the presence keeps Discord's rate limits at bay.
+const MIN_STATUS_DASHBOARD_REFRESH_RATE = 20;
+const STATUS_DASHBOARD_REFRESH_RATE = Math.max(
+    Number(process.env.STATUS_DASHBOARD_REFRESH_RATE) || 30,
+    MIN_STATUS_DASHBOARD_REFRESH_RATE,
+);
 const COOLDOWN_DURATION_MS = 30000;
 const MAX_COMMANDS_PER_WINDOW = 10;
 const commandHistory = new Map<string, number[]>();
@@ -245,7 +248,7 @@ async function updatePresence(): Promise<void> {
         activityName = `${presenceShowsVersion ? version : playerInfo} | ${inviteCode}`;
         presenceSummary = `${playerInfo} | ${version} | ${inviteCode}`;
     } else {
-        activityName = `${state.label} — ${state.detail}`;
+        activityName = `${state.emoji} ${state.label} — ${state.detail}`;
         presenceSummary = activityName;
     }
 
@@ -576,54 +579,10 @@ function clearTrackedMessage(channelId: string): void {
 }
 
 /** Builds the dashboard embed from the current server status. */
-async function buildDashboardEmbed(): Promise<EmbedBuilder> {
-    const status: ServerStatus | null = await fetchServerStatus();
-    const state = resolveServerState(status);
-
-    const embed = new EmbedBuilder()
-        .setTitle(DASHBOARD_TITLE)
-        .setTimestamp()
-        .setFooter({ text: formatFooter(STATUS_DASHBOARD_REFRESH_RATE_FORMATTED, dashboardState.ownerId) });
-
-    if (!status?.isOnline) {
-        embed.setColor(state.color).setDescription(`${state.label} — **${state.detail}**\n\n_${state.hint}_`);
-    } else {
-        const seasonEmojis: Record<string, string> = {
-            spring: "🌸 Spring",
-            summer: "☀️ Summer",
-            fall: "🍂 Fall",
-            winter: "❄️ Winter",
-        };
-        const formattedSeason = seasonEmojis[status.season?.toLowerCase()] || status.season;
-
-        embed.setColor(state.color).addFields(
-            { name: "🏡 Farm Name", value: status.farmName || "Our Farm", inline: true },
-            { name: "🗺️ Farm Layout", value: getFarmTypeName(status.farmTypeKey), inline: true },
-            {
-                name: "📶 Server Status",
-                value: status.isReady ? "✅ Ready & Running" : `⏳ ${state.detail}`,
-                inline: true,
-            },
-            {
-                name: "👥 Active Players",
-                value: `**${status.playerCount} / ${status.maxPlayers}** ${status.isPaused ? "_(Paused)_" : ""}`,
-                inline: true,
-            },
-            {
-                name: "📅 In-Game Date",
-                value: `Year ${status.year}, ${formattedSeason}, Day ${status.day}`,
-                inline: true,
-            },
-            { name: "⏰ Clock Time", value: formatStardewTime(status.timeOfDay), inline: true },
-            {
-                name: "🔑 Invite Code",
-                value: `\`${joinableInviteCode(status) ?? "None Available"}\``,
-                inline: false,
-            },
-        );
-    }
-
-    return embed;
+async function fetchDashboardEmbed(): Promise<EmbedBuilder> {
+    const status = await fetchServerStatus();
+    const footer = formatFooter(STATUS_DASHBOARD_REFRESH_RATE, dashboardState.ownerId);
+    return buildDashboardEmbed(status, resolveServerState(status), footer);
 }
 
 /** Interval entry point: updates the dashboard in every matching channel, skipping ticks that overlap. */
@@ -633,7 +592,7 @@ async function updateLiveDashboard(): Promise<void> {
     }
     dashboardUpdateInFlight = true;
     try {
-        const embed = await buildDashboardEmbed();
+        const embed = await fetchDashboardEmbed();
         for (const channel of resolveChannels(DASHBOARD_CHANNEL)) {
             try {
                 await runDashboardUpdate(channel, embed);
@@ -748,21 +707,6 @@ async function runDashboardUpdate(channel: PostableChannel, embed: EmbedBuilder)
     }
 }
 
-// Helper to match Stardew Farm types cleanly
-function getFarmTypeName(key: string): string {
-    const types: Record<string, string> = {
-        Standard: "Standard 🌾",
-        Riverland: "Riverland 🐟",
-        Forest: "Forest 🌲",
-        Hilltop: "Hilltop ⛏️",
-        Wilderness: "Wilderness 🦁",
-        FourCorners: "Four Corners 🗺️",
-        Beach: "Beach 🏖️",
-        MeadowlandsFarm: "Meadowlands 🐓",
-    };
-    return types[key] || key || "Unknown Type";
-}
-
 // ============================================================================
 // MAIN MESSAGE EVENT ROUTER (Commands + Chat Relay)
 // ============================================================================
@@ -815,10 +759,7 @@ client.on(Events.MessageCreate, async (message: Message) => {
     const input = inOwnChannel ? null : parseCommand(message);
     if (input) {
         if (isRateLimited(message.author.id)) {
-            const warning = await reply(
-                message,
-                "⏳ **Whoa, slow down!** You're sending commands too quickly. Please wait a bit before trying again.",
-            );
+            const warning = await reply(message, "Too many commands; please wait a moment before trying again.");
             if (warning) {
                 setTimeout(() => warning.delete().catch(() => {}), 5000);
             }
@@ -832,31 +773,14 @@ client.on(Events.MessageCreate, async (message: Message) => {
                 const state = resolveServerState(status);
 
                 if (!status?.isOnline) {
-                    await reply(message, `**Server Status:** ${state.label} — ${state.detail}`);
+                    await reply(message, `**Status:** ${formatStateLine(state)}`);
                     return;
                 }
 
-                const seasonEmojis: Record<string, string> = {
-                    spring: "🌸 Spring",
-                    summer: "☀️ Summer",
-                    fall: "🍂 Fall",
-                    winter: "❄️ Winter",
-                };
-                const formattedSeason = seasonEmojis[status.season?.toLowerCase()] || status.season;
-
-                const lines = [
-                    `🏡 **Farm Name:** ${status.farmName}`,
-                    `🗺️ **Farm Type:** ${getFarmTypeName(status.farmTypeKey)}`,
-                    `👥 **Players:** ${status.playerCount}/${status.maxPlayers} ${status.isPaused ? "(⏸️ Paused)" : "(▶️ Live)"}`,
-                    `📅 **Date:** Day ${status.day} of ${formattedSeason}, Year ${status.year}`,
-                    `⏰ **Time:** ${formatStardewTime(status.timeOfDay)}`,
-                    `📡 **Server State:** ${status.isReady ? "Ready ✓" : `Busy (${state.detail}) ⏳`}`,
-                    `🔑 **Invite Code:** \`${joinableInviteCode(status) ?? "None"}\``,
-                ];
-
+                const lines = buildStatusFields(status, state).map((field) => `**${field.name}:** ${field.value}`);
                 await reply(message, lines.join("\n"));
             } catch (_e) {
-                await reply(message, "⚠️ Failed to load server status.");
+                await reply(message, "Could not load the server status.");
             }
             return;
         }
@@ -874,22 +798,16 @@ client.on(Events.MessageCreate, async (message: Message) => {
                     ),
                 ]);
 
-                const onlineList = playersRes.players.filter((p) => p.isOnline).map((p) => `• 🟢 **${p.name}**`);
+                const online = playersRes.players.filter((p) => p.isOnline).map((p) => p.name);
 
                 const lines = [
-                    `📊 **Roster Information**`,
-                    `━━━━━━━━━━━━━━━━━━━━━━━━`,
-                    `🟢 **Online Now (${onlineList.length}):**`,
-                    onlineList.length ? onlineList.join("\n") : "• Nobody online",
-                    `\n🛖 **Cabin Strategy & Real Estate:**`,
-                    `• Total Cabins Built: **${cabinsRes.totalCount}**`,
-                    `• Assigned to Players: **${cabinsRes.assignedCount}**`,
-                    `• Available Vacancies: **${cabinsRes.availableCount}**`,
+                    `**Online (${online.length}):** ${online.length ? online.join(", ") : "nobody"}`,
+                    `**Cabins:** ${cabinsRes.totalCount} built, ${cabinsRes.assignedCount} assigned, ${cabinsRes.availableCount} available`,
                 ];
 
                 await reply(message, lines.join("\n"));
             } catch (_e) {
-                await reply(message, "⚠️ Failed to parse player lists and cabin layouts.");
+                await reply(message, "Could not load the player list.");
             }
             return;
         }
@@ -906,23 +824,18 @@ client.on(Events.MessageCreate, async (message: Message) => {
                 ]);
 
                 const lines = [
-                    `⚙️ **Server Configuration & Telemetry**`,
-                    `━━━━━━━━━━━━━━━━━━━━━━━━`,
-                    `🖥️ **Performance Metrics:**`,
-                    `• Tick Speed: **${stats.tps.toFixed(1)} / ${stats.targetTps} TPS** (Ticks Per Sec)`,
-                    `• (Web)VNC Frame Rate: **${stats.fps.toFixed(1)} FPS**`,
-                    `• Average Tick Time: **${stats.avgTickMs.toFixed(2)} ms**`,
-                    `• Ram Overhead: **${stats.memoryMb.toFixed(1)} MB**`,
-                    `\n🛠️ **Gameplay Rules:**`,
-                    `• Wallet-Type: **${settings.server.separateWallets ? "💰 Separate Wallets" : "🤝 Shared Wallet"}**`,
-                    `• Profit Margin Multiplier: **${settings.game.profitMargin}x**`,
-                    `• Night Monsters Spawn: **${settings.game.spawnMonstersAtNight}**`,
-                    `• Cabin Strategy: \`${settings.server.cabinStrategy}\` ([Learn More](https://docs.junimoserver.com/features/cabin-strategies.html#cabinstack-default))`,
+                    `**Tick rate:** ${stats.tps.toFixed(1)} / ${stats.targetTps} TPS, ${stats.avgTickMs.toFixed(2)} ms per tick`,
+                    `**Frame rate:** ${stats.fps.toFixed(1)} FPS`,
+                    `**Memory:** ${stats.memoryMb.toFixed(1)} MB`,
+                    `**Wallets:** ${settings.server.separateWallets ? "separate" : "shared"}`,
+                    `**Profit margin:** ${settings.game.profitMargin}x`,
+                    `**Monsters at night:** ${settings.game.spawnMonstersAtNight}`,
+                    `**Cabin strategy:** \`${settings.server.cabinStrategy}\` (<https://docs.junimoserver.com/features/cabin-strategies>)`,
                 ];
 
                 await reply(message, lines.join("\n"));
             } catch (_e) {
-                await reply(message, "⚠️ Failed to retrieve system performance diagnostics.");
+                await reply(message, "Could not load the server settings.");
             }
             return;
         }
@@ -930,11 +843,11 @@ client.on(Events.MessageCreate, async (message: Message) => {
         // COMMAND: !help
         if (input === "!help") {
             const helpLines = [
-                `🤖 **Stardew Server Bot Commands** (mention me, e.g. <@${client.user?.id}> !status):`,
-                `• \`!status\` - View current farm date, time, player count, and the invite code.`,
-                `• \`!players\` - List who is online, and cabin availability.`,
-                `• \`!server\` - Check hardware telemetry (TPS/FPS/RAM) and farm settings.`,
-                `• \`!help\` - Display this command map.`,
+                `**Commands** (mention me, e.g. <@${client.user?.id}> !status):`,
+                `\`!status\` - server state, players, in-game date, versions, tick rate, and the invite code`,
+                `\`!players\` - who is online, and cabin availability`,
+                `\`!server\` - tick rate, memory, and gameplay settings`,
+                `\`!help\` - this list`,
             ];
             await reply(message, helpLines.join("\n"));
             return;
@@ -1141,7 +1054,9 @@ client.once(Events.ClientReady, async () => {
         log.info(`Chat relay channel: ${describeChannelRef(CHAT_CHANNEL)}`);
     }
     if (DASHBOARD_CHANNEL) {
-        log.info(`Status dashboard channel: ${describeChannelRef(DASHBOARD_CHANNEL)}`);
+        log.info(
+            `Status dashboard channel: ${describeChannelRef(DASHBOARD_CHANNEL)}, updating every ${STATUS_DASHBOARD_REFRESH_RATE}s`,
+        );
     }
 
     // Perform startup checks

--- a/tools/discord-bot/src/index.ts
+++ b/tools/discord-bot/src/index.ts
@@ -187,6 +187,9 @@ function startHeartbeat(): void {
 // Polled by several callers, so only reachability changes are logged.
 let statusFetchFailure: string | null | undefined;
 
+// The last status seen with live game data; shown on the dashboard while the server is unreachable.
+let lastKnownStatus: ServerStatus | null = null;
+
 /**
  * Fetches the server status from the HTTP API.
  */
@@ -204,6 +207,9 @@ async function fetchServerStatus(): Promise<ServerStatus | null> {
 
         const status = await response.json();
         reportStatusFetch(null);
+        if (status?.isOnline) {
+            lastKnownStatus = status;
+        }
         return status;
     } catch (error) {
         reportStatusFetch(error instanceof Error ? error.message : String(error));
@@ -241,14 +247,15 @@ async function updatePresence(): Promise<void> {
     let presenceSummary: string;
 
     if (state.kind === "online" && status) {
-        const playerInfo = `${status.playerCount}/${status.maxPlayers} players`;
+        const players = `${status.playerCount}/${status.maxPlayers} players`;
         const version = `v${status.serverVersion}`;
-        const inviteCode = joinableInviteCode(status) ?? "No code";
+        const invite = joinableInviteCode(status);
         presenceShowsVersion = !presenceShowsVersion;
-        activityName = `${presenceShowsVersion ? version : playerInfo} | ${inviteCode}`;
-        presenceSummary = `${playerInfo} | ${version} | ${inviteCode}`;
+        const lead = presenceShowsVersion ? version : players;
+        activityName = invite ? `${lead}, code ${invite}` : lead;
+        presenceSummary = invite ? `${players}, ${version}, code ${invite}` : `${players}, ${version}`;
     } else {
-        activityName = `${state.emoji} ${state.label} — ${state.detail}`;
+        activityName = state.detail;
         presenceSummary = activityName;
     }
 
@@ -581,8 +588,9 @@ function clearTrackedMessage(channelId: string): void {
 /** Builds the dashboard embed from the current server status. */
 async function fetchDashboardEmbed(): Promise<EmbedBuilder> {
     const status = await fetchServerStatus();
-    const footer = formatFooter(STATUS_DASHBOARD_REFRESH_RATE, dashboardState.ownerId);
-    return buildDashboardEmbed(status, resolveServerState(status), footer);
+    const lastChecked = new Date().toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    const footer = formatFooter(STATUS_DASHBOARD_REFRESH_RATE, dashboardState.ownerId, lastChecked);
+    return buildDashboardEmbed(status, resolveServerState(status), footer, lastKnownStatus);
 }
 
 /** Interval entry point: updates the dashboard in every matching channel, skipping ticks that overlap. */
@@ -777,7 +785,10 @@ client.on(Events.MessageCreate, async (message: Message) => {
                     return;
                 }
 
-                const lines = buildStatusFields(status, state).map((field) => `**${field.name}:** ${field.value}`);
+                const lines = [
+                    `**Status:** ${formatStateLine(state)}`,
+                    ...buildStatusFields(status).map((field) => `**${field.name}:** ${field.value}`),
+                ];
                 await reply(message, lines.join("\n"));
             } catch (_e) {
                 await reply(message, "Could not load the server status.");

--- a/tools/discord-bot/src/serverState.test.ts
+++ b/tools/discord-bot/src/serverState.test.ts
@@ -1,5 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { formatStardewTime, joinableInviteCode } from "./serverState";
+import { formatStardewDate, formatStardewTime, joinableInviteCode } from "./serverState";
+
+describe("formatStardewDate", () => {
+    test("capitalized season, day, and year", () => {
+        expect(formatStardewDate({ season: "spring", day: 14, year: 1 })).toBe("Spring 14, Year 1");
+    });
+
+    test("tolerates a missing season", () => {
+        expect(formatStardewDate({ season: "", day: 1, year: 2 })).toBe("1, Year 2");
+    });
+});
 
 describe("joinableInviteCode", () => {
     test("is the Steam code once published", () => {

--- a/tools/discord-bot/src/serverState.test.ts
+++ b/tools/discord-bot/src/serverState.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatStardewDate, formatStardewTime, joinableInviteCode } from "./serverState";
+import { formatStardewDate, formatStardewTime, formatUptime, joinableInviteCode } from "./serverState";
 
 describe("formatStardewDate", () => {
     test("capitalized season, day, and year", () => {
@@ -35,5 +35,20 @@ describe("formatStardewTime", () => {
 
     test("hours past 24 are after midnight", () => {
         expect(formatStardewTime(2550)).toBe("1:50 AM");
+    });
+});
+
+describe("formatUptime", () => {
+    const start = "2026-01-01T00:00:00Z";
+    const startMs = Date.parse(start);
+
+    test("days+hours, hours+minutes, or just minutes", () => {
+        expect(formatUptime(start, startMs + (3 * 1440 + 4 * 60) * 60000)).toBe("3d 4h");
+        expect(formatUptime(start, startMs + (4 * 60 + 12) * 60000)).toBe("4h 12m");
+        expect(formatUptime(start, startMs + 12 * 60000)).toBe("12m");
+    });
+
+    test("clamps a start in the future to 0m", () => {
+        expect(formatUptime(start, startMs - 60000)).toBe("0m");
     });
 });

--- a/tools/discord-bot/src/serverState.ts
+++ b/tools/discord-bot/src/serverState.ts
@@ -70,6 +70,12 @@ export function joinableInviteCode(status: Pick<ServerStatus, "steamInviteCode">
     return status.steamInviteCode || null;
 }
 
+/** The in-game calendar as "Spring 14, Year 1". */
+export function formatStardewDate(status: Pick<ServerStatus, "day" | "season" | "year">): string {
+    const season = status.season ? `${status.season[0].toUpperCase()}${status.season.slice(1)} ` : "";
+    return `${season}${status.day}, Year ${status.year}`;
+}
+
 /** The game's HHMM clock integer (600, 1330, 2550) as a 12-hour time; hours past 24 are after midnight. */
 export function formatStardewTime(timeOfDay: number): string {
     const hours24 = Math.floor(timeOfDay / 100) % 24;

--- a/tools/discord-bot/src/serverState.ts
+++ b/tools/discord-bot/src/serverState.ts
@@ -84,21 +84,36 @@ export function formatStardewTime(timeOfDay: number): string {
     return `${hours12}:${String(minutes).padStart(2, "0")} ${hours24 < 12 ? "AM" : "PM"}`;
 }
 
+/** Coarse uptime for display ("3d 4h", "4h 12m", "12m"); precise seconds would only churn between polls. */
+export function formatUptime(startedAtUtc: string, now: number): string {
+    const totalMinutes = Math.max(0, Math.floor((now - Date.parse(startedAtUtc)) / 60000));
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+    if (days > 0) {
+        return `${days}d ${hours}h`;
+    }
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
+}
+
 /** `null` is an unreachable /status: the port is closed, so the server is offline. */
 export function resolveServerState(status: StatusSignals | null): ServerState {
     if (status === null) {
         return {
             kind: "offline",
             label: "Offline",
-            detail: "The server is offline.",
+            detail: "Currently unreachable.",
             hint: "No game data can be pulled right now. Check back later!",
         };
     }
 
     if (status.isOnline) {
         return status.isReady
-            ? { kind: "online", label: "Online", detail: "Ready & running." }
-            : { kind: "busy", label: "Busy", detail: "Saving, changing day, or running an event." };
+            ? { kind: "online", label: "Online", detail: "Ready to join" }
+            : { kind: "busy", label: "Busy", detail: "Saving or running an event." };
     }
 
     switch (status.phase) {


### PR DESCRIPTION
Cleans up how the server status is presented across the Discord bot and the docs status widget so the two read consistently.

## Discord status dashboard (embed)
- Drops the redundant per-state sentence: the description is just the `dot label` headline.
- A live server shows its uptime on the headline (`up 3d 4h`).
- States with no game data (starting, offline-without-history) show a short hint in place of empty fields.
- Each state's embed color is the Twemoji hex of its status dot, so the accent bar matches the dot the reader sees.
- An unreachable server falls back to the last-known snapshot's fields instead of going blank.

## Bot presence & `!status`
- Presence text is plainer — no emoji markup baked into the activity string.
- `!status` now leads with the state line, then the fields.

## Docs status widget
- Uptime reads `up 3d 4h`, matching the bot's headline.
- TPS and ping icons swapped for better-fitting glyphs.
- Doc copy for the widget and the Discord states updated to match the new wording.

## Tooling
- Worktrees copy `tools/discli-docker/.env` so discli works via `docker compose exec`.

## Testing
- `bun test` in `tools/discord-bot` (dashboard + serverState unit tests) passes.
- Docs `npm run typecheck` (vue-tsc) clean.
- Mocked all five states in the test Discord channel to eyeball the rendering before wiring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned Discord server-status dashboards with clearer state, in-game date, versions, tick rate, uptime, invite code, refresh timing, and last-checked information.
  - Offline dashboards can now display the most recent known server details.
  - Status messages and commands use simpler, more consistent formatting.
  - Public status widgets now show clearer date, uptime, and build-version information.

- **Documentation**
  - Updated setup and usage guidance to reflect the revised dashboard, status messages, and 20-second minimum refresh interval.
  - Clarified Busy status behavior and public endpoint security requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->