### PR TITLE
fix: keep Discord release and preview posts within the embed limit

### DIFF
--- a/.github/actions/build-changelog/action.yml
+++ b/.github/actions/build-changelog/action.yml
@@ -19,7 +19,7 @@ inputs:
 
 outputs:
   markdown:
-    description: Changelog markdown (at most 3500 code points)
+    description: Changelog markdown (at most 3200 code points)
     value: ${{ steps.changelog.outputs.markdown }}
   count:
     description: Commits in the range
@@ -36,6 +36,11 @@ outputs:
   compare-url:
     description: GitHub compare URL for the range
     value: ${{ steps.changelog.outputs.compare-url }}
+  upgrade-notes:
+    description: >
+      Markdown flagging docker-compose.yml / .env.example changes in the range; empty if none,
+      otherwise ends with a blank line.
+    value: ${{ steps.files.outputs.upgrade-notes }}
 
 runs:
   using: composite
@@ -60,3 +65,30 @@ runs:
       run: |
         git log --first-parent --format='%H%x1f%s' "$BASE_OID..$HEAD_OID" \
           | node "$GITHUB_ACTION_PATH/../../scripts/build-changelog.js"
+
+    - name: Flag changed operator files
+      id: files
+      shell: bash
+      env:
+        BASE_OID: ${{ steps.range.outputs.base-oid }}
+        HEAD_OID: ${{ steps.range.outputs.head-oid }}
+        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+      run: |
+        set -euo pipefail
+        changed=$(git diff --name-only "$BASE_OID" "$HEAD_OID" -- docker-compose.yml .env.example)
+        notes=""
+        if grep -qx 'docker-compose.yml' <<< "$changed"; then
+          notes+='⚠ `docker-compose.yml` changed — the update command below replaces yours. Hand-edited it? Move the edits to `docker-compose.override.yml` first.'$'\n'
+        fi
+        if grep -qx '.env.example' <<< "$changed"; then
+          notes+="⚠ \`.env.example\` changed — check [the new file](${REPO_URL}/blob/${HEAD_OID}/.env.example) for options to add to your \`.env\`."$'\n'
+        fi
+        {
+          echo "upgrade-notes<<EOF_UPGRADE_NOTES"
+          # notes ends in a newline; one more makes the trailing blank line.
+          if [ -n "$notes" ]; then
+            printf '%s\n\n' "$notes"
+          fi
+          echo "EOF_UPGRADE_NOTES"
+        } >> "$GITHUB_OUTPUT"
+        echo "changed: ${changed:-none}"

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -16,10 +16,12 @@ const HEADER = "**Changes**";
 const VISIBLE_TYPES = ["feat", "fix", "perf", "revert", "docs"];
 const HIDDEN_TYPES = new Set(["style", "chore", "refactor", "test", "build", "ci"]);
 
-// We measure length in code points (what Discord counts), not JS string length. 3500 leaves room
-// under Discord's 4096-char description limit for the "Use it" block the caller appends, and under
-// the 6000-char limit for the whole embed.
-const BUDGET = 3500;
+// We measure length in code points (what Discord counts), not JS string length. The caller appends
+// its upgrade notes and "Update" block to this markdown as one embed description, so the budget is
+// Discord's 4096 description limit minus ~900 reserved for that appended text (worst case ~870:
+// both upgrade-note warnings plus the longest "Update" block). Title + description stay well under
+// the 6000-char whole-embed limit. discord-notify rejects an over-limit post, so keep the reserve.
+const BUDGET = 3200;
 
 const CONVENTIONAL_RE = /^([a-z]+)(\([^()]*\))?(!)?: \S/i;
 const PR_SUFFIX_RE = /\s*\(#(\d+)\)$/;

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -3,7 +3,7 @@
 //
 // These lock in how the Discord post looks: one flat "Changes" list in release-please's type order,
 // nothing ever dropped (a subject we can't parse is listed after the known types), markdown special
-// characters escaped, a diff link on every result, and the whole thing kept under the 3500-code-point
+// characters escaped, a diff link on every result, and the whole thing kept under the code-point
 // budget — trimming between whole lines with an "…and N more" note when it's too long.
 
 const { test } = require("node:test");


### PR DESCRIPTION
Keeps the release and preview Discord posts within Discord's 4096-char embed-description limit, and adds the `upgrade-notes` output the update posts use.

- The changelog markdown is now budgeted in **code points** (what Discord counts), reserving room for the caller's appended `upgrade-notes` + "Update" block so an over-limit post can't red a release build.
- New `upgrade-notes` output on the `build-changelog` action: surfaces when `.env.example` gained new options between the two commits, so release/preview posts can flag it.

Part of splitting the old #621 into focused PRs. `feat/one-command-update` (#642) consumes this `upgrade-notes` output (empty-safe if this lands after), so merging this first is preferred.
