### PR TITLE
feat(docker): quieter server console that exits when the server isn't running

### DIFF
--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -16,7 +16,7 @@
 - Branch must be up to date with `master`, approved, green. Behind: use the PR's **Update branch** button.
 - Approve: comment `!approve` on the PR (`gh pr review --approve` fails for the author).
 - Merge: `gh pr merge <num> --squash [--auto]`. Squash uses the PR title as the commit subject and drops the body, so the PR title is the changelog line.
-- A PR that ships several player/admin-facing changes gets one changelog line per change by passing them as the squash body: `gh pr merge <num> --squash --body-file <file>`, one `type(scope): subject` per line (each meeting the subject rule below). release-please and the Discord changelog list every such line. Keep the lines in the PR description under a `### 📝 Changelog` heading so reviewers see them.
+- Exception, several changes in one PR: `gh pr merge <num> --squash --body-file <file>` with one `type(scope): subject` per line; release-please and the Discord changelog list each.
 - `--rebase` only when the PR is a series of independent player/admin-facing changes that each deserve their own line; then every commit subject must meet the subject rule below.
 
 ## Chained PRs
@@ -41,7 +41,7 @@ gh pr merge <child-num> --squash --auto
 - No `Co-Authored-By` trailer. No co-author attribution in PRs.
 - Subjects (PR title, commit subject) are changelog lines: lead with the player/admin-facing outcome ("festivals no longer kick players who moved their cabin"), not the mechanism, and say what kind of thing shipped ("embeddable live server status widget for web pages", not "status widget backed by /status").
 - Commit body in plain English — what changed, why, what tests cover it — no unexplained in-house terms.
-- A squashed PR is one changelog line by default, so it holds one change. A fix that belongs to a sibling feature still in review moves into that feature's PR instead of riding along. A PR that has already grown several changes uses the squash-body mechanism above rather than being split after the fact.
+- A squashed PR is one changelog line, so it holds one change. A fix that belongs to a sibling feature still in review moves into that feature's PR instead of riding along.
 - PR description: bullet points of changes.
 
 ## Bot review threads

--- a/.claude/rules/universal/git-workflow.md
+++ b/.claude/rules/universal/git-workflow.md
@@ -16,6 +16,7 @@
 - Branch must be up to date with `master`, approved, green. Behind: use the PR's **Update branch** button.
 - Approve: comment `!approve` on the PR (`gh pr review --approve` fails for the author).
 - Merge: `gh pr merge <num> --squash [--auto]`. Squash uses the PR title as the commit subject and drops the body, so the PR title is the changelog line.
+- A PR that ships several player/admin-facing changes gets one changelog line per change by passing them as the squash body: `gh pr merge <num> --squash --body-file <file>`, one `type(scope): subject` per line (each meeting the subject rule below). release-please and the Discord changelog list every such line. Keep the lines in the PR description under a `### 📝 Changelog` heading so reviewers see them.
 - `--rebase` only when the PR is a series of independent player/admin-facing changes that each deserve their own line; then every commit subject must meet the subject rule below.
 
 ## Chained PRs
@@ -40,7 +41,7 @@ gh pr merge <child-num> --squash --auto
 - No `Co-Authored-By` trailer. No co-author attribution in PRs.
 - Subjects (PR title, commit subject) are changelog lines: lead with the player/admin-facing outcome ("festivals no longer kick players who moved their cabin"), not the mechanism, and say what kind of thing shipped ("embeddable live server status widget for web pages", not "status widget backed by /status").
 - Commit body in plain English — what changed, why, what tests cover it — no unexplained in-house terms.
-- A squashed PR is one changelog line, so it holds one change. A fix that belongs to a sibling feature still in review moves into that feature's PR instead of riding along.
+- A squashed PR is one changelog line by default, so it holds one change. A fix that belongs to a sibling feature still in review moves into that feature's PR instead of riding along. A PR that has already grown several changes uses the squash-body mechanism above rather than being split after the fact.
 - PR description: bullet points of changes.
 
 ## Bot review threads

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,12 +6,6 @@
 
 <!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
 
-### 📝 Changelog
-
-<!-- Only if the PR ships more than one player/admin-facing change. One conventional-commit line
-     per change (e.g. "fix(docker): ..."); the maintainer passes these as the squash-commit body so
-     each becomes its own release-notes line. Delete this section otherwise. -->
-
 <!----------------------------------------------------------------------
 Before creating the pull request, please make sure you do the following:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,12 @@
 
 <!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
 
+### 📝 Changelog
+
+<!-- Only if the PR ships more than one player/admin-facing change. One conventional-commit line
+     per change (e.g. "fix(docker): ..."); the maintainer passes these as the squash-commit body so
+     each becomes its own release-notes line. Delete this section otherwise. -->
+
 <!----------------------------------------------------------------------
 Before creating the pull request, please make sure you do the following:
 

--- a/.github/actions/build-changelog/action.yml
+++ b/.github/actions/build-changelog/action.yml
@@ -22,13 +22,15 @@ outputs:
     description: Changelog markdown (at most 3200 code points)
     value: ${{ steps.changelog.outputs.markdown }}
   count:
-    description: Commits in the range
+    description: >
+      Changelog entries in the range: one per commit, plus one per conventional-commit line in a
+      squash commit's body
     value: ${{ steps.changelog.outputs.count }}
   visible-count:
-    description: Commits listed individually (visible sections plus Other)
+    description: Entries listed individually (visible sections plus Other)
     value: ${{ steps.changelog.outputs.visible-count }}
   hidden-count:
-    description: Commits folded into the internal-changes line
+    description: Entries folded into the internal-changes line
     value: ${{ steps.changelog.outputs.hidden-count }}
   base-tag:
     description: Tag the range starts from (the previous build)
@@ -63,7 +65,7 @@ runs:
         BASE_TAG: ${{ steps.range.outputs.base-tag }}
         REPO_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
-        git log --first-parent --format='%H%x1f%s' "$BASE_OID..$HEAD_OID" \
+        git log --first-parent --format='%H%x1f%s%x1f%b%x1e' "$BASE_OID..$HEAD_OID" \
           | node "$GITHUB_ACTION_PATH/../../scripts/build-changelog.js"
 
     - name: Flag changed operator files

--- a/.github/scripts/build-changelog.js
+++ b/.github/scripts/build-changelog.js
@@ -2,9 +2,13 @@
 // ordered the way release-please orders its release notes, trimmed to fit a Discord embed. Used
 // by .github/actions/build-changelog; the core function is exported so `npm test` can call it.
 //
-// How the action runs it: it pipes `git log --first-parent --format='%H%x1f%s' BASE..HEAD` in on
-// stdin and sets the BASE_TAG, HEAD_OID and REPO_URL env vars. We write markdown / count /
+// How the action runs it: it pipes `git log --first-parent --format='%H%x1f%s%x1f%b%x1e' BASE..HEAD`
+// in on stdin and sets the BASE_TAG, HEAD_OID and REPO_URL env vars. We write markdown / count /
 // visible-count / hidden-count / compare-url to $GITHUB_OUTPUT (or print them to stdout locally).
+//
+// A squash commit whose body carries further conventional-commit lines (release-please's
+// "multiple fixes or features in one PR" convention) contributes one entry per such line on top
+// of its subject, so the Discord post lists the same changes the release notes will.
 
 // The heading above the list. One flat list, no per-type sub-headings.
 const HEADER = "**Changes**";
@@ -65,6 +69,25 @@ function parseSubject(subject) {
         breaking: conv ? conv[3] === "!" || /\bBREAKING[ -]CHANGE\b/.test(text) : false,
         pr,
     };
+}
+
+/**
+ * Expand one commit into the subjects it contributes: its own subject, plus every body line that
+ * is itself a conventional commit (a squash of a PR shipping several changes). Body entries carry
+ * the subject's `(#N)` so they link to the same PR. Anything else in the body is ignored.
+ * @param {string} subject - Raw `git log %s` subject line.
+ * @param {string} body - Raw `git log %b` body (may be empty).
+ * @returns {string[]}
+ */
+function expandCommit(subject, body) {
+    const pr = subject.match(PR_SUFFIX_RE);
+    const suffix = pr ? ` (#${pr[1]})` : "";
+    const extra = body
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => CONVENTIONAL_RE.test(line))
+        .map((line) => `${line}${suffix}`);
+    return [subject, ...extra];
 }
 
 /** @returns {string} one `- …` bullet. A breaking change gets a ⚠ prefix; the PR link goes on the end. */
@@ -145,7 +168,7 @@ function buildChangelog(subjects, { repoUrl, baseTag, headOid }) {
     return { ...result, markdown };
 }
 
-module.exports = { buildChangelog, parseSubject, escapeMarkdown, BUDGET };
+module.exports = { buildChangelog, expandCommit, parseSubject, escapeMarkdown, BUDGET };
 
 // --- CLI entry (composite-action wiring) ---------------------------------------------
 
@@ -167,12 +190,15 @@ function main() {
     const headOid = requireEnv("HEAD_OID");
     const repoUrl = requireEnv("REPO_URL");
 
-    // Each line is `<sha>\x1f<subject>`. We split on the \x1f, which guarantees one line per commit
-    // even when the subject is empty, so the commit count stays correct.
+    // Each record is `<sha>\x1f<subject>\x1f<body>\x1e`. Bodies span lines, so records are split
+    // on the \x1e terminator and fields on \x1f; a record with an empty subject still counts.
     const subjects = readFileSync(0, "utf8")
-        .split("\n")
-        .filter((line) => line.includes("\x1f"))
-        .map((line) => line.slice(line.indexOf("\x1f") + 1));
+        .split("\x1e")
+        .filter((record) => record.includes("\x1f"))
+        .flatMap((record) => {
+            const [, subject = "", body = ""] = record.split("\x1f");
+            return expandCommit(subject.trim(), body);
+        });
 
     const result = buildChangelog(subjects, { repoUrl, baseTag, headOid });
     const delimiter = `EOF_${randomUUID()}`;
@@ -190,7 +216,7 @@ function main() {
     if (process.env.GITHUB_OUTPUT) {
         appendFileSync(process.env.GITHUB_OUTPUT, output);
     }
-    console.log(`${result.count} commits (${result.visibleCount} visible, ${result.hiddenCount} internal)`);
+    console.log(`${result.count} entries (${result.visibleCount} visible, ${result.hiddenCount} internal)`);
     console.log(result.markdown);
 }
 

--- a/.github/scripts/build-changelog.test.js
+++ b/.github/scripts/build-changelog.test.js
@@ -8,7 +8,7 @@
 
 const { test } = require("node:test");
 const assert = require("node:assert/strict");
-const { buildChangelog, BUDGET } = require("./build-changelog.js");
+const { buildChangelog, expandCommit, BUDGET } = require("./build-changelog.js");
 
 const OPTS = {
     repoUrl: "https://github.com/o/r",
@@ -185,6 +185,27 @@ test("release-please's release commit is excluded from every count", () => {
     assert.deepEqual([result.count, result.visibleCount, result.hiddenCount], [2, 1, 1]);
     // A plain chore mentioning "release" without a version is NOT the release commit.
     assert.equal(buildChangelog(["chore: release notes cleanup"], OPTS).hiddenCount, 1);
+});
+
+test("a squash commit's conventional body lines become their own entries, linked to the same PR", () => {
+    const body = [
+        "Prose describing the change, which is not an entry.",
+        "",
+        "fix(docker): the console exits when the server isn't running",
+        "  feat(docker): startup noise is hidden  ",
+        "not a conventional line",
+        "chore: internal tidy-up",
+    ].join("\n");
+    assert.deepEqual(expandCommit("feat(docker): quieter console (#661)", body), [
+        "feat(docker): quieter console (#661)",
+        "fix(docker): the console exits when the server isn't running (#661)",
+        "feat(docker): startup noise is hidden (#661)",
+        "chore: internal tidy-up (#661)",
+    ]);
+    // Without a PR suffix on the subject, body entries get none either.
+    assert.deepEqual(expandCommit("fix: direct push", "feat: extra"), ["fix: direct push", "feat: extra"]);
+    // An empty body contributes nothing.
+    assert.deepEqual(expandCommit("fix: alone (#1)", ""), ["fix: alone (#1)"]);
 });
 
 test("zero commits reports no changes since the base tag", () => {

--- a/docker/modern/rootfs/opt/bin/attach-cli
+++ b/docker/modern/rootfs/opt/bin/attach-cli
@@ -19,21 +19,54 @@ COLOR_BORDER_ACTIVE=$COLOR_BRAND_3
 COLOR_STATUSBAR_BACKGROUND=$COLOR_BRAND_3
 COLOR_STATUSBAR_TEXT=$COLOR_BRAND_1
 
+# The launcher outlives SMAPI (it waits on it), so once it's gone the server has crashed or never
+# started: no log will ever appear, so bail instead of waiting forever.
+# Exact command-line match, so a shell merely mentioning the path doesn't count as the launcher.
+server_alive() { pgrep -f -x '([^ ]*/)?bash /opt/bin/start-game\.sh' >/dev/null 2>&1; }
+
+exit_server_not_running() {
+    echo ""
+    echo "The server is not running (it crashed or failed to start), so there is nothing to attach to."
+    echo "Check the logs, fix the issue, then start it again:"
+    echo "  docker compose logs --tail 200 server"
+    echo "  docker compose up -d"
+    exit 1
+}
+
 # Wait for server to be ready
 if [ ! -f "$LOG_FILE" ]; then
     echo "Waiting for server to be ready..."
     while [ ! -f "$LOG_FILE" ]; do
+        server_alive || exit_server_not_running
         sleep 1
     done
 fi
+server_alive || exit_server_not_running
 
 start_output_pane() {
     local session_name="$1"
     local log_file="$2"
 
+    # Build the startup-noise filter (see strip-startup-noise.awk). Fall back to a no-op
+    # passthrough if awk or the filter is unusable, so the console is never blanked.
+    # mawk block-buffers stdout and ignores fflush(), so under `tail -f` (no EOF) its output
+    # never reaches the pane — it needs `-W interactive`. busybox/gawk flush via fflush() in
+    # the program and warn on/reject -W, so only add it for mawk (which accepts it silently).
+    local noise_filter="/opt/bin/strip-startup-noise.awk"
+    local log_filter="cat"
+    if command -v awk >/dev/null 2>&1 && [ -r "$noise_filter" ]; then
+        local awk_flush=""
+        if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
+            awk_flush="-W interactive"
+        fi
+        if printf '\n' | awk $awk_flush -f "$noise_filter" >/dev/null 2>&1; then
+            log_filter="awk $awk_flush -f $noise_filter"
+        fi
+    fi
+
     # Pin default-shell so panes and #() jobs never inherit an account shell that can't run
     # commands (the production baseimage writes /sbin/nologin for every account)
-    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter} | sed 's/\x1b\[30m/\x1b[90m/g'"
 }
 
 start_input_pane_split() {

--- a/docker/modern/rootfs/opt/bin/attach-cli
+++ b/docker/modern/rootfs/opt/bin/attach-cli
@@ -47,26 +47,19 @@ start_output_pane() {
     local session_name="$1"
     local log_file="$2"
 
-    # Build the startup-noise filter (see strip-startup-noise.awk). Fall back to a no-op
-    # passthrough if awk or the filter is unusable, so the console is never blanked.
-    # mawk block-buffers stdout and ignores fflush(), so under `tail -f` (no EOF) its output
-    # never reaches the pane — it needs `-W interactive`. busybox/gawk flush via fflush() in
-    # the program and warn on/reject -W, so only add it for mawk (which accepts it silently).
-    local noise_filter="/opt/bin/strip-startup-noise.awk"
-    local log_filter="cat"
-    if command -v awk >/dev/null 2>&1 && [ -r "$noise_filter" ]; then
-        local awk_flush=""
-        if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
-            awk_flush="-W interactive"
-        fi
-        if printf '\n' | awk $awk_flush -f "$noise_filter" >/dev/null 2>&1; then
-            log_filter="awk $awk_flush -f $noise_filter"
-        fi
+    # Startup-noise filter (see strip-startup-noise.awk). mawk block-buffers stdout and ignores
+    # fflush(), so under `tail -f` (no EOF) its output never reaches the pane — it needs
+    # `-W interactive`. busybox/gawk flush via fflush() in the program and warn on -W, so only
+    # add it for mawk (which accepts it silently).
+    local awk_flush=""
+    if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
+        awk_flush="-W interactive"
     fi
+    local log_filter="awk $awk_flush -f /opt/bin/strip-startup-noise.awk"
 
     # Pin default-shell so panes and #() jobs never inherit an account shell that can't run
     # commands (the production baseimage writes /sbin/nologin for every account)
-    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter}"
 }
 
 start_input_pane_split() {

--- a/docker/modern/rootfs/opt/bin/start-game.sh
+++ b/docker/modern/rootfs/opt/bin/start-game.sh
@@ -208,7 +208,9 @@ export LD_PRELOAD="/opt/lib/pthread_shim.so${LD_PRELOAD:+:$LD_PRELOAD}"
 
 # Start SMAPI with stdin from the FIFO. `script` gives it a PTY so it prints colors and copies
 # output to both stdout (docker logs) and LOG_FILE (tailed by attach-cli). `tail -f` keeps the
-# FIFO open between writers.
+# FIFO open between writers. Keep this pipeline unfiltered: startup noise is filtered at the read
+# site instead (attach-cli tails through strip-startup-noise.awk). A filter interposed on
+# script's stdout here stalled the session under `wait`, so don't reintroduce one.
 script -q -f --return -c "tail -f \"${INPUT_FIFO}\" | \"${SMAPI_EXECUTABLE}\"" "${LOG_FILE}" &
 SMAPI_PID=$!
 

--- a/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
+++ b/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
@@ -17,16 +17,23 @@
 # Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
 # handled alike; the original line is printed unchanged (color preserved). The XACT
 # block ends at the next SMAPI log line (prefix mirrors ServerContainer
-# .SmapiLogLinePrefix) or a "Process terminated." fatal sentinel — both always print,
-# so a real crash is never swallowed. Every drop is an exact message match, never a
-# level match, so real warnings/errors always pass through.
+# .SmapiLogLinePrefix) or any unprefixed fatal-crash header the runtime writes without a
+# SMAPI prefix — .NET FailFast ("Process terminated."), an unhandled exception, or a
+# stack overflow — so a real crash landing in the XACT window is never swallowed. Every
+# drop is an exact message match, never a level match, so real warnings/errors always
+# pass through.
 BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
 {
     clean = $0
     gsub(sgr, "", clean)
 
-    # A new SMAPI log line or the .NET FailFast sentinel ends suppression and prints.
-    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ || clean ~ /^Process terminated\./) {
+    # A new SMAPI log line, or any unprefixed fatal-crash header (FailFast, an unhandled
+    # exception, or a stack overflow), ends suppression and prints — so a crash landing
+    # in the XACT window is never swallowed.
+    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ ||
+        clean ~ /^Process terminated\./ ||
+        clean ~ /^Unhandled [Ee]xception[.:]/ ||
+        clean ~ /^Stack overflow\./) {
         suppress = 0
     } else if (suppress) {
         next

--- a/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
+++ b/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
@@ -15,14 +15,15 @@
 #      accurate, but not actionable on a dedicated server.
 #
 # Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
-# handled alike; the original line is printed unchanged (color preserved). The XACT
+# handled alike; the original line is printed with its color intact, except that black
+# text is recolored gray so trace logs stay readable on a dark pane. The XACT
 # block ends at the next SMAPI log line (prefix mirrors ServerContainer
 # .SmapiLogLinePrefix) or any unprefixed fatal-crash header the runtime writes without a
 # SMAPI prefix — .NET FailFast ("Process terminated."), an unhandled exception, or a
 # stack overflow — so a real crash landing in the XACT window is never swallowed. Every
 # drop is an exact message match, never a level match, so real warnings/errors always
 # pass through.
-BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
+BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; black = esc "[[]30m"; gray = esc "[90m"; suppress = 0 }
 {
     clean = $0
     gsub(sgr, "", clean)
@@ -57,6 +58,7 @@ BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
         next
     }
 
+    gsub(black, gray)
     print
     fflush()
 }

--- a/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
+++ b/docker/modern/rootfs/opt/bin/strip-startup-noise.awk
@@ -1,0 +1,55 @@
+# Drops known-benign, non-actionable server startup noise from the attach-cli console, which
+# tails /tmp/server-output.log through this filter. The on-disk /tmp/server-output.log and
+# docker logs stay raw. Keep in sync with the copy in the other image's rootfs (legacy
+# /opt/base/bin, modern /opt/bin).
+#
+#   1. "[S_API FAIL] ...SteamNetworkingUtils003 before SteamAPI_Init succeeded." —
+#      Steamworks.NET's CSteamGameServerAPIContext.Init probes the client
+#      networking-utils interface before falling back to the gameserver one inside
+#      GameServer.Init (SteamGameServerService); the failed probe is cosmetic.
+#   2. The "[ERROR game] Game.Initialize() caught exception initializing XACT."
+#      block (header + exception + stack trace) — audio content is absent by design
+#      on the headless server, so this failure is expected.
+#   3. SMAPI's one-shot startup warnings acknowledging this server's deliberate config
+#      (disabled content-integrity checks, disabled update checks, developer mode) —
+#      accurate, but not actionable on a dedicated server.
+#
+# Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
+# handled alike; the original line is printed unchanged (color preserved). The XACT
+# block ends at the next SMAPI log line (prefix mirrors ServerContainer
+# .SmapiLogLinePrefix) or a "Process terminated." fatal sentinel — both always print,
+# so a real crash is never swallowed. Every drop is an exact message match, never a
+# level match, so real warnings/errors always pass through.
+BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
+{
+    clean = $0
+    gsub(sgr, "", clean)
+
+    # A new SMAPI log line or the .NET FailFast sentinel ends suppression and prints.
+    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ || clean ~ /^Process terminated\./) {
+        suppress = 0
+    } else if (suppress) {
+        next
+    }
+
+    # Start dropping the headless-audio XACT error block (header included).
+    if (clean ~ /^\[[0-9:]+[ \t]+ERROR[ \t]+game\][ \t]+Game\.Initialize\(\) caught exception initializing XACT/) {
+        suppress = 1
+        next
+    }
+
+    # Drop the single benign native Steam interface-probe line.
+    if (clean ~ /\[S_API FAIL\] Tried to access Steam interface SteamNetworkingUtils003 before SteamAPI_Init succeeded\./) {
+        next
+    }
+
+    # Drop SMAPI's one-shot startup warnings acknowledging this server's deliberate config.
+    if (clean ~ /You disabled content integrity checks/ ||
+        clean ~ /You disabled update checks, so you won't be notified/ ||
+        clean ~ /You enabled developer mode, so the console will be much more verbose/) {
+        next
+    }
+
+    print
+    fflush()
+}

--- a/docker/rootfs/opt/base/bin/attach-cli
+++ b/docker/rootfs/opt/base/bin/attach-cli
@@ -21,24 +21,69 @@ COLOR_BORDER_ACTIVE=$COLOR_BRAND_3
 COLOR_STATUSBAR_BACKGROUND=$COLOR_BRAND_3
 COLOR_STATUSBAR_TEXT=$COLOR_BRAND_1
 
-# Wait for server to be ready
+# The launcher outlives SMAPI (it waits on it), so once it's gone the server has crashed or never
+# started and the container is on its way down: no log will ever appear, so bail instead of
+# waiting forever. A present log with no launcher is the same case, just after a crash.
+# Exact command-line match, so a shell merely mentioning the path (`bash -c 'cat /startapp.sh'`)
+# doesn't count as the launcher.
+server_alive() { pgrep -f -x '([^ ]*/)?bash /startapp\.sh' >/dev/null 2>&1; }
+
+exit_server_not_running() {
+    echo ""
+    echo "The server is not running (it crashed or failed to start), so there is nothing to attach to."
+    echo "Check the logs, fix the issue, then start it again:"
+    echo "  docker compose logs --tail 200 server"
+    echo "  docker compose up -d"
+    exit 1
+}
+
+# Wait for server to be ready. The launcher writes the lifecycle phase for the API port
+# (downloading | starting) — surface it so a multi-minute first boot doesn't read as a hang.
 if [ ! -f "$LOG_FILE" ]; then
     echo "Waiting for server to be ready..."
+    last_phase=""
     while [ ! -f "$LOG_FILE" ]; do
+        server_alive || exit_server_not_running
+        phase="$(cat /tmp/startup-phase 2>/dev/null)"
+        if [ "$phase" != "$last_phase" ]; then
+            case "$phase" in
+                downloading) echo "The game is still downloading (follow it with: docker compose logs -f steam-auth). This can take several minutes." ;;
+                starting)    echo "Game files are ready, starting the server..." ;;
+            esac
+            last_phase="$phase"
+        fi
         sleep 1
     done
 fi
+server_alive || exit_server_not_running
 
 start_output_pane() {
     local session_name="$1"
     local log_file="$2"
+
+    # Build the startup-noise filter (see strip-startup-noise.awk). Fall back to a no-op
+    # passthrough if awk or the filter is unusable, so the console is never blanked.
+    # mawk block-buffers stdout and ignores fflush(), so under `tail -f` (no EOF) its output
+    # never reaches the pane — it needs `-W interactive`. busybox/gawk flush via fflush() in
+    # the program and warn on/reject -W, so only add it for mawk (which accepts it silently).
+    local noise_filter="/opt/base/bin/strip-startup-noise.awk"
+    local log_filter="cat"
+    if command -v awk >/dev/null 2>&1 && [ -r "$noise_filter" ]; then
+        local awk_flush=""
+        if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
+            awk_flush="-W interactive"
+        fi
+        if printf '\n' | awk $awk_flush -f "$noise_filter" >/dev/null 2>&1; then
+            log_filter="awk $awk_flush -f $noise_filter"
+        fi
+    fi
 
     # Pin default-shell before the first pane spawns: the baseimage writes /sbin/nologin as every
     # account's shell, and tmux would adopt it (killing each pane and #() job instantly) since
     # Debian 13's usr-merge makes that path resolvable
     # Using `stty` to prevent user input (focus is still possible, and needed for scrolling)
     # Using `sed` to replace black text with gray to make trace logs easier to read
-    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter} | sed 's/\x1b\[30m/\x1b[90m/g'"
 }
 
 # Add command input pane at bottom (exactly 2 lines - tmux minimum)

--- a/docker/rootfs/opt/base/bin/attach-cli
+++ b/docker/rootfs/opt/base/bin/attach-cli
@@ -61,29 +61,21 @@ start_output_pane() {
     local session_name="$1"
     local log_file="$2"
 
-    # Build the startup-noise filter (see strip-startup-noise.awk). Fall back to a no-op
-    # passthrough if awk or the filter is unusable, so the console is never blanked.
-    # mawk block-buffers stdout and ignores fflush(), so under `tail -f` (no EOF) its output
-    # never reaches the pane — it needs `-W interactive`. busybox/gawk flush via fflush() in
-    # the program and warn on/reject -W, so only add it for mawk (which accepts it silently).
-    local noise_filter="/opt/base/bin/strip-startup-noise.awk"
-    local log_filter="cat"
-    if command -v awk >/dev/null 2>&1 && [ -r "$noise_filter" ]; then
-        local awk_flush=""
-        if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
-            awk_flush="-W interactive"
-        fi
-        if printf '\n' | awk $awk_flush -f "$noise_filter" >/dev/null 2>&1; then
-            log_filter="awk $awk_flush -f $noise_filter"
-        fi
+    # Startup-noise filter (see strip-startup-noise.awk). mawk block-buffers stdout and ignores
+    # fflush(), so under `tail -f` (no EOF) its output never reaches the pane — it needs
+    # `-W interactive`. busybox/gawk flush via fflush() in the program and warn on -W, so only
+    # add it for mawk (which accepts it silently).
+    local awk_flush=""
+    if [ -z "$(awk -W interactive 'BEGIN{}' </dev/null 2>&1)" ]; then
+        awk_flush="-W interactive"
     fi
+    local log_filter="awk $awk_flush -f /opt/base/bin/strip-startup-noise.awk"
 
     # Pin default-shell before the first pane spawns: the baseimage writes /sbin/nologin as every
     # account's shell, and tmux would adopt it (killing each pane and #() job instantly) since
     # Debian 13's usr-merge makes that path resolvable
     # Using `stty` to prevent user input (focus is still possible, and needed for scrolling)
-    # Using `sed` to replace black text with gray to make trace logs easier to read
-    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter} | sed 's/\x1b\[30m/\x1b[90m/g'"
+    tmux start-server \; set-option -g default-shell /bin/sh \; new-session -d -s "$session_name" "stty -echo; tail -n 1000 -f ${log_file} | ${log_filter}"
 }
 
 # Add command input pane at bottom (exactly 2 lines - tmux minimum)

--- a/docker/rootfs/opt/base/bin/strip-startup-noise.awk
+++ b/docker/rootfs/opt/base/bin/strip-startup-noise.awk
@@ -17,16 +17,23 @@
 # Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
 # handled alike; the original line is printed unchanged (color preserved). The XACT
 # block ends at the next SMAPI log line (prefix mirrors ServerContainer
-# .SmapiLogLinePrefix) or a "Process terminated." fatal sentinel — both always print,
-# so a real crash is never swallowed. Every drop is an exact message match, never a
-# level match, so real warnings/errors always pass through.
+# .SmapiLogLinePrefix) or any unprefixed fatal-crash header the runtime writes without a
+# SMAPI prefix — .NET FailFast ("Process terminated."), an unhandled exception, or a
+# stack overflow — so a real crash landing in the XACT window is never swallowed. Every
+# drop is an exact message match, never a level match, so real warnings/errors always
+# pass through.
 BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
 {
     clean = $0
     gsub(sgr, "", clean)
 
-    # A new SMAPI log line or the .NET FailFast sentinel ends suppression and prints.
-    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ || clean ~ /^Process terminated\./) {
+    # A new SMAPI log line, or any unprefixed fatal-crash header (FailFast, an unhandled
+    # exception, or a stack overflow), ends suppression and prints — so a crash landing
+    # in the XACT window is never swallowed.
+    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ ||
+        clean ~ /^Process terminated\./ ||
+        clean ~ /^Unhandled [Ee]xception[.:]/ ||
+        clean ~ /^Stack overflow\./) {
         suppress = 0
     } else if (suppress) {
         next

--- a/docker/rootfs/opt/base/bin/strip-startup-noise.awk
+++ b/docker/rootfs/opt/base/bin/strip-startup-noise.awk
@@ -15,14 +15,15 @@
 #      accurate, but not actionable on a dedicated server.
 #
 # Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
-# handled alike; the original line is printed unchanged (color preserved). The XACT
+# handled alike; the original line is printed with its color intact, except that black
+# text is recolored gray so trace logs stay readable on a dark pane. The XACT
 # block ends at the next SMAPI log line (prefix mirrors ServerContainer
 # .SmapiLogLinePrefix) or any unprefixed fatal-crash header the runtime writes without a
 # SMAPI prefix — .NET FailFast ("Process terminated."), an unhandled exception, or a
 # stack overflow — so a real crash landing in the XACT window is never swallowed. Every
 # drop is an exact message match, never a level match, so real warnings/errors always
 # pass through.
-BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
+BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; black = esc "[[]30m"; gray = esc "[90m"; suppress = 0 }
 {
     clean = $0
     gsub(sgr, "", clean)
@@ -57,6 +58,7 @@ BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
         next
     }
 
+    gsub(black, gray)
     print
     fflush()
 }

--- a/docker/rootfs/opt/base/bin/strip-startup-noise.awk
+++ b/docker/rootfs/opt/base/bin/strip-startup-noise.awk
@@ -1,0 +1,55 @@
+# Drops known-benign, non-actionable server startup noise from the attach-cli console, which
+# tails /tmp/server-output.log through this filter. The on-disk /tmp/server-output.log and
+# docker logs stay raw. Keep in sync with the copy in the other image's rootfs (legacy
+# /opt/base/bin, modern /opt/bin).
+#
+#   1. "[S_API FAIL] ...SteamNetworkingUtils003 before SteamAPI_Init succeeded." —
+#      Steamworks.NET's CSteamGameServerAPIContext.Init probes the client
+#      networking-utils interface before falling back to the gameserver one inside
+#      GameServer.Init (SteamGameServerService); the failed probe is cosmetic.
+#   2. The "[ERROR game] Game.Initialize() caught exception initializing XACT."
+#      block (header + exception + stack trace) — audio content is absent by design
+#      on the headless server, so this failure is expected.
+#   3. SMAPI's one-shot startup warnings acknowledging this server's deliberate config
+#      (disabled content-integrity checks, disabled update checks, developer mode) —
+#      accurate, but not actionable on a dedicated server.
+#
+# Matching is done on an ANSI-SGR-stripped copy so colorized and plain lines are
+# handled alike; the original line is printed unchanged (color preserved). The XACT
+# block ends at the next SMAPI log line (prefix mirrors ServerContainer
+# .SmapiLogLinePrefix) or a "Process terminated." fatal sentinel — both always print,
+# so a real crash is never swallowed. Every drop is an exact message match, never a
+# level match, so real warnings/errors always pass through.
+BEGIN { esc = sprintf("%c", 27); sgr = esc "[[][0-9;]*m"; suppress = 0 }
+{
+    clean = $0
+    gsub(sgr, "", clean)
+
+    # A new SMAPI log line or the .NET FailFast sentinel ends suppression and prints.
+    if (clean ~ /^\[[0-9:]+[ \t]+[A-Za-z]+[ \t]+/ || clean ~ /^Process terminated\./) {
+        suppress = 0
+    } else if (suppress) {
+        next
+    }
+
+    # Start dropping the headless-audio XACT error block (header included).
+    if (clean ~ /^\[[0-9:]+[ \t]+ERROR[ \t]+game\][ \t]+Game\.Initialize\(\) caught exception initializing XACT/) {
+        suppress = 1
+        next
+    }
+
+    # Drop the single benign native Steam interface-probe line.
+    if (clean ~ /\[S_API FAIL\] Tried to access Steam interface SteamNetworkingUtils003 before SteamAPI_Init succeeded\./) {
+        next
+    }
+
+    # Drop SMAPI's one-shot startup warnings acknowledging this server's deliberate config.
+    if (clean ~ /You disabled content integrity checks/ ||
+        clean ~ /You disabled update checks, so you won't be notified/ ||
+        clean ~ /You enabled developer mode, so the console will be much more verbose/) {
+        next
+    }
+
+    print
+    fflush()
+}

--- a/docker/rootfs/startapp.sh
+++ b/docker/rootfs/startapp.sh
@@ -318,6 +318,10 @@ init_steam_sdk() {
         echo "Steam SDK already linked"
     fi
 
+    # Ensure the SDK's own dlopen("steamclient.so") resolves on the first (bare)
+    # attempt, so the loader skips the "dlopen failed" fallback probe on startup.
+    export LD_LIBRARY_PATH="${STEAM_SDK_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
     # Create steam_appid.txt with Stardew Valley's AppID
     # The SDK defaults to 480 (Spacewar) which causes SDR connection failures
     echo "413150" > "${GAME_DEST_DIR}/steam_appid.txt"

--- a/tests/JunimoServer.Tests/AttachCliTests.cs
+++ b/tests/JunimoServer.Tests/AttachCliTests.cs
@@ -78,13 +78,18 @@ public class AttachCliTests : TestBase
         """;
 
     /// <summary>
-    /// Feeds a sample XACT error block through the in-image startup-noise filter and checks
+    /// Feeds sample XACT error blocks through the in-image startup-noise filter and checks
     /// what survives. The filter (strip-startup-noise.awk, which attach-cli tails the console
     /// through) suppresses the benign headless-audio XACT block, but must NOT swallow a real
     /// crash the runtime writes without a SMAPI prefix — an unhandled exception or a stack
     /// overflow — that lands inside the XACT suppression window. Runs the shipped artifact, not
     /// a copy. Creates no tmux session, so it does not race AttachCli_StartsSessionWithLivePanes
     /// on the shared server (that test's one-concurrent-run caveat is about tmux, avoided here).
+    ///
+    /// Each crash header gets its OWN XACT block: a header that clears suppression also clears
+    /// it for everything after, so a single shared block would let the first header's assertion
+    /// mask a missing terminator for the second (the second line would print merely because
+    /// suppression was already off). Independent blocks exercise each terminator branch.
     /// </summary>
     private const string NoiseFilterScenario = """
         set -u
@@ -96,9 +101,12 @@ public class AttachCliTests : TestBase
           '   at Microsoft.Xna.Framework.Audio.AudioEngine..ctor()' \
           'Unhandled Exception:' \
           'System.NullReferenceException: boom' \
+          '[12:01:00 ERROR game] Game.Initialize() caught exception initializing XACT: no audio' \
+          'Microsoft.Xna.Framework.Audio.NoAudioHardwareException: No audio device' \
+          '   at Microsoft.Xna.Framework.Audio.AudioEngine..ctor()' \
           'Stack overflow.' \
           '   at StardewValley.Deep.Recursion()' \
-          '[12:00:05 INFO SMAPI] Continuing' | awk -f "$filter")
+          '[12:02:00 INFO SMAPI] Continuing' | awk -f "$filter")
         printf '%s\n' "$out" | grep -q 'caught exception initializing XACT' && echo "VERDICT:XACT_LEAKED" || echo "VERDICT:XACT_DROPPED"
         printf '%s\n' "$out" | grep -q '^Unhandled Exception:' && echo "VERDICT:UNHANDLED_KEPT" || echo "VERDICT:UNHANDLED_SWALLOWED"
         printf '%s\n' "$out" | grep -q '^Stack overflow\.' && echo "VERDICT:STACKOVERFLOW_KEPT" || echo "VERDICT:STACKOVERFLOW_SWALLOWED"

--- a/tests/JunimoServer.Tests/AttachCliTests.cs
+++ b/tests/JunimoServer.Tests/AttachCliTests.cs
@@ -77,6 +77,34 @@ public class AttachCliTests : TestBase
         exit 0
         """;
 
+    /// <summary>
+    /// Feeds a sample XACT error block through the in-image startup-noise filter and checks
+    /// what survives. The filter (strip-startup-noise.awk, which attach-cli tails the console
+    /// through) suppresses the benign headless-audio XACT block, but must NOT swallow a real
+    /// crash the runtime writes without a SMAPI prefix — an unhandled exception or a stack
+    /// overflow — that lands inside the XACT suppression window. Runs the shipped artifact, not
+    /// a copy. Creates no tmux session, so it does not race AttachCli_StartsSessionWithLivePanes
+    /// on the shared server (that test's one-concurrent-run caveat is about tmux, avoided here).
+    /// </summary>
+    private const string NoiseFilterScenario = """
+        set -u
+        filter=/opt/base/bin/strip-startup-noise.awk
+        if [ ! -r "$filter" ]; then echo "VERDICT:NO_FILTER"; exit 0; fi
+        out=$(printf '%s\n' \
+          '[12:00:00 ERROR game] Game.Initialize() caught exception initializing XACT: no audio' \
+          'Microsoft.Xna.Framework.Audio.NoAudioHardwareException: No audio device' \
+          '   at Microsoft.Xna.Framework.Audio.AudioEngine..ctor()' \
+          'Unhandled Exception:' \
+          'System.NullReferenceException: boom' \
+          'Stack overflow.' \
+          '   at StardewValley.Deep.Recursion()' \
+          '[12:00:05 INFO SMAPI] Continuing' | awk -f "$filter")
+        printf '%s\n' "$out" | grep -q 'caught exception initializing XACT' && echo "VERDICT:XACT_LEAKED" || echo "VERDICT:XACT_DROPPED"
+        printf '%s\n' "$out" | grep -q '^Unhandled Exception:' && echo "VERDICT:UNHANDLED_KEPT" || echo "VERDICT:UNHANDLED_SWALLOWED"
+        printf '%s\n' "$out" | grep -q '^Stack overflow\.' && echo "VERDICT:STACKOVERFLOW_KEPT" || echo "VERDICT:STACKOVERFLOW_SWALLOWED"
+        exit 0
+        """;
+
     public AttachCliTests() { }
 
     /// <summary>
@@ -138,6 +166,44 @@ public class AttachCliTests : TestBase
         Assert.True(
             symptomLines == "0",
             $"attach-cli output must contain neither 'no server running' nor 'no sessions' (the reported regression symptoms); got {symptomLines} matching line(s). attach-cli output (excerpt): {attachLog}"
+        );
+    }
+
+    /// <summary>
+    /// The startup-noise filter must strip the headless-audio XACT block while letting an
+    /// unprefixed fatal-crash header (unhandled exception, stack overflow) that lands in the
+    /// XACT window pass through to the console — otherwise a real crash is invisible to an
+    /// operator watching attach-cli.
+    /// </summary>
+    [Fact]
+    public async Task StartupNoiseFilter_StripsXactBlock_ButKeepsUnprefixedCrash()
+    {
+        var result = await Server
+            .Container.ExecAsync(new[] { "sh", "-c", NoiseFilterScenario }, TestCt)
+            .WaitAsync(TestCt);
+
+        Log($"noise-filter scenario output:\n{result.Stdout}");
+        if (!string.IsNullOrWhiteSpace(result.Stderr))
+        {
+            Log($"noise-filter scenario stderr:\n{result.Stderr}");
+        }
+
+        Assert.True(
+            result.ExitCode == DockerExitCodes.Success,
+            $"Scenario script must exit 0 (verdicts ride stdout sentinels); got {result.ExitCode}: {result.Stderr}"
+        );
+
+        Assert.True(
+            result.Stdout.Contains("VERDICT:XACT_DROPPED", StringComparison.Ordinal),
+            $"Filter must drop the benign headless-audio XACT block; got: {result.Stdout}"
+        );
+        Assert.True(
+            result.Stdout.Contains("VERDICT:UNHANDLED_KEPT", StringComparison.Ordinal),
+            $"An 'Unhandled Exception:' header landing in the XACT window must NOT be swallowed; got: {result.Stdout}"
+        );
+        Assert.True(
+            result.Stdout.Contains("VERDICT:STACKOVERFLOW_KEPT", StringComparison.Ordinal),
+            $"A 'Stack overflow.' header landing in the XACT window must NOT be swallowed; got: {result.Stdout}"
         );
     }
 

--- a/tests/JunimoServer.Tests/Containers/ServerContainer.cs
+++ b/tests/JunimoServer.Tests/Containers/ServerContainer.cs
@@ -1042,13 +1042,26 @@ public class ServerContainer : IAsyncDisposable
             // Continuation line belonging to the current error
             _currentErrorDetails.Add(line.TrimEnd());
         }
-        else if (line.StartsWith("Process terminated.", StringComparison.Ordinal))
+        else if (IsUnprefixedCrashHeader(line))
         {
-            // .NET runtime FailFast (e.g. missing libicu) prints unprefixed to
-            // stderr — start a fatal error block so startup fails as an app
-            // crash instead of masquerading as a daemon/transport timeout.
+            // The .NET runtime writes these unprefixed to stderr — start a fatal
+            // error block so startup fails as an app crash instead of
+            // masquerading as a daemon/transport timeout.
             _currentErrorHeader = line;
         }
+    }
+
+    // Fatal crash headers the runtime writes without a SMAPI prefix: FailFast
+    // (e.g. missing libicu), an unhandled exception that escaped SMAPI's
+    // handlers, or a stack overflow. Keep in sync with the terminator set in
+    // docker/rootfs/opt/base/bin/strip-startup-noise.awk (the attach-cli
+    // startup-noise filter ends its suppression window on the same headers).
+    private static bool IsUnprefixedCrashHeader(string line)
+    {
+        return line.StartsWith("Process terminated.", StringComparison.Ordinal)
+            || line.StartsWith("Unhandled exception.", StringComparison.Ordinal)
+            || line.StartsWith("Unhandled Exception:", StringComparison.Ordinal)
+            || line.StartsWith("Stack overflow.", StringComparison.Ordinal);
     }
 
     private void FlushError()


### PR DESCRIPTION
## Summary

A quieter, more informative server console.

## Changes
- **Startup-noise filter** — attach-cli drops known-benign startup noise (the headless XACT audio failure, a benign Steam interface probe, and SMAPI's deliberate-config warnings) from the console; the on-disk log and `docker logs` stay raw.
- **Exit when the server isn't running** — attach-cli bails with guidance when the launcher process is gone, instead of waiting forever for a log that will never appear; the legacy image also surfaces the first-boot phase during a long download.
- **Faster Steam SDK load** — the SDK dir is added to `LD_LIBRARY_PATH` so `steamclient.so` resolves on the first dlopen, dropping the startup "dlopen failed" fallback probe.

### 📝 Changelog

```
feat(docker): server console hides known-benign startup noise
fix(docker): server console exits with guidance instead of waiting when the server isn't running
fix(docker): Steam SDK loads on the first dlopen, without the startup fallback probe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer status messages while the server downloads and launches.
  - Added descriptive errors when the server stops unexpectedly during startup.
  - Improved console output by filtering known, non-actionable startup messages while preserving meaningful warnings and errors.

- **Bug Fixes**
  - Improved Steam SDK library discovery for more reliable server startup.
  - Ensured genuine crash messages remain visible in filtered startup output.
  - Improved detection and reporting of unhandled exceptions and stack overflow failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
