### PR TITLE
fix: pin deploys to the resolved image and ship the matching compose

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -161,32 +161,9 @@ jobs:
           fi
           echo "::endgroup::"
 
-      - name: Create deploy directory
-        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
-        with:
-          host: ${{ secrets.DEPLOY_SSH_HOST }}
-          username: ${{ secrets.DEPLOY_SSH_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
-          script: mkdir -p ~/srv/${{ matrix.environment }}
-
-      - name: Copy files to server
-        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
-        with:
-          host: ${{ secrets.DEPLOY_SSH_HOST }}
-          username: ${{ secrets.DEPLOY_SSH_USER }}
-          key: ${{ secrets.DEPLOY_SSH_KEY }}
-          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
-          source: "docker-compose.yml,.env,docker/proxy"
-          target: ~/srv/${{ matrix.environment }}
-
-      # Resolves what the alias (matrix.image_tag) actually points at, for the internal-ci
-      # notification: the image's revision label → the build tag on that commit → the
-      # IMAGE_VERSION operators would type. Reading the registry (not github.sha) is correct
-      # for all three triggers — workflow_run, release, workflow_dispatch. The alias could in
-      # principle move between this inspect and the VPS's `docker compose pull`, but that
-      # needs a full preview build to finish inside that window; accepted. This step must
-      # never fail the deploy: every lookup degrades to a short SHA or "unknown".
+      # Image revision label → build tag → the IMAGE_VERSION operators would type. The SHA selects
+      # the operator files and the tag pins .env below (the alias may move before the VPS pulls);
+      # the rest feeds the notification. Never fails the deploy.
       - name: Resolve deployed version
         id: version
         env:
@@ -231,6 +208,9 @@ jobs:
           else
             version_value="unknown (\`$TAG\`)"
           fi
+          if [ -z "$sha" ]; then
+            echo "::warning::image revision unknown; operator files stay at the trigger commit and IMAGE_VERSION at the alias"
+          fi
           commit_sha=${sha:-$FALLBACK_SHA}
           commit_value="[\`${commit_sha:0:7}\`]($REPO_URL/commit/$commit_sha)"
 
@@ -242,6 +222,46 @@ jobs:
           jq -cn --arg commit "$commit_value" \
             '[{name: "Commit", value: $commit, inline: true}]' \
             | sed 's/^/failure_fields=/' >> "$GITHUB_OUTPUT"
+          echo "sha=$commit_sha" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # github.sha can be newer than the image (redeploy after a compose bump on master).
+      - name: Align operator files and IMAGE_VERSION with the image
+        env:
+          SHA: ${{ steps.version.outputs.sha }}
+          TRIGGER_SHA: ${{ github.sha }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -n "$VERSION" ]; then
+            sed -i "s/^IMAGE_VERSION=.*/IMAGE_VERSION=$VERSION/" .env
+            echo "IMAGE_VERSION pinned to $VERSION"
+          fi
+          if [ "$SHA" = "$TRIGGER_SHA" ]; then
+            echo "Operator files already at $SHA"
+            exit 0
+          fi
+          git fetch --no-tags --depth=1 origin "$SHA"
+          git checkout "$SHA" -- docker-compose.yml docker/proxy
+          echo "Operator files checked out at $SHA"
+
+      - name: Create deploy directory
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          script: mkdir -p ~/srv/${{ matrix.environment }}
+
+      - name: Copy files to server
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_SSH_PORT || 22 }}
+          source: "docker-compose.yml,.env,docker/proxy"
+          target: ~/srv/${{ matrix.environment }}
 
       - name: Pull and restart containers
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5

--- a/docs/developers/contributing/ci-cd.md
+++ b/docs/developers/contributing/ci-cd.md
@@ -83,10 +83,8 @@ Preview images are tagged with:
 # Pull latest preview
 docker pull sdvd/server:preview
 
-# Use preview in docker-compose.yml
-services:
-  server:
-    image: sdvd/server:preview
+# Use preview: set IMAGE_VERSION=preview in .env, then
+docker compose pull && docker compose up -d --remove-orphans
 ```
 
 ### Batching Features
@@ -453,13 +451,13 @@ To manually trigger a deployment:
 The pipeline:
 
 1. Creates/updates `.env` file with secrets and correct `IMAGE_VERSION`
-2. Copies `docker-compose.yml` to VPS
+2. Copies `docker-compose.yml` and `docker/proxy` (at the image's commit) to the VPS
 3. Pulls the appropriate Docker images
 4. Restarts containers
 5. Verifies deployment health
 
 ::: tip
-The pipeline uses the same `docker-compose.yml` from the repository, ensuring consistency between local development and deployed environments. The `IMAGE_VERSION` environment variable controls which image tag is used.
+The `IMAGE_VERSION` environment variable controls which image tag is used.
 :::
 
 ## Cleanup Caches


### PR DESCRIPTION
Makes the VPS deploy ship the `docker-compose.yml` (and `docker/proxy`) that matches the image it actually deploys, instead of whatever the trigger commit happened to be.

- **Resolve the deployed version:** read the image's revision label → the build tag on that commit → the `IMAGE_VERSION` operators would type. Works for all triggers (workflow_run, release, workflow_dispatch); every lookup degrades gracefully to a short SHA / "unknown" and never fails the deploy.
- **Align operator files to the image:** pin `.env`'s `IMAGE_VERSION` to the resolved version, and check out `docker-compose.yml` + `docker/proxy` at the image's commit before copying to the VPS. Handles `github.sha` being newer than the image (e.g. a redeploy after a compose bump on `master`).

Part of splitting the old #621 into focused PRs. Independent of the other PRs (touches only `deploy-server.yml` + a CI-CD doc); no merge-order constraint.
