### PR TITLE
feat: cleaner Discord release and preview posts

### DIFF
--- a/.github/actions/build-changelog/action.yml
+++ b/.github/actions/build-changelog/action.yml
@@ -38,8 +38,8 @@ outputs:
     value: ${{ steps.changelog.outputs.compare-url }}
   upgrade-notes:
     description: >
-      Markdown flagging docker-compose.yml / .env.example changes in the range; empty if none,
-      otherwise ends with a blank line.
+      "Config changed" list flagging docker-compose.yml / .env.example changes in the range;
+      empty if none, otherwise ends with a blank line.
     value: ${{ steps.files.outputs.upgrade-notes }}
 
 runs:
@@ -72,22 +72,20 @@ runs:
       env:
         BASE_OID: ${{ steps.range.outputs.base-oid }}
         HEAD_OID: ${{ steps.range.outputs.head-oid }}
-        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
         set -euo pipefail
         changed=$(git diff --name-only "$BASE_OID" "$HEAD_OID" -- docker-compose.yml .env.example)
         notes=""
         if grep -qx 'docker-compose.yml' <<< "$changed"; then
-          notes+='⚠ `docker-compose.yml` changed — the update command below replaces yours. Hand-edited it? Move the edits to `docker-compose.override.yml` first.'$'\n'
+          notes+='- `docker-compose.yml`: how to [customize](https://docs.junimoserver.com/admins/operations/upgrading#customizing-docker-compose)'$'\n'
         fi
         if grep -qx '.env.example' <<< "$changed"; then
-          notes+="⚠ \`.env.example\` changed — check [the new file](${REPO_URL}/blob/${HEAD_OID}/.env.example) for options to add to your \`.env\`."$'\n'
+          notes+='- `.env.example`: see the [new options](https://docs.junimoserver.com/admins/configuration/environment)'$'\n'
         fi
         {
           echo "upgrade-notes<<EOF_UPGRADE_NOTES"
-          # notes ends in a newline; one more makes the trailing blank line.
           if [ -n "$notes" ]; then
-            printf '%s\n\n' "$notes"
+            printf '**Config changed**\n%s\n' "$notes"
           fi
           echo "EOF_UPGRADE_NOTES"
         } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -107,9 +107,6 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
         return { ...result, markdown: `No changes since \`${baseTag}\` · ${diffLink}` };
     }
 
-    // The last line of the changelog. It holds up to three pieces, joined with " · ": an "…and N
-    // more" note when we had to drop entries, the "+N internal changes" count, and always the diff
-    // link. The " · " separator matches the "· #PR" that ends each entry above, so it all reads alike.
     const bottomLine = (droppedCount) => {
         const parts = [];
         if (droppedCount > 0) {
@@ -119,7 +116,7 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
             parts.push(`+${hiddenCount} internal change${hiddenCount === 1 ? "" : "s"}`);
         }
         parts.push(diffLink);
-        return parts.join(" · ");
+        return `- ${parts.join(" · ")}`;
     };
 
     const entryLines = [...VISIBLE_TYPES.flatMap((t) => visible.get(t)), ...other].map((e) => renderEntry(e, repoUrl));

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -37,7 +37,7 @@ test("lists visible types in release-please priority order under one Changes hea
             "- perf: fewer allocations · [#3](https://github.com/o/r/pull/3)",
             "- revert: undo the thing · [#4](https://github.com/o/r/pull/4)",
             "- docs: explain cabins · [#5](https://github.com/o/r/pull/5)",
-            `[diff](${COMPARE})`,
+            `- [diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [5, 5, 0]);
@@ -45,7 +45,7 @@ test("lists visible types in release-please priority order under one Changes hea
 
 test("hidden-only range is just the Changes heading and the internal-changes bottom line", () => {
     const result = buildChangelog(["ci: bump action (#9)", "chore: tidy", "refactor: rename (#8)"], OPTS);
-    assert.equal(result.markdown, ["**Changes**", `+3 internal changes · [diff](${COMPARE})`].join("\n"));
+    assert.equal(result.markdown, ["**Changes**", `- +3 internal changes · [diff](${COMPARE})`].join("\n"));
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 0, 3]);
 });
 
@@ -56,7 +56,7 @@ test("mixed range lists visible entries and folds hidden ones into the bottom li
         [
             "**Changes**",
             "- fix(ci): quote globs · [#2](https://github.com/o/r/pull/2)",
-            `+2 internal changes · [diff](${COMPARE})`,
+            `- +2 internal changes · [diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [3, 1, 2]);
@@ -64,14 +64,14 @@ test("mixed range lists visible entries and folds hidden ones into the bottom li
 
 test("a single internal change uses the singular note", () => {
     const result = buildChangelog(["chore: bump deps"], OPTS);
-    assert.equal(result.markdown, ["**Changes**", `+1 internal change · [diff](${COMPARE})`].join("\n"));
+    assert.equal(result.markdown, ["**Changes**", `- +1 internal change · [diff](${COMPARE})`].join("\n"));
 });
 
 test("a subject without (#N) is listed without a PR link", () => {
     const result = buildChangelog(["feat(tools): add request-correlation context"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Changes**", "- feat(tools): add request-correlation context", `[diff](${COMPARE})`].join("\n"),
+        ["**Changes**", "- feat(tools): add request-correlation context", `- [diff](${COMPARE})`].join("\n"),
     );
 });
 
@@ -83,7 +83,7 @@ test("a non-conventional subject is listed after the visible types, verbatim, ne
             "**Changes**",
             "- feat: real feature · [#6](https://github.com/o/r/pull/6)",
             "- Update README badges · [#7](https://github.com/o/r/pull/7)",
-            `[diff](${COMPARE})`,
+            `- [diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.equal(result.visibleCount, 2);
@@ -93,7 +93,7 @@ test("an unknown conventional type is listed after the visible types", () => {
     const result = buildChangelog(["wip: half-done thing (#7)"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Changes**", "- wip: half-done thing · [#7](https://github.com/o/r/pull/7)", `[diff](${COMPARE})`].join(
+        ["**Changes**", "- wip: half-done thing · [#7](https://github.com/o/r/pull/7)", `- [diff](${COMPARE})`].join(
             "\n",
         ),
     );
@@ -106,7 +106,7 @@ test("feat!: gets the breaking-change warning marker", () => {
         [
             "**Changes**",
             "- ⚠ feat!: drop LAN transport · [#10](https://github.com/o/r/pull/10)",
-            `[diff](${COMPARE})`,
+            `- [diff](${COMPARE})`,
         ].join("\n"),
     );
 });
@@ -121,7 +121,7 @@ test("markdown special characters in subjects are escaped", () => {
         [
             "**Changes**",
             "- fix: escape \\`code\\` and \\*stars\\* and \\_under\\_ and \\~tilde\\~ and \\|pipe\\| and \\\\slash",
-            `[diff](${COMPARE})`,
+            `- [diff](${COMPARE})`,
         ].join("\n"),
     );
 });
@@ -133,7 +133,7 @@ test("a subject with markdown link syntax cannot inject a masked link", () => {
         [
             "**Changes**",
             "- feat: \\[deployment guide\\](https://attacker.example) · [#13](https://github.com/o/r/pull/13)",
-            `[diff](${COMPARE})`,
+            `- [diff](${COMPARE})`,
         ].join("\n"),
     );
 });
@@ -142,7 +142,7 @@ test("a non-ASCII subject passes through and the budget counts code points", () 
     const result = buildChangelog(["feat: 🎉 支持中文标题 (#12)"], OPTS);
     assert.equal(
         result.markdown,
-        ["**Changes**", "- feat: 🎉 支持中文标题 · [#12](https://github.com/o/r/pull/12)", `[diff](${COMPARE})`].join(
+        ["**Changes**", "- feat: 🎉 支持中文标题 · [#12](https://github.com/o/r/pull/12)", `- [diff](${COMPARE})`].join(
             "\n",
         ),
     );
@@ -163,8 +163,8 @@ test("an over-budget list is cut at a line boundary with an …and N more notice
     // count, folds the internal change in, and carries the diff link.
     const keptEntries = lines.filter((l) => l.startsWith("- feat:")).length;
     assert.ok(keptEntries > 0 && keptEntries < 100);
-    assert.equal(lines[lines.length - 1], `…and ${100 - keptEntries} more · +1 internal change · [diff](${COMPARE})`);
-    for (const line of lines.filter((l) => l.startsWith("- "))) {
+    assert.equal(lines[lines.length - 1], `- …and ${100 - keptEntries} more · +1 internal change · [diff](${COMPARE})`);
+    for (const line of lines.filter((l) => l.startsWith("- feat:"))) {
         assert.match(line, /· \[#\d+\]\(https:\/\/github\.com\/o\/r\/pull\/\d+\)$/);
     }
 });
@@ -179,7 +179,7 @@ test("release-please's release commit is excluded from every count", () => {
         [
             "**Changes**",
             "- fix: stop the crash · [#2](https://github.com/o/r/pull/2)",
-            `+1 internal change · [diff](${COMPARE})`,
+            `- +1 internal change · [diff](${COMPARE})`,
         ].join("\n"),
     );
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [2, 1, 1]);

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -205,9 +205,10 @@ jobs:
           description: |
             ${{ steps.changelog.outputs.markdown }}
 
-            ${{ steps.changelog.outputs.upgrade-notes }}**Update** (set `IMAGE_VERSION=preview` in `.env` first)
-            ```curl -fsSL https://docs.junimoserver.com/update.sh | bash```
-            Windows: `powershell -c "irm https://docs.junimoserver.com/update.ps1 | iex"`. Pin this build instead: `IMAGE_VERSION=${{ needs.calculate-version.outputs.preview_version }}`.
+            ${{ steps.changelog.outputs.upgrade-notes }}**Update** ([documentation](https://docs.junimoserver.com/admins/operations/upgrading))
+            Set `IMAGE_VERSION=preview` in `.env`, then run:
+            Linux/macOS: `curl -fsSL https://docs.junimoserver.com/update.sh | bash`
+            Windows: `powershell -c "irm https://docs.junimoserver.com/update.ps1 | iex"`
 
       - name: Update preview tracking tag
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -148,9 +148,9 @@ jobs:
           description: |
             ${{ steps.changelog.outputs.markdown }}
 
-            ${{ steps.changelog.outputs.upgrade-notes }}**Update**
-            ```curl -fsSL https://docs.junimoserver.com/update.sh | bash```
-            Windows: `powershell -c "irm https://docs.junimoserver.com/update.ps1 | iex"`. Pin instead of following `latest`: `IMAGE_VERSION=${{ needs.release-please.outputs.version }}` in `.env`.
+            ${{ steps.changelog.outputs.upgrade-notes }}**Update** ([documentation](https://docs.junimoserver.com/admins/operations/upgrading))
+            Linux/macOS: `curl -fsSL https://docs.junimoserver.com/update.sh | bash`
+            Windows: `powershell -c "irm https://docs.junimoserver.com/update.ps1 | iex"`
 
   stamp-issue-versions:
     name: Stamp Issue Versions


### PR DESCRIPTION
## Summary
- Replace the noisy `⚠` upgrade-note warnings with a compact **Config changed** list that links the upgrade docs instead of inlining the guidance.
- Render the changelog's bottom line (`+N internal changes · diff`) as a list bullet, so it sits in the same list as the entries above.
- Tidy the **Update** block: one-line inline commands for Linux/macOS and Windows, and drop the pin-this-build line so users follow their configured channel by default.
- Update the build-changelog unit tests for the bulleted bottom line.

## Notes
Affects the preview and release Discord posts only. Tests: `node --test .github/scripts/build-changelog.test.js` (14/14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Upgrade guidance now links directly to relevant documentation.
  - Configuration changes are presented with clearer upgrade notes.

- **Improvements**
  - Release and preview notifications now include upgrade notes and separate update commands for Linux/macOS and Windows.
  - Changelog diff links now render consistently as bulleted list items.
  - Removed outdated instructions about pinning image versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->