### PR TITLE
feat(steam): auto-renew Steam refresh tokens and warn before they expire

### DIFF
--- a/docs/admins/quick-start/installation.md
+++ b/docs/admins/quick-start/installation.md
@@ -74,7 +74,7 @@ Follow the prompts for Steam Guard:
 This also downloads the game files. You can skip this step if Steam can log in without prompts, for example with a saved session or `STEAM_REFRESH_TOKEN`. In that case the server downloads the files itself the first time it starts.
 
 ::: tip Steam tokens expire
-Steam login tokens last about 200 days. steam-auth asks Steam to renew the token automatically and, during the last 14 days before expiry, warns daily in its logs if it still needs attention. Re-run `docker compose run --rm -it steam-auth setup` before yours expires to keep the server authenticated.
+Steam login tokens last about 200 days. steam-auth automatically renews saved-session tokens and, during the last 14 days before expiry, warns daily in its logs if one still needs attention. Re-run `docker compose run --rm -it steam-auth setup` before yours expires to keep the server authenticated. A token supplied via `STEAM_REFRESH_TOKEN` is not renewed — mint a new one with `setup` and `export-token` instead.
 :::
 
 ## 4. Start the Server

--- a/docs/admins/quick-start/installation.md
+++ b/docs/admins/quick-start/installation.md
@@ -74,7 +74,7 @@ Follow the prompts for Steam Guard:
 This also downloads the game files. You can skip this step if Steam can log in without prompts, for example with a saved session or `STEAM_REFRESH_TOKEN`. In that case the server downloads the files itself the first time it starts.
 
 ::: tip Steam tokens expire
-Steam login tokens last about 200 days. Re-run `docker compose run --rm -it steam-auth setup` before yours expires to keep the server authenticated.
+Steam login tokens last about 200 days. steam-auth asks Steam to renew the token automatically and, during the last 14 days before expiry, warns daily in its logs if it still needs attention. Re-run `docker compose run --rm -it steam-auth setup` before yours expires to keep the server authenticated.
 :::
 
 ## 4. Start the Server

--- a/docs/admins/troubleshooting.md
+++ b/docs/admins/troubleshooting.md
@@ -53,7 +53,13 @@ Common fixes:
 
 ### Token expired
 
-Steam tokens last about 200 days. When expired:
+Steam tokens last about 200 days. The steam-auth container asks Steam to renew its token once a day and saves the new one when Steam agrees — which it only does close to expiry. For the last 14 days before expiry, a daily warning in `docker compose logs steam-auth` reports the latest renewal result:
+
+- **"Steam declined to renew it today"** — expected until Steam's renewal window opens; the warning stops once a renewal succeeds.
+- **"Renewal failed with AccessDenied"** (or another Steam result) — this token cannot be renewed; re-run setup before the expiry date in the warning.
+- Tokens supplied via `STEAM_REFRESH_TOKEN` or `STEAM_ACCOUNTS` are never renewed; mint a new one with `setup` and `export-token`, then update the variable.
+
+Once a token has expired, the log says so and names the fix:
 
 ```sh
 docker compose run --rm -it steam-auth setup

--- a/docs/admins/troubleshooting.md
+++ b/docs/admins/troubleshooting.md
@@ -56,7 +56,7 @@ Common fixes:
 Steam tokens last about 200 days. The steam-auth container asks Steam to renew its token once a day and saves the new one when Steam agrees — which it only does close to expiry. For the last 14 days before expiry, a daily warning in `docker compose logs steam-auth` reports the latest renewal result:
 
 - **"Steam declined to renew it today"** — expected until Steam's renewal window opens; the warning stops once a renewal succeeds.
-- **"Renewal failed with AccessDenied"** (or another Steam result) — this token cannot be renewed; re-run setup before the expiry date in the warning.
+- **"Renewal failed with AccessDenied"** (or another Steam result) — Steam rejected this renewal attempt; if it keeps failing, re-run setup before the expiry date in the warning.
 - Tokens supplied via `STEAM_REFRESH_TOKEN` or `STEAM_ACCOUNTS` are never renewed; mint a new one with `setup` and `export-token`, then update the variable.
 
 Once a token has expired, the log says so and names the fix:

--- a/docs/developers/architecture/steam-auth.md
+++ b/docs/developers/architecture/steam-auth.md
@@ -53,13 +53,45 @@ The steam-auth HTTP API exposes:
 
 ### GET /health
 
-Health check endpoint.
+Health check endpoint. Always 200 while the HTTP server is up; per-account login state and refresh-token expiry are in the body.
 
 ```json
 {
   "status": "ok",
   "logged_in": true,
-  "timestamp": "2026-01-16T12:00:00.000Z"
+  "timestamp": "2026-01-16T12:00:00.000Z",
+  "accounts": [
+    {
+      "index": 0,
+      "username": "steamuser",
+      "logged_in": true,
+      "steam_id": "76561198012345678",
+      "token_expires_at": "2026-08-04T12:00:00.000Z",
+      "token_days_remaining": 200,
+      "token_last_renewal_at": "2026-01-16T11:59:30.000Z",
+      "token_last_renewal_outcome": "refused"
+    }
+  ]
+}
+```
+
+### POST /steam/renew-token
+
+Asks Steam to renew the account's refresh token over the live session (`?account=N`, default 0). Steam decides whether to issue one; `outcome` is:
+
+- `renewed` — a new token was issued. It is saved before the response returns, because Steam invalidates the previous token on renewal. If saving fails, `outcome` stays `renewed` and `error` says so, since the new token is now the only valid one.
+- `refused` — Steam answered without a token, the normal result far from expiry.
+- `failed` — Steam rejected the request; `error` carries the Steam result name. The token still logs in until it expires.
+
+Returns 409 for tokens supplied via environment variables, since the environment copy would go stale.
+
+```json
+{
+  "renewed": true,
+  "outcome": "renewed",
+  "error": null,
+  "previous_expires_at": "2026-02-01T12:00:00.000Z",
+  "expires_at": "2026-08-20T12:00:00.000Z"
 }
 ```
 
@@ -85,11 +117,14 @@ The steam-auth service supports several commands:
 | `download` | Download/update game files (uses saved session) |
 | `ticket` | Output encrypted app ticket to stdout |
 | `export-token` | Export saved refresh token for CI use |
+| `renew` | Ask Steam to renew saved refresh tokens. Opens its own Steam session, so stop `serve` first; while `serve` runs use `POST /steam/renew-token` instead |
 | `serve` | Run HTTP API for runtime ticket requests (default) |
 
 ## Token Persistence
 
-Refresh tokens are saved to `/data/steam-session/session-{username}.json` and reused on container restart. Steam tokens typically last 200 days.
+Refresh tokens are saved to `/data/steam-session/{username}/session.json` and reused on container restart. Steam tokens typically last 200 days; the expiry comes from the token's JWT `exp` claim and is logged at every login and exposed per account in `GET /health`. An expired token fails login immediately with the setup command instead of retrying.
+
+`serve` asks Steam once a day to renew each saved-session token and logs the answer. Steam only issues a new token close to expiry and does not publish the window, so the request is made unconditionally rather than gated on remaining days. A renewed token replaces the saved session before anything else can observe it, because Steam invalidates the previous one. Tokens supplied via environment variables are skipped. During the last 14 days a daily warning reports the last renewal outcome (also `token_last_renewal_outcome` in `GET /health`).
 
 ## How Invite Codes Work
 

--- a/docs/developers/architecture/steam-auth.md
+++ b/docs/developers/architecture/steam-auth.md
@@ -124,7 +124,7 @@ The steam-auth service supports several commands:
 
 Refresh tokens are saved to `/data/steam-session/{username}/session.json` and reused on container restart. Steam tokens typically last 200 days; the expiry comes from the token's JWT `exp` claim and is logged at every login and exposed per account in `GET /health`. An expired token fails login immediately with the setup command instead of retrying.
 
-`serve` asks Steam once a day to renew each saved-session token and logs the answer. Steam only issues a new token close to expiry and does not publish the window, so the request is made unconditionally rather than gated on remaining days. A renewed token replaces the saved session before anything else can observe it, because Steam invalidates the previous one. Tokens supplied via environment variables are skipped. During the last 14 days a daily warning reports the last renewal outcome (also `token_last_renewal_outcome` in `GET /health`).
+`serve` asks Steam once a day to renew each saved-session token and logs the answer. Steam only issues a new token close to expiry and does not publish the window, so the request is made unconditionally rather than gated on remaining days. A renewed token replaces the saved session before anything else can observe it, because Steam invalidates the previous one; if saving fails, the new token lives only in the running process, and a restart before the next successful save needs `setup`. Tokens supplied via environment variables are skipped. During the last 14 days a daily warning reports the last renewal outcome (also `token_last_renewal_outcome` in `GET /health`).
 
 ## How Invite Codes Work
 

--- a/tests/SteamService.Tests/TokenExpiryTests.cs
+++ b/tests/SteamService.Tests/TokenExpiryTests.cs
@@ -46,6 +46,14 @@ public class TokenExpiryTests
         Assert.Null(SteamAuthService.GetTokenExpiry(Jwt(new { exp = "soon" })));
     }
 
+    [Fact]
+    public void OutOfRangeExpReturnsNull()
+    {
+        // Fits Int64 but is far outside DateTimeOffset's range; must not throw.
+        Assert.Null(SteamAuthService.GetTokenExpiry(Jwt(new { exp = 99_999_999_999_999L })));
+        Assert.Null(SteamAuthService.GetTokenExpiry(Jwt(new { exp = long.MinValue })));
+    }
+
     private static string Jwt(object payload)
     {
         static string B64Url(string s) =>

--- a/tests/SteamService.Tests/TokenExpiryTests.cs
+++ b/tests/SteamService.Tests/TokenExpiryTests.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace SteamService.Tests;
+
+public class TokenExpiryTests
+{
+    [Fact]
+    public void ReadsExpClaimFromBase64UrlPayload()
+    {
+        var exp = new DateTimeOffset(2026, 12, 31, 23, 59, 59, TimeSpan.Zero);
+
+        var parsed = SteamAuthService.GetTokenExpiry(Jwt(new { exp = exp.ToUnixTimeSeconds() }));
+
+        Assert.Equal(exp, parsed);
+    }
+
+    [Fact]
+    public void PayloadNeedingPaddingStillParses()
+    {
+        // Shorter and longer payloads land on every base64 remainder class.
+        foreach (var filler in new[] { "", "a", "ab", "abc", "abcd" })
+        {
+            var exp = 1_800_000_000L;
+            var parsed = SteamAuthService.GetTokenExpiry(Jwt(new { exp, sub = filler }));
+
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(exp), parsed);
+        }
+    }
+
+    [Theory]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("a.b.c.d")]
+    [InlineData("h.!!notbase64!!.s")]
+    public void NonJwtInputReturnsNull(string token)
+    {
+        Assert.Null(SteamAuthService.GetTokenExpiry(token));
+    }
+
+    [Fact]
+    public void MissingOrNonNumericExpReturnsNull()
+    {
+        Assert.Null(SteamAuthService.GetTokenExpiry(Jwt(new { sub = "1" })));
+        Assert.Null(SteamAuthService.GetTokenExpiry(Jwt(new { exp = "soon" })));
+    }
+
+    private static string Jwt(object payload)
+    {
+        static string B64Url(string s) =>
+            Convert
+                .ToBase64String(Encoding.UTF8.GetBytes(s))
+                .TrimEnd('=')
+                .Replace('+', '-')
+                .Replace('/', '_');
+
+        return $"{B64Url("{\"alg\":\"none\"}")}.{B64Url(JsonSerializer.Serialize(payload))}.sig";
+    }
+}

--- a/tools/steam-service/Program.cs
+++ b/tools/steam-service/Program.cs
@@ -946,59 +946,71 @@ async Task MaintainTokensAsync(Dictionary<int, SteamAuthService> accts)
     {
         foreach (var svc in accts.Values)
         {
-            if (svc.IsLoggedIn && !svc.TokenFromEnv)
+            // Fire-and-forget loop: a throw from the free-text logger in the warning path would
+            // otherwise kill it silently. LogEvent never throws.
+            try
             {
-                try
+                if (svc.IsLoggedIn && !svc.TokenFromEnv)
                 {
-                    await svc.RenewRefreshTokenAsync();
+                    try
+                    {
+                        await svc.RenewRefreshTokenAsync();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log(
+                            $"[SteamService] A{svc.AccountIndex}: Token renewal failed: {ex.Message}"
+                        );
+                    }
                 }
-                catch (Exception ex)
-                {
-                    Logger.Log(
-                        $"[SteamService] A{svc.AccountIndex}: Token renewal failed: {ex.Message}"
-                    );
-                }
-            }
 
-            if (svc.TokenExpiresAt is not { } expiry)
+                if (svc.TokenExpiresAt is not { } expiry)
+                {
+                    continue;
+                }
+
+                var remaining = expiry - DateTimeOffset.UtcNow;
+                if (remaining > threshold)
+                {
+                    continue;
+                }
+
+                const string setup = "`docker compose run --rm -it steam-auth setup`";
+                var lastAttempt = $"last attempt {svc.LastRenewalAttemptAt:yyyy-MM-dd HH:mm} UTC";
+                var renewalState = svc.TokenFromEnv
+                    ? $"Renewal is off for environment-supplied tokens; mint a new one with {setup} + `export-token` and update the variable."
+                    : svc.LastRenewalOutcome switch
+                    {
+                        SteamAuthService.TokenRenewalOutcome.Refused =>
+                            $"Steam declined to renew it today ({lastAttempt}). Re-run {setup} before then.",
+                        SteamAuthService.TokenRenewalOutcome.Failed =>
+                            $"Renewal failed with {svc.LastRenewalError} ({lastAttempt}). Re-run {setup} before then.",
+                        _ => $"No renewal attempt has completed yet. Re-run {setup} before then.",
+                    };
+
+                Logger.Log(
+                    $"[SteamService] WARNING: A{svc.AccountIndex} ({svc.Username}) refresh token "
+                        + $"expires {expiry:yyyy-MM-dd} UTC ({Math.Max(0, (int)remaining.TotalDays)} days). "
+                        + renewalState
+                );
+                Logger.LogEvent(
+                    "account_token_expiring",
+                    new
+                    {
+                        account = svc.AccountIndex,
+                        expiresAt = expiry.ToString("o"),
+                        daysRemaining = (int)remaining.TotalDays,
+                        lastRenewalOutcome = SteamAuthService.OutcomeName(svc.LastRenewalOutcome),
+                    }
+                );
+            }
+            catch (Exception ex)
             {
-                continue;
+                Logger.LogEvent(
+                    "account_token_maintenance_error",
+                    new { account = svc.AccountIndex, error = ex.Message }
+                );
             }
-
-            var remaining = expiry - DateTimeOffset.UtcNow;
-            if (remaining > threshold)
-            {
-                continue;
-            }
-
-            const string setup = "`docker compose run --rm -it steam-auth setup`";
-            var lastAttempt = $"last attempt {svc.LastRenewalAttemptAt:yyyy-MM-dd HH:mm} UTC";
-            var renewalState = svc.TokenFromEnv
-                ? $"Renewal is off for environment-supplied tokens; mint a new one with {setup} + `export-token` and update the variable."
-                : svc.LastRenewalOutcome switch
-                {
-                    SteamAuthService.TokenRenewalOutcome.Refused =>
-                        $"Steam declined to renew it today ({lastAttempt}). Re-run {setup} before then.",
-                    SteamAuthService.TokenRenewalOutcome.Failed =>
-                        $"Renewal failed with {svc.LastRenewalError} ({lastAttempt}). Re-run {setup} before then.",
-                    _ => $"No renewal attempt has completed yet. Re-run {setup} before then.",
-                };
-
-            Logger.Log(
-                $"[SteamService] WARNING: A{svc.AccountIndex} ({svc.Username}) refresh token "
-                    + $"expires {expiry:yyyy-MM-dd} UTC ({Math.Max(0, (int)remaining.TotalDays)} days). "
-                    + renewalState
-            );
-            Logger.LogEvent(
-                "account_token_expiring",
-                new
-                {
-                    account = svc.AccountIndex,
-                    expiresAt = expiry.ToString("o"),
-                    daysRemaining = (int)remaining.TotalDays,
-                    lastRenewalOutcome = SteamAuthService.OutcomeName(svc.LastRenewalOutcome),
-                }
-            );
         }
 
         await Task.Delay(TimeSpan.FromDays(1));

--- a/tools/steam-service/Program.cs
+++ b/tools/steam-service/Program.cs
@@ -11,6 +11,7 @@
  *   download     - Download/update game depot (uses saved session or token)
  *   ticket       - Output encrypted app ticket to stdout
  *   export-token - Output saved refresh token for CI use
+ *   renew        - Ask Steam to renew saved refresh tokens (stop serve first)
  *   serve        - Run HTTP API for runtime ticket requests (default)
  *
  * Environment Variables (JSON format - preferred for multi-account):
@@ -295,6 +296,51 @@ switch (command)
         }
         break;
 
+    case "renew":
+        // Opens its own Steam session per account, and Steam allows one live session per account,
+        // so stop serve first. While serve runs, POST /steam/renew-token does the same in-session.
+        if (accounts.Count == 0)
+        {
+            Logger.Log(
+                "[SteamService] No account configured (set STEAM_USERNAME or STEAM_ACCOUNTS)"
+            );
+            Environment.Exit(1);
+        }
+
+        foreach (var (idx, svc) in accounts.OrderBy(kv => kv.Key))
+        {
+            Logger.Log($"[SteamService] --- Account {idx}: {svc.Username} ---");
+            try
+            {
+                await LoginAccountAsync(svc, accountConfigs[idx]);
+                if (!svc.IsLoggedIn)
+                {
+                    continue;
+                }
+
+                var result = await svc.RenewRefreshTokenAsync();
+                Console.WriteLine(
+                    JsonSerializer.Serialize(
+                        new
+                        {
+                            account = idx,
+                            username = svc.Username,
+                            renewed = result.Renewed,
+                            outcome = SteamAuthService.OutcomeName(result.Outcome),
+                            error = result.Error,
+                            previous_expires_at = result.PreviousExpiry?.ToString("o"),
+                            expires_at = result.NewExpiry?.ToString("o"),
+                        }
+                    )
+                );
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[SteamService] A{idx}: Token renewal failed: {ex.Message}");
+            }
+        }
+        break;
+
     case "download":
         if (accounts.TryGetValue(0, out var dlSvc))
         {
@@ -364,6 +410,7 @@ switch (command)
         Console.WriteLine("  download     Download/update game depot");
         Console.WriteLine("  ticket       Output encrypted app ticket to stdout");
         Console.WriteLine("  export-token Export saved refresh tokens (for CI)");
+        Console.WriteLine("  renew        Renew saved refresh tokens (stop serve first)");
         Console.WriteLine("  serve        Run HTTP API (default)");
         Environment.Exit(1);
         return;
@@ -496,6 +543,12 @@ async Task RunHttpServerAsync(
                     username = s.Username,
                     logged_in = s.IsLoggedIn,
                     steam_id = s.SteamId,
+                    token_expires_at = s.TokenExpiresAt?.ToString("o"),
+                    token_days_remaining = s.TokenExpiresAt is { } exp
+                        ? (int?)Math.Floor((exp - DateTimeOffset.UtcNow).TotalDays)
+                        : null,
+                    token_last_renewal_at = s.LastRenewalAttemptAt?.ToString("o"),
+                    token_last_renewal_outcome = SteamAuthService.OutcomeName(s.LastRenewalOutcome),
                 });
 
             return Results.Json(
@@ -595,6 +648,48 @@ async Task RunHttpServerAsync(
             catch (Exception ex)
             {
                 Logger.Log($"[HTTP] Error getting refresh token: {ex.Message}");
+                return Results.Json(new { error = ex.Message }, statusCode: 500);
+            }
+        }
+    );
+
+    // Renews over the live session, so it never collides with serve's own login the way a
+    // second `renew` process would (Steam allows one session per account).
+    app.MapPost(
+        "/steam/renew-token",
+        async (HttpContext ctx) =>
+        {
+            try
+            {
+                var svc = await EnsureAccountReadyAsync(ctx);
+                if (svc.TokenFromEnv)
+                {
+                    return Results.Json(
+                        new
+                        {
+                            error = "Token was supplied via environment; renewing it here would "
+                                + "invalidate that copy. Mint a new one with setup + export-token "
+                                + "and update the environment value.",
+                        },
+                        statusCode: 409
+                    );
+                }
+
+                var result = await svc.RenewRefreshTokenAsync();
+                return Results.Json(
+                    new
+                    {
+                        renewed = result.Renewed,
+                        outcome = SteamAuthService.OutcomeName(result.Outcome),
+                        error = result.Error,
+                        previous_expires_at = result.PreviousExpiry?.ToString("o"),
+                        expires_at = result.NewExpiry?.ToString("o"),
+                    }
+                );
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"[HTTP] Token renewal failed: {ex.Message}");
                 return Results.Json(new { error = ex.Message }, statusCode: 500);
             }
         }
@@ -727,6 +822,7 @@ async Task RunHttpServerAsync(
     Console.WriteLine("  GET  /steam/ready         - Readiness check (?account=N)");
     Console.WriteLine("  GET  /steam/app-ticket    - Get encrypted app ticket (?account=N)");
     Console.WriteLine("  GET  /steam/refresh-token - Get refresh token (?account=N)");
+    Console.WriteLine("  POST /steam/renew-token   - Renew the refresh token (?account=N)");
     Console.WriteLine("  POST /steam/lobby/create  - Create lobby (?account=N)");
 
     // Volumes provisioned before the execstack patch existed still carry the flag on the
@@ -760,6 +856,8 @@ async Task RunHttpServerAsync(
     });
 
     await Task.WhenAll(loginTasks);
+
+    _ = Task.Run(() => MaintainTokensAsync(accts));
 
     // First-run bootstrap, so a fresh `docker compose up` self-provisions without a manual `setup`.
     // Keyed on the completion marker startapp.sh gates on, so a half-finished download resumes
@@ -822,6 +920,88 @@ async Task BootstrapGameFilesAsync(
             await Task.Delay(delay);
             delay = TimeSpan.FromTicks(Math.Min(delay.Ticks * 2, maxDelay.Ticks));
         }
+    }
+}
+
+/// <summary>
+/// Daily per-account maintenance. The renewal request is unconditional because Steam only issues
+/// a new token close to expiry and does not publish the window, so there is nothing to gate on.
+/// Environment-supplied tokens are skipped: Steam invalidates the old token on renewal, which
+/// would leave the environment copy stale.
+/// </summary>
+async Task MaintainTokensAsync(Dictionary<int, SteamAuthService> accts)
+{
+    foreach (var svc in accts.Values.Where(s => s.TokenFromEnv))
+    {
+        Logger.Log(
+            $"[SteamService] A{svc.AccountIndex} ({svc.Username}): token renewal is off for "
+                + "environment-supplied tokens, because Steam invalidates the old token on renewal "
+                + "and the environment copy would go stale. Mint a new one with `setup` + "
+                + "`export-token` before it expires."
+        );
+    }
+
+    var threshold = TimeSpan.FromDays(14);
+    while (true)
+    {
+        foreach (var svc in accts.Values)
+        {
+            if (svc.IsLoggedIn && !svc.TokenFromEnv)
+            {
+                try
+                {
+                    await svc.RenewRefreshTokenAsync();
+                }
+                catch (Exception ex)
+                {
+                    Logger.Log(
+                        $"[SteamService] A{svc.AccountIndex}: Token renewal failed: {ex.Message}"
+                    );
+                }
+            }
+
+            if (svc.TokenExpiresAt is not { } expiry)
+            {
+                continue;
+            }
+
+            var remaining = expiry - DateTimeOffset.UtcNow;
+            if (remaining > threshold)
+            {
+                continue;
+            }
+
+            const string setup = "`docker compose run --rm -it steam-auth setup`";
+            var lastAttempt = $"last attempt {svc.LastRenewalAttemptAt:yyyy-MM-dd HH:mm} UTC";
+            var renewalState = svc.TokenFromEnv
+                ? $"Renewal is off for environment-supplied tokens; mint a new one with {setup} + `export-token` and update the variable."
+                : svc.LastRenewalOutcome switch
+                {
+                    SteamAuthService.TokenRenewalOutcome.Refused =>
+                        $"Steam declined to renew it today ({lastAttempt}). Re-run {setup} before then.",
+                    SteamAuthService.TokenRenewalOutcome.Failed =>
+                        $"Renewal failed with {svc.LastRenewalError} ({lastAttempt}). Re-run {setup} before then.",
+                    _ => $"No renewal attempt has completed yet. Re-run {setup} before then.",
+                };
+
+            Logger.Log(
+                $"[SteamService] WARNING: A{svc.AccountIndex} ({svc.Username}) refresh token "
+                    + $"expires {expiry:yyyy-MM-dd} UTC ({Math.Max(0, (int)remaining.TotalDays)} days). "
+                    + renewalState
+            );
+            Logger.LogEvent(
+                "account_token_expiring",
+                new
+                {
+                    account = svc.AccountIndex,
+                    expiresAt = expiry.ToString("o"),
+                    daysRemaining = (int)remaining.TotalDays,
+                    lastRenewalOutcome = SteamAuthService.OutcomeName(svc.LastRenewalOutcome),
+                }
+            );
+        }
+
+        await Task.Delay(TimeSpan.FromDays(1));
     }
 }
 

--- a/tools/steam-service/SteamAuthService.cs
+++ b/tools/steam-service/SteamAuthService.cs
@@ -89,6 +89,47 @@ public class SteamAuthService
 
     public bool IsLoggedIn { get; private set; }
     public string? SteamId => _steamClient.SteamID?.ConvertToUInt64().ToString();
+
+    /// <summary>Expiry of the refresh token last used to log in, from its JWT `exp` claim.</summary>
+    public DateTimeOffset? TokenExpiresAt { get; private set; }
+
+    /// <summary>
+    /// True when the refresh token came from STEAM_REFRESH_TOKEN / STEAM_ACCOUNTS rather than the
+    /// saved session. Renewal is refused for these: Steam invalidates the old token on renewal,
+    /// which would silently break the env copy.
+    /// </summary>
+    public bool TokenFromEnv { get; private set; }
+
+    /// <summary>
+    /// Steam's answer to a renewal request: a new token, a refusal (OK with no token, the normal
+    /// answer far from expiry), or an authentication failure (the token can no longer be renewed
+    /// but still logs in until <c>exp</c>).
+    /// </summary>
+    public enum TokenRenewalOutcome
+    {
+        Renewed,
+        Refused,
+        Failed,
+    }
+
+    /// <summary>Result of <see cref="RenewRefreshTokenAsync"/>; <c>Error</c> is the <see cref="EResult"/> name when <see cref="TokenRenewalOutcome.Failed"/>.</summary>
+    public record TokenRenewalResult(
+        TokenRenewalOutcome Outcome,
+        DateTimeOffset? PreviousExpiry,
+        DateTimeOffset? NewExpiry,
+        string? Error
+    )
+    {
+        public bool Renewed => Outcome == TokenRenewalOutcome.Renewed;
+    }
+
+    /// <summary>When <see cref="RenewRefreshTokenAsync"/> last asked Steam and what Steam answered.</summary>
+    public DateTimeOffset? LastRenewalAttemptAt { get; private set; }
+    public TokenRenewalOutcome? LastRenewalOutcome { get; private set; }
+    public string? LastRenewalError { get; private set; }
+
+    private const string SetupHint =
+        "Re-authenticate with: docker compose run --rm -it steam-auth setup";
     public ulong CurrentLobbyId => _currentLobbyId;
 
     public SteamAuthService(
@@ -244,6 +285,12 @@ public class SteamAuthService
         if (IsTerminalLogoff(result))
         {
             return; // banned/disabled
+        }
+
+        if (TokenExpiresAt is { } expiry && expiry <= DateTimeOffset.UtcNow)
+        {
+            Logger.Log($"{_logPrefix} Not reconnecting: refresh token expired. {SetupHint}");
+            return;
         }
 
         if (Interlocked.CompareExchange(ref _reconnectInProgress, 1, 0) != 0)
@@ -573,6 +620,7 @@ public class SteamAuthService
 
         _username = session.Value.username;
         _refreshToken = session.Value.refreshToken;
+        TokenFromEnv = false;
 
         await ConnectAndLoginAsync(_refreshToken);
     }
@@ -585,6 +633,7 @@ public class SteamAuthService
     {
         _username = username;
         _refreshToken = refreshToken;
+        TokenFromEnv = true;
 
         Logger.Log($"{_logPrefix} Logging in with provided token for {username}...");
         await ConnectAndLoginAsync(refreshToken);
@@ -784,6 +833,20 @@ public class SteamAuthService
         const int baseDelaySeconds = 5;
         var loginTimeout = TimeSpan.FromSeconds(30);
 
+        TokenExpiresAt = GetTokenExpiry(refreshToken);
+        if (TokenExpiresAt is { } expired && expired <= DateTimeOffset.UtcNow)
+        {
+            // Steam would reject it anyway; fail fast with the fix instead of five retries.
+            Logger.Log(
+                $"{_logPrefix} Refresh token expired on {expired:yyyy-MM-dd HH:mm:ss} UTC. {SetupHint}"
+            );
+            Logger.LogEvent(
+                "account_token_expired",
+                new { prefix = _logPrefix, expiresAt = expired.ToString("o") }
+            );
+            throw new Exception($"Refresh token expired on {expired:yyyy-MM-dd}. {SetupHint}");
+        }
+
         for (int attempt = 1; attempt <= maxRetries; attempt++)
         {
             var tcs = new TaskCompletionSource<bool>();
@@ -794,7 +857,13 @@ public class SteamAuthService
                 Logger.Log(
                     $"{_logPrefix} Logging in as {_username} with token ({refreshToken.Length} chars)..."
                 );
-                PrintTokenExpiry(refreshToken);
+                if (TokenExpiresAt is { } expiry)
+                {
+                    var remaining = expiry - DateTimeOffset.UtcNow;
+                    Logger.Log(
+                        $"{_logPrefix} Token expires: {expiry:yyyy-MM-dd HH:mm:ss} UTC ({remaining.Days} days remaining)"
+                    );
+                }
             }
             else
             {
@@ -846,53 +915,172 @@ public class SteamAuthService
             }
         }
 
-        throw new Exception($"Login failed after {maxRetries} attempts");
+        throw new Exception(
+            $"Login failed after {maxRetries} attempts. If Steam rejected the token, {SetupHint}"
+        );
     }
 
-    private void PrintTokenExpiry(string token)
+    /// <summary>
+    /// Expiry from the token's JWT <c>exp</c> claim, or null when the token is not a parseable JWT
+    /// or carries no <c>exp</c>. Steam never published the signing key, so the claim is read
+    /// unverified.
+    /// </summary>
+    internal static DateTimeOffset? GetTokenExpiry(string token)
     {
         try
         {
-            // JWT format: header.payload.signature
             var parts = token.Split('.');
             if (parts.Length != 3)
             {
-                return;
+                return null;
             }
 
-            // Decode payload (base64url)
-            var payload = parts[1];
-            // Add padding if needed
-            payload = payload.Replace('-', '+').Replace('_', '/');
-            switch (payload.Length % 4)
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
+            payload += (payload.Length % 4) switch
             {
-                case 2:
-                    payload += "==";
-                    break;
-                case 3:
-                    payload += "=";
-                    break;
-            }
+                2 => "==",
+                3 => "=",
+                _ => "",
+            };
 
-            var json = Encoding.UTF8.GetString(Convert.FromBase64String(payload));
-            var doc = JsonDocument.Parse(json);
-
-            if (doc.RootElement.TryGetProperty("exp", out var expProp))
-            {
-                var exp = expProp.GetInt64();
-                var expiryDate = DateTimeOffset.FromUnixTimeSeconds(exp);
-                var remaining = expiryDate - DateTimeOffset.UtcNow;
-
-                Logger.Log(
-                    $"{_logPrefix} Token expires: {expiryDate:yyyy-MM-dd HH:mm:ss} UTC ({remaining.Days} days remaining)"
-                );
-            }
+            using var doc = JsonDocument.Parse(Convert.FromBase64String(payload));
+            return
+                doc.RootElement.TryGetProperty("exp", out var exp)
+                && exp.ValueKind == JsonValueKind.Number
+                ? DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64())
+                : null;
         }
-        catch (Exception ex) when (ex is JsonException or FormatException or KeyNotFoundException)
+        catch (Exception ex) when (ex is JsonException or FormatException)
         {
-            // Token expiry parsing is non-critical, just skip it
+            return null;
         }
     }
+
+    /// <summary>
+    /// Asks Steam for a renewed refresh token over the logged-in session. Steam decides whether
+    /// to issue one; the result reports whether it did. A renewed token replaces the saved
+    /// session before returning because Steam invalidates the previous token on renewal.
+    /// Holds the login semaphore so the reconnect loop never reads the token mid-swap. An
+    /// <see cref="AuthenticationException"/> is reported as <see cref="TokenRenewalOutcome.Failed"/>
+    /// rather than thrown: the session stays up and the token keeps logging in until it expires.
+    /// </summary>
+    public async Task<TokenRenewalResult> RenewRefreshTokenAsync()
+    {
+        if (!IsLoggedIn)
+        {
+            throw new InvalidOperationException("Not logged in");
+        }
+
+        if (TokenFromEnv)
+        {
+            throw new InvalidOperationException(
+                "Token was supplied via environment; renewing it here would invalidate that copy. "
+                    + "Renew where the token is minted and update the environment value."
+            );
+        }
+
+        await _loginSemaphore.WaitAsync();
+        try
+        {
+            if (!IsLoggedIn || _refreshToken == null || _username == null)
+            {
+                throw new InvalidOperationException("Not logged in");
+            }
+
+            var steamId =
+                _steamClient.SteamID
+                ?? throw new InvalidOperationException("No SteamID on session");
+            var previousExpiry = TokenExpiresAt;
+            var attemptedAt = DateTimeOffset.UtcNow;
+            TokenRenewalOutcome outcome;
+            string? error = null;
+
+            try
+            {
+                var response = await _steamClient.Authentication.GenerateAccessTokenForAppAsync(
+                    steamId,
+                    _refreshToken,
+                    allowRenewal: true
+                );
+
+                if (string.IsNullOrEmpty(response.RefreshToken))
+                {
+                    outcome = TokenRenewalOutcome.Refused;
+                }
+                else
+                {
+                    // Steam has already invalidated the old token, so the new one is adopted
+                    // even if persisting it fails; that failure is reported, not hidden.
+                    _refreshToken = response.RefreshToken;
+                    TokenExpiresAt = GetTokenExpiry(_refreshToken);
+                    outcome = TokenRenewalOutcome.Renewed;
+                    try
+                    {
+                        SaveSession(_username, _refreshToken);
+                    }
+                    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                    {
+                        error = $"renewed but not saved: {ex.Message}";
+                        Logger.Log(
+                            $"{_logPrefix} Refresh token renewed but saving the session failed ({ex.Message}). "
+                                + "The new token exists only in this process; if the sidecar restarts before "
+                                + $"a successful save, {SetupHint}"
+                        );
+                    }
+                }
+            }
+            catch (AuthenticationException ex)
+            {
+                outcome = TokenRenewalOutcome.Failed;
+                error = ex.Result.ToString();
+            }
+            catch (Exception ex)
+            {
+                LastRenewalAttemptAt = attemptedAt;
+                LastRenewalOutcome = TokenRenewalOutcome.Failed;
+                LastRenewalError = ex.Message;
+                throw;
+            }
+
+            LastRenewalAttemptAt = attemptedAt;
+            LastRenewalOutcome = outcome;
+            LastRenewalError = error;
+
+            Logger.Log(
+                outcome switch
+                {
+                    TokenRenewalOutcome.Renewed =>
+                        $"{_logPrefix} Refresh token renewed; new expiry {TokenExpiresAt:yyyy-MM-dd HH:mm:ss} UTC",
+                    TokenRenewalOutcome.Failed =>
+                        $"{_logPrefix} Refresh token renewal failed with {error} (current expiry {previousExpiry:yyyy-MM-dd HH:mm:ss} UTC)",
+                    _ =>
+                        $"{_logPrefix} Steam did not issue a new refresh token (current expiry {previousExpiry:yyyy-MM-dd HH:mm:ss} UTC)",
+                }
+            );
+            Logger.LogEvent(
+                "account_token_renewal",
+                new
+                {
+                    prefix = _logPrefix,
+                    outcome = OutcomeName(outcome),
+                    renewed = outcome == TokenRenewalOutcome.Renewed,
+                    error,
+                    previousExpiry = previousExpiry?.ToString("o"),
+                    newExpiry = TokenExpiresAt?.ToString("o"),
+                }
+            );
+
+            return new TokenRenewalResult(outcome, previousExpiry, TokenExpiresAt, error);
+        }
+        finally
+        {
+            _loginSemaphore.Release();
+        }
+    }
+
+    /// <summary>Wire form of an outcome in log events and HTTP JSON (lower-case).</summary>
+    public static string? OutcomeName(TokenRenewalOutcome? outcome) =>
+        outcome?.ToString().ToLowerInvariant();
 
     // ========================================================================
     // App Ticket (Encrypted App Ticket for Galaxy cross-platform auth)

--- a/tools/steam-service/SteamAuthService.cs
+++ b/tools/steam-service/SteamAuthService.cs
@@ -947,7 +947,10 @@ public class SteamAuthService
             return
                 doc.RootElement.TryGetProperty("exp", out var exp)
                 && exp.ValueKind == JsonValueKind.Number
-                ? DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64())
+                && exp.TryGetInt64(out var seconds)
+                && seconds >= DateTimeOffset.MinValue.ToUnixTimeSeconds()
+                && seconds <= DateTimeOffset.MaxValue.ToUnixTimeSeconds()
+                ? DateTimeOffset.FromUnixTimeSeconds(seconds)
                 : null;
         }
         catch (Exception ex) when (ex is JsonException or FormatException)


### PR DESCRIPTION
## Summary

The steam-auth sidecar now keeps its Steam refresh token alive instead of letting it silently
expire and take Galaxy auth down with it. Previously a token was minted at `setup` and reused
until it died (~200 days), with `serve` staying up reporting `logged_in=false` and no operator
warning.

## Changes

- **Daily renewal loop in `serve`** — asks Steam once a day to renew each saved-session token and
  persists the new one when Steam agrees. The request is unconditional because Steam only renews
  close to expiry and does not publish its window, so there is nothing to gate on.
- **Expiry warnings** — during the last 14 days before expiry a daily log warning names the last
  renewal outcome (`refused` / `failed`) and the fix.
- **Environment-supplied tokens are skipped** (`STEAM_REFRESH_TOKEN` / `STEAM_ACCOUNTS`), since
  renewal would invalidate the environment copy; they get a startup notice instead.
- **Expiry surfaced** — parsed from the JWT `exp` claim, logged at every login, and exposed per
  account in `GET /health` (`token_expires_at`, `token_days_remaining`, `token_last_renewal_*`).
  An already-expired token now fails login fast with the setup command instead of retrying.
- **Manual renewal** — adds `POST /steam/renew-token` and a `renew` CLI command.
- **Docs** — troubleshooting, installation quick-start, and the developer steam-auth architecture
  reference updated for the renewal behaviour and the corrected session path
  (`{username}/session.json`).

## Testing

- `TokenExpiryTests` covers JWT `exp` parsing across base64url padding classes and non-JWT input.
- `dotnet test tests/SteamService.Tests` — 14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Steam authentication now requests daily renewal for eligible saved-session tokens.
  - Added token expiry and renewal status to health information.
  - Added commands and API support for manually renewing tokens.
  - Environment-supplied tokens are excluded from automatic renewal.

- **Bug Fixes**
  - Improved handling of invalid token expiry values without service errors.

- **Documentation**
  - Expanded setup, troubleshooting, and developer documentation with renewal behavior, warnings, outcomes, and token expiry details.

- **Tests**
  - Added coverage for token expiry detection and invalid token formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->