### PR TITLE
fix(docker): server console commands work when the host enables protected FIFOs

### DIFF
--- a/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
+++ b/.claude/plans/docker-modern/phase-2-remove-shell-dependencies/01-http-command-api.md
@@ -9,7 +9,7 @@ client that runs on demand — including against remote servers.
 ## How commands work today
 
 The launch in `docker/modern/rootfs/opt/bin/start-game.sh` runs SMAPI with its stdin coming from a
-named pipe (`tail -f` on `/tmp/smapi-input` piped into SMAPI, wrapped in `script` to get a PTY for
+named pipe (`tail -f` on `/tmp/junimo/smapi-input` piped into SMAPI, wrapped in `script` to get a PTY for
 coloured output). Anything written to that FIFO becomes a SMAPI console command. Two shell pieces
 write to it:
 

--- a/docker/modern/rootfs/opt/bin/server-command-loop
+++ b/docker/modern/rootfs/opt/bin/server-command-loop
@@ -6,7 +6,7 @@
 # Takes the session name as first argument.
 
 SESSION_NAME="$1"
-INPUT_FIFO="/tmp/smapi-input"
+INPUT_FIFO="/tmp/junimo/smapi-input"
 PASSWORD_MODE_FILE="/tmp/smapi-password-mode"
 HISTFILE="/tmp/server-command-history"
 HISTSIZE=1000

--- a/docker/modern/rootfs/opt/bin/start-game.sh
+++ b/docker/modern/rootfs/opt/bin/start-game.sh
@@ -191,11 +191,8 @@ init_permissions
 
 # Run the game through SMAPI with FIFO for command input
 LOG_FILE="/tmp/server-output.log"
-# The command FIFO lives in a private dir, not directly in /tmp: with fs.protected_fifos enabled
-# on the host, a process cannot open a FIFO it does not own for writing inside a sticky
-# world-writable dir (/tmp is 1777). This game process runs as the app user and owns the FIFO, but
-# attach-cli's command loop and toggle-rendering run as root via `docker compose exec` — so a FIFO
-# in /tmp itself rejects their writes (EACCES). A non-world-writable dir sidesteps the check.
+# Not directly in /tmp: with fs.protected_fifos set on the host, root (attach-cli, toggle-rendering)
+# cannot write to a FIFO owned by the app user inside a sticky world-writable dir.
 FIFO_DIR="/tmp/junimo"
 INPUT_FIFO="${FIFO_DIR}/smapi-input"
 
@@ -209,8 +206,9 @@ mkfifo "${INPUT_FIFO}"
 # __pthread_key_create (glibc internal symbol not provided by musl/gcompat)
 export LD_PRELOAD="/opt/lib/pthread_shim.so${LD_PRELOAD:+:$LD_PRELOAD}"
 
-# Start SMAPI with stdin from FIFO, output to log file and stdout
-# Using 'script' to create a PTY so SMAPI outputs colors (thinks it's a terminal)
+# Start SMAPI with stdin from the FIFO. `script` gives it a PTY so it prints colors and copies
+# output to both stdout (docker logs) and LOG_FILE (tailed by attach-cli). `tail -f` keeps the
+# FIFO open between writers.
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!
 

--- a/docker/modern/rootfs/opt/bin/start-game.sh
+++ b/docker/modern/rootfs/opt/bin/start-game.sh
@@ -191,10 +191,17 @@ init_permissions
 
 # Run the game through SMAPI with FIFO for command input
 LOG_FILE="/tmp/server-output.log"
-INPUT_FIFO="/tmp/smapi-input"
+# The command FIFO lives in a private dir, not directly in /tmp: with fs.protected_fifos enabled
+# on the host, a process cannot open a FIFO it does not own for writing inside a sticky
+# world-writable dir (/tmp is 1777). This game process runs as the app user and owns the FIFO, but
+# attach-cli's command loop and toggle-rendering run as root via `docker compose exec` — so a FIFO
+# in /tmp itself rejects their writes (EACCES). A non-world-writable dir sidesteps the check.
+FIFO_DIR="/tmp/junimo"
+INPUT_FIFO="${FIFO_DIR}/smapi-input"
 
 touch "${LOG_FILE}"
 
+mkdir -p "${FIFO_DIR}"
 rm -f "${INPUT_FIFO}"
 mkfifo "${INPUT_FIFO}"
 

--- a/docker/modern/rootfs/opt/bin/toggle-rendering.sh
+++ b/docker/modern/rootfs/opt/bin/toggle-rendering.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Sends rendering toggle command to SMAPI via the input FIFO
-INPUT_FIFO="/tmp/smapi-input"
+INPUT_FIFO="/tmp/junimo/smapi-input"
 
 if [ ! -p "$INPUT_FIFO" ]; then
     echo "SMAPI not running"

--- a/docker/rootfs/opt/base/bin/server-command-loop
+++ b/docker/rootfs/opt/base/bin/server-command-loop
@@ -6,7 +6,7 @@
 # Takes the session name as first argument.
 
 SESSION_NAME="$1"
-INPUT_FIFO="/tmp/smapi-input"
+INPUT_FIFO="/tmp/junimo/smapi-input"
 PASSWORD_MODE_FILE="/tmp/smapi-password-mode"
 HISTFILE="/tmp/server-command-history"
 HISTSIZE=1000

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -339,11 +339,8 @@ init_permissions
 
 # Run the game through SMAPI (with FIFO to pipe commands via CLI).
 LOG_FILE="/tmp/server-output.log"
-# The command FIFO lives in a private dir, not directly in /tmp: with fs.protected_fifos enabled
-# on the host, a process cannot open a FIFO it does not own for writing inside a sticky
-# world-writable dir (/tmp is 1777). This game process runs as the app user and owns the FIFO, but
-# attach-cli's command loop and toggle-rendering run as root via `docker compose exec` — so a FIFO
-# in /tmp itself rejects their writes (EACCES). A non-world-writable dir sidesteps the check.
+# Not directly in /tmp: with fs.protected_fifos set on the host, root (attach-cli, toggle-rendering)
+# cannot write to a FIFO owned by the app user inside a sticky world-writable dir.
 FIFO_DIR="/tmp/junimo"
 INPUT_FIFO="${FIFO_DIR}/smapi-input"
 
@@ -355,15 +352,13 @@ mkdir -p "${FIFO_DIR}"
 rm -f "${INPUT_FIFO}"
 mkfifo "${INPUT_FIFO}"
 
-# Start SMAPI, piping stdin from FIFO and output to log file + stdout
-# Using `script` to create a PTY so SMAPI prints colored output (make it think it's a terminal)
-# Using `tail -f` on the FIFO to keep it open and avoid blocking
-# Caveat: the PTY covers stdout only, and the FIFO only ever delivers \n-terminated lines — SMAPI
-# prompts that read a raw keystroke (Console.ReadKey: crash/update markers, PressAnyKeyToExit)
-# can't be answered through this channel; prevent them upstream (see clear_smapi_marker_prompts)
+# Start SMAPI with stdin from the FIFO. `script` gives it a PTY so it prints colors and copies
+# output to both stdout (docker logs) and LOG_FILE (tailed by attach-cli). `tail -f` keeps the
+# FIFO open between writers.
+# The FIFO only delivers newline-terminated lines, so prompts that read a raw keystroke
+# (Console.ReadKey: crash/update markers, PressAnyKeyToExit) cannot be answered here. They are
+# prevented upstream in clear_smapi_marker_prompts.
 echo "Starting SMAPI..."
-# `script` writes to both stdout (docker logs) and the typescript file (${LOG_FILE}, tailed by
-# attach-cli and read by `cat`).
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!
 

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -362,10 +362,8 @@ mkfifo "${INPUT_FIFO}"
 # prompts that read a raw keystroke (Console.ReadKey: crash/update markers, PressAnyKeyToExit)
 # can't be answered through this channel; prevent them upstream (see clear_smapi_marker_prompts)
 echo "Starting SMAPI..."
-# `script` writes to both stdout (docker logs) and the typescript file (${LOG_FILE}, read by
-# attach-cli / `cat`). Keep this pipeline unfiltered: startup noise is filtered at the read
-# site instead (attach-cli tails through strip-startup-noise.awk). A filter interposed on
-# script's stdout here stalled the session under `wait`, so don't reintroduce one.
+# `script` writes to both stdout (docker logs) and the typescript file (${LOG_FILE}, tailed by
+# attach-cli and read by `cat`).
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!
 

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -339,23 +339,33 @@ init_permissions
 
 # Run the game through SMAPI (with FIFO to pipe commands via CLI).
 LOG_FILE="/tmp/server-output.log"
-INPUT_FIFO="/tmp/smapi-input"
+# The command FIFO lives in a private dir, not directly in /tmp: with fs.protected_fifos enabled
+# on the host, a process cannot open a FIFO it does not own for writing inside a sticky
+# world-writable dir (/tmp is 1777). This game process runs as the app user and owns the FIFO, but
+# attach-cli's command loop and toggle-rendering run as root via `docker compose exec` — so a FIFO
+# in /tmp itself rejects their writes (EACCES). A non-world-writable dir sidesteps the check.
+FIFO_DIR="/tmp/junimo"
+INPUT_FIFO="${FIFO_DIR}/smapi-input"
 
 # Ensure log file exists
 touch "${LOG_FILE}"
 
 # Ensure FIFO pipe exists
+mkdir -p "${FIFO_DIR}"
 rm -f "${INPUT_FIFO}"
 mkfifo "${INPUT_FIFO}"
 
 # Start SMAPI, piping stdin from FIFO and output to log file + stdout
 # Using `script` to create a PTY so SMAPI prints colored output (make it think it's a terminal)
 # Using `tail -f` on the FIFO to keep it open and avoid blocking
-# Note: `script` writes to both stdout (for docker logs) and the typescript file simultaneously
 # Caveat: the PTY covers stdout only, and the FIFO only ever delivers \n-terminated lines — SMAPI
 # prompts that read a raw keystroke (Console.ReadKey: crash/update markers, PressAnyKeyToExit)
 # can't be answered through this channel; prevent them upstream (see clear_smapi_marker_prompts)
 echo "Starting SMAPI..."
+# `script` writes to both stdout (docker logs) and the typescript file (${LOG_FILE}, read by
+# attach-cli / `cat`). Keep this pipeline unfiltered: startup noise is filtered at the read
+# site instead (attach-cli tails through strip-startup-noise.awk). A filter interposed on
+# script's stdout here stalled the session under `wait`, so don't reintroduce one.
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!
 


### PR DESCRIPTION
## Summary

Server console commands (via attach-cli and toggle-rendering) now work on hosts that enable `fs.protected_fifos`.

## Change
- The SMAPI command FIFO moves from `/tmp/smapi-input` to `/tmp/junimo/smapi-input`. With `fs.protected_fifos` enabled, a process cannot open a FIFO it does not own for writing inside a sticky world-writable dir (`/tmp` is 1777). The game owns the FIFO, but attach-cli's command loop and toggle-rendering run as root via `docker compose exec`, so their writes to a FIFO in `/tmp` itself were rejected (EACCES). A non-world-writable dir sidesteps the check.
- Applies to both the modern and legacy images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMAPI command handling in environments with protected temporary-file permissions.
  * Moved command communication to a dedicated temporary directory to help prevent permission-related failures.
  * The required temporary directory is now created automatically during startup.
  * Updated related documentation to reflect the new command communication location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->