### PR TITLE
docs: document SERVER_TPS and related server env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,7 +45,7 @@ VNC_PASSWORD=""
 ########################################
 
 # Target ticks per second (default and maximum: 60, minimum: 1).
-# Lower reduces CPU at the cost of choppier NPC movement. 20-30 suits production.
+# Lower reduces CPU.
 # SERVER_TPS=60
 
 # TPS-agnostic pacing (default: true): fades and NPC/monster/projectile movement advance

--- a/docs/admins/configuration/environment.md
+++ b/docs/admins/configuration/environment.md
@@ -27,6 +27,10 @@ These must be set for the server to function:
 | `PROXY_ROUTING` | `path` (`https://HOST/NAME/`) or `subdomain` (`https://NAME.HOST/`) | `path` |
 | `COMPOSE_PROFILES` | `proxy` starts the bundled HTTPS proxy; leave unset to use your own | - |
 | `SERVER_FPS` | Render rate: `0` = rendering disabled, `N > 0` = render at N fps | `0` |
+| `SERVER_TPS` | Simulation ticks per second (`1`–`60`); lower cuts CPU use | `60` |
+| `SDVD_TPS_AGNOSTIC_PACING` | Keep fades and NPC/monster/projectile movement at wall-clock speed regardless of `SERVER_TPS`; `false` restores vanilla per-tick pacing | `true` |
+| `CROP_SAVER_LIGHTNING_IMMUNITY` | Managed crops survive lightning strikes | `true` |
+| `STEAM_KEEP_LANGUAGES` | Comma-separated language codes whose fonts to keep in the game download (e.g. `ru-RU,ja-JP`); empty keeps English only | (English only) |
 | `VERBOSE_LOGGING` | Override verbose logging setting | - |
 
 ## Security Variables


### PR DESCRIPTION
## Summary
- Add `environment.md` rows for `SERVER_TPS`, `SDVD_TPS_AGNOSTIC_PACING`, `CROP_SAVER_LIGHTNING_IMMUNITY`, and `STEAM_KEEP_LANGUAGES` — all configurable but previously undocumented.
- Fix the `.env.example` `SERVER_TPS` note: default is 60, and the "20-30 suits production" guidance was misleading, so it's dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added documentation for four runtime configuration variables, including simulation tick rate, wall-clock pacing, crop lightning immunity, and retained Steam languages.
  - Included default values and descriptions for each newly documented setting.
  - Simplified the `SERVER_TPS` comment in the example environment configuration by removing specific guidance about NPC movement and production recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->