### PR TITLE
ci: deploy health check catches crash-looping containers

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -307,7 +307,7 @@ jobs:
             echo "::endgroup::"
 
             echo "::group::Health check"
-            if docker compose ps | grep -qE "unhealthy|Exit"; then
+            if docker compose ps | grep -qE "unhealthy|Exit|Restarting"; then
               echo "::error::Container health check failed"
               docker compose logs --tail=50
               exit 1
@@ -329,7 +329,7 @@ jobs:
               # Retries cover the certificate order, which can take a minute on first start.
               if ! curl -fsS --retry 12 --retry-delay 10 --retry-all-errors "$url" > /dev/null; then
                 echo "::error::Proxy check failed: $url"
-                docker compose logs --tail=50 proxy
+                docker compose logs --tail=50 proxy server
                 exit 1
               fi
               echo "$url OK"


### PR DESCRIPTION
## Summary
- Add `Restarting` to the health-gate grep so a crash-looping container fails the deploy. Previously only `unhealthy|Exit` matched, and a restart loop passed the gate as healthy.
- Dump **server** logs alongside proxy logs when the proxy check fails, so the failure output shows the actual cause.

## Why
The preview 502 (a crash-looping server) passed the deploy health check, because a container stuck in `Restarting` never shows as `Exit` or `unhealthy` at the moment the gate runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment health checks to detect containers that are repeatedly restarting.
  * Enhanced troubleshooting information by including server container logs when proxy checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->