### PR TITLE
chore: enforce a commit-scope enum with casing validation

### DIFF
--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -36,6 +36,7 @@ gh pr merge <child-num> --squash --auto
 ## Commits and PRs
 
 - Conventional commits (commitlint), body lines max 100 chars, `git commit -F <file>`.
+- Pick the `type(scope)` via the `commit` skill — it carries the enforced type list and the files-edited→scope map.
 - No `Co-Authored-By` trailer. No co-author attribution in PRs.
 - Subjects (PR title, commit subject) are changelog lines: lead with the player/admin-facing outcome ("festivals no longer kick players who moved their cabin"), not the mechanism, and say what kind of thing shipped ("embeddable live server status widget for web pages", not "status widget backed by /status").
 - Commit body in plain English — what changed, why, what tests cover it — no unexplained in-house terms.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: commit
+description: Composes a Conventional Commit message or PR title that passes this repo's commitlint gate — provides the enforced type list, the scope enum as a files-edited→scope lookup, and the optional-scope rule. Use before running `git commit`, or when setting a PR/squash title, in this repo.
+---
+
+# Commit conventions
+
+Commit and PR titles are `type(scope): subject`, enforced by `commitlint.config.js` at commit time (lefthook `commit-msg`) and in CI (`validate-commits`, `validate-pr-title`). Resolve type and scope by lookup, not recall. `commitlint.config.js` `scope-enum` is the authoritative scope list; the map below routes to it and must stay in sync with it.
+
+Subject-writing rules (changelog-facing wording, 100-char body lines, no `Co-Authored-By`) live in `.claude/rules/universal/git-workflow.md` — this skill only picks `type(scope)`.
+
+## Step 1 — type (what *kind* of work is it?)
+
+| Type | Kind | Changelog |
+|---|---|---|
+| `feat` | New player/admin-facing capability | Features (minor bump) |
+| `fix` | Bug fix in shipped behavior | Bug Fixes (patch bump) |
+| `perf` | Faster/lighter shipped behavior | shown |
+| `revert` | Reverts a commit | shown |
+| `docs` | Documentation only | shown |
+| `refactor` | Restructure, no behavior change | hidden |
+| `test` | Test code only | hidden |
+| `build` | How artifacts are compiled — Dockerfile build stages, `.csproj`, `Directory.Build.props`, SMAPI bumps | hidden |
+| `ci` | Pipelines, GitHub Actions, release automation | hidden |
+| `chore` | Everything else with no kind-specific type — deps, repo config, `.claude/` | hidden |
+| `style` | Formatting only | hidden |
+
+- **`ci` and `build` are types, never scopes** — `ci:` / `build:`, never `fix(ci)` or `chore(ci)`. CI is scope-free (`ci(e2e)` is rejected).
+- **`chore` is the fallback**, not the parent, of the hidden types. Use `test`/`refactor`/`build`/`ci`/`style` when the kind fits; `chore` only when none does — never `chore(<kind>)`.
+
+## Step 2 — scope (which *area*? map from the files you edited)
+
+Scope is optional. When present, it must be one of these. Match on the paths you actually changed:
+
+| Files edited | Scope |
+|---|---|
+| `Services/AlwaysOnServer/`, `Services/HostAutomation/` | `host` |
+| `Services/{GameManager,GameThread,ServerOptim,PersistentOption,Settings}/`, `ModEntry.cs`, `ModService.cs`, `Env.cs`, `Util/`, `mod/JunimoServer.Shared/` | `core` |
+| `Services/Api/` | `api` |
+| `Services/SteamGameServer/`, `Services/AuthService/`, `tools/steam-service/` | `steam` |
+| `Services/PasswordProtection/`, `Services/Roles/` | `auth` |
+| `Services/Lobby/` | `lobby` |
+| `Services/CabinManager/` | `cabins` |
+| `Services/ChatCommands/`, `Services/Commands/` (framework + relay + generic commands) | `chat` |
+| `Services/{SaveImport,GameCreator,GameLoader}/` | `saves` |
+| `Services/CropSaver/` | `crop-saver` |
+| `Services/{NetworkTweaks,MessageInterceptors,Security}/` | `networking` |
+| `Services/GameTweaks/`, `Services/NpcIntegrity/` | `gameplay` |
+| interop with another/3rd-party mod | `compat` (reserved — no backing code yet) |
+| `Services/Backup/` | `backup` |
+| `Services/Diagnostics/`, `tools/diagnostics/` | `diagnostics` |
+| `tools/discord-bot/` | `discord` |
+| `docker/` runtime image (rootfs, entrypoint, s6, proxy) | `docker` *(build stages → type `build`)* |
+| `tests/JunimoServer.Tests/` | `tests` |
+| `tests/JunimoServer.TestRunner/` | `test-runner` |
+| `tests/test-client/` | `test-client` |
+| `tests/test-ui/` | `test-ui` |
+| `tools/` dev CLIs (netdebug, openapi-generator, xnb-unpacker, dll-patcher, discli-docker, lobby-layout-preview-poc) | `tools` |
+| `.claude/` | `claude` |
+| `docs/` | `docs` |
+| `Makefile`, `lefthook.yml`, `renovate.json`, `.gitattributes`, `.editorconfig`, `biome.jsonc`, root `package.json` | `repo` |
+| Renovate-authored dependency bumps only (don't hand-author) | `deps`, `deps-dev`, `deps/*` |
+
+Two routing rules:
+- **A feature-specific command attributes to its feature**, not `chat` — a `!cabin` behavior change is `feat(cabins)`, a `saves` console command is `feat(saves)`. Only the command framework, Discord relay, and generic commands (`!invite`, `!login`) are `chat`.
+- **New *settings* attribute to the feature they configure** (a new cabin option is `feat(cabins)`), not `core`.
+
+## Step 3 — when unsure, don't guess
+
+- **The change spans several areas, or no row fits cleanly → omit the scope.** A bare `type: subject` is always valid; a wrong scope is a rejected commit. Omitting beats guessing.
+- **Unsure a scope is valid → validate before committing:** `printf 'feat(scope): x\n' | npx commitlint`. Exit 0 = valid.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -24,6 +24,64 @@ module.exports = {
         'ci'        // Continuous Integration
       ]
     ],
+    // A scope names an *area*, never a kind of work (`ci`/`build` are types, so
+    // there is no scope `ci`). Optional by design — no `scope-empty` rule. The
+    // `.claude/skills/commit` skill maps files-edited→scope and must stay in sync
+    // with this list. The `deps`/`deps/*` block mirrors renovate.json — keep it
+    // in sync or Renovate's own PRs fail.
+    'scope-enum': [
+      2,
+      'always',
+      [
+        // Product / runtime — recurring, changelog-facing areas
+        'host',
+        'core',
+        'api',
+        'steam',
+        'auth',
+        'lobby',
+        'cabins',
+        'chat',
+        'saves',
+        'crop-saver',
+        'networking',
+        'gameplay',
+        'compat',
+        'backup',
+        'diagnostics',
+        'discord',
+        // Infrastructure — runtime image / container config
+        'docker',
+        // Tooling / repo
+        'tests',
+        'test-runner',
+        'test-client',
+        'test-ui',
+        'tools',
+        'claude',
+        'docs',
+        'repo',
+        // Renovate emits these, humans don't. `deps-dev` is emitted for
+        // devDependency updates and is not itself a renovate.json scope.
+        'deps',
+        'deps-dev',
+        'deps/server',
+        'deps/steam-service',
+        'deps/discord-bot',
+        'deps/test-runner',
+        'deps/test-client',
+        'deps/test-ui',
+        'deps/tools',
+        'deps/project',
+        'deps/docs',
+        'deps/docker',
+        'deps/github-actions',
+        'deps/dotnet-sdk'
+      ]
+    ],
+    // Enforce kebab-case so casing drift (`cropSaver`) can't reappear; the
+    // `deps/*` slash forms and `deps-dev` hyphen still pass.
+    'scope-case': [2, 'always', 'kebab-case'],
     // Ensure subject is not empty
     'subject-empty': [2, 'never'],
     // Ensure type is not empty

--- a/docs/developers/contributing/index.md
+++ b/docs/developers/contributing/index.md
@@ -109,26 +109,52 @@ We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) fo
 
 **Format:**
 ```
-<type>: <description>
+<type>(<scope>): <description>
 
 [optional body]
 ```
 
-**Types:**
-- `feat:` - New feature (bumps minor version: 1.0.0 → 1.1.0)
-- `fix:` - Bug fix (bumps patch version: 1.0.0 → 1.0.1)
-- `docs:` - Documentation only (no version bump)
-- `chore:` - Maintenance tasks (no version bump)
-- `refactor:` - Code refactoring (no version bump)
-- `test:` - Adding tests (no version bump)
+Pick the **type** first — what *kind* of work it is; it drives the changelog and version bump. The **scope** is *which area* it touches, and is optional. **Kind → type, area → scope.**
+
+**Types** (11, all enforced):
+
+| Type | Use for | Changelog |
+|---|---|---|
+| `feat` | New player/admin-facing capability | Features (minor bump) |
+| `fix` | Bug fix in shipped behavior | Bug Fixes (patch bump) |
+| `perf` | Faster/lighter shipped behavior | Performance |
+| `revert` | Reverts a previous commit | shown |
+| `docs` | Documentation only | shown |
+| `refactor` | Restructure with no behavior change | hidden |
+| `test` | Test code only | hidden |
+| `build` | How artifacts are compiled/produced — Dockerfile build stages, `.csproj`, `Directory.Build.props`, SMAPI-version bumps | hidden |
+| `ci` | Pipelines, GitHub Actions, release automation | hidden |
+| `chore` | Everything else with no more specific kind — deps, repo config, `.claude/` | hidden |
+| `style` | Formatting only | hidden |
+
+**`ci` and `build` are types, never scopes** — a CI change is `ci:`, a build-system change is `build:`, never `fix(ci)` or `chore(ci)`. Reach for a hidden type when its *kind* fits (`test`, `refactor`, `build`, `ci`, `style`); use `chore` only when none does — never `chore(<kind>)`, which throws the area away.
+
+**Scopes** — optional, but when present must come from the enforced enum below (spelling and kebab-casing are validated, so `fix(cabin)` and `crop_saver` are rejected):
+
+| Group | Scopes |
+|---|---|
+| Product / runtime | `host` `core` `api` `steam` `auth` `lobby` `cabins` `chat` `saves` `crop-saver` `networking` `gameplay` `compat` `backup` `diagnostics` `discord` |
+| Infrastructure | `docker` |
+| Tooling / repo | `tests` `test-runner` `test-client` `test-ui` `tools` `claude` `docs` `repo` |
+| Dependencies (Renovate-emitted) | `deps` `deps-dev` `deps/*` |
+
+Rough guide: `host` = unattended host behavior (auto-pause/sleep, festivals); `core` = the server process/infrastructure; `chat` = the command framework + Discord relay, but a feature-specific command attributes to its feature (a `!cabin` change is `feat(cabins)`); `gameplay` = server-side vanilla-behavior tweaks; `compat` = interop with other/3rd-party mods.
+
+A bare `feat: …` with no scope is valid — that's the pressure-release valve for rare one-off areas. The enum lives in [`commitlint.config.js`](https://github.com/stardew-valley-dedicated-server/server/blob/master/commitlint.config.js); adding a recurring area is a one-line PR against it.
 
 **Breaking changes:**
 - `feat!:` or `BREAKING CHANGE:` in body (bumps major version: 1.0.0 → 2.0.0)
 
 **Examples:**
 ```bash
-git commit -m "feat: add cabin management system"
-git commit -m "fix: resolve memory leak in server loop"
+git commit -m "feat(cabins): add cabin management system"
+git commit -m "fix(core): resolve memory leak in the game loop"
+git commit -m "ci: cache NuGet restore across build jobs"
 git commit -m "docs: update installation guide"
 git commit -m "feat!: redesign configuration format"
 ```
@@ -137,6 +163,7 @@ git commit -m "feat!: redesign configuration format"
 
 After running `make install`, git hooks will automatically validate your commits:
 - ❌ Invalid: `"update readme"` → Error: type missing
+- ❌ Invalid: `"fix(cabin): typo"` → Error: scope not in enum (it's `cabins`)
 - ✅ Valid: `"docs: update readme"` → Accepted
 
 #### Making the Pull Request

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
       "release-type": "simple",
       "package-name": "sdvd-server",
       "include-component-in-tag": false,
-      "pull-request-title-pattern": "chore${scope}: release ${version}",
+      "pull-request-title-pattern": "chore: release ${version}",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## What

Establishes a fixed, enforced set of commit **types** and **scopes** so commit and PR titles stay consistent and changelog-ready.

- **`commitlint.config.js`** — add `scope-enum` (authoritative scope list) and `scope-case` (kebab-case). Scopes remain optional, but a present scope must be in the enum and correctly cased. The `deps`/`deps/*` scopes mirror `renovate.json` so Renovate's own PRs pass.
- **`docs/developers/contributing/index.md`** — document the type/scope model for contributors (kind → type, area → scope), with the enforced type table and scope groups.
- **`.claude/skills/commit/SKILL.md`** — new skill that resolves `type(scope)` by lookup (type table + files-edited→scope map) rather than recall.
- **`.claude/rules/universal/git-workflow.md`** — point contributors/agents at the commit skill.
- **`release-please-config.json`** — drop `${scope}` from the release PR title pattern so automated release PRs are `chore: release X.Y.Z` (a valid bare chore) instead of `chore(master): …`, which the new enum would reject.

## Enforcement

- **Type** — required; one of the 11 enforced types.
- **Scope** — optional; if present, must be in the enum and kebab-cased (`fix(cabin)`, `crop_saver` are rejected).
- Runs locally via lefthook `commit-msg` and in CI (`validate-commits` + `validate-pr-title`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
