### PR TITLE
feat: update scripts back up docker-compose.yml before replacing it

### DIFF
--- a/docs/admins/operations/upgrading.md
+++ b/docs/admins/operations/upgrading.md
@@ -39,7 +39,7 @@ Settings such as ports and passwords go in `.env`; see [Environment Variables](/
 
 ### Updates replace `docker-compose.yml`
 
-The update command overwrites `docker-compose.yml`. If you edited it by hand (extra mod mounts, port changes), move those edits to a `docker-compose.override.yml` before running the command, or they are lost and the server starts without them. See [Customizing docker-compose](#customizing-docker-compose).
+The update command overwrites `docker-compose.yml`, saving the previous file as a timestamped `.bak` first. Keep hand edits (extra mod mounts, port changes) in a `docker-compose.override.yml` instead, so they survive every update. See [Customizing docker-compose](#customizing-docker-compose).
 
 ### Empty `VNC_PASSWORD` no longer aborts startup unconditionally
 

--- a/docs/public/update.ps1
+++ b/docs/public/update.ps1
@@ -35,7 +35,13 @@ if ($sha -and $sha -ne 'unknown') {
 }
 
 Write-Host 'Fetching docker-compose.yml...'
-Invoke-WebRequest -UseBasicParsing -Uri $composeUrl -OutFile docker-compose.yml
+$tmp = New-TemporaryFile
+Invoke-WebRequest -UseBasicParsing -Uri $composeUrl -OutFile $tmp
+$backup = "docker-compose.yml.$(Get-Date -Format 'yyyyMMdd-HHmmss').bak"
+Copy-Item docker-compose.yml $backup -Force
+Move-Item $tmp docker-compose.yml -Force
+Write-Host "Replaced docker-compose.yml (backup: $backup)"
+Write-Host 'Custom changes? Use docker-compose.override.yml: https://docs.junimoserver.com/admins/operations/upgrading#customizing-docker-compose'
 
 Write-Host 'Restarting...'
 docker compose up -d --remove-orphans

--- a/docs/public/update.sh
+++ b/docs/public/update.sh
@@ -36,7 +36,11 @@ fi
 echo "Fetching docker-compose.yml..."
 tmp="$(mktemp)"
 curl -fsSL -o "$tmp" "$compose_url" || die "Could not download docker-compose.yml from $compose_url"
+backup="docker-compose.yml.$(date +%Y%m%d-%H%M%S).bak"
+cp docker-compose.yml "$backup"
 mv "$tmp" docker-compose.yml
+echo "Replaced docker-compose.yml (backup: $backup)"
+echo "Custom changes? Use docker-compose.override.yml: https://docs.junimoserver.com/admins/operations/upgrading#customizing-docker-compose"
 
 echo "Restarting..."
 docker compose up -d --remove-orphans


### PR DESCRIPTION
## Summary
- `update.sh` and `update.ps1` save the current `docker-compose.yml` as a **timestamped `.bak`** before overwriting it, so an operator's hand-edits are recoverable. The timestamp keeps every backup rather than clobbering a single `.bak`.
- Both download the new file to a temp path first, so a failed fetch can't clobber the live file or its backup.
- Document the backup in the upgrading guide.

## Why
The update scripts always own `docker-compose.yml` and overwrite it unconditionally. Custom changes belong in `docker-compose.override.yml`, but the backup gives a safety net for anyone who edited the file directly.