### PR TITLE
fix: preview server no longer crash-loops when USER_ID/GROUP_ID are unset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 # Updates replace this file. Settings go in `.env` (see `.env.example`), everything else in a
-# `docker-compose.override.yml`. A bare variable is passed through only when set; the image owns
-# the default. Bump SDVD_COMPOSE_REV on every change here (checked by docker/rootfs/startapp.sh).
+# `docker-compose.override.yml`. Bump SDVD_COMPOSE_REV on every change here.
 
 services:
   # Main game server
@@ -23,12 +22,11 @@ services:
       - ./.local-container/settings:/data/settings
       - ./diagnostics:/data/diagnostics
     environment:
-      - SDVD_COMPOSE_REV=2
+      - SDVD_COMPOSE_REV=3
       - STEAM_AUTH_URL=http://steam-auth:${STEAM_AUTH_PORT:-3001}
       - SETTINGS_PATH=/data/settings/server-settings.json
-      # uid/gid the game runs as after the root init (docs: environment.md, Host / Permissions).
-      - USER_ID
-      - GROUP_ID
+      - USER_ID=${USER_ID:-1000}
+      - GROUP_ID=${GROUP_ID:-1000}
       - VNC_PASSWORD
       - SERVER_NAME
       - ALLOW_INSECURE_SETUP
@@ -63,9 +61,8 @@ services:
       - game-data:/data/game
     environment:
       - PORT=${STEAM_AUTH_PORT:-3001}
-      # Same ids as the server: both write the shared game-data volume.
-      - USER_ID
-      - GROUP_ID
+      - USER_ID=${USER_ID:-1000}
+      - GROUP_ID=${GROUP_ID:-1000}
       - STEAM_USERNAME
       - STEAM_PASSWORD
       - STEAM_REFRESH_TOKEN

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -20,7 +20,7 @@ API_PORT="${API_PORT:-8080}"
 PHASE_FILE="/tmp/startup-phase"
 # SDVD_COMPOSE_REV of the docker-compose.yml this image ships with (validate-pr.yml keeps them
 # equal). Keep it a bare unindented assignment — validate-pr.yml greps this exact line.
-EXPECTED_COMPOSE_REV=2
+EXPECTED_COMPOSE_REV=3
 
 # Validate required environment variables
 validate_environment() {


### PR DESCRIPTION
## Summary
- Restore `${USER_ID:-1000}`/`${GROUP_ID:-1000}` defaults on the **server** and **steam-auth** services. The bare pass-throughs from #641 stripped the image's uid/gid defaults whenever the deploy `.env` didn't set them, so `10-init-users.sh` read an unset var under `set -u` and the server crash-looped — the preview **502**.
- Bump `SDVD_COMPOSE_REV` to 3 (`docker-compose.yml`) and `EXPECTED_COMPOSE_REV` (`startapp.sh`); validate-pr.yml requires them equal.

## Why
Deploys that don't set `USER_ID`/`GROUP_ID` (the common case) lost the image's baked-in 1000/1000 defaults, taking the server down on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container setup reliability by applying default user and group IDs when values are not explicitly provided.
  * Updated compose version validation to ensure the configuration and container image remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->